### PR TITLE
Add the role-assignment layer, so a tenant can grant less than full control

### DIFF
--- a/erun-backend/erun-backend-api/internal/model/role.go
+++ b/erun-backend/erun-backend-api/internal/model/role.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type Role struct {
+	bun.BaseModel `bun:"table:roles,alias:ro"`
+	RoleID        string `json:"roleId" bun:"role_id,pk,scanonly"`
+	TenantID      string `json:"tenantId" bun:"tenant_id,scanonly"`
+	Name          string `json:"name" bun:"name"`
+	// Permissions is read-only, derived data populated by role read queries; it
+	// has no column of its own on roles.
+	Permissions []RolePermission `json:"permissions,omitempty" bun:"-"`
+	CreatedAt   time.Time        `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt   time.Time        `json:"updatedAt" bun:"updated_at,scanonly"`
+}

--- a/erun-backend/erun-backend-api/internal/model/role_permission.go
+++ b/erun-backend/erun-backend-api/internal/model/role_permission.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type RolePermission struct {
+	bun.BaseModel    `bun:"table:role_permissions,alias:rp"`
+	RolePermissionID string `json:"rolePermissionId" bun:"role_permission_id,pk,scanonly"`
+	TenantID         string `json:"tenantId" bun:"tenant_id,scanonly"`
+	RoleID           string `json:"roleId" bun:"role_id"`
+	// APIMethod/APIPath are set together for an exact grant; APIMethodPattern/
+	// APIPathPattern are set together for a regex grant. Exactly one pair is
+	// non-empty, enforced by role_permissions_exact_or_pattern_check.
+	APIMethod        string    `json:"apiMethod,omitempty" bun:"api_method,nullzero"`
+	APIPath          string    `json:"apiPath,omitempty" bun:"api_path,nullzero"`
+	APIMethodPattern string    `json:"apiMethodPattern,omitempty" bun:"api_method_pattern,nullzero"`
+	APIPathPattern   string    `json:"apiPathPattern,omitempty" bun:"api_path_pattern,nullzero"`
+	CreatedAt        time.Time `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt        time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
+}

--- a/erun-backend/erun-backend-api/internal/model/user_role.go
+++ b/erun-backend/erun-backend-api/internal/model/user_role.go
@@ -1,0 +1,16 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type UserRole struct {
+	bun.BaseModel `bun:"table:user_roles,alias:ur"`
+	TenantID      string    `json:"tenantId" bun:"tenant_id,scanonly"`
+	UserID        string    `json:"userId" bun:"user_id"`
+	RoleID        string    `json:"roleId" bun:"role_id"`
+	CreatedAt     time.Time `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt     time.Time `json:"updatedAt" bun:"updated_at,scanonly"`
+}

--- a/erun-backend/erun-backend-api/internal/repository/errors.go
+++ b/erun-backend/erun-backend-api/internal/repository/errors.go
@@ -14,6 +14,10 @@ var (
 	ErrNotFound               = errors.New("not found")
 	ErrMissingSecurityContext = errors.New("missing security context")
 	ErrConflict               = errors.New("conflict")
+	// ErrLastGrantCapableRole guards against a tenant locking itself out of its
+	// own role management: revoking it would leave no user able to grant roles,
+	// and there would be no recovery lever left inside the product.
+	ErrLastGrantCapableRole = errors.New("revoking this role would leave the tenant with no user able to grant roles")
 )
 
 func normalizeNoRows(err error) error {
@@ -30,6 +34,15 @@ func normalizeNoRows(err error) error {
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError
 	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.UniqueViolation
+}
+
+// isForeignKeyViolation reports whether PostgreSQL rejected a write because a
+// referenced row does not exist for the caller's own tenant — e.g. a role_id
+// or user_id that belongs to a different tenant, which RLS makes invisible
+// rather than merely forbidden.
+func isForeignKeyViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgerrcode.ForeignKeyViolation
 }
 
 // pgErrorCode returns the PostgreSQL SQLSTATE of err, if err wraps one.

--- a/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
@@ -53,6 +53,75 @@ func TestBootstrapFirstIdentityEnrolsPlatformTenantWhenERUNTenantSet(t *testing.
 	if user.UserID == "" {
 		t.Fatal("expected a bootstrapped user")
 	}
+	assertHasReadAllAndWriteAll(t, db, user.UserID)
+}
+
+// TestFirstTenantUserBootstrapGrantsBothPredefinedRoles proves the
+// per-tenant-first-user path (a token resolving to an already-registered
+// tenant with zero users) grants the same ReadAll+WriteAll shape as
+// empty-database bootstrap, so the role-assignment API added alongside it
+// changes nothing about how a new tenant gets its first admin.
+func TestFirstTenantUserBootstrapGrantsBothPredefinedRoles(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+
+	// Bootstrap the platform's own OPERATIONS tenant first, then register a
+	// second, ordinary tenant with zero users of its own.
+	_, _, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  "https://issuer.example/frs",
+		Subject: "operator-subject",
+	})
+	mustNoErr(t, err, "bootstrap platform tenant")
+
+	var secondTenantID string
+	mustNoErr(t, db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, 'COMPANY') RETURNING tenant_id`,
+		"second-tenant",
+	).Scan(&secondTenantID), "seed second tenant")
+	_, err = db.Exec(`INSERT INTO issuers (issuer) VALUES ($1)`, "https://issuer.example/second-tenant")
+	mustNoErr(t, err, "register second tenant issuer")
+	_, err = db.Exec(
+		`INSERT INTO tenant_issuers (tenant_id, issuer, name) VALUES ($1, $2, $3)`,
+		secondTenantID, "https://issuer.example/second-tenant", "second tenant issuer",
+	)
+	mustNoErr(t, err, "map second tenant issuer")
+
+	tenant, user, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  "https://issuer.example/second-tenant",
+		Subject: "second-tenant-first-user",
+	})
+	mustNoErr(t, err, "bootstrap second tenant's first user")
+	if tenant.TenantID != secondTenantID {
+		t.Fatalf("expected the second tenant, got %q", tenant.TenantID)
+	}
+	assertHasReadAllAndWriteAll(t, db, user.UserID)
+}
+
+// assertHasReadAllAndWriteAll locks in that bootstrap keeps granting exactly
+// the predefined ReadAll+WriteAll shape, so the fine-grained role-assignment
+// API added alongside it stays additive rather than changing the default.
+func assertHasReadAllAndWriteAll(t *testing.T, db *sql.DB, userID string) {
+	t.Helper()
+	var names []string
+	rows, err := db.Query(`
+		SELECT ro.name
+		  FROM user_roles ur
+		  JOIN roles ro ON ro.tenant_id = ur.tenant_id AND ro.role_id = ur.role_id
+		 WHERE ur.user_id = $1
+		 ORDER BY ro.name
+	`, userID)
+	mustNoErr(t, err, "query bootstrapped user's roles")
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var name string
+		mustNoErr(t, rows.Scan(&name), "scan role name")
+		names = append(names, name)
+	}
+	mustNoErr(t, rows.Err(), "iterate role names")
+	if len(names) != 2 || names[0] != "ReadAll" || names[1] != "WriteAll" {
+		t.Fatalf("expected exactly [ReadAll WriteAll], got %v", names)
+	}
 }
 
 func TestBootstrapFirstIdentityFallsBackWhenERUNTenantAbsent(t *testing.T) {

--- a/erun-backend/erun-backend-api/internal/repository/roles.go
+++ b/erun-backend/erun-backend-api/internal/repository/roles.go
@@ -1,0 +1,267 @@
+package repository
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/uptrace/bun"
+)
+
+type RoleRepository struct {
+	txs *TxManager
+}
+
+func NewRoleRepository(txs *TxManager) *RoleRepository {
+	return &RoleRepository{txs: txs}
+}
+
+// RolePermissionInput is a caller-supplied permission grant for role creation.
+// Exactly one of the exact pair (APIMethod/APIPath) or the pattern pair
+// (APIMethodPattern/APIPathPattern) must be set, mirroring
+// role_permissions_exact_or_pattern_check.
+type RolePermissionInput struct {
+	APIMethod        string
+	APIPath          string
+	APIMethodPattern string
+	APIPathPattern   string
+}
+
+var validAPIMethods = map[string]bool{
+	"GET": true, "HEAD": true, "OPTIONS": true,
+	"POST": true, "PUT": true, "PATCH": true, "DELETE": true,
+}
+
+func (p RolePermissionInput) validate() error {
+	exact := p.APIMethod != "" || p.APIPath != ""
+	pattern := p.APIMethodPattern != "" || p.APIPathPattern != ""
+	if exact == pattern {
+		// Both an exact and a pattern field set, or neither: exactly one form
+		// is required, matching role_permissions_exact_or_pattern_check.
+		return ErrInvalidInput
+	}
+	if exact {
+		return p.validateExact()
+	}
+	return p.validatePattern()
+}
+
+func (p RolePermissionInput) validateExact() error {
+	if p.APIMethod == "" || p.APIPath == "" || !validAPIMethods[p.APIMethod] {
+		return ErrInvalidInput
+	}
+	return nil
+}
+
+func (p RolePermissionInput) validatePattern() error {
+	if p.APIMethodPattern == "" || p.APIPathPattern == "" {
+		return ErrInvalidInput
+	}
+	if _, err := regexp.Compile(p.APIMethodPattern); err != nil {
+		return ErrInvalidInput
+	}
+	if _, err := regexp.Compile(p.APIPathPattern); err != nil {
+		return ErrInvalidInput
+	}
+	return nil
+}
+
+// List returns the caller's tenant's roles, each with its permissions.
+func (r *RoleRepository) List(ctx context.Context) ([]model.Role, error) {
+	var roles []model.Role
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		if err := tx.NewRaw(`
+			SELECT role_id, tenant_id, name, created_at, updated_at
+			  FROM roles
+			 ORDER BY name
+		`).Scan(ctx, &roles); err != nil {
+			return err
+		}
+		if len(roles) == 0 {
+			return nil
+		}
+		var permissions []model.RolePermission
+		if err := tx.NewRaw(`
+			SELECT role_permission_id, tenant_id, role_id, api_method, api_path, api_method_pattern, api_path_pattern, created_at, updated_at
+			  FROM role_permissions
+			 ORDER BY role_id, created_at
+		`).Scan(ctx, &permissions); err != nil {
+			return err
+		}
+		byRole := make(map[string][]model.RolePermission, len(roles))
+		for _, permission := range permissions {
+			byRole[permission.RoleID] = append(byRole[permission.RoleID], permission)
+		}
+		for i := range roles {
+			roles[i].Permissions = byRole[roles[i].RoleID]
+		}
+		return nil
+	})
+	return roles, err
+}
+
+// ForUser returns the roles assigned to a user in the caller's tenant.
+func (r *RoleRepository) ForUser(ctx context.Context, userID string) ([]model.Role, error) {
+	var roles []model.Role
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewRaw(`
+			SELECT ro.role_id, ro.tenant_id, ro.name, ro.created_at, ro.updated_at
+			  FROM user_roles ur
+			  JOIN roles ro
+			    ON ro.tenant_id = ur.tenant_id
+			   AND ro.role_id = ur.role_id
+			 WHERE ur.user_id = ?
+			 ORDER BY ro.name
+		`, userID).Scan(ctx, &roles)
+	})
+	return roles, err
+}
+
+// Create makes a new tenant-owned role with the given permissions. At least
+// one permission is required — a role with no permissions could never be
+// granted meaningfully.
+func (r *RoleRepository) Create(ctx context.Context, name string, permissions []RolePermissionInput) (model.Role, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || len(permissions) == 0 {
+		return model.Role{}, ErrInvalidInput
+	}
+	for _, permission := range permissions {
+		if err := permission.validate(); err != nil {
+			return model.Role{}, err
+		}
+	}
+
+	var role model.Role
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		role = model.Role{Name: name}
+		if err := tx.NewInsert().Model(&role).Column("name").Returning("*").Scan(ctx); err != nil {
+			if isUniqueViolation(err) {
+				return ErrConflict
+			}
+			return err
+		}
+		for _, permission := range permissions {
+			rolePermission, err := insertRolePermission(ctx, tx, role.RoleID, permission)
+			if err != nil {
+				return err
+			}
+			role.Permissions = append(role.Permissions, rolePermission)
+		}
+		return nil
+	})
+	if err != nil {
+		return model.Role{}, err
+	}
+	return role, nil
+}
+
+func insertRolePermission(ctx context.Context, tx bun.Tx, roleID string, permission RolePermissionInput) (model.RolePermission, error) {
+	rolePermission := model.RolePermission{
+		RoleID:           roleID,
+		APIMethod:        permission.APIMethod,
+		APIPath:          permission.APIPath,
+		APIMethodPattern: permission.APIMethodPattern,
+		APIPathPattern:   permission.APIPathPattern,
+	}
+	err := tx.NewInsert().
+		Model(&rolePermission).
+		Column("role_id", "api_method", "api_path", "api_method_pattern", "api_path_pattern").
+		Returning("*").
+		Scan(ctx)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return model.RolePermission{}, ErrConflict
+		}
+		return model.RolePermission{}, err
+	}
+	return rolePermission, nil
+}
+
+// Grant assigns a role to a user. A role_id or user_id from another tenant is
+// invisible under RLS, so the insert's foreign keys report it as not found
+// rather than forbidden.
+func (r *RoleRepository) Grant(ctx context.Context, userID string, roleID string) (model.UserRole, error) {
+	userID = strings.TrimSpace(userID)
+	roleID = strings.TrimSpace(roleID)
+	grant := model.UserRole{UserID: userID, RoleID: roleID}
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewInsert().
+			Model(&grant).
+			Column("user_id", "role_id").
+			Returning("*").
+			Scan(ctx)
+		if err != nil {
+			if isUniqueViolation(err) {
+				return ErrConflict
+			}
+			if isForeignKeyViolation(err) {
+				return ErrNotFound
+			}
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return model.UserRole{}, err
+	}
+	return grant, nil
+}
+
+// Revoke removes a role assignment, refusing when doing so would leave the
+// tenant with no user able to grant roles — the one failure this feature must
+// make impossible rather than merely recoverable. The check runs inside the
+// same transaction as the delete and rolls the delete back on refusal.
+func (r *RoleRepository) Revoke(ctx context.Context, userID string, roleID string) error {
+	return r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		result, err := tx.NewRaw(`
+			DELETE FROM user_roles
+			 WHERE user_id = ?
+			   AND role_id = ?
+		`, userID, roleID).Exec(ctx)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+		stillGrantCapable, err := tenantHasGrantCapableUser(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if !stillGrantCapable {
+			return ErrLastGrantCapableRole
+		}
+		return nil
+	})
+}
+
+// grantRoleMethod and grantRolePath are the canonical route that lets an
+// operator recover from a bad role assignment: as long as one user can reach
+// it, the tenant can always grant its way back to a working state.
+const (
+	grantRoleMethod = "POST"
+	grantRolePath   = "/v1/users/{user_id}/roles"
+)
+
+// tenantHasGrantCapableUser reports whether any user in the tenant currently
+// holds a permission that would authorize granting a role to a user. It reuses
+// the same rule matcher Authorize enforces with, so this invariant and request
+// enforcement cannot disagree about what "grant-capable" means.
+func tenantHasGrantCapableUser(ctx context.Context, tx bun.Tx) (bool, error) {
+	var rules []permissionRule
+	if err := tx.NewRaw(`
+		SELECT rp.api_method, rp.api_path, rp.api_method_pattern, rp.api_path_pattern
+		  FROM user_roles ur
+		  JOIN role_permissions rp
+		    ON rp.tenant_id = ur.tenant_id
+		   AND rp.role_id = ur.role_id
+	`).Scan(ctx, &rules); err != nil {
+		return false, err
+	}
+	return rulesAllow(rules, grantRoleMethod, grantRolePath)
+}

--- a/erun-backend/erun-backend-api/internal/repository/roles_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/roles_e2e_test.go
@@ -1,0 +1,281 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Role assignment writes real transaction-local RLS role switches and reads
+// role_permissions through the same matcher Authorize enforces with, so it is
+// exercised against a real migrated PostgreSQL rather than a fake that agrees
+// with itself.
+func rolesDatabase(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	databaseURL := os.Getenv("ERUN_E2E_ROLES_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("opt-in: set ERUN_E2E_ROLES_DATABASE_URL to a migrated PostgreSQL")
+	}
+	db, err := sql.Open("pgx", databaseURL)
+	mustNoErr(t, err, "open db")
+	t.Cleanup(func() { _ = db.Close() })
+
+	var tenantID string
+	err = db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, 'COMPANY') RETURNING tenant_id`,
+		"roles-e2e-"+time.Now().Format("20060102150405.000000"),
+	).Scan(&tenantID)
+	mustNoErr(t, err, "seed tenant")
+	t.Cleanup(func() { clearPermissionsTenant(t, db, tenantID) })
+	return db, tenantID
+}
+
+func rolesContext(tenantID, userID string) context.Context {
+	return security.WithContext(context.Background(), security.Context{
+		TenantID: tenantID, TenantType: "COMPANY", ErunUserID: userID,
+	})
+}
+
+// TestRoleRepositoryCreateGrantAndListRoundTrip proves the whole assignment
+// path end to end: a role narrowed to one path can be created, granted to a
+// user, and read back both from the tenant's role list and from that user's
+// own roles.
+func TestRoleRepositoryCreateGrantAndListRoundTrip(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	admin := seedPermissionsUser(t, db, tenantID, "admin")
+	reviewer := seedPermissionsUser(t, db, tenantID, "reviewer")
+	ctx := rolesContext(tenantID, admin)
+
+	role, err := roles.Create(ctx, "ReviewsReader", []RolePermissionInput{
+		{APIMethod: "GET", APIPath: "/v1/reviews"},
+	})
+	mustNoErr(t, err, "create role")
+	if role.RoleID == "" || len(role.Permissions) != 1 {
+		t.Fatalf("expected a created role with one permission, got %+v", role)
+	}
+
+	if _, err := roles.Grant(ctx, reviewer, role.RoleID); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	tenantRoles, err := roles.List(ctx)
+	mustNoErr(t, err, "list tenant roles")
+	assertRoleListedWithPermission(t, tenantRoles, role.RoleID, "GET", "/v1/reviews")
+
+	userRoles, err := roles.ForUser(ctx, reviewer)
+	mustNoErr(t, err, "list user roles")
+	if len(userRoles) != 1 || userRoles[0].RoleID != role.RoleID {
+		t.Fatalf("expected the reviewer to hold exactly the granted role, got %+v", userRoles)
+	}
+}
+
+// assertRoleListedWithPermission asserts roleID appears in roles with exactly
+// one permission matching the given exact method/path.
+func assertRoleListedWithPermission(t *testing.T, roles []model.Role, roleID, method, path string) {
+	t.Helper()
+	for _, r := range roles {
+		if r.RoleID != roleID {
+			continue
+		}
+		if len(r.Permissions) != 1 || r.Permissions[0].APIMethod != method || r.Permissions[0].APIPath != path {
+			t.Fatalf("expected the role's permission to round-trip, got %+v", r.Permissions)
+		}
+		return
+	}
+	t.Fatal("expected the created role in the tenant's role list")
+}
+
+// TestRoleRepositoryCustomRoleIsPermittedItsOwnPathAndRefusedEveryOther is the
+// permit-and-refuse property the feature exists to enable: a role narrowed to
+// one exact method/path must let a caller through to that path and refuse
+// every other path, checked against the real authorizer.
+func TestRoleRepositoryCustomRoleIsPermittedItsOwnPathAndRefusedEveryOther(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	authorizer := &PermissionAuthorizer{txs: txs}
+	admin := seedPermissionsUser(t, db, tenantID, "admin")
+	narrow := seedPermissionsUser(t, db, tenantID, "narrow")
+	ctx := rolesContext(tenantID, admin)
+
+	role, err := roles.Create(ctx, "ReviewsReader", []RolePermissionInput{
+		{APIMethod: "GET", APIPath: "/v1/reviews"},
+	})
+	mustNoErr(t, err, "create role")
+	if _, err := roles.Grant(ctx, narrow, role.RoleID); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+
+	narrowCtx := rolesContext(tenantID, narrow)
+	if err := authorizer.Authorize(narrowCtx, "GET", "/v1/reviews"); err != nil {
+		t.Fatalf("expected the narrow role's own path to be permitted, got %v", err)
+	}
+	for _, refused := range []struct{ method, path string }{
+		{"GET", "/v1/whoami"},
+		{"POST", "/v1/reviews"},
+		{"GET", "/v1/reviews/{review_id}"},
+	} {
+		err := authorizer.Authorize(narrowCtx, refused.method, refused.path)
+		if !errors.Is(err, ErrForbidden) {
+			t.Fatalf("%s %s: expected forbidden, got %v", refused.method, refused.path, err)
+		}
+	}
+}
+
+// TestRoleRepositoryExistingReadAllWriteAllUserIsUnaffected proves the
+// assignment layer is purely additive: a user holding the predefined
+// ReadAll+WriteAll roles (the bootstrap shape) keeps exactly that access after
+// this feature is exercised alongside it.
+func TestRoleRepositoryExistingReadAllWriteAllUserIsUnaffected(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	authorizer := &PermissionAuthorizer{txs: txs}
+	admin := seedPermissionsUser(t, db, tenantID, "admin")
+	grantRole(t, db, tenantID, admin, "ReadAll", []seededPermission{
+		{methodPattern: "^(GET|HEAD|OPTIONS)$", pathPattern: "^/.*$"},
+	})
+	grantRole(t, db, tenantID, admin, "WriteAll", []seededPermission{
+		{methodPattern: "^(POST|PUT|PATCH|DELETE)$", pathPattern: "^/.*$"},
+	})
+
+	ctx := rolesContext(tenantID, admin)
+	for _, permitted := range []struct{ method, path string }{
+		{"GET", "/v1/reviews"},
+		{"POST", "/v1/reviews"},
+		{"DELETE", "/v1/environments/{environment_id}"},
+	} {
+		if err := authorizer.Authorize(ctx, permitted.method, permitted.path); err != nil {
+			t.Fatalf("%s %s: expected the untouched ReadAll+WriteAll user to still be permitted, got %v", permitted.method, permitted.path, err)
+		}
+	}
+}
+
+// TestRoleRepositoryRevokeRefusesLastGrantCapableRole is the lockout guard
+// the feature must make impossible: revoking the tenant's only role that can
+// grant roles is refused, and the assignment is left exactly as it was.
+func TestRoleRepositoryRevokeRefusesLastGrantCapableRole(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	admin := seedPermissionsUser(t, db, tenantID, "sole-admin")
+	grantRole(t, db, tenantID, admin, "WriteAll", []seededPermission{
+		{methodPattern: "^(POST|PUT|PATCH|DELETE)$", pathPattern: "^/.*$"},
+	})
+
+	var writeAllRoleID string
+	err := db.QueryRow(`SELECT role_id FROM roles WHERE tenant_id = $1 AND name = 'WriteAll'`, tenantID).Scan(&writeAllRoleID)
+	mustNoErr(t, err, "look up seeded WriteAll role id")
+
+	ctx := rolesContext(tenantID, admin)
+	err = roles.Revoke(ctx, admin, writeAllRoleID)
+	if !errors.Is(err, ErrLastGrantCapableRole) {
+		t.Fatalf("expected ErrLastGrantCapableRole, got %v", err)
+	}
+
+	var stillAssigned int
+	mustNoErr(t, db.QueryRow(
+		`SELECT COUNT(*) FROM user_roles WHERE tenant_id = $1 AND user_id = $2 AND role_id = $3`,
+		tenantID, admin, writeAllRoleID,
+	).Scan(&stillAssigned), "count assignment after refused revoke")
+	if stillAssigned != 1 {
+		t.Fatalf("expected the refused revoke to leave the assignment in place, found %d rows", stillAssigned)
+	}
+}
+
+// TestRoleRepositoryRevokeSucceedsWhenAnotherGrantCapableUserRemains is the
+// other side of the same guard: revoking is fine as long as the tenant is not
+// left with zero grant-capable users.
+func TestRoleRepositoryRevokeSucceedsWhenAnotherGrantCapableUserRemains(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	first := seedPermissionsUser(t, db, tenantID, "first-admin")
+	second := seedPermissionsUser(t, db, tenantID, "second-admin")
+	grantRole(t, db, tenantID, first, "WriteAll", []seededPermission{
+		{methodPattern: "^(POST|PUT|PATCH|DELETE)$", pathPattern: "^/.*$"},
+	})
+
+	var writeAllRoleID string
+	err := db.QueryRow(`SELECT role_id FROM roles WHERE tenant_id = $1 AND name = 'WriteAll'`, tenantID).Scan(&writeAllRoleID)
+	mustNoErr(t, err, "look up seeded WriteAll role id")
+	_, err = db.Exec(`INSERT INTO user_roles (tenant_id, user_id, role_id) VALUES ($1, $2, $3)`, tenantID, second, writeAllRoleID)
+	mustNoErr(t, err, "assign WriteAll to second admin")
+
+	ctx := rolesContext(tenantID, first)
+	if err := roles.Revoke(ctx, first, writeAllRoleID); err != nil {
+		t.Fatalf("expected revoke to succeed while another grant-capable user remains, got %v", err)
+	}
+}
+
+// TestRoleRepositoryGrantRejectsCrossTenantRole proves RLS, not application
+// code, is what stops a role from another tenant being granted: the role_id
+// is invisible to this tenant's transaction, so the insert's foreign key
+// fails and Grant reports it as not found.
+func TestRoleRepositoryGrantRejectsCrossTenantRole(t *testing.T) {
+	db, tenantA := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	userA := seedPermissionsUser(t, db, tenantA, "user-a")
+
+	var tenantB string
+	err := db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, 'COMPANY') RETURNING tenant_id`,
+		"roles-e2e-cross-"+time.Now().Format("20060102150405.000000"),
+	).Scan(&tenantB)
+	mustNoErr(t, err, "seed second tenant")
+	t.Cleanup(func() { clearPermissionsTenant(t, db, tenantB) })
+	adminB := seedPermissionsUser(t, db, tenantB, "admin-b")
+	ctxB := rolesContext(tenantB, adminB)
+	roleB, err := roles.Create(ctxB, "ReviewsReader", []RolePermissionInput{
+		{APIMethod: "GET", APIPath: "/v1/reviews"},
+	})
+	mustNoErr(t, err, "create role in tenant B")
+
+	ctxA := rolesContext(tenantA, userA)
+	if _, err := roles.Grant(ctxA, userA, roleB.RoleID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound granting a cross-tenant role, got %v", err)
+	}
+}
+
+func TestRoleRepositoryCreateRejectsDuplicateName(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	admin := seedPermissionsUser(t, db, tenantID, "admin")
+	ctx := rolesContext(tenantID, admin)
+
+	_, err := roles.Create(ctx, "ReviewsReader", []RolePermissionInput{{APIMethod: "GET", APIPath: "/v1/reviews"}})
+	mustNoErr(t, err, "create role")
+	_, err = roles.Create(ctx, "ReviewsReader", []RolePermissionInput{{APIMethod: "GET", APIPath: "/v1/audit-events"}})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict for a duplicate role name, got %v", err)
+	}
+}
+
+func TestRoleRepositoryGrantRejectsDuplicateAssignment(t *testing.T) {
+	db, tenantID := rolesDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	roles := &RoleRepository{txs: txs}
+	admin := seedPermissionsUser(t, db, tenantID, "admin")
+	reviewer := seedPermissionsUser(t, db, tenantID, "reviewer")
+	ctx := rolesContext(tenantID, admin)
+
+	role, err := roles.Create(ctx, "ReviewsReader", []RolePermissionInput{{APIMethod: "GET", APIPath: "/v1/reviews"}})
+	mustNoErr(t, err, "create role")
+	if _, err := roles.Grant(ctx, reviewer, role.RoleID); err != nil {
+		t.Fatalf("first grant: %v", err)
+	}
+	if _, err := roles.Grant(ctx, reviewer, role.RoleID); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrConflict granting the same role twice, got %v", err)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/roles_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/roles_test.go
@@ -1,0 +1,136 @@
+package repository
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestRolePermissionInputValidate(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		input   RolePermissionInput
+		wantErr bool
+	}{
+		{
+			name:  "valid exact",
+			input: RolePermissionInput{APIMethod: "GET", APIPath: "/v1/reviews"},
+		},
+		{
+			name:  "valid pattern",
+			input: RolePermissionInput{APIMethodPattern: "^GET$", APIPathPattern: "^/v1/reviews$"},
+		},
+		{
+			name:    "neither form set",
+			input:   RolePermissionInput{},
+			wantErr: true,
+		},
+		{
+			name: "both forms set",
+			input: RolePermissionInput{
+				APIMethod: "GET", APIPath: "/v1/reviews",
+				APIMethodPattern: "^GET$", APIPathPattern: "^/v1/reviews$",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "exact method without path",
+			input:   RolePermissionInput{APIMethod: "GET"},
+			wantErr: true,
+		},
+		{
+			name:    "exact path without method",
+			input:   RolePermissionInput{APIPath: "/v1/reviews"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid exact method",
+			input:   RolePermissionInput{APIMethod: "TRACE", APIPath: "/v1/reviews"},
+			wantErr: true,
+		},
+		{
+			name:    "pattern method without path pattern",
+			input:   RolePermissionInput{APIMethodPattern: "^GET$"},
+			wantErr: true,
+		},
+		{
+			name:    "uncompilable method pattern",
+			input:   RolePermissionInput{APIMethodPattern: "(", APIPathPattern: "^/v1/reviews$"},
+			wantErr: true,
+		},
+		{
+			name:    "uncompilable path pattern",
+			input:   RolePermissionInput{APIMethodPattern: "^GET$", APIPathPattern: "("},
+			wantErr: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := testCase.input.validate()
+			if testCase.wantErr && err == nil {
+				t.Fatalf("expected an error, got none")
+			}
+			if !testCase.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestTenantHasGrantCapableUserReusesRuleMatcher locks in that the lockout
+// guard shares rulesAllow with Authorize: a role permitting the grant route
+// (exactly or via a pattern that covers it) makes the tenant grant-capable,
+// and one that does not, does not.
+func TestTenantHasGrantCapableUserReusesRuleMatcher(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		rules   []permissionRule
+		capable bool
+	}{
+		{
+			name:    "no rules at all",
+			rules:   nil,
+			capable: false,
+		},
+		{
+			name: "exact grant route",
+			rules: []permissionRule{
+				{APIMethod: valid(grantRoleMethod), APIPath: valid(grantRolePath)},
+			},
+			capable: true,
+		},
+		{
+			name: "WriteAll-shaped pattern covers it",
+			rules: []permissionRule{
+				{APIMethodPattern: valid("^(POST|PUT|PATCH|DELETE)$"), APIPathPattern: valid("^/.*$")},
+			},
+			capable: true,
+		},
+		{
+			name: "ReadAll-shaped pattern does not cover a write",
+			rules: []permissionRule{
+				{APIMethodPattern: valid("^(GET|HEAD|OPTIONS)$"), APIPathPattern: valid("^/.*$")},
+			},
+			capable: false,
+		},
+		{
+			name: "a narrow pattern for a different path",
+			rules: []permissionRule{
+				{APIMethodPattern: valid("^POST$"), APIPathPattern: valid("^/v1/reviews$")},
+			},
+			capable: false,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			allowed, err := rulesAllow(testCase.rules, grantRoleMethod, grantRolePath)
+			if err != nil {
+				t.Fatalf("rulesAllow: %v", err)
+			}
+			if allowed != testCase.capable {
+				t.Fatalf("expected capable=%v, got %v", testCase.capable, allowed)
+			}
+		})
+	}
+}
+
+func valid(value string) sql.NullString {
+	return sql.NullString{String: value, Valid: true}
+}

--- a/erun-backend/erun-backend-api/internal/routes/roles.go
+++ b/erun-backend/erun-backend-api/internal/routes/roles.go
@@ -1,0 +1,150 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	apirepository "github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+// RoleRepository is the persistence dependency for role management and
+// role-assignment routes.
+type RoleRepository interface {
+	List(ctx context.Context) ([]model.Role, error)
+	Create(ctx context.Context, name string, permissions []apirepository.RolePermissionInput) (model.Role, error)
+	ForUser(ctx context.Context, userID string) ([]model.Role, error)
+	Grant(ctx context.Context, userID string, roleID string) (model.UserRole, error)
+	Revoke(ctx context.Context, userID string, roleID string) error
+}
+
+type RoleRoutes struct {
+	roles RoleRepository
+}
+
+func RegisterRoleRoutes(register ProtectedRouteRegistrar, roles RoleRepository) {
+	routes := RoleRoutes{roles: roles}
+	register(http.MethodGet, "/v1/roles", http.HandlerFunc(routes.listRoles))
+	register(http.MethodPost, "/v1/roles", http.HandlerFunc(routes.createRole))
+	register(http.MethodGet, "/v1/users/{user_id}/roles", http.HandlerFunc(routes.listUserRoles))
+	register(http.MethodPost, "/v1/users/{user_id}/roles", http.HandlerFunc(routes.grantUserRole))
+	register(http.MethodDelete, "/v1/users/{user_id}/roles/{role_id}", http.HandlerFunc(routes.revokeUserRole))
+}
+
+type createRolePermissionRequest struct {
+	APIMethod        string `json:"apiMethod,omitempty"`
+	APIPath          string `json:"apiPath,omitempty"`
+	APIMethodPattern string `json:"apiMethodPattern,omitempty"`
+	APIPathPattern   string `json:"apiPathPattern,omitempty"`
+}
+
+type createRoleRequest struct {
+	Name        string                        `json:"name"`
+	Permissions []createRolePermissionRequest `json:"permissions"`
+}
+
+func (routes RoleRoutes) listRoles(w http.ResponseWriter, req *http.Request) {
+	roles, err := routes.roles.List(req.Context())
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, roles)
+}
+
+func (routes RoleRoutes) createRole(w http.ResponseWriter, req *http.Request) {
+	var body createRoleRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if len(body.Permissions) == 0 {
+		writeError(w, http.StatusBadRequest, "at least one permission is required")
+		return
+	}
+	permissions := make([]apirepository.RolePermissionInput, 0, len(body.Permissions))
+	for _, permission := range body.Permissions {
+		permissions = append(permissions, apirepository.RolePermissionInput{
+			APIMethod:        strings.TrimSpace(permission.APIMethod),
+			APIPath:          strings.TrimSpace(permission.APIPath),
+			APIMethodPattern: strings.TrimSpace(permission.APIMethodPattern),
+			APIPathPattern:   strings.TrimSpace(permission.APIPathPattern),
+		})
+	}
+
+	role, err := routes.roles.Create(req.Context(), name, permissions)
+	if err != nil {
+		if errors.Is(err, apirepository.ErrInvalidInput) {
+			writeError(w, http.StatusBadRequest, "each permission needs exactly one of an exact method/path pair or a method-pattern/path-pattern pair, with a valid HTTP method and, for patterns, a compilable regular expression")
+			return
+		}
+		if errors.Is(err, apirepository.ErrConflict) {
+			writeError(w, http.StatusConflict, "a role with this name, or a permission on it, already exists in this tenant")
+			return
+		}
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, role)
+}
+
+func (routes RoleRoutes) listUserRoles(w http.ResponseWriter, req *http.Request) {
+	roles, err := routes.roles.ForUser(req.Context(), req.PathValue("user_id"))
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, roles)
+}
+
+type grantUserRoleRequest struct {
+	RoleID string `json:"roleId"`
+}
+
+func (routes RoleRoutes) grantUserRole(w http.ResponseWriter, req *http.Request) {
+	var body grantUserRoleRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	roleID := strings.TrimSpace(body.RoleID)
+	if roleID == "" {
+		writeError(w, http.StatusBadRequest, "roleId is required")
+		return
+	}
+
+	grant, err := routes.roles.Grant(req.Context(), req.PathValue("user_id"), roleID)
+	if err != nil {
+		if errors.Is(err, apirepository.ErrConflict) {
+			writeError(w, http.StatusConflict, "the user already holds this role")
+			return
+		}
+		if errors.Is(err, apirepository.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "the user or role does not exist in this tenant")
+			return
+		}
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, grant)
+}
+
+func (routes RoleRoutes) revokeUserRole(w http.ResponseWriter, req *http.Request) {
+	err := routes.roles.Revoke(req.Context(), req.PathValue("user_id"), req.PathValue("role_id"))
+	if err != nil {
+		if errors.Is(err, apirepository.ErrLastGrantCapableRole) {
+			writeError(w, http.StatusConflict, err.Error())
+			return
+		}
+		writeRepositoryError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/erun-backend/erun-backend-api/internal/routes/roles_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/roles_test.go
@@ -1,0 +1,238 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	apirepository "github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+type stubRoleRepository struct {
+	roles     []model.Role
+	listErr   error
+	createErr error
+	gotName   string
+	gotPerms  []apirepository.RolePermissionInput
+	created   model.Role
+
+	forUser    []model.Role
+	forUserErr error
+	gotUserID  string
+
+	grantErr error
+	granted  model.UserRole
+	gotGrant struct{ userID, roleID string }
+
+	revokeErr error
+	gotRevoke struct{ userID, roleID string }
+}
+
+func (r *stubRoleRepository) List(_ context.Context) ([]model.Role, error) {
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.roles, nil
+}
+
+func (r *stubRoleRepository) Create(_ context.Context, name string, permissions []apirepository.RolePermissionInput) (model.Role, error) {
+	r.gotName = name
+	r.gotPerms = permissions
+	if r.createErr != nil {
+		return model.Role{}, r.createErr
+	}
+	return r.created, nil
+}
+
+func (r *stubRoleRepository) ForUser(_ context.Context, userID string) ([]model.Role, error) {
+	r.gotUserID = userID
+	if r.forUserErr != nil {
+		return nil, r.forUserErr
+	}
+	return r.forUser, nil
+}
+
+func (r *stubRoleRepository) Grant(_ context.Context, userID string, roleID string) (model.UserRole, error) {
+	r.gotGrant = struct{ userID, roleID string }{userID, roleID}
+	if r.grantErr != nil {
+		return model.UserRole{}, r.grantErr
+	}
+	return r.granted, nil
+}
+
+func (r *stubRoleRepository) Revoke(_ context.Context, userID string, roleID string) error {
+	r.gotRevoke = struct{ userID, roleID string }{userID, roleID}
+	return r.revokeErr
+}
+
+func TestListRolesReturnsRepositoryRoles(t *testing.T) {
+	roles := &stubRoleRepository{roles: []model.Role{{RoleID: "role-1", Name: "ReadAll"}}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/roles", nil)
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.listRoles(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateRoleRejectsMissingName(t *testing.T) {
+	roles := &stubRoleRepository{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/roles", bytes.NewBufferString(`{"permissions":[{"apiMethod":"GET","apiPath":"/v1/reviews"}]}`))
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.createRole(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateRoleRejectsNoPermissions(t *testing.T) {
+	roles := &stubRoleRepository{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/roles", bytes.NewBufferString(`{"name":"Reviewer"}`))
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.createRole(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateRoleNarrowedToOnePathSucceeds(t *testing.T) {
+	roles := &stubRoleRepository{created: model.Role{RoleID: "role-1", Name: "Reviewer"}}
+	body := `{"name":"Reviewer","permissions":[{"apiMethod":"GET","apiPath":"/v1/reviews"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/roles", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.createRole(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if roles.gotName != "Reviewer" || len(roles.gotPerms) != 1 || roles.gotPerms[0].APIMethod != "GET" || roles.gotPerms[0].APIPath != "/v1/reviews" {
+		t.Fatalf("Create called with name=%q perms=%+v", roles.gotName, roles.gotPerms)
+	}
+}
+
+func TestCreateRoleMapsInvalidInputToBadRequest(t *testing.T) {
+	roles := &stubRoleRepository{createErr: apirepository.ErrInvalidInput}
+	body := `{"name":"Reviewer","permissions":[{"apiMethod":"GET","apiPath":"/v1/reviews"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/roles", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.createRole(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCreateRoleMapsConflictToStatusConflict(t *testing.T) {
+	roles := &stubRoleRepository{createErr: apirepository.ErrConflict}
+	body := `{"name":"ReadAll","permissions":[{"apiMethod":"GET","apiPath":"/v1/reviews"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/roles", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.createRole(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestListUserRolesUsesPathUserID(t *testing.T) {
+	roles := &stubRoleRepository{forUser: []model.Role{{RoleID: "role-1", Name: "ReadAll"}}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/users/user-1/roles", nil)
+	req.SetPathValue("user_id", "user-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.listUserRoles(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if roles.gotUserID != "user-1" {
+		t.Fatalf("ForUser called with userID=%q, want user-1", roles.gotUserID)
+	}
+}
+
+func TestGrantUserRoleRejectsMissingRoleID(t *testing.T) {
+	roles := &stubRoleRepository{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/user-1/roles", bytes.NewBufferString(`{}`))
+	req.SetPathValue("user_id", "user-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.grantUserRole(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGrantUserRoleSucceeds(t *testing.T) {
+	roles := &stubRoleRepository{granted: model.UserRole{UserID: "user-1", RoleID: "role-1"}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/user-1/roles", bytes.NewBufferString(`{"roleId":"role-1"}`))
+	req.SetPathValue("user_id", "user-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.grantUserRole(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if roles.gotGrant.userID != "user-1" || roles.gotGrant.roleID != "role-1" {
+		t.Fatalf("Grant called with %+v, want user-1/role-1", roles.gotGrant)
+	}
+}
+
+func TestGrantUserRoleMapsConflictToStatusConflict(t *testing.T) {
+	roles := &stubRoleRepository{grantErr: apirepository.ErrConflict}
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/user-1/roles", bytes.NewBufferString(`{"roleId":"role-1"}`))
+	req.SetPathValue("user_id", "user-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.grantUserRole(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGrantUserRoleMapsNotFoundToStatusNotFound(t *testing.T) {
+	roles := &stubRoleRepository{grantErr: apirepository.ErrNotFound}
+	req := httptest.NewRequest(http.MethodPost, "/v1/users/user-1/roles", bytes.NewBufferString(`{"roleId":"role-1"}`))
+	req.SetPathValue("user_id", "user-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.grantUserRole(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRevokeUserRoleSucceeds(t *testing.T) {
+	roles := &stubRoleRepository{}
+	req := httptest.NewRequest(http.MethodDelete, "/v1/users/user-1/roles/role-1", nil)
+	req.SetPathValue("user_id", "user-1")
+	req.SetPathValue("role_id", "role-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.revokeUserRole(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204; body=%s", rec.Code, rec.Body.String())
+	}
+	if roles.gotRevoke.userID != "user-1" || roles.gotRevoke.roleID != "role-1" {
+		t.Fatalf("Revoke called with %+v, want user-1/role-1", roles.gotRevoke)
+	}
+}
+
+// TestRevokeUserRoleRefusesLastGrantCapableRole is the route-level half of the
+// lockout guard: the repository's refusal must reach the caller as a 409 with
+// an actionable message, not a generic 500.
+func TestRevokeUserRoleRefusesLastGrantCapableRole(t *testing.T) {
+	roles := &stubRoleRepository{revokeErr: apirepository.ErrLastGrantCapableRole}
+	req := httptest.NewRequest(http.MethodDelete, "/v1/users/user-1/roles/role-1", nil)
+	req.SetPathValue("user_id", "user-1")
+	req.SetPathValue("role_id", "role-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.revokeUserRole(rec, req)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRevokeUserRoleMapsNotFoundToStatusNotFound(t *testing.T) {
+	roles := &stubRoleRepository{revokeErr: apirepository.ErrNotFound}
+	req := httptest.NewRequest(http.MethodDelete, "/v1/users/user-1/roles/role-1", nil)
+	req.SetPathValue("user_id", "user-1")
+	req.SetPathValue("role_id", "role-1")
+	rec := httptest.NewRecorder()
+	RoleRoutes{roles: roles}.revokeUserRole(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -338,6 +338,7 @@ func registerDatabaseRoutes(register routes.ProtectedRouteRegistrar, options Han
 	routes.RegisterConfigRoute(register, repos.tenants, repos.environments, repos.contexts)
 	routes.RegisterProvisionRoute(register, repos.tenants, repos.environments, repos.tenantQuotas)
 	routes.RegisterUserRoutes(register, repository.NewUserRepository(txManager))
+	routes.RegisterRoleRoutes(register, repository.NewRoleRepository(txManager))
 	registerIdentityAdminRoutes(register, options, txManager)
 }
 

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -115,6 +115,11 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/tenants` | List every tenant (operations-only caller), or a single-item list containing just the caller's own tenant otherwise. | Tenant member (read) |
 | `POST` | `/v1/users` | Enroll a user in the caller's tenant, or — operations-only — an explicitly named other tenant. Body below. | Tenant member (write); cross-tenant needs Operations |
 | `GET` | `/v1/users` | List the caller's tenant's users, or — operations-only — an explicitly named other tenant's via `?tenantId=`. | Tenant member (read); cross-tenant needs Operations |
+| `GET` | `/v1/roles` | List the caller's tenant's roles with their permissions. | Tenant member (read) |
+| `POST` | `/v1/roles` | Create a tenant-owned role with one or more permissions. Body below. | Tenant member (write) |
+| `GET` | `/v1/users/{user_id}/roles` | List a user's assigned roles. | Tenant member (read) |
+| `POST` | `/v1/users/{user_id}/roles` | Grant a role to a user. Body below. | Tenant member (write) |
+| `DELETE` | `/v1/users/{user_id}/roles/{role_id}` | Revoke a role from a user; refused if it would leave the tenant with no user able to grant roles. | Tenant member (write) |
 
 `GET /v1/config` is the console's read model over the per-tenant erun config — the backend DB is the system of record for the tenant's environments and cloud contexts, and this endpoint returns them denormalized as the on-disk erun config shape. All of these reads are tenant-scoped by row-level security, so a token only ever sees its own tenant's rows.
 
@@ -735,7 +740,7 @@ Both act on the caller's own resolved tenant by default. An explicit `tenantId` 
 }
 ```
 
-Omitting `issuer`/`subject` enrolls a username with **no external identity yet** — the row exists, but no token can resolve to it until one is linked, and there is no separate endpoint to link one after the fact in this build. Enrollment grants the same predefined `ReadAll`/`WriteAll` roles every bootstrapped user gets — there is no finer-grained role-assignment surface yet.
+Omitting `issuer`/`subject` enrolls a username with **no external identity yet** — the row exists, but no token can resolve to it until one is linked, and there is no separate endpoint to link one after the fact in this build. Enrollment grants the same predefined `ReadAll`/`WriteAll` roles every bootstrapped user gets — this is the safe default for a tenant's first user (see [empty-database bootstrap](#tenant-issuers) above), not the only role shape a tenant can hold. [`GET`/`POST /v1/roles`](#roles-endpoints) and [`/v1/users/{user_id}/roles`](#roles-endpoints) below are how an operator narrows a user's access after enrollment.
 
 This endpoint requires the caller to already know the enrollee's `issuer`/`subject` from the identity provider. [`POST /v1/identity/users`](/agent-reference/identity-administration) is the higher-level alternative for a platform running its own IdP (Zitadel): it creates the IdP identity itself and calls this same mapping with the subject the IdP returns, in one action, restricted to an `OPERATIONS` tenant.
 
@@ -762,6 +767,64 @@ This endpoint requires the caller to already know the enrollee's `issuer`/`subje
 | `400` | `username` is empty, or the body is not valid JSON. | Send a non-empty `username`. |
 | `403` | `tenantId` (or `?tenantId=`) names a different tenant than the caller's own, and the caller's resolved tenant is not `OPERATIONS`. | Omit `tenantId` to act on your own tenant, or call from an operations-tenant token. |
 | `409` | `POST /v1/users`: a user with that `username` already exists in the target tenant (`users_tenant_username_key`). | Use a different username, or omit `tenantId` if you meant your own tenant. |
+
+### Roles and role assignment {#roles-endpoints}
+
+A **role** is a named, tenant-owned bundle of permissions; a **permission** is one API method + path grant, either an exact pair (`apiMethod`/`apiPath`) or a regex pattern pair (`apiMethodPattern`/`apiPathPattern`) — the same shape `role_permissions` stores and [the capability set](#capability-set) resolves against. `ReadAll` and `WriteAll` are two such roles, predefined per tenant and granted to every bootstrapped user; a tenant can also define its own narrower roles and assign them instead. All five endpoints below act on the caller's own resolved tenant — RLS scopes every read and write, and there is no operations-tenant cross-tenant override (unlike `/v1/users`).
+
+**`GET /v1/roles`** lists the tenant's roles with their permissions. **`POST /v1/roles`** creates one:
+
+```jsonc
+// POST /v1/roles body
+{
+  "name": "ReviewsReader",
+  "permissions": [
+    { "apiMethod": "GET", "apiPath": "/v1/reviews" },
+    { "apiMethodPattern": "^GET$", "apiPathPattern": "^/v1/reviews/.*$" }
+  ]
+}
+
+// 201 response
+{
+  "roleId": "019a7fa5-c2c0-7c55-bc70-714873a71f70",
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
+  "name": "ReviewsReader",
+  "permissions": [
+    { "rolePermissionId": "019a7fa5-…", "tenantId": "019a7fa5-…", "roleId": "019a7fa5-…", "apiMethod": "GET", "apiPath": "/v1/reviews", "createdAt": "…", "updatedAt": "…" },
+    { "rolePermissionId": "019a7fa5-…", "tenantId": "019a7fa5-…", "roleId": "019a7fa5-…", "apiMethodPattern": "^GET$", "apiPathPattern": "^/v1/reviews/.*$", "createdAt": "…", "updatedAt": "…" }
+  ],
+  "createdAt": "2026-06-24T10:00:00Z",
+  "updatedAt": "2026-06-24T10:00:00Z"
+}
+```
+
+Each permission needs **exactly one** of the exact pair or the pattern pair (matching `role_permissions_exact_or_pattern_check`); an exact `apiMethod` must be one of `GET`/`HEAD`/`OPTIONS`/`POST`/`PUT`/`PATCH`/`DELETE`, and both pattern fields must compile as regular expressions. At least one permission is required — a role with none could never be granted meaningfully.
+
+**`GET /v1/users/{user_id}/roles`** lists a user's assigned roles. **`POST /v1/users/{user_id}/roles`** grants one; **`DELETE /v1/users/{user_id}/roles/{role_id}`** revokes one:
+
+```jsonc
+// POST /v1/users/019a7fa5-…-f60/roles body
+{ "roleId": "019a7fa5-c2c0-7c55-bc70-714873a71f70" }
+
+// 201 response
+{
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
+  "userId": "019a7fa5-c2c0-7c55-bc70-714873a71f60",
+  "roleId": "019a7fa5-c2c0-7c55-bc70-714873a71f70",
+  "createdAt": "2026-06-24T10:00:00Z",
+  "updatedAt": "2026-06-24T10:00:00Z"
+}
+```
+
+**The lockout guard.** `DELETE /v1/users/{user_id}/roles/{role_id}` refuses when the revoke would leave the tenant with **no user holding a role that can grant roles** (a permission matching `POST /v1/users/{user_id}/roles` itself) — the one failure this feature makes impossible rather than merely recoverable, since there would be no lever left inside the product to undo it. The check runs against every user in the tenant, not just the one being revoked, so revoking a role from one admin while another admin still holds a grant-capable role succeeds normally.
+
+**Error behaviour.** Bare HTTP status, plain-text body, same as `/v1/users`:
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `POST /v1/roles`: `name` is empty, no permissions given, or a permission fails the exact/pattern-exclusivity, method-enum, or regex-compile checks above. `POST /v1/users/{user_id}/roles`: `roleId` is empty. | Fix the request body per the rules above. |
+| `404` | The `role_id` or `user_id` does not exist in the caller's tenant (a cross-tenant reference is invisible under RLS, not merely forbidden). | Use an ID that belongs to your own tenant. |
+| `409` | `POST /v1/roles`: a role with this name, or one of its permissions, already exists in the tenant. `POST /v1/users/{user_id}/roles`: the user already holds this role. `DELETE .../roles/{role_id}`: the lockout guard above refused the revoke. | Use a different name, or accept the existing grant; for the lockout case, grant a recovery role to another user (or the same user) before revoking this one. |
 
 ### `PUT /v1/tenants/{tenant_id}/quota` {#put-v1tenantstenant_idquota}
 


### PR DESCRIPTION
Every enrolled user received `ReadAll` **and** `WriteAll` — every method on every
path — with no way to grant less and no way to change it afterwards. Enrolling
someone was granting tenant admin; deactivation was the only other lever.

The fine-grained schema (`roles`, `role_permissions`, `user_roles`) and its
enforcement (`PermissionAuthorizer`) already existed. **Only the assignment
layer was missing**, and that is exactly what this adds — tenant-scoped under
RLS, with no operations gate, since a tenant manages its own roles:

- `GET`/`POST /v1/roles` — list and create a tenant's roles, each carrying
  exact (`apiMethod`/`apiPath`) or pattern (`apiMethodPattern`/`apiPathPattern`)
  permissions
- `GET`/`POST /v1/users/{user_id}/roles`, `DELETE /v1/users/{user_id}/roles/{role_id}`

## The lockout guard

`Revoke` performs the delete and then re-checks, **inside the same transaction**,
whether any user in the tenant still holds a permission matching
`POST /v1/users/{user_id}/roles`. If not it returns `ErrLastGrantCapableRole`
and the delete rolls back.

It re-checks using the **same `rulesAllow` matcher `Authorize` enforces with**,
so the guard cannot drift from enforcement — a guard that disagrees with the
thing it guards is how several defects landed in this repo recently.

## Enrolment default is deliberately unchanged

Bootstrap still grants both predefined roles unconditionally: a tenant's first
user must have full control or a new tenant is unusable. That is now **locked
in by assertions** rather than left implicit — both the empty-database bootstrap
test and a new first-tenant-user test assert it survives.

Existing users are provably unaffected:
`TestRoleRepositoryExistingReadAllWriteAllUserIsUnaffected` grants the
predefined roles exactly as bootstrap does and confirms `Authorize` still
permits reads, writes and deletes across arbitrary paths.

## Verification against real enforcement, not fakes

A disposable `postgres:18.3` container with the real Atlas migrations applied:

- `TestRoleRepositoryCustomRoleIsPermittedItsOwnPathAndRefusedEveryOther` — a
  role narrowed to `GET /v1/reviews` is **permitted** that exact call and
  **refused** `GET /v1/whoami`, `POST /v1/reviews` and
  `GET /v1/reviews/{review_id}`, through the real `PermissionAuthorizer`. Both
  directions, because a permission check that never refuses is not a check.
- Plus round-trip, duplicate-name and duplicate-grant conflicts, and
  cross-tenant invisibility under RLS (`ErrNotFound`).
- All 8 new e2e tests pass; the container was torn down afterwards.

## Gates

- `go build` / `go vet` in `erun-backend-api` → clean
- `golangci-lint` (pinned v2.2.2) → **0 issues** (two `cyclop` findings fixed by
  extracting helpers, not suppressed)
- `go test ./...` with e2e DB gates enabled → **all green**
- `erun-docs` build → clean, no broken anchors
- `make check` → **exit 0**, coverage **76.1%** (≥ 75.8%)

## What is deliberately not in this PR

Scoped to the API and assignment layer, complete, with the rest stated rather
than half-built:

- **no `erun-console` UI** for viewing/granting/revoking roles
- **no `erun-cli` command or MCP tool** wrapping these endpoints
- the operations-gate-on-roles decision, which #1481 itself recommends
  deferring

**So today an operator can only reach role management over raw HTTP.** That is a
real gap, not a silent one — #1481 stays open for it. Worth noting the
desktop-surface gate does not catch this: it gates registered CLI commands and
MCP tools, and this PR registers none.

Docs updated in the same PR (`api-protocol.md`): the five endpoints, a "Roles
and role assignment" section covering schema, bodies, validation rules, the
lockout guard and errors, and a correction to the `/v1/users` note that said
"no finer-grained role-assignment surface yet".

Refs #1481