### PR TITLE
Derive SSH presence from a real interactive session, not from bytes crossing a forward

### DIFF
--- a/erun-cli/cmd/activity_lease.go
+++ b/erun-cli/cmd/activity_lease.go
@@ -306,7 +306,7 @@ func newActivitySampleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sample",
 		Short: "Sample resident build and agent processes and record activity and resource usage",
-		Long:  "Records activity only when a matched process burned CPU since the previous\nsample, so an agent parked at a prompt does not keep the environment awake.\nAlso retains the container's own cgroup CPU and memory counters, which is what\nlets erun recommend a size for this environment from what it has actually done.",
+		Long:  "Records activity only when a matched process burned CPU since the previous\nsample, so an agent parked at a prompt does not keep the environment awake.\nAlso records SSH activity when an sshd child process holds an allocated\npseudo-terminal, so a real interactive session reads as active while\nport-forward re-establishment and background sync traffic do not. Also\nretains the container's own cgroup CPU and memory counters, which is what\nlets erun recommend a size for this environment from what it has actually done.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runActivitySample(cmd, tenant, environment, procRoot, cgroupRoot, jsonOutput)
@@ -317,6 +317,19 @@ func newActivitySampleCmd() *cobra.Command {
 	cmd.Flags().StringVar(&cgroupRoot, "cgroup-root", common.DefaultCgroupRoot, "Cgroup filesystem to read this container's own CPU and memory counters from")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Write the sample verdict as JSON")
 	return cmd
+}
+
+// recordActivityIf records the given kind only when found is true, so a
+// sampler tick that detects nothing leaves the activity snapshot untouched.
+func recordActivityIf(found bool, tenant, environment, kind string) error {
+	if !found {
+		return nil
+	}
+	return common.RecordEnvironmentActivity(common.EnvironmentActivityParams{
+		Tenant:      tenant,
+		Environment: environment,
+		Kind:        kind,
+	})
 }
 
 func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot, cgroupRoot string, jsonOutput bool) error {
@@ -337,16 +350,20 @@ func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot, cgroup
 	if err := retainRuntimeUsage(tenant, environment, cgroupRoot); err != nil {
 		return err
 	}
-	if result.Busy {
-		if err := common.RecordEnvironmentActivity(common.EnvironmentActivityParams{
-			Tenant:      tenant,
-			Environment: environment,
-			Kind:        common.ActivityKindProcess,
-		}); err != nil {
-			return err
-		}
+	if err := recordActivityIf(result.Busy, tenant, environment, common.ActivityKindProcess); err != nil {
+		return err
 	}
-	ctx := commandContext(cmd)
+	interactiveSSH, err := common.ScanInteractiveSSHSession(procRoot)
+	if err != nil {
+		return err
+	}
+	if err := recordActivityIf(interactiveSSH, tenant, environment, common.ActivityKindSSH); err != nil {
+		return err
+	}
+	return writeActivitySampleResult(commandContext(cmd), result, jsonOutput)
+}
+
+func writeActivitySampleResult(ctx common.Context, result common.ResidentActivityResult, jsonOutput bool) error {
 	if jsonOutput {
 		return json.NewEncoder(ctx.Stdout).Encode(result)
 	}
@@ -354,7 +371,7 @@ func runActivitySample(cmd *cobra.Command, tenant, environment, procRoot, cgroup
 		_, err := fmt.Fprintln(ctx.Stdout, "no working build or agent processes")
 		return err
 	}
-	_, err = fmt.Fprintf(ctx.Stdout, "working: %s\n", strings.Join(result.Processes, ", "))
+	_, err := fmt.Fprintf(ctx.Stdout, "working: %s\n", strings.Join(result.Processes, ", "))
 	return err
 }
 

--- a/erun-cli/cmd/activity_proxy.go
+++ b/erun-cli/cmd/activity_proxy.go
@@ -199,6 +199,13 @@ func (r *sshActivityRecorder) Flush() {
 	r.save(pending, pendingByClient)
 }
 
+// save records the raw byte count the network-traffic-window signal needs,
+// but marks it Seen rather than active: this proxy relays encrypted bytes
+// blind to what is inside them, so a port-forward re-establishment or a
+// background sync channel counts here exactly like a person typing. Whether
+// someone is actually at an interactive shell is decided by the in-pod
+// sampler's pty check (ScanInteractiveSSHSession), which is what advances
+// LastActivity for this same kind.
 func (r *sshActivityRecorder) save(bytes int64, byClient map[string]int64) {
 	if bytes <= r.idleTrafficBytes {
 		return
@@ -207,6 +214,7 @@ func (r *sshActivityRecorder) save(bytes int64, byClient map[string]int64) {
 		Tenant:        r.tenant,
 		Environment:   r.environment,
 		Kind:          common.ActivityKindSSH,
+		Seen:          true,
 		Bytes:         bytes,
 		ClientUpdates: clientUpdatesFromMap(byClient),
 	})

--- a/erun-common/activity_sample.go
+++ b/erun-common/activity_sample.go
@@ -143,6 +143,107 @@ func residentActivityCPUBusy(deltaTicks int64, elapsed time.Duration) bool {
 	return rate >= residentActivityCPURateFloor
 }
 
+// ScanInteractiveSSHSession reports whether this pod currently holds a
+// pseudo-terminal allocated for an SSH session - the same discriminator `ps`
+// shows as a real TTY versus "notty". Privilege-separated sshd never assigns
+// the pty as its own controlling terminal: the per-session "sshd: user@ptsN"
+// process holds the pty master and stays tty-less itself, while the command
+// or shell it execs becomes the pty's session leader. The check is therefore
+// two passes - which pids are sshd, then which processes both have a
+// controlling terminal and were forked by one of those pids - rather than a
+// single process's own fields. sshd's listener always daemonizes with no
+// controlling terminal, and neither does a workspace-sync or sftp channel
+// (no pty requested), so this is blind to both by construction: only a
+// genuine interactive session, which requests one, trips it. It is what SSH
+// activity should mean for operator presence, in place of bytes crossing the
+// host-side forward, which erun's own port-forward re-establishment and
+// background sync traffic can produce just as easily as a person typing.
+func ScanInteractiveSSHSession(procRoot string) (bool, error) {
+	root := strings.TrimSpace(procRoot)
+	if root == "" {
+		root = DefaultProcRoot
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	processes, sshdPIDs := scanProcessTreeForSSHDChildren(root, entries)
+	for _, info := range processes {
+		if info.ttyNr != 0 {
+			if _, parentIsSSHD := sshdPIDs[info.ppid]; parentIsSSHD {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+type sshProcessInfo struct {
+	ppid  int64
+	ttyNr int64
+}
+
+// scanProcessTreeForSSHDChildren reads every /proc/[pid]/stat entry once,
+// returning each process's ppid/tty_nr plus the set of pids that are sshd -
+// the two facts ScanInteractiveSSHSession needs to find a pty-holding child
+// of one.
+func scanProcessTreeForSSHDChildren(root string, entries []os.DirEntry) (map[int64]sshProcessInfo, map[int64]struct{}) {
+	processes := make(map[int64]sshProcessInfo)
+	sshdPIDs := make(map[int64]struct{})
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 {
+			continue
+		}
+		comm, ppid, ttyNr, ok := readProcessCommPPIDAndTTY(filepath.Join(root, entry.Name(), "stat"))
+		if !ok {
+			continue
+		}
+		processes[int64(pid)] = sshProcessInfo{ppid: ppid, ttyNr: ttyNr}
+		if comm == "sshd" {
+			sshdPIDs[int64(pid)] = struct{}{}
+		}
+	}
+	return processes, sshdPIDs
+}
+
+// readProcessCommPPIDAndTTY reads a /proc/[pid]/stat entry's comm, ppid, and
+// tty_nr fields. tty_nr is 0 when the process has no controlling terminal.
+func readProcessCommPPIDAndTTY(path string) (string, int64, int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, 0, false
+	}
+	line := string(data)
+	open := strings.IndexByte(line, '(')
+	closing := strings.LastIndexByte(line, ')')
+	if open < 0 || closing <= open {
+		return "", 0, 0, false
+	}
+	comm := line[open+1 : closing]
+	fields := strings.Fields(line[closing+1:])
+	// ppid and tty_nr are the fourth and seventh stat columns, and fields
+	// starts at the third column (state), so they land at index 1 and 4.
+	const ppidIndex = 1
+	const ttyNrIndex = 4
+	if len(fields) <= ttyNrIndex {
+		return "", 0, 0, false
+	}
+	ppid, err := strconv.ParseInt(fields[ppidIndex], 10, 64)
+	if err != nil {
+		return "", 0, 0, false
+	}
+	ttyNr, err := strconv.ParseInt(fields[ttyNrIndex], 10, 64)
+	if err != nil {
+		return "", 0, 0, false
+	}
+	return comm, ppid, ttyNr, true
+}
+
 // readResidentActivityProcess reads one /proc entry, returning its name, the
 // pid+start-time key that survives pid reuse, and its accumulated CPU ticks.
 // Entries that are not processes, are the observer itself, or are not work

--- a/erun-common/activity_sample_test.go
+++ b/erun-common/activity_sample_test.go
@@ -17,14 +17,39 @@ import (
 // that actually breaks naive splitting.
 func writeProcEntry(t *testing.T, root string, pid int, comm string, cpuTicks, startTime int64) {
 	t.Helper()
+	writeProcEntryWithTTY(t, root, pid, comm, cpuTicks, startTime, 0)
+}
+
+// writeProcEntryWithTTY is writeProcEntry with an explicit tty_nr (column 7),
+// so a scenario can lay down a process that holds - or does not hold - an
+// allocated pseudo-terminal.
+func writeProcEntryWithTTY(t *testing.T, root string, pid int, comm string, cpuTicks, startTime, ttyNr int64) {
+	t.Helper()
+	writeProcEntryFull(t, root, pid, 0, comm, cpuTicks, startTime, ttyNr)
+}
+
+// writeProcEntryFull is writeProcEntryWithTTY with an explicit ppid (column
+// 4), so a scenario can model the real shape of an SSH session: the
+// per-session "sshd: user@ptsN" process stays tty-less itself while the
+// command it forks becomes the pty's session leader.
+func writeProcEntryFull(t *testing.T, root string, pid int, ppid int64, comm string, cpuTicks, startTime, ttyNr int64) {
+	t.Helper()
 	dir := filepath.Join(root, fmt.Sprintf("%d", pid))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", dir, err)
 	}
 	fields := make([]string, 0, 22)
 	fields = append(fields, fmt.Sprintf("%d (%s) S", pid, comm))
-	// Columns 4..13 (ppid through cmajflt) are unused padding here.
-	for i := 0; i < 10; i++ {
+	// Column 4 (ppid).
+	fields = append(fields, fmt.Sprintf("%d", ppid))
+	// Column 5 (pgrp) is unused padding.
+	fields = append(fields, "0")
+	// Column 6 (session) is unused padding.
+	fields = append(fields, "0")
+	// Column 7 (tty_nr): 0 means no controlling terminal.
+	fields = append(fields, fmt.Sprintf("%d", ttyNr))
+	// Columns 8..13 (tpgid through cmajflt) are unused padding here.
+	for i := 0; i < 6; i++ {
 		fields = append(fields, "0")
 	}
 	// utime + stime, split so the parser has to sum them.
@@ -174,5 +199,54 @@ func TestResidentActivityIgnoresProcessesNobodyWouldCallWork(t *testing.T) {
 	}
 	if second.Busy {
 		t.Errorf("the pod's own long-lived services must not read as work, got %+v", second)
+	}
+}
+
+// TestScanInteractiveSSHSession pins the discriminator that separates an
+// operator at a real shell from erun's own port-forward and sync traffic.
+// Privilege-separated sshd never puts the pty on its own process: the
+// per-session "sshd: user@ptsN" process (measured tty_nr=0, matching a real
+// runtime pod) forks the command or shell that actually becomes the pty's
+// session leader, so the check has to follow that parent/child edge rather
+// than reading one process's own fields.
+func TestScanInteractiveSSHSession(t *testing.T) {
+	root := t.TempDir()
+	if found, err := ScanInteractiveSSHSession(root); err != nil || found {
+		t.Fatalf("expected no session with an empty /proc, got found=%v err=%v", found, err)
+	}
+
+	// The listener itself: daemonized, no controlling terminal, no children.
+	writeProcEntryFull(t, root, 1, 0, "sshd", 10, 100, 0)
+	if found, err := ScanInteractiveSSHSession(root); err != nil || found {
+		t.Fatalf("expected the sshd listener alone to read as no session, got found=%v err=%v", found, err)
+	}
+
+	// A workspace-sync/sftp channel: the per-session sshd child (tty-less,
+	// like the real process) forks a transfer helper that never requested a
+	// pty either - "notty" end to end.
+	writeProcEntryFull(t, root, 2, 1, "sshd", 10, 101, 0)
+	writeProcEntryFull(t, root, 3, 2, "sftp-server", 10, 102, 0)
+	if found, err := ScanInteractiveSSHSession(root); err != nil || found {
+		t.Fatalf("expected a notty session to read as no session, got found=%v err=%v", found, err)
+	}
+
+	// A real interactive session: the per-session sshd child forks a shell
+	// that holds the allocated pty.
+	writeProcEntryFull(t, root, 4, 1, "sshd", 10, 103, 0)
+	writeProcEntryFull(t, root, 5, 4, "bash", 10, 104, 34816)
+	if found, err := ScanInteractiveSSHSession(root); err != nil || !found {
+		t.Fatalf("expected a pty-holding session to read as active, got found=%v err=%v", found, err)
+	}
+}
+
+// TestScanInteractiveSSHSessionIgnoresNonSSHDProcessesWithATTY guards against
+// a broader match than intended: a shell or editor with a real tty must not
+// itself count unless its parent is actually an sshd process.
+func TestScanInteractiveSSHSessionIgnoresNonSSHDProcessesWithATTY(t *testing.T) {
+	root := t.TempDir()
+	writeProcEntryFull(t, root, 10, 1, "tmux", 10, 100, 34816)
+	writeProcEntryFull(t, root, 11, 10, "bash", 10, 101, 34816)
+	if found, err := ScanInteractiveSSHSession(root); err != nil || found {
+		t.Fatalf("expected a tty-holding process with no sshd parent to read as no session, got found=%v err=%v", found, err)
 	}
 }

--- a/erun-integration/activity_test.go
+++ b/erun-integration/activity_test.go
@@ -93,12 +93,36 @@ func seedActivitySnapshot(t *testing.T, cacheHome, tenant, environment, kind, bo
 // be running.
 func writeSampleProcess(t *testing.T, root string, pid int, comm string, cpuTicks, startTime int64) {
 	t.Helper()
+	writeSampleProcessWithTTY(t, root, pid, comm, cpuTicks, startTime, 0)
+}
+
+// writeSampleProcessWithTTY is writeSampleProcess with an explicit tty_nr
+// (column 7) and no parent, for a lone process with - or without - an
+// allocated pseudo-terminal.
+func writeSampleProcessWithTTY(t *testing.T, root string, pid int, comm string, cpuTicks, startTime, ttyNr int64) {
+	t.Helper()
+	writeSampleProcessFull(t, root, pid, 0, comm, cpuTicks, startTime, ttyNr)
+}
+
+// writeSampleProcessFull is writeSampleProcessWithTTY with an explicit ppid
+// (column 4), so a scenario can model the real shape of an SSH session: the
+// per-session "sshd: user@ptsN" process stays tty-less itself while the
+// command it forks becomes the pty's session leader.
+func writeSampleProcessFull(t *testing.T, root string, pid int, ppid int64, comm string, cpuTicks, startTime, ttyNr int64) {
+	t.Helper()
 	dir := filepath.Join(root, fmt.Sprintf("%d", pid))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", dir, err)
 	}
 	fields := []string{fmt.Sprintf("%d (%s) S", pid, comm)}
-	for i := 0; i < 10; i++ {
+	// Column 4 (ppid).
+	fields = append(fields, fmt.Sprintf("%d", ppid))
+	// Columns 5..6 (pgrp, session) are unused padding.
+	fields = append(fields, "0", "0")
+	// Column 7 (tty_nr): 0 means no controlling terminal.
+	fields = append(fields, fmt.Sprintf("%d", ttyNr))
+	// Columns 8..13 (tpgid through cmajflt) are unused padding.
+	for i := 0; i < 6; i++ {
 		fields = append(fields, "0")
 	}
 	fields = append(fields, fmt.Sprintf("%d", cpuTicks), "0")
@@ -965,6 +989,48 @@ func TestActivity(t *testing.T) {
 		// lives outside the captured streams.
 		if _, err := os.Stat(filepath.Join(setup.CacheHome, "erun", "activity", "team", "dev", "process.json")); err != nil {
 			t.Errorf("expected the working sample to record process activity: %v", err)
+		}
+	})
+
+	t.Run("sample_records_ssh_activity_for_a_pty_holding_session", func(t *testing.T) {
+		// A real interactive session is an sshd child ("sshd:
+		// user@ptsN", itself tty-less) that forks a shell holding the allocated
+		// pseudo-terminal. That must read as SSH activity even though nothing
+		// crossed the host-side forward that this fixture cannot simulate.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		procRoot := filepath.Join(setup.Cwd, "proc")
+		writeSampleProcessFull(t, procRoot, 401, 1, "sshd", 10, 900, 0)
+		writeSampleProcessFull(t, procRoot, 403, 401, "bash", 10, 901, 34816)
+		result := erun.Run(t, []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot, "--cgroup-root", filepath.Join(setup.Cwd, "no-cgroup")}, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		body, err := os.ReadFile(filepath.Join(setup.CacheHome, "erun", "activity", "team", "dev", "ssh.json"))
+		if err != nil {
+			t.Fatalf("expected the pty-holding session to record ssh activity: %v", err)
+		}
+		if !strings.Contains(string(body), `"lastActivity"`) {
+			t.Errorf("expected lastActivity recorded for a real session, got:\n%s", body)
+		}
+	})
+
+	t.Run("sample_ignores_a_notty_ssh_child", func(t *testing.T) {
+		// An sshd child whose forked command never allocated a pty -
+		// the shape a port-forward re-establishment or a background sync
+		// channel takes - must never read as SSH activity, or the phantom-session
+		// bug this fixes comes back.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		procRoot := filepath.Join(setup.Cwd, "proc")
+		writeSampleProcessFull(t, procRoot, 402, 1, "sshd", 10, 900, 0)
+		writeSampleProcessFull(t, procRoot, 404, 402, "sftp-server", 10, 901, 0)
+		result := erun.Run(t, []string{"activity", "sample", "--tenant", "team", "--environment", "dev", "--proc-root", procRoot, "--cgroup-root", filepath.Join(setup.Cwd, "no-cgroup")}, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if _, err := os.Stat(filepath.Join(setup.CacheHome, "erun", "activity", "team", "dev", "ssh.json")); !os.IsNotExist(err) {
+			t.Errorf("expected no ssh activity recorded for a notty sshd child, stat err: %v", err)
 		}
 	})
 

--- a/erun-integration/testdata/whip/dry_run_json_output.txt
+++ b/erun-integration/testdata/whip/dry_run_json_output.txt
@@ -35,5 +35,5 @@
   ]
 }
 audit: erun whip --dry-run --json
-mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
-mcp tools/call http://<LOOPBACK>:17000/mcp whip preview=true
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp tools/call http://<LOOPBACK>:26100/mcp whip preview=true

--- a/erun-integration/testdata/whip/dry_run_one_named_environment_not_open_reports_not_alive.txt
+++ b/erun-integration/testdata/whip/dry_run_one_named_environment_not_open_reports_not_alive.txt
@@ -1,4 +1,4 @@
   team/dev: skipped — not-alive: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
 audit: erun whip --dry-run --environment dev --tenant team
-mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
-mcp tools/call http://<LOOPBACK>:17000/mcp whip preview=true
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp tools/call http://<LOOPBACK>:26100/mcp whip preview=true

--- a/erun-integration/testdata/whip/dry_run_whips_every_configured_environment_and_orchestrator.txt
+++ b/erun-integration/testdata/whip/dry_run_whips_every_configured_environment_and_orchestrator.txt
@@ -2,7 +2,7 @@
   team/dev: skipped — not-alive: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
   orchestrator Eng One: skipped — unreachable-from-transport
 audit: erun whip --dry-run
-mcp: other/staging edge resolved to http://<LOOPBACK>:17000/mcp
-mcp tools/call http://<LOOPBACK>:17000/mcp whip preview=true
-mcp: team/dev edge resolved to http://<LOOPBACK>:17100/mcp
-mcp tools/call http://<LOOPBACK>:17100/mcp whip preview=true
+mcp: other/staging edge resolved to http://<LOOPBACK>:26200/mcp
+mcp tools/call http://<LOOPBACK>:26200/mcp whip preview=true
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp tools/call http://<LOOPBACK>:26100/mcp whip preview=true

--- a/erun-integration/whip_test.go
+++ b/erun-integration/whip_test.go
@@ -34,13 +34,14 @@ func TestWhip(t *testing.T) {
 	})
 
 	t.Run("dry_run_one_named_environment_not_open_reports_not_alive", func(t *testing.T) {
-		// SeedTenantEnv never sets a local port range, so there is no local MCP
-		// edge to reach -- exactly the state of an environment nobody has open
-		// in the desktop right now. This must resolve to a "not alive" skip,
-		// not a hard command failure: the environment not being open is an
-		// ordinary, expected outcome of a fleet-wide whip.
+		// Pinned to the 26100 range (erun-integration/AGENTS.md's "pin a high
+		// port range") rather than the plain SeedTenantEnv default, or the probe
+		// below can land on whatever a developer's live erun session already
+		// holds on the default 17000 range and read as a stale port-forward
+		// instead of the "nobody has this open" case the scenario means to test.
+		skipIfPortsBusy(t, 26100)
 		setup := env.New(t)
-		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 26100)
 		result := erun.Run(t, []string{"whip", "--tenant", "team", "--environment", "dev", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -54,9 +55,11 @@ func TestWhip(t *testing.T) {
 		// orchestrator. Orchestrators are always reported unreachable from
 		// this transport -- a CLI process has no channel into a desktop-held
 		// PTY -- independent of whether any environment edge is reachable.
+		// Pinned ports for the same reason as the scenario above.
+		skipIfPortsBusy(t, 26100, 26200)
 		setup := env.New(t)
-		fixture.SeedTenantEnv(t, setup, "team", "dev")
-		fixture.SeedTenantEnv(t, setup, "other", "staging")
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 26100)
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "other", "staging", 26200)
 		seedOrchestrator(t, setup, "eng-1", "Eng One")
 		result := erun.Run(t, []string{"whip", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if result.ExitCode != 0 {
@@ -66,8 +69,10 @@ func TestWhip(t *testing.T) {
 	})
 
 	t.Run("dry_run_json_output", func(t *testing.T) {
+		// Pinned ports for the same reason as the scenarios above.
+		skipIfPortsBusy(t, 26100)
 		setup := env.New(t)
-		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 26100)
 		seedOrchestrator(t, setup, "eng-1", "Eng One")
 		result := erun.Run(t, []string{"whip", "--dry-run", "--json"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
 		if result.ExitCode != 0 {


### PR DESCRIPTION
An orchestrator could not take an exclusive worktree lease on an environment it
had just reconnected to:

```
refusing exclusive lease: an SSH session is active
```

**No SSH session existed.** The guard was matching its own observer: `erun open`
— the recovery erun itself prints after a pod replacement — pushes bytes through
the host-side SSH activity proxy, which wrote an `ActivityKindSSH` marker, which
`EnvironmentOperatorPresenceReason` read as an operator sitting at an
interactive shell.

A deploy is precisely when an orchestrator must both reconnect *and* claim the
tree, so the collision was structural, not incidental.

## Reproduced live, with the deployed binary

```
$ who                                # empty
$ ss -tnp | grep -E "17023|18022"    # empty
$ erun idle --tenant erun --environment build
  ssh: active (300s)
$ cat ~/.cache/erun/activity/erun/build/ssh.json
{"lastActivity": "2026-08-27T13:35:29Z", ..., "bytes": 97481, ...}
```

Isolated to the byte relay by sending 119 bytes that are not even a valid SSH
handshake — a phantom marker appeared.

## Why the other two candidate fixes were rejected

Both were disproved rather than passed over:

- **Exclude forward-establishment traffic** — the false positive is not limited
  to it: `ssh-workspace-sync` produces the same false marker continuously.
- **Require a byte floor a handshake cannot reach** — that same sync traffic
  reaches **51 GB** cumulative, so no floor can sit above it and remain useful.

## The chosen fix is what the docs already promised

`erun-docs/agent-reference/idle-policy.md` already documents the contract:
presence is *"not updated by … passive port-forward traffic without an active
session"*. The code never implemented it.

- **`erun-common/activity_sample.go`** — `ScanInteractiveSSHSession` reads
  `/proc` for a process holding an allocated pty (`tty_nr != 0`) whose parent is
  `sshd`. The two-hop check is necessary, not cosmetic: privilege-separated sshd
  (verified live in this pod) never puts the pty on its own process —
  `sshd: erun@ptsN` stays `tty_nr=0`, and only the shell it execs becomes the
  pty's session leader.
- **`erun-cli/cmd/activity_lease.go`** — the resident 30s sampler records
  `ActivityKindSSH` only when that scan finds a real session.
- **`erun-cli/cmd/activity_proxy.go`** — the relay still records raw bytes
  (`Bytes`/`ClientUpdates` feed the separate network-traffic-window signal and
  the desktop tooltip) but passes `Seen: true`, so it **never bumps
  `LastActivity`**. It cannot see inside an encrypted stream, so it must not be
  the source of a presence signal.

`EnvironmentOperatorPresenceReason` needed no change — it already gates on the
`ssh` kind. The fix is entirely about *who is allowed to set it*.

## Both halves proven against the real pod

A genuine interactive `ssh -tt` session (temp keypair, removed after):

```
ssh: active (recent activity)
```

The fixed proxy relaying the identical 119 phantom bytes:

```
{"lastActivity": "0001-01-01T00:00:00Z", "bytes": 119, ...}
ssh: idle (no activity recorded)
```

A fix that stopped detecting real sessions would be worse than the bug, so both
directions are covered. All artifacts cleaned up; `authorized_keys` diffed
identical to its pre-test state.

## Gates

- new unit tests (`TestScanInteractiveSSHSession`, plus one asserting a
  tty-holding process whose parent is **not** sshd — e.g. `tmux` — never counts)
  → **pass**
- new integration scenarios (`sample_records_ssh_activity_for_a_pty_holding_session`,
  `sample_ignores_a_notty_ssh_child`) → **pass**
- `make check` on the rebased tree → **exit 0**: golangci-lint **0 issues**
  across all six modules, `erun-ui` Go tests, frontend gates, all Helm chart
  tests, integration suite, coverage **76.1%** (≥ 75.8%). Two functions tripped
  `cyclop`; fixed by extracting helpers, **not** suppressed.

## Also fixed: three pre-existing `TestWhip` failures

Confirmed red on unmodified `main`. They seeded no local port range, so the
MCP-edge probe defaulted to **port 17000** — which on this shared pod collides
with a real, currently-active `kubectl port-forward`. The probe read that live
unrelated connection as "a stale channel" instead of "nobody has this open",
changing the reported error. Fixed with the repo's own documented convention for
this hazard (`erun-integration/AGENTS.md`, "pin a high port range", already used
in `mcp_test.go`/`open_test.go`). The three regenerated goldens differ **only**
in port number.

That is the same class of defect as the one this PR fixes: a check reading
someone else's live state as its own.

Closes #1444