### PR TITLE
Stop a release-timing golden depending on how fast the host runs git

### DIFF
--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -797,8 +798,9 @@ exit 0
 		// git's push-rejection hint block is worded differently across git
 		// versions, so it cannot be part of a reviewed golden; the `! [rejected]`
 		// line and erun's own retry line are what this scenario locks.
+		combined := normalize.Apply(result.Combined, normalize.Replacement{Pattern: regexp.MustCompile(`(?m)^hint:.*\n?`), Token: ""})
 		golden.Equal(t, "release/real_run_absorbs_a_base_branch_that_moved_during_the_build",
-			normalize.Apply(result.Combined, normalize.Replacement{Pattern: regexp.MustCompile(`(?m)^hint:.*\n?`), Token: ""}))
+			canonicalizeReleaseStageTimingOrder(t, combined))
 
 		// Side effects outside the captured streams, one per contract the
 		// absorbed push has to hold: the repository records the release it
@@ -905,6 +907,64 @@ func seedBareOrigin(t *testing.T, setup env.Setup) string {
 	fixture.RunGit(t, setup.Cwd, "remote", "add", "origin", remoteRoot)
 	fixture.RunGit(t, setup.Cwd, "push", "-u", "-q", "origin", "main")
 	return remoteRoot
+}
+
+// releaseStageTimingSiblingsToCanonicalize are this scenario's top-level
+// release-stage timing rows other than "publish", the one stage whose
+// duration (a multi-arch image build plus two chart publishes) always
+// dominates by a wide, host-independent margin. These five run sequentially
+// and each does at most a couple of real git subprocess calls, except
+// "push": this scenario's whole point is a rejected push that rebases and
+// retries, so "push" alone does several more real git subprocess calls than
+// its siblings. erun-common/timing.go's orderedTimingRows sorts by measured
+// duration, tie-breaking by name only when two rows land within a fixed
+// noise floor of each other — so whether "push"'s extra real git latency
+// crosses that floor and reorders it ahead of its siblings depends on how
+// fast git subprocesses run on the host, not on anything this scenario
+// controls. Canonicalizing this block's order before comparing keeps the
+// golden asserting what is actually stable: which five stages ran and
+// roughly how long each took, not which one happened to be a few git calls
+// slower on this particular machine.
+var releaseStageTimingSiblingsToCanonicalize = []string{
+	"post-release-version-bump", "push", "release", "sync-remote", "verify-publication",
+}
+
+// canonicalizeReleaseStageTimingOrder reorders the contiguous
+// releaseStageTimingSiblingsToCanonicalize block within a normalized
+// step-timing table into a fixed, alphabetical order, so the golden compares
+// something that does not depend on real subprocess timing. Called after
+// normalize.Apply, so every row already reads "<name> [<ELAPSED>]". Fails the
+// test loudly, rather than silently comparing the wrong thing, if the block
+// is not exactly the expected five rows in a row — a sign the production
+// output's shape changed and this helper needs to change with it.
+func canonicalizeReleaseStageTimingOrder(t *testing.T, output string) string {
+	t.Helper()
+	wantCount := len(releaseStageTimingSiblingsToCanonicalize)
+	want := make(map[string]bool, wantCount)
+	for _, name := range releaseStageTimingSiblingsToCanonicalize {
+		want["    "+name+" [<ELAPSED>]"] = true
+	}
+	lines := strings.Split(output, "\n")
+	start := -1
+	for i, line := range lines {
+		if want[line] {
+			start = i
+			break
+		}
+	}
+	if start == -1 || start+wantCount > len(lines) {
+		t.Fatalf("release stage timing siblings not found in:\n%s", output)
+	}
+	block := lines[start : start+wantCount]
+	seen := make(map[string]bool, wantCount)
+	for _, line := range block {
+		if !want[line] || seen[line] {
+			t.Fatalf("release stage timing siblings not found as the expected contiguous block in:\n%s", output)
+		}
+		seen[line] = true
+	}
+	sort.Strings(block)
+	return strings.Join(lines, "\n")
 }
 
 // remoteMainSubjects reads origin/main's commit subjects through a second


### PR DESCRIPTION
`TestRelease/real_run_absorbs_a_base_branch_that_moved_during_the_build` fails
`make check`, and `make check` runs inside the `erun-devops` image build — so
whenever it fails, **no release can be cut**. Same class of blocker as #1449.

## It is not flaky — it is deterministic per host

Measured, rather than assumed: **100% failure (20/20)** locally and on `main` at
both `bdd9ac2b` and `5fe08530`. Not intermittent-per-run.

That resolves an observation that looked contradictory: a gate on a branch cut
from `5fe08530` **passed** the same day. Different *host*, not a different run.

## Root cause

Instrumenting `timing.go` across 8 runs, `push` consistently measured
**190–275ms** while its four siblings (`post-release-version-bump`, `release`,
`sync-remote`, `verify-publication`) measured **35–83ms** — a robust gap, not
jitter. That is inherent to this scenario: its entire point is a *rejected* push
that triggers a real fetch + rebase + retry-push, so `push` runs several more
real `git` subprocesses than any sibling.

`orderedTimingRows` sorts siblings by measured duration, tie-breaking by name
only when the gap falls under a **fixed absolute 100ms noise floor**. Whether
`push`'s extra real git latency crosses that fixed floor depends entirely on how
fast git subprocesses run on the host — something the scenario does not control.
Hence the golden's row order flips by machine:

```
- post-release-version-bump [<ELAPSED>]
- push [<ELAPSED>]
+ push [<ELAPSED>]
+ post-release-version-bump [<ELAPSED>]
```

## The fix, and what it deliberately does not touch

`canonicalizeReleaseStageTimingOrder` reorders the known five-row sibling block
into a fixed alphabetical order before comparing against the golden, and
**fails loudly** (`t.Fatalf`) if that block is not found exactly as expected,
rather than silently comparing the wrong thing.

**Production `timing.go` is unchanged.** The duration-based sort is a real,
working feature for operators reading a release's step timings; every other
real-run timing golden in the suite was checked and none shows this pattern. The
canonicalization is scoped to the one scenario whose sibling durations are
inherently host-speed-relative because of its retry loop.

It is a pure text canonicalization with **no threshold**, so it is identical on
every host — not "less flaky", but no longer dependent on wall-clock measurement
at all. This follows existing precedent in `internal/normalize`, which already
drops the `(unaccounted)`/`(overlap)` rows for the same reason: their presence is
"decided by wall clock … a different amount on every host".

## Verification

- **20/20 pass** after the fix (previously 20/20 fail)
- full `TestRelease` suite (32 scenarios) run **3× consecutively** — all green,
  including the two other real-run push/release scenarios that do not hit this
  path
- `make check` (detached job, awaited in-run) → **exit 0**: lint clean across all
  Go modules, `erun-ui` Go tests, `erun-kit`/`erun-console` gates, all devops
  chart tests, integration suite, coverage **76.1%** (≥ 75.8%)

Note `make check` does not run the Playwright specs, so the three known
pre-existing reds (#1466/#1467/#1468) were out of scope for this gate.

Only `erun-integration/release_test.go` changed.

Closes #1469