### PR TITLE
Stop offering Deploy for a runtime check that never reached the cluster

### DIFF
--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -605,7 +605,11 @@ func (r *resolvedOpenRunner) ensureRuntimeDeployed() error {
 		return err
 	}
 	if !present {
-		return fmt.Errorf("runtime for %s/%s is not deployed (deployment %q not found in namespace %q); run `erun deploy %s %s` first",
+		// Builds on common.KubernetesDeploymentAbsentMessageMarker so the
+		// desktop, reading only this text across a CLI subprocess boundary, can
+		// tell a genuine absence apart from a check that could not resolve an
+		// answer without re-deriving kubectl's own error grammar.
+		return fmt.Errorf("runtime for %s/%s "+common.KubernetesDeploymentAbsentMessageMarker+" %q not found in namespace %q); run `erun deploy %s %s` first",
 			r.result.Tenant, r.result.Environment, release, namespace, r.result.Tenant, r.result.Environment)
 	}
 	return nil

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -3603,6 +3603,16 @@ func CheckKubernetesDeployment(ctx Context, params KubernetesDeploymentCheckPara
 // inspect kubectl's stderr (which carries the "context does not
 // exist" string that drives the retry-with-current-context fallback
 // in CheckKubernetesDeployment).
+//
+// A non-nil error here is never evidence the deployment is absent — that
+// case returns (false, output, nil) below. It means the check could not
+// resolve a definite answer, so the message names the recognized cause
+// (missing context, unreachable API server, credentials/permissions
+// refused) or, failing that, says plainly that the error is unrecognized —
+// never silently reads as "not deployed". The message carries kubectl's own
+// output instead of just the process's exit status, so a caller sees the
+// actual cause rather than two layers of the same content-free "exit status
+// 1".
 func checkKubernetesDeploymentWithContext(ctx Context, params KubernetesDeploymentCheckParams, kubectlContext string) (bool, string, error) {
 	args := make([]string, 0, 8)
 	if strings.TrimSpace(kubectlContext) != "" {
@@ -3626,13 +3636,58 @@ func checkKubernetesDeploymentWithContext(ctx Context, params KubernetesDeployme
 		return deployed, output, matchErr
 	}
 
-	message := strings.ToLower(output)
-	if strings.Contains(message, "notfound") || strings.Contains(message, "not found") || strings.Contains(message, "no resources found") {
+	if KubernetesResourceNotFound(output) || strings.Contains(strings.ToLower(output), "no resources found") {
 		return false, output, nil
 	}
 
-	return false, output, fmt.Errorf("failed to check deployment %q: %w", params.Name, err)
+	detail := kubernetesDeploymentCheckFailureDetail(output)
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return false, output, fmt.Errorf("could not determine whether deployment %q is deployed (%s): %w", params.Name, detail, err)
+	}
+	return false, output, fmt.Errorf("could not determine whether deployment %q is deployed (%s): %s", params.Name, detail, trimmed)
 }
+
+// kubernetesDeploymentCheckFailureDetail names why a kubectl deployment
+// presence check failed to resolve a definite answer, distinguishing causes
+// where erun could not ask the cluster at all (no context, an unreachable
+// API server, credentials or permissions refused) from an error it does not
+// recognize. Neither is evidence the deployment is absent. Reuses
+// isKubernetesContextMissingMessage for the context-missing case it already
+// covers instead of a second matcher for the same signal.
+func kubernetesDeploymentCheckFailureDetail(output string) string {
+	if isKubernetesContextMissingMessage(output) {
+		return "the configured kubernetes context was not found in kubeconfig"
+	}
+	message := strings.ToLower(output)
+	switch {
+	case strings.Contains(message, "unable to connect to the server"),
+		strings.Contains(message, "connection refused"),
+		strings.Contains(message, "no such host"),
+		strings.Contains(message, "i/o timeout"),
+		strings.Contains(message, "no configuration has been provided"):
+		return "the kubernetes api server could not be reached"
+	case strings.Contains(message, "forbidden"),
+		strings.Contains(message, "unauthorized"),
+		strings.Contains(message, "must be logged in to the server"),
+		strings.Contains(message, "must provide one of the following credentials"):
+		return "the kubernetes cluster refused the request (credentials or permissions)"
+	default:
+		return "kubectl returned an error erun does not recognize"
+	}
+}
+
+// KubernetesDeploymentAbsentMessageMarker is the fixed substring every
+// "runtime ... is not deployed" message carries when a caller has confirmed
+// a deployment is genuinely absent (checkKubernetesDeploymentWithContext
+// returning (false, _, nil) above; erun-cli/cmd/open.go's
+// ensureRuntimeDeployed builds the actual message). A caller that only has
+// the rendered error text — for example the desktop reading a CLI
+// subprocess's stderr — uses this marker to recognize that specific outcome
+// without re-deriving kubectl's own error grammar, and without mistaking a
+// check that could not resolve an answer (never contains this marker) for a
+// real absence.
+const KubernetesDeploymentAbsentMessageMarker = "is not deployed (deployment"
 
 // isKubernetesContextMissingMessage matches the family of kubectl
 // error messages that indicate the requested --context name is not

--- a/erun-common/deploy_kubernetes_check_test.go
+++ b/erun-common/deploy_kubernetes_check_test.go
@@ -1,0 +1,144 @@
+package eruncommon
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeKubectlStub points ERUN_KUBECTL_BIN at a script that prints stderr and
+// exits non-zero (or exits 0 with no output when stderr is empty), so a test
+// can drive checkKubernetesDeploymentWithContext's classification without a
+// real cluster.
+func writeKubectlStub(t *testing.T, stderr string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/kubectl-stub"
+	script := "#!/bin/sh\n"
+	if stderr != "" {
+		script += "cat <<'EOF' >&2\n" + stderr + "\nEOF\n"
+	}
+	script += "exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write kubectl stub: %v", err)
+	}
+	t.Setenv("ERUN_KUBECTL_BIN", path)
+}
+
+// TestCheckKubernetesDeploymentWithContextAbsent locks the one negative
+// answer the check may give without an error: a genuine kubectl NotFound.
+func TestCheckKubernetesDeploymentWithContextAbsent(t *testing.T) {
+	writeKubectlStub(t, `Error from server (NotFound): deployments.apps "frs-devops" not found`, 1)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error for a genuinely absent deployment: %v", err)
+	}
+	if deployed {
+		t.Fatalf("deployed = true, want false for an absent deployment")
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextPresent locks the healthy case: no
+// error, deployed.
+func TestCheckKubernetesDeploymentWithContextPresent(t *testing.T) {
+	writeKubectlStub(t, "", 0)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error for a running deployment: %v", err)
+	}
+	if !deployed {
+		t.Fatalf("deployed = false, want true when kubectl reports the deployment present")
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextMissingContext locks the fix at the
+// The heart of the defect: a deployment that is running but whose kube context could
+// not be resolved must not be reported as absent, and the returned error
+// must name the context problem, reusing isKubernetesContextMissingMessage.
+func TestCheckKubernetesDeploymentWithContextMissingContext(t *testing.T) {
+	writeKubectlStub(t, `error: context "frs-prod" does not exist`, 1)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "frs-prod")
+	if deployed {
+		t.Fatalf("deployed = true, want false when the check could not resolve an answer")
+	}
+	if err == nil {
+		t.Fatalf("expected an error naming the missing context, got nil")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "not deployed") {
+		t.Fatalf("a missing-context failure must never read as absence, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "context") {
+		t.Fatalf("error must name the missing-context cause, got: %v", err)
+	}
+	if strings.Count(err.Error(), "exit status") > 1 {
+		t.Fatalf("exit status must not be doubled, got: %v", err)
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextUnreachableAPIServer locks the
+// "could not ask" family: erun never got a response at all.
+func TestCheckKubernetesDeploymentWithContextUnreachableAPIServer(t *testing.T) {
+	writeKubectlStub(t, `Unable to connect to the server: dial tcp 10.0.0.1:443: i/o timeout`, 1)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "")
+	if deployed {
+		t.Fatalf("deployed = true, want false when the api server is unreachable")
+	}
+	if err == nil {
+		t.Fatalf("expected an error naming the unreachable cluster, got nil")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "not deployed") {
+		t.Fatalf("an unreachable-cluster failure must never read as absence, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "could not be reached") {
+		t.Fatalf("error must name the unreachable-cluster cause, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "i/o timeout") {
+		t.Fatalf("error must carry kubectl's own output, got: %v", err)
+	}
+	if strings.Count(err.Error(), "exit status") > 1 {
+		t.Fatalf("exit status must not be doubled, got: %v", err)
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextRBACDenied locks the other "could
+// not ask" family member named by the issue: a request the cluster refused.
+func TestCheckKubernetesDeploymentWithContextRBACDenied(t *testing.T) {
+	writeKubectlStub(t, `Error from server (Forbidden): deployments.apps "frs-devops" is forbidden: User "jane" cannot get resource "deployments" in API group "apps"`, 1)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "")
+	if deployed {
+		t.Fatalf("deployed = true, want false when RBAC refuses the request")
+	}
+	if err == nil {
+		t.Fatalf("expected an error naming the RBAC refusal, got nil")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "not deployed") {
+		t.Fatalf("an RBAC-denied failure must never read as absence, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "credentials or permissions") {
+		t.Fatalf("error must name the credentials/permissions cause, got: %v", err)
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextUnclassified locks the closing
+// The closing principle: an error erun does not recognize must still read as
+// unknown, carrying the raw kubectl output, and never as absence.
+func TestCheckKubernetesDeploymentWithContextUnclassified(t *testing.T) {
+	writeKubectlStub(t, `Error from server: etcdserver: request timed out`, 1)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "")
+	if deployed {
+		t.Fatalf("deployed = true, want false for an unrecognized kubectl error")
+	}
+	if err == nil {
+		t.Fatalf("expected an error for the unrecognized failure, got nil")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "not deployed") {
+		t.Fatalf("an unclassified failure must never read as absence, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "does not recognize") {
+		t.Fatalf("error must admit it does not recognize the cause, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "etcdserver: request timed out") {
+		t.Fatalf("error must carry kubectl's own output, got: %v", err)
+	}
+}

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -425,6 +425,29 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/no_shell_real_run_not_deployed_errors", normalize.Apply(result.Combined))
 	})
 
+	t.Run("no_shell_real_run_check_unreachable_errors_without_claiming_absence", func(t *testing.T) {
+		// The deployment presence check can fail without ever getting an
+		// answer — no context, an unreachable API server, credentials or
+		// permissions refused. That is not evidence the deployment is absent,
+		// so ensureRuntimeDeployed must surface the check's own classified
+		// error (naming the cause, carrying kubectl's real output) rather than
+		// the "is not deployed; run erun deploy" text reserved for a confirmed
+		// absence. The generic-error kubectl stub ("Unable to connect to the
+		// server: ... i/o timeout") is the decision input; no ports are needed
+		// because the run errors before the forwards.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlGenericError(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit when the deployment check could not resolve an answer, got 0:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "is not deployed") {
+			t.Fatalf("a check that could not ask the cluster must never read as absence, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "open/no_shell_real_run_check_unreachable_errors_without_claiming_absence", normalize.Apply(result.Combined))
+	})
+
 	t.Run("alias_prompt_skipped_when_alias_configured", func(t *testing.T) {
 		// When ~/.zshrc already carries the team-dev alias,
 		// detectOpenNoShellAliasStartupFile reports it configured

--- a/erun-integration/testdata/open/no_shell_real_run_check_unreachable_errors_without_claiming_absence.txt
+++ b/erun-integration/testdata/open/no_shell_real_run_check_unreachable_errors_without_claiming_absence.txt
@@ -1,0 +1,1 @@
+could not determine whether deployment "team-devops" is deployed (the kubernetes api server could not be reached): Unable to connect to the server: dial tcp <VERSION>.1:443: i/o timeout

--- a/erun-ui/env_ensure.go
+++ b/erun-ui/env_ensure.go
@@ -118,9 +118,12 @@ func (a *App) ensureEnvRuntime(selection uiSelection, reason envEnsureReason) bo
 }
 
 // surfaceEnvRuntimeEnsureFailure makes a failed runtime reconnect visible and
-// recoverable instead of discarding it (Nielsen #1/#9). The reconnect usually
-// fails because the runtime is not deployed — which `open` no longer fixes on
-// its own — so the recovery it points to is an explicit deploy.
+// recoverable instead of discarding it (Nielsen #1/#9). A reconnect failure is
+// not by itself evidence the runtime is down: `erun open --reconnect` can also
+// fail because it could not even ask the cluster (no context, an unreachable
+// API server, credentials or permissions refused) or for a reason this has no
+// way to recognize. Only a confirmed absent deployment gets the deploy
+// action — see runtimeCheckFoundDeploymentAbsent.
 func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
 	selection = normalizeSelection(selection)
 	// A deploy for this env being in flight IS the recovery this failure would
@@ -153,10 +156,32 @@ func (a *App) surfaceEnvRuntimeEnsureFailure(selection uiSelection, err error) {
 	// lifecycle can clear it once the state it describes moves on. Kind
 	// "warning" (not "warn") is the contract the frontend maps to the
 	// attention icon; an unrecognized kind renders as a neutral info ⓘ.
+	if runtimeCheckFoundDeploymentAbsent(err) {
+		a.emitEnvNotification("warning", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
+			"Could not reach the runtime for %s/%s: %s. Deploy the environment to bring it up.",
+			selection.Tenant, selection.Environment, strings.TrimSpace(err.Error()),
+		), notificationActionDeploy)
+		return
+	}
+	// Nothing here confirmed the deployment is absent, so a deploy is not
+	// offered: it would roll a runtime that may already be healthy. The
+	// recovery for a check that could not resolve an answer is a connectivity,
+	// credentials, or permissions fix, not a deploy.
 	a.emitEnvNotification("warning", selection.Tenant, selection.Environment, notificationSourceRuntimeUnreachable, fmt.Sprintf(
-		"Could not reach the runtime for %s/%s: %s. Deploy the environment to bring it up.",
+		"Could not tell whether the runtime for %s/%s is up: %s. Check the cluster connection, credentials, and permissions for this environment.",
 		selection.Tenant, selection.Environment, strings.TrimSpace(err.Error()),
-	), notificationActionDeploy)
+	), "")
+}
+
+// runtimeCheckFoundDeploymentAbsent reports whether err is the specific
+// "runtime is not deployed" failure ensureRuntimeDeployed
+// (erun-cli/cmd/open.go) raises for a deployment that genuinely does not
+// exist. Any other failure text — kubectl unreachable, an RBAC refusal, a
+// port-forward timeout, or anything unrecognized — must not be read as
+// absence: erun could not establish the runtime's state, so offering a
+// deploy would be acting on a state it never confirmed.
+func runtimeCheckFoundDeploymentAbsent(err error) bool {
+	return err != nil && strings.Contains(err.Error(), eruncommon.KubernetesDeploymentAbsentMessageMarker)
 }
 
 // surfaceEnvRuntimeStopped renders a stopped environment as stopped and names

--- a/erun-ui/env_ensure_test.go
+++ b/erun-ui/env_ensure_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -10,6 +11,15 @@ import (
 
 	eruncommon "github.com/sophium/erun/erun-common"
 )
+
+// deploymentAbsentErrorForTest builds the exact "runtime ... is not deployed"
+// error ensureRuntimeDeployed (erun-cli/cmd/open.go) raises for a genuinely
+// absent deployment, so a test exercises the real marker
+// runtimeCheckFoundDeploymentAbsent looks for rather than an ad hoc string.
+func deploymentAbsentErrorForTest(tenant, environment string) error {
+	return fmt.Errorf("runtime for %s/%s %s %q not found in namespace %q); run `erun deploy %s %s` first",
+		tenant, environment, eruncommon.KubernetesDeploymentAbsentMessageMarker, tenant+"-devops", tenant+"-"+environment, tenant, environment)
+}
 
 // These tests lock the per-env ensure dedupe: opening an env and respawning
 // its tabs must run the shared ensure once per (re)start window, not once per tab.
@@ -238,6 +248,7 @@ func TestSurfaceEnsureFailureSuppressedWhileDeployInFlight(t *testing.T) {
 		return nil
 	}, nil)
 	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+	absentErr := deploymentAbsentErrorForTest("erun", "remote")
 
 	app.mu.Lock()
 	app.sessions["s1"] = &managedTerminal{
@@ -249,7 +260,7 @@ func TestSurfaceEnsureFailureSuppressedWhileDeployInFlight(t *testing.T) {
 	}
 	app.mu.Unlock()
 
-	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("timed out waiting for API port-forward"))
+	app.surfaceEnvRuntimeEnsureFailure(selection, absentErr)
 
 	if got := len(emits.events(appNotificationEvent)); got != 0 {
 		t.Fatalf("banner emitted %d times during an in-flight deploy, want 0", got)
@@ -261,7 +272,7 @@ func TestSurfaceEnsureFailureSuppressedWhileDeployInFlight(t *testing.T) {
 	app.mu.Lock()
 	app.sessions["s1"].lockedByActivity = ""
 	app.mu.Unlock()
-	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("timed out waiting for API port-forward"))
+	app.surfaceEnvRuntimeEnsureFailure(selection, absentErr)
 	notes := emits.events(appNotificationEvent)
 	if len(notes) != 1 {
 		t.Fatalf("banner emitted %d times once the deploy cleared, want 1", len(notes))
@@ -351,5 +362,90 @@ func TestEnsureSuccessClearsRuntimeUnreachableNotification(t *testing.T) {
 	}
 	if payload.Tenant != "erun" || payload.Environment != "remote" || payload.Source != "" {
 		t.Fatalf("clear payload = %+v, want erun/remote with empty (any) source", payload)
+	}
+}
+
+// TestSurfaceEnsureFailureOffersDeployForGenuinelyAbsentDeployment locks the
+// one branch that still earns the Deploy action: ensureRuntimeDeployed found
+// no deployment at all.
+func TestSurfaceEnsureFailureOffersDeployForGenuinelyAbsentDeployment(t *testing.T) {
+	app, emits := capturedEnsureApp(t, func(context.Context, eruncommon.OpenResult, func(string)) error {
+		return nil
+	}, nil)
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	app.surfaceEnvRuntimeEnsureFailure(selection, deploymentAbsentErrorForTest("erun", "remote"))
+
+	notes := emits.events(appNotificationEvent)
+	if len(notes) != 1 {
+		t.Fatalf("notification emitted %d times, want 1", len(notes))
+	}
+	note, ok := notes[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("notification payload has unexpected type %T", notes[0])
+	}
+	if note.Action != notificationActionDeploy {
+		t.Fatalf("notification action = %q, want %q for a genuinely absent deployment", note.Action, notificationActionDeploy)
+	}
+	if !strings.Contains(note.Message, "Deploy the environment to bring it up") {
+		t.Fatalf("notification must name deploy as the fix, got %q", note.Message)
+	}
+}
+
+// TestSurfaceEnsureFailureOffersNoDeployForACheckThatCouldNotAsk reproduces
+// The reported production case: the deployment is healthy but the
+// check could not resolve an answer because the kube context was unavailable.
+// Following a Deploy button here would roll a healthy runtime, so the
+// notification must not carry the deploy action, and must not claim
+// unreachability the check never established.
+func TestSurfaceEnsureFailureOffersNoDeployForACheckThatCouldNotAsk(t *testing.T) {
+	app, emits := capturedEnsureApp(t, func(context.Context, eruncommon.OpenResult, func(string)) error {
+		return nil
+	}, nil)
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+	checkErr := errors.New(`could not determine whether deployment "frs-devops" is deployed (the configured kubernetes context was not found in kubeconfig): error: context "frs-prod" does not exist`)
+
+	app.surfaceEnvRuntimeEnsureFailure(selection, checkErr)
+
+	notes := emits.events(appNotificationEvent)
+	if len(notes) != 1 {
+		t.Fatalf("notification emitted %d times, want 1", len(notes))
+	}
+	note, ok := notes[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("notification payload has unexpected type %T", notes[0])
+	}
+	if note.Action != "" {
+		t.Fatalf("notification action = %q, want none — a could-not-ask failure must not offer deploy", note.Action)
+	}
+	if strings.Contains(note.Message, "Deploy the environment") {
+		t.Fatalf("notification must not suggest deploy for a check that never confirmed absence, got %q", note.Message)
+	}
+	if !strings.Contains(note.Message, "context") {
+		t.Fatalf("notification must carry the underlying cause, got %q", note.Message)
+	}
+}
+
+// TestSurfaceEnsureFailureOffersNoDeployForAnUnclassifiedFailure locks the
+// The closing principle: an error erun does not recognize must still
+// read as unknown and must not default to offering deploy.
+func TestSurfaceEnsureFailureOffersNoDeployForAnUnclassifiedFailure(t *testing.T) {
+	app, emits := capturedEnsureApp(t, func(context.Context, eruncommon.OpenResult, func(string)) error {
+		return nil
+	}, nil)
+	selection := uiSelection{Tenant: "erun", Environment: "remote"}
+
+	app.surfaceEnvRuntimeEnsureFailure(selection, errors.New("timed out waiting for API port-forward"))
+
+	notes := emits.events(appNotificationEvent)
+	if len(notes) != 1 {
+		t.Fatalf("notification emitted %d times, want 1", len(notes))
+	}
+	note, ok := notes[0].(appNotificationPayload)
+	if !ok {
+		t.Fatalf("notification payload has unexpected type %T", notes[0])
+	}
+	if note.Action != "" {
+		t.Fatalf("notification action = %q, want none for an unrecognized failure", note.Action)
 	}
 }


### PR DESCRIPTION
A `kubectl` failure that never reached the cluster was reported as a runtime
outage **with a Deploy button**, against a deployment that was running:

```
MCP port-forward: exit status 1: failed to check deployment "frs-devops": exit status 1.
Deploy the environment to bring it up.                          [Deploy] [Copy]
```

Measured against production at that moment: `frs-devops` in `frs-prod` was
**`1/1 Running`**, the deployment 88 days old, its pod up 5h28m. **The
deployment it said to bring up was up**, and taking the offered action would
have redeployed healthy production.

Only `notfound` / `not found` / `no resources found` counted as a real answer.
Everything else — unreachable API server, missing kube context, RBAC refusal,
transient error, timeout — collapsed into that one message and that one button.

This is root `AGENTS.md` failure mode 1 (*"an error whose suggested remedy does
not apply to the actual state"*) with the remedy being destructive rather than
merely useless.

## Classification, and which branch may offer an action

| Branch | Detection | Action offered |
|---|---|---|
| **Absent** | `KubernetesResourceNotFound` / "no resources found" (now via the shared helper, previously duplicated inline) | **Deploy** — correct, unchanged |
| **Missing context** | existing `isKubernetesContextMissingMessage` | none |
| **Unreachable API server** | connection-refused / no-such-host / i-o-timeout / unable-to-connect | none |
| **Credentials or permissions refused** | forbidden / unauthorized / must-provide-credentials | none |
| **Unclassifiable** | default | none — raw cause shown, **never read as absent** |

Every non-absent branch now carries kubectl's actual output instead of a second
`exit status 1`.

The action is gated on the new exported
`eruncommon.KubernetesDeploymentAbsentMessageMarker`, so the desktop's
`surfaceEnvRuntimeEnsureFailure` can recognise a genuine absence in the CLI
subprocess's rendered stderr — the only place it can observe one — and the
coupling cannot drift silently. Everything else now reads *"Could not tell
whether the runtime for X/Y is up: … Check the cluster connection, credentials,
and permissions."* with no action.

This follows the model erun already gets right in `exec_job_status`, which
reports **`state=unknown` with a reason** rather than guessing an outcome.

## Verification

Both directions, because a fix that stopped offering Deploy for genuine absence
would be worse than the bug:

- `TestSurfaceEnsureFailureOffersNoDeployForACheckThatCouldNotAsk` — reproduces
  the exact reported case (healthy deployment, unavailable kube context) and
  asserts no `Deploy` action and no "Deploy the environment" text
- `TestSurfaceEnsureFailureOffersNoDeployForAnUnclassifiedFailure` — the former
  default
- `TestSurfaceEnsureFailureOffersDeployForGenuinelyAbsentDeployment` — absence
  still gets the action
- integration scenario
  `no_shell_real_run_check_unreachable_errors_without_claiming_absence` drives
  the **real CLI binary** and asserts the output never claims "is not deployed"
- `make check` → **exit 0**: golangci-lint **0 issues** across all six modules,
  `erun-ui` Go tests, frontend gates, all chart tests, integration suite,
  coverage **76.1%**

## Callers audited

`ensureRuntimeDeployed` (updated — the harmful path); `shouldDeployRuntime`
(unaffected, already fails loudly rather than assuming); `root.go`'s two wiring
sites (pass the function value only); `erun-ui/environment_health.go`'s separate
`checkRuntimeDeployed` (already implements the correct three-state distinction,
left alone). `erun-common/stop.go`'s structurally similar `ReadRuntimeRunState`
was deliberately left alone: it already treats a read failure as "assume
running, don't touch it", which is safe by construction and offers no button.

## One pre-existing test was asserting the bug

`TestSurfaceEnsureFailureSuppressedWhileDeployInFlight` asserted that an
unclassified `"timed out waiting for API port-forward"` earned a Deploy button.
Its input was changed to a genuine-absence error so it still tests what it is
for — deploy-in-flight suppression — without locking in the behaviour this PR
removes.

Closes #1474