### PR TITLE
Give an operator control of self-registration, and make registration invite-only

### DIFF
--- a/erun-backend/erun-backend-api/internal/model/invite.go
+++ b/erun-backend/erun-backend-api/internal/model/invite.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+// Invite is a revocable, single-use invitation into a tenant (issue #1483):
+// a server-side record rather than a self-contained signed token, so it can
+// be listed and revoked before it is ever used.
+type Invite struct {
+	bun.BaseModel `bun:"table:invites,alias:i"`
+	InviteID      string `json:"inviteId" bun:"invite_id,pk,scanonly"`
+	TenantID      string `json:"tenantId" bun:"tenant_id,scanonly"`
+	// CreatedByUserID is a read-only, database-defaulted field (erun_current_user_id()).
+	CreatedByUserID string `json:"createdByUserId" bun:"created_by_user_id,scanonly"`
+	// Issuer is the inviter's own authenticated issuer, captured at creation
+	// so the unauthenticated accept flow can link the new user's external
+	// identity to the same IdP without a caller session to read it from.
+	Issuer string `json:"-" bun:"issuer,scanonly"`
+	Token  string `json:"token" bun:"token,scanonly"`
+	Email  string `json:"email,omitempty" bun:"email,scanonly"`
+	// ExpiresAt is set at creation from a fixed TTL, not caller-supplied.
+	ExpiresAt time.Time `json:"expiresAt" bun:"expires_at,scanonly"`
+	// ConsumedAt is nil until the invite is accepted.
+	ConsumedAt *time.Time `json:"consumedAt,omitempty" bun:"consumed_at,scanonly"`
+	CreatedAt  time.Time  `json:"createdAt" bun:"created_at,scanonly"`
+	UpdatedAt  time.Time  `json:"updatedAt" bun:"updated_at,scanonly"`
+}

--- a/erun-backend/erun-backend-api/internal/repository/invites.go
+++ b/erun-backend/erun-backend-api/internal/repository/invites.go
@@ -1,0 +1,192 @@
+package repository
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/uptrace/bun"
+)
+
+const inviteColumns = `invite_id, tenant_id, created_by_user_id, issuer, token, email, expires_at, consumed_at, created_at, updated_at`
+
+type InviteRepository struct {
+	txs *TxManager
+}
+
+func NewInviteRepository(txs *TxManager) *InviteRepository {
+	return &InviteRepository{txs: txs}
+}
+
+// InviteFilter scopes List. TenantID, when set, is the explicit target
+// tenant — required for an operations-scoped caller, since erun_operations
+// bypasses RLS and would otherwise return every tenant's invites, mirroring
+// UserFilter.
+type InviteFilter struct {
+	TenantID string
+}
+
+// CreateInviteParams is the invite-creation input. TenantID, when set,
+// targets a tenant other than the caller's own resolved tenant — honored
+// only for an operations-scoped caller (enforced by the route, not here),
+// mirroring CreateUserParams. Issuer is the inviter's own authenticated
+// issuer, captured so the accept flow (which has no caller session) can
+// link the new user's external identity correctly.
+type CreateInviteParams struct {
+	TenantID string
+	Issuer   string
+	Email    string
+	TTL      time.Duration
+}
+
+// Create mints a new invite token and persists its record. The token is
+// generated here, not accepted from a caller, so an invite can never be
+// created for a token of the caller's choosing.
+func (r *InviteRepository) Create(ctx context.Context, params CreateInviteParams) (model.Invite, error) {
+	tenantID := strings.TrimSpace(params.TenantID)
+	issuer := strings.TrimSpace(params.Issuer)
+	email := strings.TrimSpace(params.Email)
+	token, err := generateInviteToken()
+	if err != nil {
+		return model.Invite{}, fmt.Errorf("generate invite token: %w", err)
+	}
+	expiresAt := time.Now().Add(params.TTL)
+
+	var invite model.Invite
+	err = r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		var scanErr error
+		if tenantID != "" {
+			scanErr = tx.NewRaw(`
+				INSERT INTO invites (tenant_id, issuer, token, email, expires_at)
+				VALUES (?, ?, ?, ?, ?)
+				RETURNING `+inviteColumns, tenantID, issuer, token, nullIfEmpty(email), expiresAt).Scan(ctx, &invite)
+		} else {
+			scanErr = tx.NewRaw(`
+				INSERT INTO invites (issuer, token, email, expires_at)
+				VALUES (?, ?, ?, ?)
+				RETURNING `+inviteColumns, issuer, token, nullIfEmpty(email), expiresAt).Scan(ctx, &invite)
+		}
+		return normalizeNoRows(scanErr)
+	})
+	if err != nil {
+		return model.Invite{}, err
+	}
+	return invite, nil
+}
+
+// List returns the filter's target tenant's outstanding (unconsumed)
+// invites — the ones an operator can still revoke or hand out again.
+func (r *InviteRepository) List(ctx context.Context, filter InviteFilter) ([]model.Invite, error) {
+	tenantID := strings.TrimSpace(filter.TenantID)
+	var invites []model.Invite
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return tx.NewRaw(`
+			SELECT `+inviteColumns+`
+			  FROM invites
+			 WHERE tenant_id = ?
+			   AND consumed_at IS NULL
+			 ORDER BY created_at DESC
+		`, tenantID).Scan(ctx, &invites)
+	})
+	return invites, err
+}
+
+// Revoke deletes an outstanding invite by its globally unique ID. RLS scopes
+// which row a caller can reach the same way Get(ctx, id) does elsewhere in
+// this package, so no separate tenant filter is needed here.
+func (r *InviteRepository) Revoke(ctx context.Context, inviteID string) error {
+	return r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		result, err := tx.NewRaw(`DELETE FROM invites WHERE invite_id = ?`, inviteID).Exec(ctx)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
+var (
+	// ErrInviteExpired reports a token that resolved to a real, unconsumed
+	// invite whose expires_at has already passed.
+	ErrInviteExpired = errors.New("invite has expired")
+	// ErrInviteConsumed reports a token that has already been used —
+	// invites are single-use by design.
+	ErrInviteConsumed = errors.New("invite has already been used")
+)
+
+// ConsumedInvite is what a successful ConsumeByToken hands back: the invite
+// record plus the target tenant's own type, which the caller needs to bind
+// the correct database role (erun_tenant vs erun_operations) for the
+// enrollment that follows.
+type ConsumedInvite struct {
+	Invite     model.Invite
+	TenantType string
+}
+
+// ConsumeByToken atomically validates and marks an invite consumed, for the
+// unauthenticated accept endpoint: there is no caller identity yet, so this
+// runs under WithinSystemTx (erun_operations, no tenant scoping) rather than
+// the normal authenticated WithinTx. ErrNotFound/ErrInviteExpired/
+// ErrInviteConsumed are distinguished so the accept flow can tell an
+// invitee exactly why their link doesn't work, per #1483's own requirement
+// that a stale link says so plainly instead of failing generically.
+func (r *InviteRepository) ConsumeByToken(ctx context.Context, token string) (ConsumedInvite, error) {
+	token = strings.TrimSpace(token)
+	var result ConsumedInvite
+	err := r.txs.WithinSystemTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		var invite model.Invite
+		// FOR UPDATE serializes concurrent accept attempts against the same
+		// token so two requests cannot both observe it unconsumed and both
+		// succeed.
+		scanErr := tx.NewRaw(`
+			SELECT `+inviteColumns+`
+			  FROM invites
+			 WHERE token = ?
+			 FOR UPDATE
+		`, token).Scan(ctx, &invite)
+		if err := normalizeNoRows(scanErr); err != nil {
+			return err
+		}
+		if invite.ConsumedAt != nil {
+			return ErrInviteConsumed
+		}
+		if time.Now().After(invite.ExpiresAt) {
+			return ErrInviteExpired
+		}
+		var tenantType string
+		if err := tx.NewRaw(`SELECT type FROM tenants WHERE tenant_id = ?`, invite.TenantID).Scan(ctx, &tenantType); err != nil {
+			return normalizeNoRows(err)
+		}
+		if _, err := tx.NewRaw(`UPDATE invites SET consumed_at = now() WHERE invite_id = ?`, invite.InviteID).Exec(ctx); err != nil {
+			return err
+		}
+		invite.Token = "" // consumed; no longer meaningful to hand back
+		result = ConsumedInvite{Invite: invite, TenantType: tenantType}
+		return nil
+	})
+	return result, err
+}
+
+const inviteTokenBytes = 32
+
+// generateInviteToken mints a high-entropy, URL-safe opaque token — the
+// credential is the token itself (the accept endpoint is unauthenticated),
+// so it must not be guessable the way a sequential or short ID would be.
+func generateInviteToken() (string, error) {
+	raw := make([]byte, inviteTokenBytes)
+	if _, err := cryptorand.Read(raw); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}

--- a/erun-backend/erun-backend-api/internal/repository/invites_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/invites_e2e_test.go
@@ -1,0 +1,189 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// Invite creation/listing/revocation is RLS-protected like every other
+// tenant-owned table, and ConsumeByToken deliberately runs with no
+// authenticated security context at all (WithinSystemTx) — both properties
+// only mean something against a real migrated PostgreSQL, not a fake that
+// agrees with itself.
+func invitesDatabase(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	databaseURL := os.Getenv("ERUN_E2E_INVITES_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("opt-in: set ERUN_E2E_INVITES_DATABASE_URL to a migrated PostgreSQL")
+	}
+	db, err := sql.Open("pgx", databaseURL)
+	mustNoErr(t, err, "open db")
+	t.Cleanup(func() { _ = db.Close() })
+
+	tenantID := seedInvitesTenant(t, db, "invites-e2e", "COMPANY")
+	t.Cleanup(func() { clearInvitesTenant(t, db, tenantID) })
+	return db, tenantID
+}
+
+func seedInvitesTenant(t *testing.T, db *sql.DB, label, tenantType string) string {
+	t.Helper()
+	var tenantID string
+	err := db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, $2) RETURNING tenant_id`,
+		label+"-"+time.Now().Format("20060102150405.000000"), tenantType,
+	).Scan(&tenantID)
+	mustNoErr(t, err, "seed tenant")
+	return tenantID
+}
+
+func clearInvitesTenant(t *testing.T, db *sql.DB, tenantID string) {
+	t.Helper()
+	for _, table := range []string{"invites", "users", "tenants"} {
+		if _, err := db.Exec(`DELETE FROM `+table+` WHERE tenant_id = $1`, tenantID); err != nil {
+			t.Logf("clearing %s for tenant %s: %v", table, tenantID, err)
+		}
+	}
+}
+
+func seedInvitesUser(t *testing.T, db *sql.DB, tenantID, username string) string {
+	t.Helper()
+	var userID string
+	err := db.QueryRow(
+		`INSERT INTO users (tenant_id, username) VALUES ($1, $2) RETURNING user_id`,
+		tenantID, username,
+	).Scan(&userID)
+	mustNoErr(t, err, "seed user "+username)
+	return userID
+}
+
+func invitesContext(tenantID, tenantType, userID string) context.Context {
+	return security.WithContext(context.Background(), security.Context{
+		TenantID: tenantID, TenantType: tenantType, ErunUserID: userID,
+	})
+}
+
+// TestInviteCreateListRevoke locks the operator-facing CRUD contract (#1483
+// items 2/3): a created invite is listed as outstanding, and revoking it
+// both removes it from that list and refuses a second revoke.
+func TestInviteCreateListRevoke(t *testing.T) {
+	db, tenantID := invitesDatabase(t)
+	inviter := seedInvitesUser(t, db, tenantID, "inviter")
+	ctx := invitesContext(tenantID, "COMPANY", inviter)
+	repo := NewInviteRepository(NewTxManager(db, DialectPostgres))
+
+	invite, err := repo.Create(ctx, CreateInviteParams{Issuer: "https://auth.example.com", Email: "new@example.com", TTL: time.Hour})
+	mustNoErr(t, err, "create invite")
+	if invite.Token == "" {
+		t.Fatal("created invite has no token")
+	}
+	if invite.CreatedByUserID != inviter {
+		t.Fatalf("createdByUserId = %q, want the authenticated caller %q", invite.CreatedByUserID, inviter)
+	}
+
+	listed, err := repo.List(ctx, InviteFilter{TenantID: tenantID})
+	mustNoErr(t, err, "list invites")
+	if len(listed) != 1 || listed[0].InviteID != invite.InviteID {
+		t.Fatalf("listed %+v, want exactly the created invite", listed)
+	}
+
+	mustNoErr(t, repo.Revoke(ctx, invite.InviteID), "revoke invite")
+
+	listed, err = repo.List(ctx, InviteFilter{TenantID: tenantID})
+	mustNoErr(t, err, "list invites after revoke")
+	if len(listed) != 0 {
+		t.Fatalf("listed %d invites after revoke, want 0", len(listed))
+	}
+
+	if err := repo.Revoke(ctx, invite.InviteID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("revoking an already-revoked invite = %v, want ErrNotFound", err)
+	}
+}
+
+// TestInviteConsumeByTokenIsSingleUse locks #1483's single-use requirement:
+// a second accept of the same token is refused, asserted against the
+// persisted row (consumed_at set), not just the returned error.
+func TestInviteConsumeByTokenIsSingleUse(t *testing.T) {
+	db, tenantID := invitesDatabase(t)
+	inviter := seedInvitesUser(t, db, tenantID, "inviter")
+	ctx := invitesContext(tenantID, "COMPANY", inviter)
+	repo := NewInviteRepository(NewTxManager(db, DialectPostgres))
+
+	invite, err := repo.Create(ctx, CreateInviteParams{Issuer: "https://auth.example.com", TTL: time.Hour})
+	mustNoErr(t, err, "create invite")
+
+	consumed, err := repo.ConsumeByToken(context.Background(), invite.Token)
+	mustNoErr(t, err, "consume invite")
+	if consumed.Invite.InviteID != invite.InviteID {
+		t.Fatalf("consumed invite id = %q, want %q", consumed.Invite.InviteID, invite.InviteID)
+	}
+	if consumed.TenantType != "COMPANY" {
+		t.Fatalf("consumed tenant type = %q, want COMPANY", consumed.TenantType)
+	}
+
+	var consumedAt sql.NullTime
+	mustNoErr(t, db.QueryRow(`SELECT consumed_at FROM invites WHERE invite_id = $1`, invite.InviteID).Scan(&consumedAt), "read back consumed_at")
+	if !consumedAt.Valid {
+		t.Fatal("consumed_at was not persisted")
+	}
+
+	if _, err := repo.ConsumeByToken(context.Background(), invite.Token); !errors.Is(err, ErrInviteConsumed) {
+		t.Fatalf("second consume = %v, want ErrInviteConsumed", err)
+	}
+}
+
+// TestInviteConsumeByTokenRefusesExpiredAndUnknownTokens locks the other two
+// states #1483 asks to distinguish plainly: an expired invite and one that
+// never existed.
+func TestInviteConsumeByTokenRefusesExpiredAndUnknownTokens(t *testing.T) {
+	db, tenantID := invitesDatabase(t)
+	inviter := seedInvitesUser(t, db, tenantID, "inviter")
+	ctx := invitesContext(tenantID, "COMPANY", inviter)
+	repo := NewInviteRepository(NewTxManager(db, DialectPostgres))
+
+	expired, err := repo.Create(ctx, CreateInviteParams{Issuer: "https://auth.example.com", TTL: -time.Hour})
+	mustNoErr(t, err, "create already-expired invite")
+
+	if _, err := repo.ConsumeByToken(context.Background(), expired.Token); !errors.Is(err, ErrInviteExpired) {
+		t.Fatalf("consuming an expired invite = %v, want ErrInviteExpired", err)
+	}
+
+	if _, err := repo.ConsumeByToken(context.Background(), "not-a-real-token"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("consuming an unknown token = %v, want ErrNotFound", err)
+	}
+}
+
+// TestInviteCreateTargetingAnotherTenantRequiresExplicitOverride locks that
+// InviteFilter/CreateInviteParams' TenantID override actually scopes rows to
+// the named tenant rather than the caller's own session tenant — the
+// primitive resolveTargetTenant's OPERATIONS-only gate builds on at the
+// route layer.
+func TestInviteCreateTargetingAnotherTenantRequiresExplicitOverride(t *testing.T) {
+	db, callerTenantID := invitesDatabase(t)
+	otherTenantID := seedInvitesTenant(t, db, "invites-e2e-other", "COMPANY")
+	t.Cleanup(func() { clearInvitesTenant(t, db, otherTenantID) })
+	inviter := seedInvitesUser(t, db, callerTenantID, "inviter")
+	// erun_operations is what makes a cross-tenant explicit TenantID actually
+	// land against a different tenant than the caller's own session tenant.
+	ctx := invitesContext(callerTenantID, "OPERATIONS", inviter)
+	repo := NewInviteRepository(NewTxManager(db, DialectPostgres))
+
+	invite, err := repo.Create(ctx, CreateInviteParams{TenantID: otherTenantID, Issuer: "https://auth.example.com", TTL: time.Hour})
+	mustNoErr(t, err, "create invite for another tenant")
+	if invite.TenantID != otherTenantID {
+		t.Fatalf("invite tenantId = %q, want the targeted tenant %q", invite.TenantID, otherTenantID)
+	}
+
+	listedOwn, err := repo.List(ctx, InviteFilter{TenantID: callerTenantID})
+	mustNoErr(t, err, "list caller's own tenant")
+	if len(listedOwn) != 0 {
+		t.Fatalf("caller's own tenant listed %d invites, want 0 (the invite targeted the other tenant)", len(listedOwn))
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/tx.go
+++ b/erun-backend/erun-backend-api/internal/repository/tx.go
@@ -44,6 +44,30 @@ func (m *TxManager) WithinTx(ctx context.Context, fn func(context.Context, bun.T
 	return m.db.RunInTx(ctx, nil, fn)
 }
 
+// WithinSystemTx runs fn in a transaction bound to the erun_operations
+// database role with no caller identity and no tenant scoping — the narrow
+// escape hatch AGENTS.md's Row-Level Security section calls for "before
+// tenant context exists". Its one legitimate caller today is the invite
+// accept flow: resolving an unauthenticated invite token to its target
+// tenant has no security.Context to read a tenant from, the same problem
+// root resolution tables like tenant_issuers solve by carrying no RLS at
+// all, except invites is tenant-owned end to end (created, listed, and
+// revoked under normal per-tenant RLS) so it cannot go that route. Every
+// statement fn issues must name its own tenant_id explicitly:
+// erun_operations' RLS policy grants it every tenant's rows regardless of
+// erun.tenant_id, so nothing here provides tenant isolation on its own.
+func (m *TxManager) WithinSystemTx(ctx context.Context, fn func(context.Context, bun.Tx) error) error {
+	if m.dialect != DialectPostgres {
+		return m.db.RunInTx(ctx, nil, fn)
+	}
+	return m.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		if _, err := tx.ExecContext(ctx, `SET LOCAL ROLE erun_operations`); err != nil {
+			return err
+		}
+		return fn(ctx, tx)
+	})
+}
+
 func (m *TxManager) setPostgresSecurityContext(ctx context.Context, tx bun.Tx, securityContext security.Context) error {
 	role := "erun_tenant"
 	if securityContext.TenantType == "OPERATIONS" {

--- a/erun-backend/erun-backend-api/internal/routes/identity.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/zitadel"
@@ -32,9 +33,17 @@ type IdentityEnroller interface {
 	Enroll(ctx context.Context, params service.EnrollIdentityParams) (service.EnrollIdentityResult, error)
 }
 
+// EnrolledUserLister is the erun-side half of the Users list: which of the
+// IdP's identities are also enrolled erun users of the caller's own tenant.
+// *repository.UserRepository satisfies it.
+type EnrolledUserLister interface {
+	List(ctx context.Context, filter repository.UserFilter) ([]model.User, error)
+}
+
 type IdentityRoutes struct {
-	admin    IdentityAdminClient
-	enroller IdentityEnroller
+	admin     IdentityAdminClient
+	enroller  IdentityEnroller
+	erunUsers EnrolledUserLister
 }
 
 // RegisterIdentityRoutes registers the identity-administration surface
@@ -48,8 +57,8 @@ type IdentityRoutes struct {
 // is not a company tenant's business, and effective-permission gating still
 // applies on top via the normal role_permissions mechanism every registered
 // route already gets.
-func RegisterIdentityRoutes(register ProtectedRouteRegistrar, admin IdentityAdminClient, enroller IdentityEnroller) {
-	routes := IdentityRoutes{admin: admin, enroller: enroller}
+func RegisterIdentityRoutes(register ProtectedRouteRegistrar, admin IdentityAdminClient, enroller IdentityEnroller, erunUsers EnrolledUserLister) {
+	routes := IdentityRoutes{admin: admin, enroller: enroller, erunUsers: erunUsers}
 	register(http.MethodGet, "/v1/identity/users", http.HandlerFunc(routes.listUsers))
 	register(http.MethodPost, "/v1/identity/users", http.HandlerFunc(routes.createUser))
 	register(http.MethodPost, "/v1/identity/users/{external_id}/deactivate", http.HandlerFunc(routes.deactivateUser))
@@ -91,16 +100,60 @@ func (r IdentityRoutes) securityContext(w http.ResponseWriter, req *http.Request
 	return securityContext, true
 }
 
+// identityUserView reports one identity of the platform's IdP org alongside
+// whether it is also an enrolled erun user of the caller's own tenant. The
+// IdP's user list (zitadel.Client.ListUsers) and erun's own users table are
+// two separate systems — see that method's doc comment — so a row present
+// here with Enrolled=false is a self-registered or otherwise unmapped IdP
+// account that cannot use erun, not a tenant member, and must not render as
+// one.
+type identityUserView struct {
+	zitadel.User
+	Enrolled   bool   `json:"enrolled"`
+	ErunUserID string `json:"erunUserId,omitempty"`
+}
+
 func (r IdentityRoutes) listUsers(w http.ResponseWriter, req *http.Request) {
-	if _, ok := r.securityContext(w, req); !ok {
+	securityContext, ok := r.securityContext(w, req)
+	if !ok {
 		return
 	}
-	users, err := r.admin.ListUsers(req.Context())
+	idpUsers, err := r.admin.ListUsers(req.Context())
 	if err != nil {
 		writeIdentityAdminError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, users)
+	erunUsers, err := r.erunUsers.List(req.Context(), repository.UserFilter{TenantID: securityContext.TenantID})
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	views := mergeIdentityUsers(idpUsers, erunUsers)
+	writeJSON(w, http.StatusOK, views)
+}
+
+// mergeIdentityUsers cross-references the IdP's own identities against
+// erun's enrolled users of the caller's tenant by external subject
+// (zitadel.User.ID == model.User.ExternalUserID), so the console can tell a
+// tenant member apart from an IdP-only account instead of rendering every
+// row in the org identically.
+func mergeIdentityUsers(idpUsers []zitadel.User, erunUsers []model.User) []identityUserView {
+	enrolledBySubject := make(map[string]model.User, len(erunUsers))
+	for _, u := range erunUsers {
+		if u.ExternalUserID != "" {
+			enrolledBySubject[u.ExternalUserID] = u
+		}
+	}
+	views := make([]identityUserView, 0, len(idpUsers))
+	for _, u := range idpUsers {
+		view := identityUserView{User: u}
+		if erunUser, ok := enrolledBySubject[u.ID]; ok {
+			view.Enrolled = true
+			view.ErunUserID = erunUser.UserID
+		}
+		views = append(views, view)
+	}
+	return views
 }
 
 type enrollIdentityUserRequest struct {
@@ -231,6 +284,7 @@ func (r IdentityRoutes) getOrgSettings(w http.ResponseWriter, req *http.Request)
 // package's params type, keeping the HTTP contract owned by this layer.
 type updateOrgSettingsRequest struct {
 	ForceMFA                  *bool   `json:"forceMfa,omitempty"`
+	AllowRegister             *bool   `json:"allowRegister,omitempty"`
 	MinPasswordLength         *uint64 `json:"minPasswordLength,omitempty"`
 	PasswordRequiresUppercase *bool   `json:"passwordRequiresUppercase,omitempty"`
 	PasswordRequiresLowercase *bool   `json:"passwordRequiresLowercase,omitempty"`
@@ -249,6 +303,7 @@ func (r IdentityRoutes) updateOrgSettings(w http.ResponseWriter, req *http.Reque
 	}
 	settings, err := r.admin.UpdateOrgSettings(req.Context(), zitadel.UpdateOrgSettingsParams{
 		ForceMFA:                  body.ForceMFA,
+		AllowRegister:             body.AllowRegister,
 		MinPasswordLength:         body.MinPasswordLength,
 		PasswordRequiresUppercase: body.PasswordRequiresUppercase,
 		PasswordRequiresLowercase: body.PasswordRequiresLowercase,

--- a/erun-backend/erun-backend-api/internal/routes/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity_test.go
@@ -3,15 +3,26 @@ package routes
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/zitadel"
 )
+
+type stubEnrolledUserLister struct {
+	users []model.User
+	err   error
+}
+
+func (s *stubEnrolledUserLister) List(context.Context, repository.UserFilter) ([]model.User, error) {
+	return s.users, s.err
+}
 
 type stubIdentityAdminClient struct {
 	users             []zitadel.User
@@ -102,11 +113,48 @@ func TestListUsersForbidsNonOperationsTenant(t *testing.T) {
 
 func TestListUsersReturnsAdminResult(t *testing.T) {
 	admin := &stubIdentityAdminClient{users: []zitadel.User{{ID: "u1", Username: "alice"}}}
-	routes := IdentityRoutes{admin: admin}
+	routes := IdentityRoutes{admin: admin, erunUsers: &stubEnrolledUserLister{}}
 	rec := httptest.NewRecorder()
 	routes.listUsers(rec, identityRequest(http.MethodGet, "/v1/identity/users", "", string(model.TenantTypeOperations)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestListUsersDistinguishesEnrolledFromIdPOnly locks the core of #1482's
+// Users-page fix: a self-registered IdP account with no erun mapping must
+// not render identically to an actual tenant member. It also proves the
+// machine-account signal survives the merge unchanged.
+func TestListUsersDistinguishesEnrolledFromIdPOnly(t *testing.T) {
+	admin := &stubIdentityAdminClient{users: []zitadel.User{
+		{ID: "sub-alice", Username: "alice", Email: "alice@example.com"},
+		{ID: "sub-stranger", Username: "stranger", Email: "stranger@example.com"},
+		{ID: "sub-svc", Username: "admin-sa", IsMachine: true},
+	}}
+	erunUsers := &stubEnrolledUserLister{users: []model.User{
+		{UserID: "erun-alice", Username: "alice", ExternalUserID: "sub-alice"},
+	}}
+	routes := IdentityRoutes{admin: admin, erunUsers: erunUsers}
+	rec := httptest.NewRecorder()
+	routes.listUsers(rec, identityRequest(http.MethodGet, "/v1/identity/users", "", string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var views []identityUserView
+	if err := json.Unmarshal(rec.Body.Bytes(), &views); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(views) != 3 {
+		t.Fatalf("got %d views, want 3", len(views))
+	}
+	if !views[0].Enrolled || views[0].ErunUserID != "erun-alice" {
+		t.Fatalf("views[0] (alice) = %+v, want Enrolled with erun-alice", views[0])
+	}
+	if views[1].Enrolled || views[1].ErunUserID != "" {
+		t.Fatalf("views[1] (stranger) = %+v, want not enrolled", views[1])
+	}
+	if !views[2].IsMachine || views[2].Enrolled {
+		t.Fatalf("views[2] (admin-sa) = %+v, want a machine account, not enrolled", views[2])
 	}
 }
 
@@ -209,6 +257,28 @@ func TestUpdateOrgSettingsPassesOnlyProvidedFields(t *testing.T) {
 	}
 	if admin.gotUpdateParams.MinPasswordLength != nil {
 		t.Fatalf("gotUpdateParams.MinPasswordLength = %v, want nil when not provided", admin.gotUpdateParams.MinPasswordLength)
+	}
+	if admin.gotUpdateParams.AllowRegister != nil {
+		t.Fatalf("gotUpdateParams.AllowRegister = %v, want nil when not provided", admin.gotUpdateParams.AllowRegister)
+	}
+}
+
+// TestUpdateOrgSettingsThreadsAllowRegister locks the actual lever #1482
+// asks for: closing (or reopening) self-registration must reach the
+// Zitadel client's params, the same way forceMfa already does.
+func TestUpdateOrgSettingsThreadsAllowRegister(t *testing.T) {
+	admin := &stubIdentityAdminClient{}
+	routes := IdentityRoutes{admin: admin}
+	rec := httptest.NewRecorder()
+	routes.updateOrgSettings(rec, identityRequest(http.MethodPatch, "/v1/identity/org-settings", `{"allowRegister":false}`, string(model.TenantTypeOperations)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if admin.gotUpdateParams.AllowRegister == nil || *admin.gotUpdateParams.AllowRegister {
+		t.Fatalf("gotUpdateParams.AllowRegister = %v, want false", admin.gotUpdateParams.AllowRegister)
+	}
+	if admin.gotUpdateParams.ForceMFA != nil {
+		t.Fatalf("gotUpdateParams.ForceMFA = %v, want nil when not provided", admin.gotUpdateParams.ForceMFA)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/routes/invites.go
+++ b/erun-backend/erun-backend-api/internal/routes/invites.go
@@ -1,0 +1,200 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/zitadel"
+)
+
+// inviteTTL is the fixed lifetime every invite is minted with (#1483 item 7:
+// invites expire by default). Not yet operator-configurable — a fixed,
+// honest default is simpler than a per-invite input nobody has asked for.
+const inviteTTL = 7 * 24 * time.Hour
+
+// InviteStore is the persistence dependency for POST/GET/DELETE /v1/invites.
+// *repository.InviteRepository satisfies it.
+type InviteStore interface {
+	Create(ctx context.Context, params repository.CreateInviteParams) (model.Invite, error)
+	List(ctx context.Context, filter repository.InviteFilter) ([]model.Invite, error)
+	Revoke(ctx context.Context, inviteID string) error
+}
+
+type InviteRoutes struct {
+	invites InviteStore
+}
+
+// RegisterInviteRoutes registers the authenticated half of #1483's
+// invite-only registration model: an enrolled user creates, lists, and
+// revokes invites for a tenant they can access. Unlike identity
+// administration (which is restricted to an OPERATIONS tenant, since it
+// manages the platform's shared IdP org settings), invite creation is open
+// to every tenant — a COMPANY tenant needs its own way to add members, and
+// resolveTargetTenant already gates the one case that needs to stay
+// OPERATIONS-only: minting an invite for a tenant other than the caller's
+// own, which is how an invite to an OPERATIONS tenant (a cross-tenant grant
+// by URL) gets its own explicit gate today, ahead of #1481's finer-grained
+// permission.
+func RegisterInviteRoutes(register ProtectedRouteRegistrar, invites InviteStore) {
+	routes := InviteRoutes{invites: invites}
+	register(http.MethodPost, "/v1/invites", http.HandlerFunc(routes.createInvite))
+	register(http.MethodGet, "/v1/invites", http.HandlerFunc(routes.listInvites))
+	register(http.MethodDelete, "/v1/invites/{invite_id}", http.HandlerFunc(routes.revokeInvite))
+}
+
+type createInviteRequest struct {
+	Email    string `json:"email,omitempty"`
+	TenantID string `json:"tenantId,omitempty"`
+}
+
+func (r InviteRoutes) createInvite(w http.ResponseWriter, req *http.Request) {
+	securityContext, ok := security.FromContext(req.Context())
+	if !ok {
+		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		return
+	}
+	var body createInviteRequest
+	if err := decodeJSON(req, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	targetTenantID, err := resolveTargetTenant(securityContext, body.TenantID)
+	if err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+	// TenantID is only passed through when it differs from the caller's own
+	// session tenant, the same convention CreateUserParams uses.
+	overrideTenantID := ""
+	if targetTenantID != securityContext.TenantID {
+		overrideTenantID = targetTenantID
+	}
+
+	invite, err := r.invites.Create(req.Context(), repository.CreateInviteParams{
+		TenantID: overrideTenantID,
+		Issuer:   securityContext.ExternalIssuer,
+		Email:    strings.TrimSpace(body.Email),
+		TTL:      inviteTTL,
+	})
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, invite)
+}
+
+func (r InviteRoutes) listInvites(w http.ResponseWriter, req *http.Request) {
+	securityContext, ok := security.FromContext(req.Context())
+	if !ok {
+		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		return
+	}
+	targetTenantID, err := resolveTargetTenant(securityContext, req.URL.Query().Get("tenantId"))
+	if err != nil {
+		writeError(w, http.StatusForbidden, err.Error())
+		return
+	}
+	invites, err := r.invites.List(req.Context(), repository.InviteFilter{TenantID: targetTenantID})
+	if err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, invites)
+}
+
+func (r InviteRoutes) revokeInvite(w http.ResponseWriter, req *http.Request) {
+	if err := r.invites.Revoke(req.Context(), req.PathValue("invite_id")); err != nil {
+		writeRepositoryError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// InviteAccepter accepts an invite token and enrolls the invitee.
+// *service.InviteService satisfies it.
+type InviteAccepter interface {
+	Accept(ctx context.Context, params service.AcceptInviteParams) (service.AcceptInviteResult, error)
+}
+
+type acceptInviteRequest struct {
+	Token     string `json:"token"`
+	Username  string `json:"username"`
+	Email     string `json:"email,omitempty"`
+	FirstName string `json:"firstName,omitempty"`
+	LastName  string `json:"lastName,omitempty"`
+	Password  string `json:"password"`
+}
+
+// acceptInviteResponse mirrors enrollIdentityUserResponse's half-landed
+// shape: ErunUser absent with Error set means the IdP identity was created
+// but the erun-side mapping failed, reported rather than swallowed.
+type acceptInviteResponse struct {
+	IdPUser  zitadel.User `json:"idpUser"`
+	ErunUser *model.User  `json:"erunUser,omitempty"`
+	Error    string       `json:"error,omitempty"`
+}
+
+// RegisterInviteAcceptRoute registers POST /v1/invites/accept directly on
+// the mux, unauthenticated: an invitee accepting an invite has no bearer
+// token yet — the token in the request body is the credential, the same
+// shape the DNS-01 broker and registry token routes already use for a
+// caller that authenticates some other way than the user-OIDC bearer token.
+func RegisterInviteAcceptRoute(mux *http.ServeMux, accepter InviteAccepter) {
+	mux.HandleFunc("POST /v1/invites/accept", func(w http.ResponseWriter, req *http.Request) {
+		var body acceptInviteRequest
+		if err := decodeJSON(req, &body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		token := strings.TrimSpace(body.Token)
+		username := strings.TrimSpace(body.Username)
+		password := strings.TrimSpace(body.Password)
+		if token == "" || username == "" || password == "" {
+			writeError(w, http.StatusBadRequest, "token, username, and password are required")
+			return
+		}
+		result, err := accepter.Accept(req.Context(), service.AcceptInviteParams{
+			Token:     token,
+			Username:  username,
+			Email:     strings.TrimSpace(body.Email),
+			FirstName: strings.TrimSpace(body.FirstName),
+			LastName:  strings.TrimSpace(body.LastName),
+			Password:  password,
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrIdentityMappingFailed) {
+				writeJSON(w, http.StatusCreated, acceptInviteResponse{IdPUser: result.IdPUser, Error: err.Error()})
+				return
+			}
+			writeInviteAcceptError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusCreated, acceptInviteResponse{IdPUser: result.IdPUser, ErunUser: &result.ErunUser})
+	})
+}
+
+// writeInviteAcceptError distinguishes the token-shaped failures #1483 asks
+// to report plainly (not found, expired, already consumed) from a downstream
+// Zitadel failure, which forwards the IdP's own real status and message the
+// same way writeIdentityAdminError does.
+func writeInviteAcceptError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, repository.ErrNotFound):
+		writeError(w, http.StatusNotFound, "invite link is invalid")
+	case errors.Is(err, repository.ErrInviteExpired):
+		writeError(w, http.StatusGone, "invite link has expired")
+	case errors.Is(err, repository.ErrInviteConsumed):
+		writeError(w, http.StatusGone, "invite link has already been used")
+	case errors.Is(err, service.ErrInviteEmailMismatch):
+		writeError(w, http.StatusBadRequest, err.Error())
+	default:
+		writeIdentityAdminError(w, err)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/invites_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/invites_test.go
@@ -1,0 +1,214 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/zitadel"
+)
+
+type stubInviteStore struct {
+	created    model.Invite
+	createErr  error
+	gotCreate  repository.CreateInviteParams
+	listed     []model.Invite
+	listErr    error
+	gotFilter  repository.InviteFilter
+	revokeErr  error
+	gotRevoked string
+}
+
+func (s *stubInviteStore) Create(_ context.Context, params repository.CreateInviteParams) (model.Invite, error) {
+	s.gotCreate = params
+	return s.created, s.createErr
+}
+
+func (s *stubInviteStore) List(_ context.Context, filter repository.InviteFilter) ([]model.Invite, error) {
+	s.gotFilter = filter
+	return s.listed, s.listErr
+}
+
+func (s *stubInviteStore) Revoke(_ context.Context, inviteID string) error {
+	s.gotRevoked = inviteID
+	return s.revokeErr
+}
+
+func inviteRequest(method, path, body, tenantID, tenantType, issuer string) *http.Request {
+	reader := bytes.NewBufferString(body)
+	req := httptest.NewRequest(method, path, reader)
+	return req.WithContext(security.WithContext(req.Context(), security.Context{
+		TenantID:       tenantID,
+		TenantType:     tenantType,
+		ErunUserID:     "caller-user",
+		ExternalIssuer: issuer,
+	}))
+}
+
+func TestCreateInviteForOwnTenantIsAllowedForAnyTenantType(t *testing.T) {
+	store := &stubInviteStore{created: model.Invite{InviteID: "invite-1", TenantID: "tenant-a", Token: "tok"}}
+	routes := InviteRoutes{invites: store}
+	rec := httptest.NewRecorder()
+	routes.createInvite(rec, inviteRequest(http.MethodPost, "/v1/invites", `{"email":"new@example.com"}`, "tenant-a", string(model.TenantTypeCompany), "https://auth.example.com"))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if store.gotCreate.TenantID != "" {
+		t.Fatalf("TenantID override = %q, want empty for the caller's own tenant", store.gotCreate.TenantID)
+	}
+	if store.gotCreate.Issuer != "https://auth.example.com" {
+		t.Fatalf("Issuer = %q, want the caller's own authenticated issuer", store.gotCreate.Issuer)
+	}
+}
+
+// TestCreateInviteForAnotherTenantRequiresOperations locks #1483 item 4's
+// coarse gate: a COMPANY-tenant caller cannot mint an invite for a tenant
+// other than their own.
+func TestCreateInviteForAnotherTenantRequiresOperations(t *testing.T) {
+	store := &stubInviteStore{}
+	routes := InviteRoutes{invites: store}
+	rec := httptest.NewRecorder()
+	routes.createInvite(rec, inviteRequest(http.MethodPost, "/v1/invites", `{"tenantId":"tenant-b"}`, "tenant-a", string(model.TenantTypeCompany), "https://auth.example.com"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+func TestCreateInviteForAnotherTenantSucceedsForOperations(t *testing.T) {
+	store := &stubInviteStore{created: model.Invite{InviteID: "invite-2", TenantID: "tenant-b"}}
+	routes := InviteRoutes{invites: store}
+	rec := httptest.NewRecorder()
+	routes.createInvite(rec, inviteRequest(http.MethodPost, "/v1/invites", `{"tenantId":"tenant-b"}`, "tenant-ops", string(model.TenantTypeOperations), "https://auth.example.com"))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	if store.gotCreate.TenantID != "tenant-b" {
+		t.Fatalf("TenantID override = %q, want tenant-b", store.gotCreate.TenantID)
+	}
+}
+
+func TestListInvitesScopesToTheResolvedTenant(t *testing.T) {
+	store := &stubInviteStore{listed: []model.Invite{{InviteID: "invite-1"}}}
+	routes := InviteRoutes{invites: store}
+	rec := httptest.NewRecorder()
+	routes.listInvites(rec, inviteRequest(http.MethodGet, "/v1/invites", "", "tenant-a", string(model.TenantTypeCompany), "https://auth.example.com"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if store.gotFilter.TenantID != "tenant-a" {
+		t.Fatalf("TenantID filter = %q, want the caller's own tenant", store.gotFilter.TenantID)
+	}
+}
+
+func TestRevokeInviteNotFound(t *testing.T) {
+	store := &stubInviteStore{revokeErr: repository.ErrNotFound}
+	routes := InviteRoutes{invites: store}
+	req := inviteRequest(http.MethodDelete, "/v1/invites/invite-1", "", "tenant-a", string(model.TenantTypeCompany), "https://auth.example.com")
+	req.SetPathValue("invite_id", "invite-1")
+	rec := httptest.NewRecorder()
+	routes.revokeInvite(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if store.gotRevoked != "invite-1" {
+		t.Fatalf("gotRevoked = %q, want invite-1", store.gotRevoked)
+	}
+}
+
+type stubInviteAccepter struct {
+	result service.AcceptInviteResult
+	err    error
+}
+
+func (s *stubInviteAccepter) Accept(context.Context, service.AcceptInviteParams) (service.AcceptInviteResult, error) {
+	return s.result, s.err
+}
+
+func acceptRequest(body string) *http.Request {
+	return httptest.NewRequest(http.MethodPost, "/v1/invites/accept", bytes.NewBufferString(body))
+}
+
+func TestInviteAcceptRequiresTokenUsernameAndPassword(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterInviteAcceptRoute(mux, &stubInviteAccepter{})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, acceptRequest(`{"username":"someone","password":"pw"}`))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for a missing token; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestInviteAcceptSucceeds(t *testing.T) {
+	accepter := &stubInviteAccepter{result: service.AcceptInviteResult{
+		IdPUser:  zitadel.User{ID: "idp-1", Username: "newbie"},
+		ErunUser: model.User{UserID: "erun-1", Username: "newbie"},
+	}}
+	mux := http.NewServeMux()
+	RegisterInviteAcceptRoute(mux, accepter)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, acceptRequest(`{"token":"tok","username":"newbie","password":"S3cret!Pass"}`))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp acceptInviteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ErunUser == nil || resp.ErunUser.UserID != "erun-1" {
+		t.Fatalf("resp.ErunUser = %+v, want erun-1", resp.ErunUser)
+	}
+}
+
+// TestInviteAcceptReportsEachTokenStatePlainly locks #1483 item 7: a stale
+// or revoked link says exactly why, rather than a generic failure.
+func TestInviteAcceptReportsEachTokenStatePlainly(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"unknown token", repository.ErrNotFound, http.StatusNotFound},
+		{"expired", repository.ErrInviteExpired, http.StatusGone},
+		{"already consumed", repository.ErrInviteConsumed, http.StatusGone},
+		{"email mismatch", service.ErrInviteEmailMismatch, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			RegisterInviteAcceptRoute(mux, &stubInviteAccepter{err: tc.err})
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, acceptRequest(`{"token":"tok","username":"newbie","password":"S3cret!Pass"}`))
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d for %s; body=%s", rec.Code, tc.want, tc.name, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestInviteAcceptReportsHalfLandedFailure(t *testing.T) {
+	accepter := &stubInviteAccepter{
+		result: service.AcceptInviteResult{IdPUser: zitadel.User{ID: "idp-9", Username: "orphan"}},
+		err:    service.ErrIdentityMappingFailed,
+	}
+	mux := http.NewServeMux()
+	RegisterInviteAcceptRoute(mux, accepter)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, acceptRequest(`{"token":"tok","username":"orphan","password":"S3cret!Pass"}`))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201 (IdP half landed); body=%s", rec.Code, rec.Body.String())
+	}
+	var resp acceptInviteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Error == "" || resp.ErunUser != nil || resp.IdPUser.ID != "idp-9" {
+		t.Fatalf("resp = %+v, want the orphaned IdP identity reported with an error and no erunUser", resp)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/service/invites.go
+++ b/erun-backend/erun-backend-api/internal/service/invites.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/zitadel"
+)
+
+// InviteConsumer resolves and consumes an invite token.
+// *repository.InviteRepository satisfies it.
+type InviteConsumer interface {
+	ConsumeByToken(ctx context.Context, token string) (repository.ConsumedInvite, error)
+}
+
+// InviteZitadelAdmin is the Zitadel surface AcceptInvite needs. *zitadel.Client satisfies it.
+type InviteZitadelAdmin interface {
+	CreateHumanUser(ctx context.Context, params zitadel.CreateHumanUserParams) (zitadel.User, error)
+}
+
+// ErrInviteEmailMismatch reports that the invite pinned a specific email and
+// the accepting request supplied a different one.
+var ErrInviteEmailMismatch = errors.New("invite is pinned to a different email address")
+
+// InviteService coordinates invite acceptance: consuming the token, creating
+// the IdP identity, and creating the erun user mapping are three separate
+// systems that must agree on the outcome, the same shape IdentityService
+// already coordinates for admin-composed enrollment.
+type InviteService struct {
+	invites InviteConsumer
+	admin   InviteZitadelAdmin
+	users   IdentityUserCreator
+}
+
+func NewInviteService(invites InviteConsumer, admin InviteZitadelAdmin, users IdentityUserCreator) *InviteService {
+	return &InviteService{invites: invites, admin: admin, users: users}
+}
+
+// AcceptInviteParams is the accept-flow input. Unauthenticated — the token
+// itself is the only credential the caller presents — so every other field
+// is supplied by the invitee.
+type AcceptInviteParams struct {
+	Token     string
+	Username  string
+	Email     string
+	FirstName string
+	LastName  string
+	Password  string
+}
+
+// AcceptInviteResult reports what actually landed, mirroring
+// EnrollIdentityResult's half-landed-failure shape: ErunUser is the zero
+// value when the erun-side mapping failed after the IdP user was created,
+// and IdPUser is still populated so the caller can report the orphaned IdP
+// identity precisely.
+type AcceptInviteResult struct {
+	IdPUser  zitadel.User
+	ErunUser model.User
+}
+
+// Accept consumes an invite token and lands the invitee as an enrolled erun
+// user of the invite's target tenant.
+//
+// Unlike Enroll's admin-composed path — which never sets a caller-supplied
+// password, so no admin ever handles a credential belonging to someone
+// else's account (see zitadel.CreateHumanUserParams' own doc) — the
+// invitee is present and choosing their own password right now: there is no
+// "someone else's account" to protect them from, and Zitadel's usual
+// email-invite flow would be the wrong choice regardless, since that link
+// has nothing to do with the credential just supplied. So this always sets
+// InitialPassword, which also marks the email verified and lands
+// USER_STATE_ACTIVE immediately — the same combination CreateHumanUser
+// already uses for the no-SMTP fallback, reused here for a different
+// reason (a present invitee, not absent mail).
+func (s *InviteService) Accept(ctx context.Context, params AcceptInviteParams) (AcceptInviteResult, error) {
+	consumed, err := s.invites.ConsumeByToken(ctx, params.Token)
+	if err != nil {
+		return AcceptInviteResult{}, err
+	}
+	invite := consumed.Invite
+
+	email := strings.TrimSpace(params.Email)
+	switch {
+	case invite.Email == "":
+		// no pinned email; use whatever the invitee supplied
+	case email == "":
+		email = invite.Email
+	case !strings.EqualFold(email, invite.Email):
+		return AcceptInviteResult{}, ErrInviteEmailMismatch
+	}
+
+	idpUser, err := s.admin.CreateHumanUser(ctx, zitadel.CreateHumanUserParams{
+		Username:        params.Username,
+		Email:           email,
+		FirstName:       params.FirstName,
+		LastName:        params.LastName,
+		InitialPassword: params.Password,
+	})
+	if err != nil {
+		return AcceptInviteResult{}, fmt.Errorf("create identity provider user: %w", err)
+	}
+
+	// The invite's target tenant is not the ctx caller's tenant (there is no
+	// caller) — it is a synthetic security context built from what
+	// ConsumeByToken resolved, the same "resolve tenant, then bind its own
+	// security context" shape IdentityRepository's per-tenant first-user
+	// bootstrap already uses for an equally caller-less enrollment.
+	tenantCtx := security.WithContext(ctx, security.Context{
+		TenantID:   invite.TenantID,
+		TenantType: consumed.TenantType,
+	})
+	erunUser, err := s.users.Create(tenantCtx, repository.CreateUserParams{
+		Username: params.Username,
+		Issuer:   invite.Issuer,
+		Subject:  idpUser.ID,
+	})
+	if err != nil {
+		return AcceptInviteResult{IdPUser: idpUser}, fmt.Errorf("%w: idp user id %s: %w", ErrIdentityMappingFailed, idpUser.ID, err)
+	}
+	return AcceptInviteResult{IdPUser: idpUser, ErunUser: erunUser}, nil
+}

--- a/erun-backend/erun-backend-api/internal/service/invites_test.go
+++ b/erun-backend/erun-backend-api/internal/service/invites_test.go
@@ -1,0 +1,176 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/zitadel"
+)
+
+type stubInviteConsumer struct {
+	result   repository.ConsumedInvite
+	err      error
+	gotToken string
+	calls    int
+}
+
+func (s *stubInviteConsumer) ConsumeByToken(_ context.Context, token string) (repository.ConsumedInvite, error) {
+	s.gotToken = token
+	s.calls++
+	return s.result, s.err
+}
+
+type stubInviteZitadelAdmin struct {
+	user      zitadel.User
+	err       error
+	gotParams zitadel.CreateHumanUserParams
+	calls     int
+}
+
+func (s *stubInviteZitadelAdmin) CreateHumanUser(_ context.Context, params zitadel.CreateHumanUserParams) (zitadel.User, error) {
+	s.gotParams = params
+	s.calls++
+	return s.user, s.err
+}
+
+type stubInviteUserCreator struct {
+	user               model.User
+	err                error
+	gotParams          repository.CreateUserParams
+	gotSecurityContext security.Context
+	calls              int
+}
+
+func (s *stubInviteUserCreator) Create(ctx context.Context, params repository.CreateUserParams) (model.User, error) {
+	s.gotParams = params
+	s.calls++
+	if sc, ok := security.FromContext(ctx); ok {
+		s.gotSecurityContext = sc
+	}
+	return s.user, s.err
+}
+
+func testConsumedInvite() repository.ConsumedInvite {
+	return repository.ConsumedInvite{
+		Invite: model.Invite{
+			InviteID: "invite-1",
+			TenantID: "tenant-1",
+			Issuer:   "https://auth.example.com",
+		},
+		TenantType: "COMPANY",
+	}
+}
+
+// TestAcceptInviteHappyPath locks the core of #1483's accept flow: a
+// consumed invite's tenant and issuer drive the IdP identity and the erun
+// user mapping, bound to the invite's own target tenant rather than any
+// caller session (there is none).
+func TestAcceptInviteHappyPath(t *testing.T) {
+	invites := &stubInviteConsumer{result: testConsumedInvite()}
+	admin := &stubInviteZitadelAdmin{user: zitadel.User{ID: "idp-1", Username: "newbie"}}
+	users := &stubInviteUserCreator{user: model.User{UserID: "erun-1", Username: "newbie"}}
+	svc := NewInviteService(invites, admin, users)
+
+	result, err := svc.Accept(context.Background(), AcceptInviteParams{
+		Token: "tok-abc", Username: "newbie", Email: "newbie@example.com", Password: "S3cret!Pass",
+	})
+	if err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if invites.gotToken != "tok-abc" {
+		t.Fatalf("gotToken = %q, want tok-abc", invites.gotToken)
+	}
+	if admin.gotParams.InitialPassword != "S3cret!Pass" {
+		t.Fatalf("InitialPassword = %q, want the invitee's own chosen password", admin.gotParams.InitialPassword)
+	}
+	if users.gotParams.Issuer != "https://auth.example.com" || users.gotParams.Subject != "idp-1" {
+		t.Fatalf("CreateUserParams = %+v, want the invite's issuer and the new IdP subject", users.gotParams)
+	}
+	if users.gotSecurityContext.TenantID != "tenant-1" || users.gotSecurityContext.TenantType != "COMPANY" {
+		t.Fatalf("security context = %+v, want bound to the invite's own target tenant", users.gotSecurityContext)
+	}
+	if result.IdPUser.ID != "idp-1" || result.ErunUser.UserID != "erun-1" {
+		t.Fatalf("result = %+v, want both halves landed", result)
+	}
+}
+
+// TestAcceptInviteReportsHalfLandedFailure mirrors Enroll's own contract:
+// an erun-side mapping failure after the IdP identity was created is
+// reported with the orphaned IdP user still attached, not swallowed.
+func TestAcceptInviteReportsHalfLandedFailure(t *testing.T) {
+	invites := &stubInviteConsumer{result: testConsumedInvite()}
+	admin := &stubInviteZitadelAdmin{user: zitadel.User{ID: "idp-2", Username: "orphan"}}
+	users := &stubInviteUserCreator{err: errors.New("db unavailable")}
+	svc := NewInviteService(invites, admin, users)
+
+	result, err := svc.Accept(context.Background(), AcceptInviteParams{Token: "tok", Username: "orphan", Password: "S3cret!Pass"})
+	if !errors.Is(err, ErrIdentityMappingFailed) {
+		t.Fatalf("err = %v, want ErrIdentityMappingFailed", err)
+	}
+	if result.IdPUser.ID != "idp-2" {
+		t.Fatalf("result.IdPUser = %+v, want the orphaned IdP identity reported", result.IdPUser)
+	}
+}
+
+// TestAcceptInviteRefusesEmailMismatch locks the pinned-email option (#1483
+// item 2): a request that supplies a different email than the invite was
+// pinned to is refused before ever reaching the identity provider.
+func TestAcceptInviteRefusesEmailMismatch(t *testing.T) {
+	pinned := testConsumedInvite()
+	pinned.Invite.Email = "expected@example.com"
+	invites := &stubInviteConsumer{result: pinned}
+	admin := &stubInviteZitadelAdmin{}
+	users := &stubInviteUserCreator{}
+	svc := NewInviteService(invites, admin, users)
+
+	_, err := svc.Accept(context.Background(), AcceptInviteParams{
+		Token: "tok", Username: "someone", Email: "different@example.com", Password: "S3cret!Pass",
+	})
+	if !errors.Is(err, ErrInviteEmailMismatch) {
+		t.Fatalf("err = %v, want ErrInviteEmailMismatch", err)
+	}
+	if admin.calls != 0 {
+		t.Fatalf("CreateHumanUser was called %d times, want 0 for a refused mismatch", admin.calls)
+	}
+}
+
+// TestAcceptInviteUsesPinnedEmailWhenRequestOmitsIt proves the pinned email
+// is not just a validation check — it is used when the accepting request
+// leaves email blank.
+func TestAcceptInviteUsesPinnedEmailWhenRequestOmitsIt(t *testing.T) {
+	pinned := testConsumedInvite()
+	pinned.Invite.Email = "expected@example.com"
+	invites := &stubInviteConsumer{result: pinned}
+	admin := &stubInviteZitadelAdmin{user: zitadel.User{ID: "idp-3"}}
+	users := &stubInviteUserCreator{user: model.User{UserID: "erun-3"}}
+	svc := NewInviteService(invites, admin, users)
+
+	if _, err := svc.Accept(context.Background(), AcceptInviteParams{Token: "tok", Username: "someone", Password: "S3cret!Pass"}); err != nil {
+		t.Fatalf("Accept: %v", err)
+	}
+	if admin.gotParams.Email != "expected@example.com" {
+		t.Fatalf("Email = %q, want the invite's pinned email", admin.gotParams.Email)
+	}
+}
+
+// TestAcceptInvitePropagatesConsumeFailureWithoutCallingZitadel locks that a
+// bad token (expired, consumed, unknown) never reaches the identity
+// provider at all.
+func TestAcceptInvitePropagatesConsumeFailureWithoutCallingZitadel(t *testing.T) {
+	invites := &stubInviteConsumer{err: repository.ErrInviteExpired}
+	admin := &stubInviteZitadelAdmin{}
+	users := &stubInviteUserCreator{}
+	svc := NewInviteService(invites, admin, users)
+
+	_, err := svc.Accept(context.Background(), AcceptInviteParams{Token: "tok", Username: "someone", Password: "S3cret!Pass"})
+	if !errors.Is(err, repository.ErrInviteExpired) {
+		t.Fatalf("err = %v, want ErrInviteExpired", err)
+	}
+	if admin.calls != 0 {
+		t.Fatalf("CreateHumanUser was called %d times, want 0 for an expired token", admin.calls)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/zitadel/client.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client.go
@@ -161,7 +161,11 @@ func truncate(body []byte, limit int) string {
 }
 
 // User is a Zitadel IdP identity, as much of it as identity administration
-// needs to display and act on.
+// needs to display and act on. IsMachine distinguishes the org's own
+// service identities (e.g. login-client, admin-sa) from human accounts —
+// Zitadel's _search response carries a "machine" object in exactly the
+// cases "human" is absent, so the two are read as a pair rather than
+// inferring one from the other's absence.
 type User struct {
 	ID        string `json:"id"`
 	Username  string `json:"username"`
@@ -169,6 +173,7 @@ type User struct {
 	Email     string `json:"email"`
 	FirstName string `json:"firstName"`
 	LastName  string `json:"lastName"`
+	IsMachine bool   `json:"isMachine"`
 }
 
 type usersSearchResponse struct {
@@ -188,10 +193,13 @@ type userSearchResult struct {
 			Email string `json:"email"`
 		} `json:"email"`
 	} `json:"human"`
+	Machine *struct {
+		Name string `json:"name"`
+	} `json:"machine"`
 }
 
 func (r userSearchResult) toUser() User {
-	u := User{ID: r.ID, Username: r.UserName, State: r.State}
+	u := User{ID: r.ID, Username: r.UserName, State: r.State, IsMachine: r.Machine != nil}
 	if r.Human == nil {
 		return u
 	}

--- a/erun-backend/erun-backend-api/internal/zitadel/client_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client_test.go
@@ -129,7 +129,12 @@ func TestListUsers(t *testing.T) {
 						"email":   map[string]any{"email": "alice@example.com"},
 					},
 				},
-				{"id": "svc1", "userName": "admin-sa", "state": "USER_STATE_ACTIVE"},
+				{
+					"id":       "svc1",
+					"userName": "admin-sa",
+					"state":    "USER_STATE_ACTIVE",
+					"machine":  map[string]any{"name": "admin-sa"},
+				},
 			},
 		})
 	})
@@ -143,8 +148,8 @@ func TestListUsers(t *testing.T) {
 	if users[0] != (User{ID: "u1", Username: "alice", State: "USER_STATE_ACTIVE", Email: "alice@example.com", FirstName: "Alice", LastName: "Operator"}) {
 		t.Fatalf("users[0] = %+v", users[0])
 	}
-	if users[1].ID != "svc1" || users[1].Email != "" {
-		t.Fatalf("users[1] = %+v, want a machine user with no email", users[1])
+	if users[1].ID != "svc1" || users[1].Email != "" || !users[1].IsMachine {
+		t.Fatalf("users[1] = %+v, want a machine user with no email and IsMachine=true", users[1])
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/zitadel/policies.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/policies.go
@@ -69,11 +69,13 @@ type domainSearchResponse struct {
 }
 
 // OrgSettings is the operator-facing view of the org settings an operator
-// actually changes: whether MFA is required, the password complexity rules,
-// and the org's verified domains (read-only here — verifying a domain is a
-// DNS/HTTP challenge flow this surface does not drive).
+// actually changes: whether MFA is required, whether the platform's IdP
+// accepts self-registration, the password complexity rules, and the org's
+// verified domains (read-only here — verifying a domain is a DNS/HTTP
+// challenge flow this surface does not drive).
 type OrgSettings struct {
 	ForceMFA                  bool     `json:"forceMfa"`
+	AllowRegister             bool     `json:"allowRegister"`
 	MinPasswordLength         uint64   `json:"minPasswordLength"`
 	PasswordRequiresUppercase bool     `json:"passwordRequiresUppercase"`
 	PasswordRequiresLowercase bool     `json:"passwordRequiresLowercase"`
@@ -87,6 +89,7 @@ type OrgSettings struct {
 // GET-then-POST round-trip in UpdateOrgSettings.
 type UpdateOrgSettingsParams struct {
 	ForceMFA                  *bool
+	AllowRegister             *bool
 	MinPasswordLength         *uint64
 	PasswordRequiresUppercase *bool
 	PasswordRequiresLowercase *bool
@@ -115,6 +118,7 @@ func (c *Client) GetOrgSettings(ctx context.Context) (OrgSettings, error) {
 	}
 	return OrgSettings{
 		ForceMFA:                  login.ForceMFA,
+		AllowRegister:             login.AllowRegister,
 		MinPasswordLength:         minLength,
 		PasswordRequiresUppercase: complexity.HasUppercase,
 		PasswordRequiresLowercase: complexity.HasLowercase,
@@ -131,8 +135,8 @@ func (c *Client) GetOrgSettings(ctx context.Context) (OrgSettings, error) {
 // URIs) sidesteps a real Zitadel behavior: re-sending an unchanged policy
 // answers 400 "NotChanged" rather than a no-op 200.
 func (c *Client) UpdateOrgSettings(ctx context.Context, params UpdateOrgSettingsParams) (OrgSettings, error) {
-	if params.ForceMFA != nil {
-		if err := c.updateLoginPolicy(ctx, *params.ForceMFA); err != nil {
+	if hasLoginPolicyChange(params) {
+		if err := c.updateLoginPolicy(ctx, params); err != nil {
 			return OrgSettings{}, err
 		}
 	}
@@ -144,21 +148,31 @@ func (c *Client) UpdateOrgSettings(ctx context.Context, params UpdateOrgSettings
 	return c.GetOrgSettings(ctx)
 }
 
+func hasLoginPolicyChange(params UpdateOrgSettingsParams) bool {
+	return params.ForceMFA != nil || params.AllowRegister != nil
+}
+
 func hasPasswordComplexityChange(params UpdateOrgSettingsParams) bool {
 	return params.MinPasswordLength != nil || params.PasswordRequiresUppercase != nil ||
 		params.PasswordRequiresLowercase != nil || params.PasswordRequiresNumber != nil ||
 		params.PasswordRequiresSymbol != nil
 }
 
-func (c *Client) updateLoginPolicy(ctx context.Context, forceMFA bool) error {
+// updateLoginPolicy applies every login-policy field params sets, the same
+// read-modify-write-only-on-diff shape updatePasswordComplexityPolicy
+// already uses: each field is diffed independently via applyBoolField, so
+// adding a new controllable login-policy field means adding one more call
+// here rather than growing a positional parameter list forever.
+func (c *Client) updateLoginPolicy(ctx context.Context, params UpdateOrgSettingsParams) error {
 	login, isDefault, err := c.getLoginPolicy(ctx)
 	if err != nil {
 		return fmt.Errorf("get zitadel login policy: %w", err)
 	}
-	if login.ForceMFA == forceMFA {
+	changed := applyBoolField(&login.ForceMFA, params.ForceMFA)
+	changed = applyBoolField(&login.AllowRegister, params.AllowRegister) || changed
+	if !changed {
 		return nil
 	}
-	login.ForceMFA = forceMFA
 	if err := c.writeLoginPolicy(ctx, login, isDefault); err != nil {
 		return fmt.Errorf("update zitadel login policy: %w", err)
 	}

--- a/erun-backend/erun-backend-api/internal/zitadel/policies_test.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/policies_test.go
@@ -132,6 +132,60 @@ func TestUpdateOrgSettingsForceMFAPreservesOtherLoginFields(t *testing.T) {
 	}
 }
 
+// TestUpdateOrgSettingsAllowRegisterPreservesOtherLoginFields is the
+// registration-control half of the same read-modify-write contract #1482
+// asks for: closing self-registration must not touch forceMfa or any other
+// login-policy field already set on the org.
+func TestUpdateOrgSettingsAllowRegisterPreservesOtherLoginFields(t *testing.T) {
+	var loginPutBody map[string]any
+	loginPuts, passwordPuts := 0, 0
+	client := routedTestClient(t, []jsonRoute{
+		{method: http.MethodGet, path: "/management/v1/policies/login", body: map[string]any{
+			"policy": map[string]any{"allowUsernamePassword": true, "allowRegister": true, "forceMfa": true, "passwordlessType": "PASSWORDLESS_TYPE_NOT_ALLOWED"},
+		}},
+		{method: http.MethodPut, path: "/management/v1/policies/login", record: func(body map[string]any) {
+			loginPuts++
+			loginPutBody = body
+		}},
+		{method: http.MethodGet, path: "/management/v1/policies/password/complexity", body: map[string]any{"policy": map[string]any{"minLength": "8"}}},
+		{method: http.MethodPut, path: "/management/v1/policies/password/complexity", record: func(map[string]any) { passwordPuts++ }},
+		emptyDomainSearchRoute(),
+	})
+
+	allowRegister := false
+	if _, err := client.UpdateOrgSettings(context.Background(), UpdateOrgSettingsParams{AllowRegister: &allowRegister}); err != nil {
+		t.Fatalf("UpdateOrgSettings(allowRegister): %v", err)
+	}
+	if loginPuts != 1 || passwordPuts != 0 {
+		t.Fatalf("loginPuts=%d passwordPuts=%d, want only the login policy touched", loginPuts, passwordPuts)
+	}
+	if loginPutBody["allowRegister"] != false || loginPutBody["forceMfa"] != true || loginPutBody["allowUsernamePassword"] != true || loginPutBody["passwordlessType"] != "PASSWORDLESS_TYPE_NOT_ALLOWED" {
+		t.Fatalf("login PUT body = %+v, want allowRegister flipped and every other field preserved", loginPutBody)
+	}
+}
+
+// TestGetOrgSettingsReportsRegistrationOpenAndClosed locks the per-state
+// read: GetOrgSettings must report whichever value the org's login policy
+// actually carries, not a hardcoded default.
+func TestGetOrgSettingsReportsRegistrationOpenAndClosed(t *testing.T) {
+	for _, allowRegister := range []bool{true, false} {
+		client := routedTestClient(t, []jsonRoute{
+			{method: http.MethodGet, path: "/management/v1/policies/login", body: map[string]any{
+				"policy": map[string]any{"allowRegister": allowRegister},
+			}},
+			{method: http.MethodGet, path: "/management/v1/policies/password/complexity", body: map[string]any{"policy": map[string]any{"minLength": "8"}}},
+			emptyDomainSearchRoute(),
+		})
+		settings, err := client.GetOrgSettings(context.Background())
+		if err != nil {
+			t.Fatalf("GetOrgSettings: %v", err)
+		}
+		if settings.AllowRegister != allowRegister {
+			t.Fatalf("AllowRegister = %v, want %v", settings.AllowRegister, allowRegister)
+		}
+	}
+}
+
 // TestUpdateOrgSettingsMinPasswordLengthPreservesOtherPasswordFields is the
 // password-policy half of the same read-modify-write contract.
 func TestUpdateOrgSettingsMinPasswordLengthPreservesOtherPasswordFields(t *testing.T) {

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -125,6 +125,16 @@ func NewHandler(options HandlerOptions) (http.Handler, error) {
 	if resolvers := resolveIdentityResolvers(options); options.MCPSigner != nil && options.TokenVerifier != nil && resolvers.tenant != nil {
 		registrytoken.NewHandler(options.TokenVerifier, resolvers.tenant, options.MCPSigner).Register(mux)
 	}
+	// Accepting an invite (#1483) has no bearer token to authenticate with —
+	// the token in the request body is the credential — so it is registered
+	// directly on the mux like the platform route above. It needs the same
+	// Zitadel client identity administration does, so it shares that
+	// optional-dependency gate: unconfigured leaves the route unregistered
+	// entirely rather than present and always failing.
+	if txManager != nil && options.IdentityAdmin != nil {
+		inviteService := service.NewInviteService(repository.NewInviteRepository(txManager), options.IdentityAdmin, repository.NewUserRepository(txManager))
+		routes.RegisterInviteAcceptRoute(mux, inviteService)
+	}
 	registerProtectedRoutes(mux, auth, options, txManager, authorizer)
 	return mux, nil
 }
@@ -350,8 +360,15 @@ func registerIdentityAdminRoutes(register routes.ProtectedRouteRegistrar, option
 	if options.IdentityAdmin == nil {
 		return
 	}
-	identityService := service.NewIdentityService(options.IdentityAdmin, repository.NewUserRepository(txManager))
-	routes.RegisterIdentityRoutes(register, options.IdentityAdmin, identityService)
+	userRepo := repository.NewUserRepository(txManager)
+	identityService := service.NewIdentityService(options.IdentityAdmin, userRepo)
+	routes.RegisterIdentityRoutes(register, options.IdentityAdmin, identityService, userRepo)
+	// Invite creation (#1483) is only meaningful when this platform enrolls
+	// users through the shared Zitadel org identity administration already
+	// depends on — a platform with no IdentityAdmin has no accept path an
+	// invite could ever complete, so it shares that same optional-dependency
+	// gate rather than registering a dead end.
+	routes.RegisterInviteRoutes(register, repository.NewInviteRepository(txManager))
 }
 
 // newEnvironmentProvisioner wires live env provisioning, which needs durable

--- a/erun-backend/erun-backend-db/atlas.hcl
+++ b/erun-backend/erun-backend-db/atlas.hcl
@@ -27,6 +27,7 @@ env "default" {
     "file://schema/tables/cloud_provider_aliases.sql",
     "file://schema/tables/context_credentials.sql",
     "file://schema/tables/usage_events.sql",
+    "file://schema/tables/invites.sql",
     "file://schema/indexes/users.sql",
     "file://schema/indexes/user_external_ids.sql",
     "file://schema/indexes/role_permissions.sql",
@@ -41,6 +42,7 @@ env "default" {
     "file://schema/indexes/contexts.sql",
     "file://schema/indexes/environments.sql",
     "file://schema/indexes/usage_events.sql",
+    "file://schema/indexes/invites.sql",
     "file://schema/triggers/comments.sql",
     "file://schema/triggers/timestamps.sql",
     "file://schema/fks/review_builds.sql",
@@ -63,6 +65,7 @@ env "default" {
     "file://schema/rls/cloud_provider_aliases.sql",
     "file://schema/rls/context_credentials.sql",
     "file://schema/rls/usage_events.sql",
+    "file://schema/rls/invites.sql",
   ]
   url = var.database_url
   dev = "docker://postgres/18/dev?search_path=public"

--- a/erun-backend/erun-backend-db/migrations/default/20260827160000_invites.sql
+++ b/erun-backend/erun-backend-db/migrations/default/20260827160000_invites.sql
@@ -1,0 +1,72 @@
+-- Create "invites" table (schema/tables/invites.sql): registration is
+-- invite-only. An invite is a server-side record (revocable, listable,
+-- single-use), not a self-contained signed token — issuer is captured from
+-- the inviter's own authenticated issuer at creation time so the accept
+-- flow, which runs with no caller identity of its own, links the new user's
+-- external identity to the same IdP the inviter reached the platform through.
+CREATE TABLE "invites" (
+  "invite_id" uuid NOT NULL DEFAULT uuidv7(),
+  "tenant_id" uuid NOT NULL DEFAULT erun_current_tenant_id(),
+  "created_by_user_id" uuid NOT NULL DEFAULT erun_current_user_id(),
+  "issuer" text NOT NULL,
+  "token" text NOT NULL,
+  "email" text NULL,
+  "expires_at" timestamptz NOT NULL,
+  "consumed_at" timestamptz NULL,
+  "created_at" timestamptz NULL,
+  "updated_at" timestamptz NULL,
+  PRIMARY KEY ("invite_id"),
+  CONSTRAINT "invites_issuer_check" CHECK (length(trim("issuer")) > 0),
+  CONSTRAINT "invites_token_check" CHECK (length(trim("token")) > 0),
+  CONSTRAINT "invites_token_key" UNIQUE ("token"),
+  CONSTRAINT "invites_tenant_invite_key" UNIQUE ("tenant_id", "invite_id"),
+  CONSTRAINT "invites_tenant_id_fkey" FOREIGN KEY ("tenant_id") REFERENCES "tenants" ("tenant_id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  -- Unlike reviews.author_user_id, an invite's creator is not necessarily a
+  -- member of the invite's own target tenant (an OPERATIONS caller may mint
+  -- an invite for a different tenant, #1483 item 4), so this references the
+  -- global users.user_id primary key rather than the tenant-scoped
+  -- (tenant_id, user_id) composite key reviews.sql uses.
+  CONSTRAINT "invites_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "users" ("user_id") ON UPDATE NO ACTION ON DELETE NO ACTION
+);
+
+-- Outstanding-invites listing index (schema/indexes/invites.sql): partial,
+-- since only unconsumed invites are what the console lists.
+CREATE INDEX "invites_tenant_outstanding_idx" ON "invites" ("tenant_id", "created_at") WHERE ("consumed_at" IS NULL);
+
+-- Timestamp trigger for the new table (atlas migrate diff omits trigger
+-- objects without an atlas login session; appended from the declarative
+-- schema; references the existing erun_set_timestamps()).
+CREATE TRIGGER invites_set_timestamps
+  BEFORE INSERT OR UPDATE ON "invites"
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();
+
+-- Grant tenant-owned CRUD on the new table to the application roles (atlas
+-- migrate diff omits permissions without an atlas login session; appended
+-- from schema/roles.sql). erun_tenant gets RLS-scoped access; erun_operations
+-- crosses tenants under its own policies, which is also what the
+-- unauthenticated accept endpoint's token lookup runs as (see
+-- repository.TxManager.WithinSystemTx).
+GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES
+  ON "invites"
+  TO erun_tenant, erun_operations;
+
+-- Row-level security for the new tenant-owned table (atlas migrate diff omits
+-- policies without an atlas login session; appended from
+-- schema/rls/invites.sql). Two policies mirror the reviews template:
+-- tenant_isolation scopes erun_tenant by erun_current_tenant_id();
+-- operations_access lets erun_operations cross tenants.
+ALTER TABLE "invites" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "invites" FORCE ROW LEVEL SECURITY;
+CREATE POLICY invites_tenant_isolation
+  ON "invites"
+  FOR ALL
+  TO erun_tenant
+  USING (tenant_id = erun_current_tenant_id())
+  WITH CHECK (tenant_id = erun_current_tenant_id());
+CREATE POLICY invites_operations_access
+  ON "invites"
+  FOR ALL
+  TO erun_operations
+  USING (true)
+  WITH CHECK (true);

--- a/erun-backend/erun-backend-db/migrations/default/atlas.sum
+++ b/erun-backend/erun-backend-db/migrations/default/atlas.sum
@@ -1,4 +1,4 @@
-h1:PpvNgY5jNR7Th6+mmqEgxVhiMz68hCByGW7+f8tAgPY=
+h1:5S93pqH0/ItCqV5aVAdHNgmYLA9DOfDClc5wQmNSAaE=
 20260501120000_initial_tenant_identity.sql h1:RpS03/4sFjbCggwYgcGNn6k3jNZCNTNl0BD/afOKFzo=
 20260503143000_tenant_issuer_names.sql h1:VEZjICG3/jU2YtEx0XX05l9Q8lJyWKeiRY8f4dXOkvE=
 20260503170000_audit_events.sql h1:OLjiGP/FhLTWvkx1bxS2xCcJK6tExdufnEC8R6LsKWA=
@@ -20,3 +20,4 @@ h1:PpvNgY5jNR7Th6+mmqEgxVhiMz68hCByGW7+f8tAgPY=
 20260824130000_review_author_reviewers_branch_uniqueness.sql h1:rjp+4qpn4U1LPRHtin1FzBICV+8Dkyd8MfEpI2mF1rc=
 20260824150000_builds_gate_kind.sql h1:bRWjAspfnysyJskXJdVW0Z9Uz0uhZZyg4iHlnRZr7r8=
 20260826160000_audit_events_api_parameters.sql h1:PkxXOcFiPrC8y5onZqwa+bTl7Vk+8w06Umm3U/GqZ9o=
+20260827160000_invites.sql h1:XnD2kIrdTOfbI8vC4XNhVxalVF75sCV9qHRqLiWZ+xw=

--- a/erun-backend/erun-backend-db/schema/indexes/invites.sql
+++ b/erun-backend/erun-backend-db/schema/indexes/invites.sql
@@ -1,0 +1,6 @@
+-- Outstanding (unconsumed) invites are what the console lists, so the
+-- partial index only covers rows that are still usable rather than every
+-- invite a tenant has ever issued.
+CREATE INDEX invites_tenant_outstanding_idx
+  ON invites (tenant_id, created_at)
+  WHERE consumed_at IS NULL;

--- a/erun-backend/erun-backend-db/schema/rls/invites.sql
+++ b/erun-backend/erun-backend-db/schema/rls/invites.sql
@@ -1,0 +1,21 @@
+ALTER TABLE invites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invites FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY invites_tenant_isolation
+  ON invites
+  FOR ALL
+  TO erun_tenant
+  USING (tenant_id = erun_current_tenant_id())
+  WITH CHECK (tenant_id = erun_current_tenant_id());
+
+-- erun_operations also backs the unauthenticated accept endpoint's
+-- token lookup: nobody has signed in yet when a token is presented, so
+-- there is no tenant to scope the initial SELECT by. See
+-- repository.TxManager.WithinSystemTx for the narrow, reviewable place
+-- that role is assumed outside a real operations-tenant caller.
+CREATE POLICY invites_operations_access
+  ON invites
+  FOR ALL
+  TO erun_operations
+  USING (true)
+  WITH CHECK (true);

--- a/erun-backend/erun-backend-db/schema/roles.sql
+++ b/erun-backend/erun-backend-db/schema/roles.sql
@@ -17,7 +17,7 @@ GRANT UPDATE (name) ON tenant_issuers TO erun_tenant;
 GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES ON tenants, tenant_issuers, issuers TO erun_operations;
 
 GRANT SELECT, INSERT, UPDATE, DELETE, REFERENCES
-  ON users, user_external_ids, roles, role_permissions, user_roles, reviews, review_merge_queue, review_reviewers, builds, releases, comments, contexts, environments, tenant_quotas, cloud_provider_aliases, context_credentials
+  ON users, user_external_ids, roles, role_permissions, user_roles, reviews, review_merge_queue, review_reviewers, builds, releases, comments, contexts, environments, tenant_quotas, cloud_provider_aliases, context_credentials, invites
   TO erun_tenant, erun_operations;
 
 GRANT SELECT, INSERT, REFERENCES

--- a/erun-backend/erun-backend-db/schema/tables/invites.sql
+++ b/erun-backend/erun-backend-db/schema/tables/invites.sql
@@ -1,0 +1,23 @@
+CREATE TABLE invites (
+  invite_id UUID PRIMARY KEY DEFAULT uuidv7(),
+  tenant_id UUID NOT NULL DEFAULT erun_current_tenant_id(),
+  created_by_user_id UUID NOT NULL DEFAULT erun_current_user_id(),
+  issuer TEXT NOT NULL,
+  token TEXT NOT NULL,
+  email TEXT,
+  expires_at TIMESTAMPTZ NOT NULL,
+  consumed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  FOREIGN KEY (tenant_id) REFERENCES tenants (tenant_id),
+  -- Unlike reviews.author_user_id, an invite's creator is not necessarily a
+  -- member of the invite's own target tenant: an OPERATIONS caller may mint
+  -- an invite for a different tenant entirely (#1483 item 4), so this
+  -- references the global users.user_id primary key rather than the
+  -- tenant-scoped (tenant_id, user_id) composite key reviews.sql uses.
+  FOREIGN KEY (created_by_user_id) REFERENCES users (user_id),
+  CONSTRAINT invites_issuer_check CHECK (length(trim(issuer)) > 0),
+  CONSTRAINT invites_token_check CHECK (length(trim(token)) > 0),
+  CONSTRAINT invites_token_key UNIQUE (token),
+  CONSTRAINT invites_tenant_invite_key UNIQUE (tenant_id, invite_id)
+);

--- a/erun-backend/erun-backend-db/schema/triggers/timestamps.sql
+++ b/erun-backend/erun-backend-db/schema/triggers/timestamps.sql
@@ -109,3 +109,8 @@ CREATE TRIGGER context_credentials_set_timestamps
   BEFORE INSERT OR UPDATE ON context_credentials
   FOR EACH ROW
   EXECUTE FUNCTION erun_set_timestamps();
+
+CREATE TRIGGER invites_set_timestamps
+  BEFORE INSERT OR UPDATE ON invites
+  FOR EACH ROW
+  EXECUTE FUNCTION erun_set_timestamps();

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -9,6 +9,7 @@ import { clearAuth } from './app/slices/authSlice';
 import type { OidcConfig } from './auth/auth';
 import { signOut } from './auth/auth';
 import { fetchPlatformConfig } from './config/platform';
+import { AcceptInvitePage } from './identity/AcceptInvitePage';
 import { AppShell } from './shell/AppShell';
 import { LandingScreen } from './shell/LandingScreen';
 import { ErrorScreen, LoadingScreen, NotEnrolledScreen } from './shell/PreShellScreens';
@@ -162,10 +163,24 @@ function AppContent({
   }
 }
 
+// isAcceptInvitePath and acceptInviteToken read the URL directly rather than
+// through a router: the console has no client-side routing today, and an
+// invite link is the one page that must render before OIDC sign-in ever
+// starts — an invitee has no bearer token and no tenant membership yet, so
+// forcing them through the normal sign-in flow first would be a dead end.
+function isAcceptInvitePath(): boolean {
+  return window.location.pathname === '/accept-invite';
+}
+
+function acceptInviteToken(): string {
+  return new URLSearchParams(window.location.search).get('token') ?? '';
+}
+
 export function App(): React.ReactElement {
   const platform = usePlatformInfo();
   const dispatch = useAppDispatch();
   const auth = useAppSelector((s) => s.auth);
+  const acceptInvite = isAcceptInvitePath();
 
   // The `.dark` class only gets applied here, once, so every pre-shell screen
   // (including the signed-out landing page) honors a stored or OS-level dark
@@ -177,16 +192,26 @@ export function App(): React.ReactElement {
 
   // Resolves the OIDC config from platform discovery (GET /v1/platform), then
   // the bearer token (an OIDC callback exchange, a token held this session,
-  // or the dev-token fallback) — see app/authThunks.ts.
+  // or the dev-token fallback) — see app/authThunks.ts. Skipped on the
+  // accept-invite page: an invitee has no identity to resolve yet.
   React.useEffect(() => {
+    if (acceptInvite) {
+      return;
+    }
     void dispatch(resolveAuth());
-  }, [dispatch]);
+  }, [dispatch, acceptInvite]);
 
   // Loads the tenant config once a token is known. `refetch` is also the
   // refresh a write surface (register/deploy) triggers on completion, so a
   // newly registered env or a settled deploy's status shows up here too —
   // via `invalidatesTags: ['Config']` on those mutations.
-  const configQuery = useGetConfigQuery(auth.token ?? '', { skip: auth.token === undefined });
+  const configQuery = useGetConfigQuery(auth.token ?? '', {
+    skip: acceptInvite || auth.token === undefined,
+  });
+
+  if (acceptInvite) {
+    return <AcceptInvitePage token={acceptInviteToken()} />;
+  }
 
   const state = computeLoadState(auth, configQuery);
 

--- a/erun-console/src/app/api/identityApi.ts
+++ b/erun-console/src/app/api/identityApi.ts
@@ -11,6 +11,11 @@ import { type NoValue, platformApi } from './platformApi';
 // USER_STATE_* values (e.g. USER_STATE_ACTIVE, USER_STATE_INACTIVE,
 // USER_STATE_INITIAL — the last one for an invite that hasn't been completed
 // yet), kept as a string for forward compatibility.
+//
+// This list is the IdP org's own membership, not erun's: enrolled is false
+// for a self-registered or otherwise unmapped account that exists in the
+// IdP but cannot use erun, and isMachine marks the platform's own service
+// identities (login-client, admin-sa) rather than a person.
 export interface IdentityUser {
   id: string;
   username: string;
@@ -18,6 +23,9 @@ export interface IdentityUser {
   email?: string;
   firstName?: string;
   lastName?: string;
+  isMachine: boolean;
+  enrolled: boolean;
+  erunUserId?: string;
 }
 
 function asNumber(value: unknown): number {
@@ -36,6 +44,9 @@ function parseIdentityUser(raw: Record<string, unknown>): IdentityUser {
     email: asOptionalString(raw.email),
     firstName: asOptionalString(raw.firstName),
     lastName: asOptionalString(raw.lastName),
+    isMachine: asBoolean(raw.isMachine),
+    enrolled: asBoolean(raw.enrolled),
+    erunUserId: asOptionalString(raw.erunUserId),
   };
 }
 
@@ -103,6 +114,7 @@ function parseEnrollResult(raw: unknown): EnrollIdentityUserResult {
 // surface does not drive.
 export interface OrgSettings {
   forceMfa: boolean;
+  allowRegister: boolean;
   minPasswordLength: number;
   passwordRequiresUppercase: boolean;
   passwordRequiresLowercase: boolean;
@@ -117,6 +129,7 @@ function parseOrgSettings(raw: unknown): OrgSettings {
   }
   return {
     forceMfa: asBoolean(raw.forceMfa),
+    allowRegister: asBoolean(raw.allowRegister),
     minPasswordLength: asNumber(raw.minPasswordLength),
     passwordRequiresUppercase: asBoolean(raw.passwordRequiresUppercase),
     passwordRequiresLowercase: asBoolean(raw.passwordRequiresLowercase),
@@ -132,6 +145,7 @@ function parseOrgSettings(raw: unknown): OrgSettings {
 // change; every other field is left at its current value server-side.
 export interface UpdateOrgSettingsInput {
   forceMfa?: boolean;
+  allowRegister?: boolean;
   minPasswordLength?: number;
   passwordRequiresUppercase?: boolean;
   passwordRequiresLowercase?: boolean;
@@ -192,6 +206,79 @@ export interface UpdateSmtpSettingsInput {
   senderName?: string;
   replyToAddress?: string;
   tls: boolean;
+}
+
+// An invite is a server-side record (#1483), not a self-contained signed
+// token — revocable and listable up until it is accepted. token is the
+// invite link's credential: the console builds the actual accept URL from
+// it locally, since the backend has no reliable notion of its own public
+// console origin.
+export interface Invite {
+  inviteId: string;
+  tenantId: string;
+  token: string;
+  email?: string;
+  expiresAt: string;
+  consumedAt?: string;
+}
+
+function parseInvite(raw: Record<string, unknown>): Invite {
+  return {
+    inviteId: asString(raw.inviteId),
+    tenantId: asString(raw.tenantId),
+    token: asString(raw.token),
+    email: asOptionalString(raw.email),
+    expiresAt: asString(raw.expiresAt),
+    consumedAt: asOptionalString(raw.consumedAt),
+  };
+}
+
+function parseInviteList(value: unknown): Invite[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord).map(parseInvite);
+}
+
+// CreateInviteInput's tenantId targets a tenant other than the caller's own
+// — honored only for an operations-scoped caller, mirroring the backend's
+// own cross-tenant enrollment convention.
+export interface CreateInviteInput {
+  email?: string;
+  tenantId?: string;
+}
+
+// AcceptInviteInput is what an invitee themselves supplies. There is no
+// bearer token for this call — the invite token in the body is the
+// credential — so acceptInvite below passes no token to httpBaseQuery.
+export interface AcceptInviteInput {
+  token: string;
+  username: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  password: string;
+}
+
+export interface AcceptInviteResult {
+  idpUser: IdentityUser;
+  erunUser?: ErunUserRef;
+  error?: string;
+}
+
+function parseAcceptInviteResult(raw: unknown): AcceptInviteResult {
+  if (!isRecord(raw) || !isRecord(raw.idpUser)) {
+    throw new Error('accept invite response was not in the expected shape');
+  }
+  const erunUserRaw = raw.erunUser;
+  return {
+    idpUser: parseIdentityUser(raw.idpUser),
+    erunUser:
+      isRecord(erunUserRaw) && asString(erunUserRaw.userId) !== ''
+        ? { userId: asString(erunUserRaw.userId), username: asString(erunUserRaw.username) }
+        : undefined,
+    error: asOptionalString(raw.error),
+  };
 }
 
 export const identityApi = platformApi.injectEndpoints({
@@ -286,6 +373,57 @@ export const identityApi = platformApi.injectEndpoints({
   }),
 });
 
+// A separate injectEndpoints call (rather than one giant endpoints object)
+// keeps each builder function under the module's max-lines-per-function
+// budget; both sets still share platformApi's one cache, tag namespace, and
+// reducer slot.
+export const inviteApi = platformApi.injectEndpoints({
+  endpoints: (builder) => ({
+    // listInvites returns the resolved tenant's outstanding (unconsumed)
+    // invites — the ones an operator can still hand out or revoke.
+    listInvites: builder.query<Invite[], string>({
+      query: (token) => ({ url: '/v1/invites', token, label: 'list invites' }),
+      transformResponse: parseInviteList,
+      providesTags: ['Invites'],
+    }),
+
+    createInvite: builder.mutation<Invite, { token: string; input: CreateInviteInput }>({
+      query: ({ token, input }) => ({
+        url: '/v1/invites',
+        method: 'POST',
+        body: input,
+        token,
+        label: 'create invite',
+      }),
+      transformResponse: parseInvite,
+      invalidatesTags: ['Invites'],
+    }),
+
+    revokeInvite: builder.mutation<NoValue, { token: string; inviteId: string }>({
+      query: ({ token, inviteId }) => ({
+        url: `/v1/invites/${encodeURIComponent(inviteId)}`,
+        method: 'DELETE',
+        token,
+        label: 'revoke invite',
+      }),
+      invalidatesTags: ['Invites'],
+    }),
+
+    // acceptInvite is the one endpoint in this module with no bearer token
+    // at all: the invitee has none yet, and the invite token in the body is
+    // the credential that authorizes this call.
+    acceptInvite: builder.mutation<AcceptInviteResult, AcceptInviteInput>({
+      query: (input) => ({
+        url: '/v1/invites/accept',
+        method: 'POST',
+        body: input,
+        label: 'accept invite',
+      }),
+      transformResponse: parseAcceptInviteResult,
+    }),
+  }),
+});
+
 export const {
   useListIdentityUsersQuery,
   useCreateIdentityUserMutation,
@@ -295,3 +433,10 @@ export const {
   useGetSmtpSettingsQuery,
   useUpdateSmtpSettingsMutation,
 } = identityApi;
+
+export const {
+  useListInvitesQuery,
+  useCreateInviteMutation,
+  useRevokeInviteMutation,
+  useAcceptInviteMutation,
+} = inviteApi;

--- a/erun-console/src/app/api/platformApi.ts
+++ b/erun-console/src/app/api/platformApi.ts
@@ -15,6 +15,14 @@ export type NoValue = ReturnType<_VoidReturning>;
 export const platformApi = createApi({
   reducerPath: 'platformApi',
   baseQuery: httpBaseQuery,
-  tagTypes: ['Config', 'Environment', 'Context', 'IdentityUsers', 'OrgSettings', 'SmtpSettings'],
+  tagTypes: [
+    'Config',
+    'Environment',
+    'Context',
+    'IdentityUsers',
+    'OrgSettings',
+    'SmtpSettings',
+    'Invites',
+  ],
   endpoints: () => ({}),
 });

--- a/erun-console/src/identity/AcceptInvitePage.test.tsx
+++ b/erun-console/src/identity/AcceptInvitePage.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithStore } from '../test/renderWithStore';
+import { AcceptInvitePage } from './AcceptInvitePage';
+
+interface MockReq {
+  method: string;
+  url: string;
+  body?: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function requestUrl(input: string | URL): string {
+  return input instanceof URL ? input.href : input;
+}
+
+function mockFetch(handler: (req: MockReq) => Response): MockReq[] {
+  const calls: MockReq[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL, init?: RequestInit) => {
+      const req: MockReq = {
+        method: init?.method ?? 'GET',
+        url: requestUrl(input),
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      };
+      calls.push(req);
+      return Promise.resolve(handler(req));
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function fillAndSubmit(username: string, password: string): void {
+  fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+    target: { value: username },
+  });
+  fireEvent.change(screen.getByLabelText('Password', { exact: false }), {
+    target: { value: password },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+}
+
+describe('AcceptInvitePage', () => {
+  it('shows a clear message when the URL carries no token', () => {
+    renderWithStore(<AcceptInvitePage token="" />);
+    expect(screen.getByText(/missing its invite token/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create account' })).not.toBeInTheDocument();
+  });
+
+  it('creates the account and points the invitee at sign-in', async () => {
+    const calls = mockFetch(() =>
+      jsonResponse({
+        idpUser: { id: 'idp-1', username: 'newbie', state: 'USER_STATE_ACTIVE' },
+        erunUser: { userId: 'erun-1', username: 'newbie' },
+      }),
+    );
+    renderWithStore(<AcceptInvitePage token="tok-abc" />);
+
+    fillAndSubmit('newbie', 'S3cret!Pass');
+
+    expect(await screen.findByText(/Your account is ready/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    const call = calls.find((c) => c.method === 'POST');
+    expect(call?.url).toBe('/v1/invites/accept');
+    expect(call?.body).toMatchObject({
+      token: 'tok-abc',
+      username: 'newbie',
+      password: 'S3cret!Pass',
+    });
+  });
+
+  it('reports an expired or already-used link plainly', async () => {
+    mockFetch(() => jsonResponse('invite link has expired', 410));
+    renderWithStore(<AcceptInvitePage token="tok-expired" />);
+
+    fillAndSubmit('newbie', 'S3cret!Pass');
+
+    expect(await screen.findByText(/expired or has already been used/)).toBeInTheDocument();
+  });
+
+  it('reports an invalid token plainly', async () => {
+    mockFetch(() => jsonResponse('invite link is invalid', 404));
+    renderWithStore(<AcceptInvitePage token="tok-bad" />);
+
+    fillAndSubmit('newbie', 'S3cret!Pass');
+
+    expect(await screen.findByText(/not valid/)).toBeInTheDocument();
+  });
+
+  it('reports a half-landed enrollment without claiming full success', async () => {
+    mockFetch(() =>
+      jsonResponse({
+        idpUser: { id: 'idp-9', username: 'orphan', state: 'USER_STATE_ACTIVE' },
+        error: 'identity created in the identity provider but the erun user mapping failed',
+      }),
+    );
+    renderWithStore(<AcceptInvitePage token="tok-orphan" />);
+
+    fillAndSubmit('orphan', 'S3cret!Pass');
+
+    expect(await screen.findByText(/could not be finished/)).toBeInTheDocument();
+    expect(screen.queryByText(/Your account is ready/)).not.toBeInTheDocument();
+  });
+});

--- a/erun-console/src/identity/AcceptInvitePage.tsx
+++ b/erun-console/src/identity/AcceptInvitePage.tsx
@@ -1,0 +1,235 @@
+import { Button, Card, CardContent, CardHeader, CardTitle, FieldLabel, Input } from 'erun-kit';
+import * as React from 'react';
+
+import { useAcceptInviteMutation } from '../app/api/identityApi';
+import { describeQueryError } from '../app/queryError';
+
+// describeAcceptError turns the invite-accept endpoint's status code into
+// the exact, distinct message #1483 asks for: an expired or consumed link
+// says so plainly rather than a generic failure, since "try again" is not
+// the right recovery for any of these three states.
+function describeAcceptError(error: unknown): string {
+  const { status, message } = describeQueryError(error);
+  switch (status) {
+    case 404:
+      return 'This invite link is not valid. Ask whoever invited you to send a new one.';
+    case 410:
+      return 'This invite link has expired or has already been used. Ask whoever invited you to send a new one.';
+    case 400:
+      return 'The email address you entered does not match the one this invite was sent to.';
+    default:
+      return message;
+  }
+}
+
+type AcceptState =
+  | { status: 'idle' }
+  | { status: 'submitting' }
+  | { status: 'succeeded' }
+  | { status: 'partial'; message: string }
+  | { status: 'error'; message: string };
+
+function TextField({
+  id,
+  label,
+  type = 'text',
+  required,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  type?: string;
+  required?: boolean;
+  value: string;
+  onChange: (value: string) => void;
+}): React.ReactElement {
+  return (
+    <div className="grid gap-2">
+      <FieldLabel htmlFor={id} required={required}>
+        {label}
+      </FieldLabel>
+      <Input
+        id={id}
+        type={type}
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+        }}
+        required={required}
+      />
+    </div>
+  );
+}
+
+// useAcceptInviteFields holds the form's five inputs as one unit, so
+// AcceptInviteForm only needs one hook call and one destructure instead of
+// five repeated pairs — mirrors OrgSettingsPanel's usePasswordComplexityFields.
+function useAcceptInviteFields(): {
+  username: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  password: string;
+  setUsername: (value: string) => void;
+  setEmail: (value: string) => void;
+  setFirstName: (value: string) => void;
+  setLastName: (value: string) => void;
+  setPassword: (value: string) => void;
+} {
+  const [username, setUsername] = React.useState('');
+  const [email, setEmail] = React.useState('');
+  const [firstName, setFirstName] = React.useState('');
+  const [lastName, setLastName] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  return {
+    username,
+    email,
+    firstName,
+    lastName,
+    password,
+    setUsername,
+    setEmail,
+    setFirstName,
+    setLastName,
+    setPassword,
+  };
+}
+
+function AcceptInviteForm({
+  token,
+  onResult,
+}: {
+  token: string;
+  onResult: (state: AcceptState) => void;
+}): React.ReactElement {
+  const fields = useAcceptInviteFields();
+  const [acceptInvite, { isLoading }] = useAcceptInviteMutation();
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    onResult({ status: 'submitting' });
+    acceptInvite({
+      token,
+      username: fields.username.trim(),
+      email: fields.email.trim() || undefined,
+      firstName: fields.firstName.trim() || undefined,
+      lastName: fields.lastName.trim() || undefined,
+      password: fields.password,
+    })
+      .unwrap()
+      .then((result) => {
+        if (result.error !== undefined) {
+          onResult({ status: 'partial', message: result.error });
+          return;
+        }
+        onResult({ status: 'succeeded' });
+      })
+      .catch((error: unknown) => {
+        onResult({ status: 'error', message: describeAcceptError(error) });
+      });
+  };
+
+  return (
+    <form className="grid gap-3" onSubmit={submit} aria-labelledby="accept-invite-heading">
+      <TextField
+        id="accept-username"
+        label="Username"
+        required
+        value={fields.username}
+        onChange={fields.setUsername}
+      />
+      <TextField
+        id="accept-email"
+        label="Email"
+        type="email"
+        value={fields.email}
+        onChange={fields.setEmail}
+      />
+      <TextField
+        id="accept-first-name"
+        label="First name"
+        value={fields.firstName}
+        onChange={fields.setFirstName}
+      />
+      <TextField
+        id="accept-last-name"
+        label="Last name"
+        value={fields.lastName}
+        onChange={fields.setLastName}
+      />
+      <TextField
+        id="accept-password"
+        label="Password"
+        type="password"
+        required
+        value={fields.password}
+        onChange={fields.setPassword}
+      />
+      <Button type="submit" disabled={isLoading} className="justify-self-start">
+        {isLoading ? 'Creating account…' : 'Create account'}
+      </Button>
+    </form>
+  );
+}
+
+function AcceptInviteResultMessage({ state }: { state: AcceptState }): React.ReactElement | null {
+  if (state.status === 'succeeded') {
+    return (
+      <p className="text-sm text-foreground" role="status">
+        Your account is ready.{' '}
+        <a className="underline" href="/">
+          Sign in
+        </a>{' '}
+        to continue.
+      </p>
+    );
+  }
+  if (state.status === 'partial') {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        Your account was created in the identity provider, but could not be finished:{' '}
+        {state.message}. Ask an operator to complete your enrollment.
+      </p>
+    );
+  }
+  if (state.status === 'error') {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        {state.message}
+      </p>
+    );
+  }
+  return null;
+}
+
+// AcceptInvitePage is the unauthenticated landing page for an invite link
+// (#1483): the invitee has no bearer token yet, so this renders standalone
+// before App.tsx's normal OIDC-gated flow ever starts. See App.tsx for the
+// path check that routes here instead of dispatching resolveAuth().
+export function AcceptInvitePage({ token }: { token: string }): React.ReactElement {
+  const [state, setState] = React.useState<AcceptState>({ status: 'idle' });
+  const done = state.status === 'succeeded' || state.status === 'partial';
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-background p-6 text-foreground">
+      <Card className="w-full max-w-md" aria-labelledby="accept-invite-heading">
+        <CardHeader>
+          <CardTitle id="accept-invite-heading">You've been invited</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4">
+          {token === '' ? (
+            <p className="text-sm text-destructive" role="alert">
+              This link is missing its invite token. Ask whoever invited you to send it again.
+            </p>
+          ) : (
+            <>
+              {!done && <AcceptInviteForm token={token} onResult={setState} />}
+              <AcceptInviteResultMessage state={state} />
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/erun-console/src/identity/InvitesPanel.test.tsx
+++ b/erun-console/src/identity/InvitesPanel.test.tsx
@@ -1,0 +1,142 @@
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithStore } from '../test/renderWithStore';
+import { InvitesPanel } from './InvitesPanel';
+
+interface MockReq {
+  method: string;
+  url: string;
+  body?: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function requestUrl(input: string | URL): string {
+  return input instanceof URL ? input.href : input;
+}
+
+function mockFetch(handler: (req: MockReq) => Response): MockReq[] {
+  const calls: MockReq[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL, init?: RequestInit) => {
+      const req: MockReq = {
+        method: init?.method ?? 'GET',
+        url: requestUrl(input),
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      };
+      calls.push(req);
+      return Promise.resolve(handler(req));
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('InvitesPanel', () => {
+  it('renders an empty state when there are no outstanding invites', async () => {
+    mockFetch(() => jsonResponse([]));
+    renderWithStore(<InvitesPanel token="dev-token" />);
+    expect(await screen.findByText('No outstanding invites.')).toBeInTheDocument();
+  });
+
+  it('lists outstanding invites returned by GET /v1/invites', async () => {
+    mockFetch((req) => {
+      if (req.url === '/v1/invites') {
+        return jsonResponse([
+          {
+            inviteId: 'invite-1',
+            tenantId: 'tenant-1',
+            token: 'tok-1',
+            email: 'new@example.com',
+            expiresAt: '2030-01-01T00:00:00Z',
+          },
+        ]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<InvitesPanel token="dev-token" />);
+    expect(await screen.findByText('new@example.com')).toBeInTheDocument();
+  });
+
+  it('creates an invite and shows the copyable accept link', async () => {
+    let listedAfterCreate = false;
+    mockFetch((req) => {
+      if (req.method === 'POST' && req.url === '/v1/invites') {
+        return jsonResponse({
+          inviteId: 'invite-2',
+          tenantId: 'tenant-1',
+          token: 'tok-abc123',
+          email: 'bob@example.com',
+          expiresAt: '2030-01-01T00:00:00Z',
+        });
+      }
+      if (req.url === '/v1/invites') {
+        listedAfterCreate = true;
+        return jsonResponse([]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<InvitesPanel token="dev-token" />);
+    await screen.findByText('No outstanding invites.');
+
+    fireEvent.change(screen.getByLabelText('Email (optional)'), {
+      target: { value: 'bob@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create invite' }));
+
+    expect(await screen.findByText('Invite created')).toBeInTheDocument();
+    const linkField = screen.getByLabelText<HTMLInputElement>('Invite link');
+    expect(linkField.value).toContain('tok-abc123');
+    expect(linkField.value).toContain('/accept-invite?token=');
+    expect(listedAfterCreate).toBe(true);
+  });
+
+  it('revokes an invite and removes it from the list', async () => {
+    let revokeCalled = false;
+    let listCount = 0;
+    mockFetch((req) => {
+      if (req.method === 'DELETE' && req.url === '/v1/invites/invite-1') {
+        revokeCalled = true;
+        return jsonResponse({}, 204);
+      }
+      if (req.url === '/v1/invites') {
+        listCount += 1;
+        const invites =
+          listCount === 1
+            ? [
+                {
+                  inviteId: 'invite-1',
+                  tenantId: 'tenant-1',
+                  token: 'tok-1',
+                  email: 'gone@example.com',
+                  expiresAt: '2030-01-01T00:00:00Z',
+                },
+              ]
+            : [];
+        return jsonResponse(invites);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<InvitesPanel token="dev-token" />);
+    await screen.findByText('gone@example.com');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+
+    await waitFor(() => {
+      expect(revokeCalled).toBe(true);
+    });
+    await screen.findByText('No outstanding invites.');
+  });
+});

--- a/erun-console/src/identity/InvitesPanel.tsx
+++ b/erun-console/src/identity/InvitesPanel.tsx
@@ -1,0 +1,254 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  EmptyState,
+  FieldLabel,
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from 'erun-kit';
+import { Mail, UserPlus } from 'lucide-react';
+import * as React from 'react';
+
+import type { CreateInviteInput, Invite } from '../app/api/identityApi';
+import type { CreateInviteState, InvitesState } from './controller';
+import { useInvitesController } from './controller';
+
+// acceptURL builds the invite link from the current origin — the backend
+// has no reliable notion of its own public console URL, but the browser
+// rendering this page always does.
+function acceptURL(token: string): string {
+  return `${window.location.origin}/accept-invite?token=${encodeURIComponent(token)}`;
+}
+
+// InviteLinkDialog shows the accept link once, right after creation — the
+// same "shown once, copyable, dismiss clears it" shape UsersPanel's
+// TemporaryPasswordDialog uses for a one-time credential.
+function InviteLinkDialog({
+  invite,
+  onDismiss,
+}: {
+  invite: Invite;
+  onDismiss: () => void;
+}): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+  const link = acceptURL(invite.token);
+
+  const copy = (): void => {
+    void navigator.clipboard.writeText(link).then(() => {
+      setCopied(true);
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onDismiss();
+        }
+      }}
+    >
+      <DialogContent aria-labelledby="invite-link-heading">
+        <DialogHeader>
+          <DialogTitle id="invite-link-heading">Invite created</DialogTitle>
+          <DialogDescription>
+            Share this link with {invite.email ?? 'the invitee'}. It expires{' '}
+            {new Date(invite.expiresAt).toLocaleString()} and can only be used once.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center gap-2">
+          <Input
+            readOnly
+            value={link}
+            aria-label="Invite link"
+            className="font-mono"
+            onFocus={(e) => {
+              e.target.select();
+            }}
+          />
+          <Button type="button" variant="outline" onClick={copy}>
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
+        </div>
+        <DialogFooter>
+          <Button type="button" onClick={onDismiss}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CreateInviteForm({
+  createState,
+  onCreate,
+}: {
+  createState: CreateInviteState;
+  onCreate: (input: CreateInviteInput) => void;
+}): React.ReactElement {
+  const [email, setEmail] = React.useState('');
+  const busy = createState.status === 'creating';
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    onCreate({ email: email.trim() || undefined });
+    setEmail('');
+  };
+
+  return (
+    <form className="grid max-w-md gap-3" onSubmit={submit} aria-labelledby="create-invite-heading">
+      <h3 id="create-invite-heading" className="text-sm font-semibold text-foreground">
+        Invite someone
+      </h3>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="invite-email">Email (optional)</FieldLabel>
+        <Input
+          id="invite-email"
+          type="email"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+          placeholder="Leave blank to let the invitee choose"
+        />
+      </div>
+      <Button type="submit" disabled={busy} className="justify-self-start">
+        {busy ? 'Creating…' : 'Create invite'}
+      </Button>
+      {createState.status === 'error' && (
+        <p className="text-sm text-destructive" role="alert">
+          Could not create invite: {createState.message}
+        </p>
+      )}
+    </form>
+  );
+}
+
+function InviteRow({
+  invite,
+  onRevoke,
+}: {
+  invite: Invite;
+  onRevoke: (inviteId: string) => void;
+}): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+  const copy = (): void => {
+    void navigator.clipboard.writeText(acceptURL(invite.token)).then(() => {
+      setCopied(true);
+    });
+  };
+  return (
+    <TableRow>
+      <TableCell className="font-medium text-foreground">{invite.email ?? '(any email)'}</TableCell>
+      <TableCell>{new Date(invite.expiresAt).toLocaleString()}</TableCell>
+      <TableCell className="flex gap-2">
+        <Button type="button" variant="outline" size="sm" onClick={copy}>
+          {copied ? 'Copied' : 'Copy link'}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            onRevoke(invite.inviteId);
+          }}
+        >
+          Revoke
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function InvitesTable({
+  invites,
+  onRevoke,
+}: {
+  invites: Invite[];
+  onRevoke: (inviteId: string) => void;
+}): React.ReactElement {
+  if (invites.length === 0) {
+    return <EmptyState icon={<Mail />} heading="No outstanding invites." />;
+  }
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Email</TableHead>
+          <TableHead>Expires</TableHead>
+          <TableHead />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invites.map((invite) => (
+          <InviteRow key={invite.inviteId} invite={invite} onRevoke={onRevoke} />
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function InvitesBody({
+  invitesState,
+  onRevoke,
+}: {
+  invitesState: InvitesState;
+  onRevoke: (inviteId: string) => void;
+}): React.ReactElement {
+  if (invitesState.status === 'loading') {
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        Loading invites…
+      </p>
+    );
+  }
+  if (invitesState.status === 'error') {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        Could not load invites: {invitesState.message}
+      </p>
+    );
+  }
+  return <InvitesTable invites={invitesState.invites} onRevoke={onRevoke} />;
+}
+
+// InvitesPanel is the console's invite-only registration surface (#1483):
+// create a revocable, single-use invite link for this tenant, list the
+// outstanding ones, and revoke. Unlike Users/OrgSettings/SmtpSettings, this
+// is not restricted to an OPERATIONS tenant — every tenant needs its own way
+// to add members, since self-registration is closed (#1482).
+export function InvitesPanel({ token }: { token: string }): React.ReactElement {
+  const { invitesState, createState, create, revoke, dismissCreated } = useInvitesController(token);
+  return (
+    <Card aria-labelledby="invites-heading">
+      <CardHeader>
+        <CardTitle id="invites-heading">
+          <UserPlus className="mr-2 inline size-4" aria-hidden="true" />
+          Invites
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-6">
+        <InvitesBody invitesState={invitesState} onRevoke={(id) => void revoke(id)} />
+        <CreateInviteForm createState={createState} onCreate={create} />
+      </CardContent>
+      {createState.status === 'created' && (
+        <InviteLinkDialog invite={createState.invite} onDismiss={dismissCreated} />
+      )}
+    </Card>
+  );
+}

--- a/erun-console/src/identity/OrgSettingsPanel.test.tsx
+++ b/erun-console/src/identity/OrgSettingsPanel.test.tsx
@@ -41,6 +41,7 @@ function mockFetch(handler: (req: MockReq) => Response): MockReq[] {
 
 const INITIAL_SETTINGS = {
   forceMfa: false,
+  allowRegister: true,
   minPasswordLength: 8,
   passwordRequiresUppercase: true,
   passwordRequiresLowercase: true,
@@ -86,6 +87,30 @@ describe('OrgSettingsPanel', () => {
     expect(patch?.url).toBe('/v1/identity/org-settings');
     expect(patch?.body).toMatchObject({ forceMfa: true });
     await screen.findByRole('checkbox', { name: 'Require multi-factor authentication' });
+  });
+
+  it('closes self-registration and PATCHes allowRegister', async () => {
+    const calls = mockFetch((req) => {
+      if (req.method === 'PATCH') {
+        return jsonResponse({ ...INITIAL_SETTINGS, allowRegister: false });
+      }
+      return jsonResponse(INITIAL_SETTINGS);
+    });
+    renderWithStore(<OrgSettingsPanel token="dev-token" />);
+    await screen.findByText('erun.example.com');
+    expect(
+      screen.getByRole('checkbox', { name: 'Allow anyone to self-register an account' }),
+    ).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(screen.getByLabelText('Allow anyone to self-register an account'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save settings' }));
+
+    await waitFor(() => {
+      expect(calls.some((c) => c.method === 'PATCH')).toBe(true);
+    });
+    const patch = calls.find((c) => c.method === 'PATCH');
+    expect(patch?.body).toMatchObject({ allowRegister: false });
+    await screen.findByText(/Self-registration is closed/);
   });
 
   it('surfaces a load error', async () => {

--- a/erun-console/src/identity/OrgSettingsPanel.tsx
+++ b/erun-console/src/identity/OrgSettingsPanel.tsx
@@ -118,6 +118,7 @@ function SettingsForm({
   onSave: (input: UpdateOrgSettingsInput) => void;
 }): React.ReactElement {
   const [forceMfa, setForceMfa] = React.useState(settings.forceMfa);
+  const [allowRegister, setAllowRegister] = React.useState(settings.allowRegister);
   const [minLength, setMinLength] = React.useState(settings.minPasswordLength);
   const complexity = usePasswordComplexityFields(settings);
 
@@ -125,6 +126,7 @@ function SettingsForm({
     event.preventDefault();
     onSave({
       forceMfa,
+      allowRegister,
       minPasswordLength: minLength,
       passwordRequiresUppercase: complexity.uppercase,
       passwordRequiresLowercase: complexity.lowercase,
@@ -148,6 +150,18 @@ function SettingsForm({
         checked={forceMfa}
         onChange={setForceMfa}
       />
+      <PolicyCheckbox
+        id="org-allow-register"
+        label="Allow anyone to self-register an account"
+        checked={allowRegister}
+        onChange={setAllowRegister}
+      />
+      {!allowRegister && (
+        <p className="text-sm text-muted-foreground">
+          Self-registration is closed. New accounts are created by inviting them or by enrolling
+          them below.
+        </p>
+      )}
       <div className="grid gap-2">
         <FieldLabel htmlFor="org-min-length">Minimum password length</FieldLabel>
         <Input

--- a/erun-console/src/identity/UsersPanel.test.tsx
+++ b/erun-console/src/identity/UsersPanel.test.tsx
@@ -172,6 +172,39 @@ describe('UsersPanel', () => {
     expect(await screen.findByText(/could not be enrolled as an erun user/)).toBeInTheDocument();
   });
 
+  it('distinguishes a tenant member from a self-registered IdP-only account', async () => {
+    mockFetch((req) => {
+      if (req.url === '/v1/identity/users') {
+        return jsonResponse([
+          { id: 'idp-1', username: 'alice', state: 'USER_STATE_ACTIVE', enrolled: true },
+          { id: 'idp-2', username: 'stranger', state: 'USER_STATE_ACTIVE', enrolled: false },
+        ]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('alice');
+
+    expect(screen.getByText('Tenant member')).toBeInTheDocument();
+    expect(screen.getByText('IdP only, not enrolled')).toBeInTheDocument();
+  });
+
+  it('does not offer Deactivate on the platform own machine accounts', async () => {
+    mockFetch((req) => {
+      if (req.url === '/v1/identity/users') {
+        return jsonResponse([
+          { id: 'svc-1', username: 'admin-sa', state: 'USER_STATE_ACTIVE', isMachine: true },
+        ]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<UsersPanel token="dev-token" />);
+    await screen.findByText('admin-sa');
+
+    expect(screen.getByText('Machine account')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Deactivate' })).not.toBeInTheDocument();
+  });
+
   it('does not deactivate a user on a single click', async () => {
     let deactivateCalled = false;
     mockFetch((req) => {

--- a/erun-console/src/identity/UsersPanel.tsx
+++ b/erun-console/src/identity/UsersPanel.tsx
@@ -268,6 +268,22 @@ function DeactivateUserDialog({
   );
 }
 
+// MembershipBadge tells the operator which of three states a row is in:
+// an enrolled erun user of this tenant, a machine identity (the platform's
+// own service accounts, never a tenant member), or an IdP-only account —
+// someone who exists in the identity provider (most likely via
+// self-registration) but has no erun access at all. Rendering all three
+// identically is exactly the surface #1482 asks not to present.
+function MembershipBadge({ user }: { user: IdentityUser }): React.ReactElement {
+  if (user.isMachine) {
+    return <span className="text-xs text-muted-foreground">Machine account</span>;
+  }
+  if (user.enrolled) {
+    return <span className="text-xs font-medium text-foreground">Tenant member</span>;
+  }
+  return <span className="text-xs text-muted-foreground">IdP only, not enrolled</span>;
+}
+
 function UserRow({
   user,
   onSetActive,
@@ -278,12 +294,19 @@ function UserRow({
   onRequestDeactivate: (user: IdentityUser) => void;
 }): React.ReactElement {
   const active = user.state === 'USER_STATE_ACTIVE';
-  const canToggle = active || user.state === 'USER_STATE_INACTIVE';
+  // The platform's own machine accounts (login-client, admin-sa) are the
+  // IdP's own service identities, not people an operator manages here — a
+  // one-click Deactivate beside them is a footgun on the sign-in path
+  // itself, so they get no toggle at all rather than a confirmation dialog.
+  const canToggle = !user.isMachine && (active || user.state === 'USER_STATE_INACTIVE');
   return (
     <TableRow>
       <TableCell className="font-medium text-foreground">{user.username}</TableCell>
       <TableCell>{user.email ?? ''}</TableCell>
       <TableCell>{user.state}</TableCell>
+      <TableCell>
+        <MembershipBadge user={user} />
+      </TableCell>
       <TableCell>
         {canToggle && (
           <Button
@@ -325,6 +348,7 @@ function UsersTable({
           <TableHead>Username</TableHead>
           <TableHead>Email</TableHead>
           <TableHead>State</TableHead>
+          <TableHead>Membership</TableHead>
           <TableHead />
         </TableRow>
       </TableHeader>

--- a/erun-console/src/identity/controller.ts
+++ b/erun-console/src/identity/controller.ts
@@ -1,17 +1,22 @@
 import * as React from 'react';
 
 import {
+  type CreateInviteInput,
   type EnrollIdentityUserInput,
   type EnrollIdentityUserResult,
   type IdentityUser,
+  type Invite,
   type OrgSettings,
   type SmtpStatus,
   type UpdateOrgSettingsInput,
   type UpdateSmtpSettingsInput,
   useCreateIdentityUserMutation,
+  useCreateInviteMutation,
   useGetOrgSettingsQuery,
   useGetSmtpSettingsQuery,
   useListIdentityUsersQuery,
+  useListInvitesQuery,
+  useRevokeInviteMutation,
   useSetIdentityUserActiveMutation,
   useUpdateOrgSettingsMutation,
   useUpdateSmtpSettingsMutation,
@@ -219,4 +224,84 @@ export function useSmtpSettingsController(token: string): SmtpSettingsController
   })();
 
   return { state, save };
+}
+
+export type InvitesState =
+  | { status: 'loading' }
+  | { status: 'ready'; invites: Invite[] }
+  | { status: 'error'; message: string };
+
+export type CreateInviteState =
+  | { status: 'idle' }
+  | { status: 'creating' }
+  | { status: 'created'; invite: Invite }
+  | { status: 'error'; message: string };
+
+export interface InvitesController {
+  invitesState: InvitesState;
+  createState: CreateInviteState;
+  create: (input: CreateInviteInput) => void;
+  revoke: (inviteId: string) => Promise<void>;
+  dismissCreated: () => void;
+}
+
+// useInvitesController lists, creates, and revokes invites (#1483). Creating
+// or revoking invalidates the list query's tag, the same pattern
+// useUsersController uses for enroll/deactivate.
+export function useInvitesController(token: string): InvitesController {
+  const listQuery = useListInvitesQuery(token);
+  const [createState, setCreateState] = React.useState<CreateInviteState>({ status: 'idle' });
+  const [revokeError, setRevokeError] = React.useState<string | undefined>(undefined);
+  const [createInvite] = useCreateInviteMutation();
+  const [revokeInviteMutation] = useRevokeInviteMutation();
+  const activeRef = useActiveRef();
+
+  const invitesState: InvitesState =
+    revokeError !== undefined
+      ? { status: 'error', message: revokeError }
+      : listQuery.error !== undefined
+        ? { status: 'error', message: queryErrorMessage(listQuery.error) }
+        : listQuery.data !== undefined
+          ? { status: 'ready', invites: listQuery.data }
+          : { status: 'loading' };
+
+  const create = React.useCallback(
+    (input: CreateInviteInput) => {
+      setCreateState({ status: 'creating' });
+      createInvite({ token, input })
+        .unwrap()
+        .then((invite) => {
+          if (activeRef.current) {
+            setCreateState({ status: 'created', invite });
+          }
+        })
+        .catch((error: unknown) => {
+          if (activeRef.current) {
+            setCreateState({ status: 'error', message: queryErrorMessage(error) });
+          }
+        });
+    },
+    [token, activeRef, createInvite],
+  );
+
+  const revoke = React.useCallback(
+    (inviteId: string): Promise<void> => {
+      setRevokeError(undefined);
+      return revokeInviteMutation({ token, inviteId })
+        .unwrap()
+        .then(() => undefined)
+        .catch((error: unknown) => {
+          if (activeRef.current) {
+            setRevokeError(queryErrorMessage(error));
+          }
+        });
+    },
+    [token, activeRef, revokeInviteMutation],
+  );
+
+  const dismissCreated = React.useCallback(() => {
+    setCreateState({ status: 'idle' });
+  }, []);
+
+  return { invitesState, createState, create, revoke, dismissCreated };
 }

--- a/erun-console/src/shell/AppShell.tsx
+++ b/erun-console/src/shell/AppShell.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { readTokenIdentity } from '../auth/identity';
 import { ConfigView } from '../config/ConfigView';
 import { EnvironmentsPanel } from '../environments/EnvironmentsPanel';
+import { InvitesPanel } from '../identity/InvitesPanel';
 import { OrgSettingsPanel } from '../identity/OrgSettingsPanel';
 import { SmtpSettingsPanel } from '../identity/SmtpSettingsPanel';
 import { UsersPanel } from '../identity/UsersPanel';
@@ -45,6 +46,8 @@ function SectionContent({
       return <ProvisionPanel token={token} />;
     case 'mcp-access':
       return <MCPAccessPanel token={token} environments={config.environments} />;
+    case 'invites':
+      return <InvitesPanel token={token} />;
     case 'users':
       return <UsersPanel token={token} />;
     case 'org-settings':

--- a/erun-console/src/shell/sections.ts
+++ b/erun-console/src/shell/sections.ts
@@ -1,5 +1,14 @@
 import type { TenantConfigView } from 'erun-kit';
-import { Cloud, KeyRound, LayoutDashboard, Mail, Server, Settings, Users } from 'lucide-react';
+import {
+  Cloud,
+  KeyRound,
+  LayoutDashboard,
+  Mail,
+  Server,
+  Settings,
+  UserPlus,
+  Users,
+} from 'lucide-react';
 
 // Identity administration (issue #1209) is restricted server-side to an
 // OPERATIONS tenant; gating the nav entries here too keeps a COMPANY-tenant
@@ -11,6 +20,7 @@ export type ConsoleSectionId =
   | 'environments'
   | 'provisioning'
   | 'mcp-access'
+  | 'invites'
   | 'users'
   | 'org-settings'
   | 'smtp-settings';
@@ -26,6 +36,11 @@ const BASE_SECTIONS: ConsoleSection[] = [
   { id: 'environments', label: 'Environments', icon: Server },
   { id: 'provisioning', label: 'Cloud contexts', icon: Cloud },
   { id: 'mcp-access', label: 'MCP access', icon: KeyRound },
+  // Unlike the OPERATIONS-only sections below, invites (#1483) are every
+  // tenant's own way to add members now that self-registration is closed
+  // (#1482) — a COMPANY tenant needs this exactly as much as an OPERATIONS
+  // one, so it belongs in the base set every tenant type sees.
+  { id: 'invites', label: 'Invites', icon: UserPlus },
 ];
 
 const OPERATIONS_SECTIONS: ConsoleSection[] = [

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -120,12 +120,16 @@ The `(iss, org) → tenant` resolution model and first-identity bootstrap above 
 | `GET` | `/v1/users/{user_id}/roles` | List a user's assigned roles. | Tenant member (read) |
 | `POST` | `/v1/users/{user_id}/roles` | Grant a role to a user. Body below. | Tenant member (write) |
 | `DELETE` | `/v1/users/{user_id}/roles/{role_id}` | Revoke a role from a user; refused if it would leave the tenant with no user able to grant roles. | Tenant member (write) |
+| `POST` | `/v1/invites` | Create a revocable, single-use invite for the caller's tenant, or — operations-only — an explicitly named other tenant. Body below. | Tenant member (write); cross-tenant needs Operations |
+| `GET` | `/v1/invites` | List the caller's tenant's outstanding (unconsumed) invites, or — operations-only — an explicitly named other tenant's via `?tenantId=`. | Tenant member (read); cross-tenant needs Operations |
+| `DELETE` | `/v1/invites/{invite_id}` | Revoke an outstanding invite. `204` on success. | Tenant member (write) |
+| `POST` | `/v1/invites/accept` | Consume an invite token and enroll the invitee. **Unauthenticated** — the invite token in the body is the credential. Body below. | None (public) |
 
 `GET /v1/config` is the console's read model over the per-tenant erun config — the backend DB is the system of record for the tenant's environments and cloud contexts, and this endpoint returns them denormalized as the on-disk erun config shape. All of these reads are tenant-scoped by row-level security, so a token only ever sees its own tenant's rows.
 
 ### `GET /v1/platform` {#platform-endpoint}
 
-The **only unauthenticated endpoint** besides `/healthz` — registered outside the auth middleware, directly on the mux next to it. A caller (chiefly the console SPA, but also the `erun cloud` provider below) has to resolve this instance's own issuer, API/console URLs, OIDC client ids, and display brand *before* it can sign in, so the endpoint carries no bearer token and no tenant scoping. No instance's name is ever hardcoded in a client; this is how one discovers it. It exists so **one built console image can serve any erunpaas instance** (issue #603): issuer, brand, and OIDC client ids are runtime config the API answers with, never baked into the frontend build.
+The only endpoint besides `/healthz` that requires **no credential of any kind** — registered outside the auth middleware, directly on the mux next to it. A caller (chiefly the console SPA, but also the `erun cloud` provider below) has to resolve this instance's own issuer, API/console URLs, OIDC client ids, and display brand *before* it can sign in, so the endpoint carries no bearer token and no tenant scoping. (`POST /v1/invites/accept` below, the [DNS-01 broker](#dns01-broker), and the [registry token service](#registry-token-endpoint) are also registered outside the OIDC auth middleware, but each authenticates its own distinct credential — an invite token, a per-env M2M token, and HTTP Basic respectively — rather than requiring none at all.) No instance's name is ever hardcoded in a client; this is how one discovers it. It exists so **one built console image can serve any erunpaas instance** (issue #603): issuer, brand, and OIDC client ids are runtime config the API answers with, never baked into the frontend build.
 
 ```jsonc
 // 200 response — every field optional; unset ones are empty strings, never omitted
@@ -713,7 +717,7 @@ The three identity rows — the `tenants` row, the `issuers` registry row (the g
 | `403` | The caller's resolved tenant is not an `OPERATIONS` tenant (the explicit operations gate, beyond the standard auth failures in [Errors](#errors)). | Call from an operations-tenant token whose roles permit the write. |
 | `500` | Persistence failed — e.g. the tenant `name` or the `(issuer, org_field_value)` mapping already exists (a uniqueness violation), or the request-scoped security context is missing (an internal wiring error). | Use a unique tenant name and issuer mapping; if it persists with unique inputs, it is a server bug. |
 
-### `POST /v1/users` and `GET /v1/users`
+### `POST /v1/users` and `GET /v1/users` {#post-v1users-and-get-v1users}
 
 Enrolls or lists users. Today the **only** other way a user comes to exist is the per-tenant first-user bootstrap (see [above](#tenant-issuers)) — this endpoint is how an authorized caller enrolls additional users beyond that first one.
 
@@ -782,6 +786,17 @@ A **role** is a named, tenant-owned bundle of permissions; a **permission** is o
     { "apiMethod": "GET", "apiPath": "/v1/reviews" },
     { "apiMethodPattern": "^GET$", "apiPathPattern": "^/v1/reviews/.*$" }
   ]
+### `POST /v1/invites`, `GET /v1/invites`, `DELETE /v1/invites/{invite_id}` {#invites}
+
+Registration is invite-only (issue #1483): self-registration on the platform's IdP is closed via [`allowRegister`](/agent-reference/identity-administration#org-settings), and this is the replacement path for adding a member. An invite is a **server-side record** — revocable and listable up until it is accepted — not a self-contained signed token; the token field below is the only part of it that ever leaves the backend.
+
+Create and list act on the caller's own resolved tenant by default. An explicit `tenantId` (body field for the `POST`, `?tenantId=` query param for the `GET`) targets a **different** tenant, honored only when the caller's resolved tenant is `OPERATIONS` — the same cross-tenant precedent [`POST`/`GET /v1/users`](#post-v1users-and-get-v1users) uses. This is deliberate for an invite whose target is an `OPERATIONS` tenant: accepting it lands the invitee with `erun_operations` database access across every tenant, so minting one needs the same operations-only gate as any other cross-tenant action today. A distinct permission scoped specifically to "invite into an OPERATIONS tenant" (rather than reusing the coarser operations-tenant-membership check) is now expressible: the role-assignment layer has since shipped, so this coarser tenant-type gate is a deliberate carry-over to be narrowed, not a missing capability.
+
+```jsonc
+// POST /v1/invites body — every field optional
+{
+  "email": "bob@example.com",   // optional — pins the invite to one email; accept refuses a different one
+  "tenantId": "019a…"           // optional — operations-only cross-tenant target
 }
 
 // 201 response
@@ -825,6 +840,84 @@ Each permission needs **exactly one** of the exact pair or the pattern pair (mat
 | `400` | `POST /v1/roles`: `name` is empty, no permissions given, or a permission fails the exact/pattern-exclusivity, method-enum, or regex-compile checks above. `POST /v1/users/{user_id}/roles`: `roleId` is empty. | Fix the request body per the rules above. |
 | `404` | The `role_id` or `user_id` does not exist in the caller's tenant (a cross-tenant reference is invisible under RLS, not merely forbidden). | Use an ID that belongs to your own tenant. |
 | `409` | `POST /v1/roles`: a role with this name, or one of its permissions, already exists in the tenant. `POST /v1/users/{user_id}/roles`: the user already holds this role. `DELETE .../roles/{role_id}`: the lockout guard above refused the revoke. | Use a different name, or accept the existing grant; for the lockout case, grant a recovery role to another user (or the same user) before revoking this one. |
+  "inviteId": "019a…",
+  "tenantId": "019a…",
+  "token": "kX92n…",             // the invite's credential — build the accept link from this
+  "email": "bob@example.com",
+  "expiresAt": "2026-09-03T16:00:00Z",   // fixed 7-day TTL, not caller-configurable today
+  "createdAt": "2026-08-27T16:00:00Z",
+  "updatedAt": "2026-08-27T16:00:00Z"
+}
+```
+
+```jsonc
+// GET /v1/invites?tenantId=019a… (operations-only cross-tenant; omit tenantId for the caller's own tenant)
+// 200 response — only outstanding (unconsumed) invites, newest first
+[
+  {
+    "inviteId": "019a…",
+    "tenantId": "019a…",
+    "token": "kX92n…",
+    "email": "bob@example.com",
+    "expiresAt": "2026-09-03T16:00:00Z",
+    "createdAt": "2026-08-27T16:00:00Z",
+    "updatedAt": "2026-08-27T16:00:00Z"
+  }
+]
+```
+
+`DELETE /v1/invites/{invite_id}` revokes it; `204` on success. There is no soft-revoke state — a revoked invite's row is gone, so a stale accept attempt against it resolves the same as an unknown token.
+
+**Error behaviour.**
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | Body is not valid JSON. | Send a valid JSON object; every field is optional. |
+| `403` | `tenantId` (or `?tenantId=`) names a different tenant than the caller's own, and the caller's resolved tenant is not `OPERATIONS`. | Omit `tenantId` to act on your own tenant, or call from an operations-tenant token. |
+| `404` | `DELETE`: `invite_id` does not name an outstanding invite in a tenant the caller can reach. | Re-check the id from `GET /v1/invites`; an already-consumed or already-revoked invite is not found here. |
+
+### `POST /v1/invites/accept` {#invites-accept}
+
+Consumes an invite token and enrolls the invitee as an erun user of the invite's target tenant. **Unauthenticated** — registered directly on the mux like [`GET /v1/platform`](#platform-endpoint) — because the invitee has no bearer token yet; the invite token in the body is what authorizes this call, and it is single-use and validated atomically (a `SELECT ... FOR UPDATE` against the invite row) so two concurrent accepts of the same token cannot both succeed.
+
+Unlike [`POST /v1/identity/users`](/agent-reference/identity-administration) (an operator composing an account for someone absent, which never sets a caller-supplied password so no operator ever handles a credential belonging to someone else's account), the invitee is present and choosing their own password right now — there is no "someone else's account" to protect them from, and Zitadel's own email-invite flow would be the wrong choice regardless, since its link has nothing to do with the credential just supplied. So this always creates the IdP identity with the supplied password as its initial password, marking the email verified and landing the account `USER_STATE_ACTIVE` immediately — no email round-trip, and it works with no SMTP configured at all (issue #1168). A future increment may prefer WebAuthn/passkey registration here instead of a password, to keep the "never handle someone else's credential" property even tighter; that is not implemented today, and `password` is required.
+
+```jsonc
+// request body
+{
+  "token": "kX92n…",              // required
+  "username": "bob",              // required
+  "email": "bob@example.com",     // optional; required to match the invite's pinned email, if it set one
+  "firstName": "Bob",             // optional
+  "lastName": "Operator",         // optional
+  "password": "the-invitee-chose-this"   // required
+}
+
+// 201 response — both halves landed
+{
+  "idpUser": { "id": "387728445393600515", "username": "bob", "state": "USER_STATE_ACTIVE" },
+  "erunUser": { "userId": "019a…", "username": "bob" }
+}
+
+// 201 response — the IdP identity was created, but the erun mapping failed
+{
+  "idpUser": { "id": "387728445393600515", "username": "bob", "state": "USER_STATE_ACTIVE" },
+  "error": "identity created in the identity provider but the erun user mapping failed: idp user id 387728445393600515: a user with this username already exists in the target tenant"
+}
+```
+
+The half-landed-failure shape mirrors `POST /v1/identity/users` exactly: a failure after the IdP identity exists is a `201` with `error` set and no `erunUser`, not an opaque failure — the console tells the invitee to ask an operator to finish the enrollment rather than retry blindly.
+
+**Error behaviour.** Each of the three invalid-token states is reported distinctly rather than as one generic failure — a stale link should say why it's stale:
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `400` | `token`/`username`/`password` empty, the body is not valid JSON, or `email` was supplied and does not match the invite's pinned email (case-insensitive). | Send all three required fields; match the pinned email exactly or omit it. |
+| `404` | `token` does not name any invite that ever existed (or it was revoked — revocation deletes the row). | Ask whoever invited you for a new link. |
+| `410` | The invite exists but has expired, or has already been consumed (single-use). | Ask whoever invited you for a new link. |
+| Forwarded from Zitadel | The IdP identity creation itself failed (e.g. the password does not meet the org's complexity policy). | The response body carries Zitadel's own message; act on it directly. |
+
+**Not audited.** Unlike `POST`/`GET`/`DELETE /v1/invites` above (which run through the authenticated middleware that writes `audit_events` for every protected request), this endpoint is registered outside that middleware — the same as [`GET /v1/platform`](#platform-endpoint) — because there is no authenticated caller identity to attribute the row to. The invite's own `created_by_user_id` plus its `consumed_at` timestamp is today's record of who accepted it and when; a dedicated audit event for acceptance is a reasonable follow-up, not yet implemented.
 
 ### `PUT /v1/tenants/{tenant_id}/quota` {#put-v1tenantstenant_idquota}
 

--- a/erun-docs/docs/agent-reference/identity-administration.md
+++ b/erun-docs/docs/agent-reference/identity-administration.md
@@ -22,7 +22,7 @@ Zitadel's built-in `ORG_USER_MANAGER` role would scope user create/list/deactiva
 
 ## `GET /v1/identity/users`
 
-Lists every identity (human and machine) the platform's IdP knows about.
+Lists every identity (human and machine) the platform's IdP knows about, cross-referenced against erun's own `users` table for the caller's tenant so the response distinguishes an enrolled tenant member from an identity that merely exists in the IdP — the fix for a self-registered account (when `allowRegister` was left open, or an account created before it was closed) rendering identically to an actual member.
 
 ```jsonc
 // 200 response
@@ -33,12 +33,30 @@ Lists every identity (human and machine) the platform's IdP knows about.
     "state": "USER_STATE_ACTIVE",     // Zitadel's own USER_STATE_* value, forwarded verbatim
     "email": "alice@example.com",
     "firstName": "Alice",
-    "lastName": "Operator"
+    "lastName": "Operator",
+    "isMachine": false,
+    "enrolled": true,                  // true only when this subject also has a row in erun's own users table for this tenant
+    "erunUserId": "019a…"              // present only when enrolled is true
+  },
+  {
+    "id": "387728394274144999",
+    "username": "stranger",
+    "state": "USER_STATE_ACTIVE",
+    "email": "stranger@example.com",
+    "isMachine": false,
+    "enrolled": false                  // exists in the IdP (e.g. self-registered) but is not a tenant member
+  },
+  {
+    "id": "387728394274100001",
+    "username": "admin-sa",
+    "state": "USER_STATE_ACTIVE",
+    "isMachine": true,                 // the platform's own service identity, never a tenant member
+    "enrolled": false
   }
 ]
 ```
 
-`email`/`firstName`/`lastName` are omitted for a machine user (e.g. the platform's own `admin-sa`/`login-client` service accounts, which this list includes).
+`email`/`firstName`/`lastName` are omitted for a machine user (e.g. the platform's own `admin-sa`/`login-client` service accounts, which this list includes — `isMachine: true` is how a client tells them apart from a human row with an unset email, and is also what the console uses to withhold the deactivate/reactivate control on those two rows).
 
 ## `POST /v1/identity/users`
 
@@ -104,7 +122,7 @@ The IdP half is created first, since the erun mapping needs the subject the IdP 
 | `404` | (Zitadel's not-found message) | `external_id` does not name a known identity. | Re-check the id from `GET /v1/identity/users`. |
 | `403` | — | Caller's tenant is not `OPERATIONS`. | Call from an operations-tenant token. |
 
-## `GET /v1/identity/org-settings`
+## `GET /v1/identity/org-settings` {#org-settings}
 
 Reads the org's current login policy, password complexity policy, and verified domains.
 
@@ -112,6 +130,7 @@ Reads the org's current login policy, password complexity policy, and verified d
 // 200 response
 {
   "forceMfa": false,
+  "allowRegister": false,           // whether the platform's IdP accepts self-registration (issue #1482)
   "minPasswordLength": 8,
   "passwordRequiresUppercase": true,
   "passwordRequiresLowercase": true,
@@ -123,13 +142,15 @@ Reads the org's current login policy, password complexity policy, and verified d
 
 `verifiedDomains` is read-only here — verifying a new domain is a DNS/HTTP challenge flow this surface does not drive.
 
+**`allowRegister`.** erun reads this field from Zitadel's own login policy but never wrote it before this endpoint could change it — the whole reported exposure of issue #1482. There is no erun-side default this endpoint imposes: a platform that has never called `PATCH` with `allowRegister` set keeps whatever value its Zitadel org already carries (Zitadel's own instance default is `true`, which is why the exposure went unnoticed). The recommended value for a platform whose access model is invite-only ([`POST /v1/invites`](/agent-reference/api-protocol#invites)) is `false`; erun does not flip it automatically on any existing platform — an operator (or their Agent) sets it explicitly via the `PATCH` below.
+
 ## `PATCH /v1/identity/org-settings`
 
 Applies only the fields present in the body; every other current value is preserved via a server-side read-modify-write against Zitadel (re-sending an unchanged value is skipped rather than sent, since Zitadel answers `400` for a write that carries no real diff). Returns the full settings after the update, same shape as the `GET` above.
 
 ```jsonc
-// request body — change only forceMfa
-{ "forceMfa": true }
+// request body — close self-registration, leave every other field untouched
+{ "allowRegister": false }
 ```
 
 **Error behaviour.**
@@ -208,4 +229,5 @@ Every request above that reaches its handler (i.e. passed authentication, tenant
 
 - [Administering identity](/collaboration/identity-administration) — the Operator view.
 - [erun API protocol](/agent-reference/api-protocol) — sign-in, tenant resolution, and the cross-cutting error model these endpoints share.
+- [`POST /v1/invites` and friends](/agent-reference/api-protocol#invites) — the invite-only registration model `allowRegister: false` above is meant to pair with; every tenant type can create its own invites, unlike this OPERATIONS-only surface.
 - [Audit log](/agent-reference/audit-log) — the event shape every mutation above writes.

--- a/erun-docs/docs/collaboration/identity-administration.md
+++ b/erun-docs/docs/collaboration/identity-administration.md
@@ -22,6 +22,7 @@ Signed in as an Operator on an **OPERATIONS** tenant, the console's **Users** vi
 The **Org settings** view lets you read and change:
 
 - Whether multi-factor authentication is required to sign in.
+- **Whether anyone can self-register an account** on the platform's IdP, versus requiring an invite (see [Inviting people](#inviting-people) below). If you have never touched this toggle, your platform keeps whatever value it already had — erun does not flip it for you. For a platform whose access model is invite-only, turning it off here is the recommended, one-time step; nothing about the invite flow below requires it, but leaving self-registration open alongside invites means a stranger can still create an account in your IdP (though not gain any erun access — enrollment, not IdP account creation, is the access boundary).
 - The password complexity policy (minimum length, and whether an uppercase letter, lowercase letter, number, or symbol is required).
 - The org's verified domains (read-only here — verifying a new domain is a DNS/HTTP challenge flow this view does not drive).
 
@@ -40,6 +41,20 @@ There is no way around supplying those values yourself — ERun cannot supply a 
 
 **To verify it worked:** once mail delivery is configured, enroll a throwaway test user (see above) — with mail configured, that enrollment emails a real sign-in link to the address you gave it, so receiving it is the proof. If nothing arrives, double check the host/port and credential with your mail provider; the error reported back is whatever your provider's server returned.
 
+## Inviting people {#inviting-people}
+
+Unlike everything above (which is restricted to an **OPERATIONS** tenant), the console's **Invites** view is available to every tenant — a **COMPANY** tenant needs its own way to add members exactly as much as an OPERATIONS one does, now that self-registration is meant to be closed.
+
+Anyone already signed in can:
+
+- **Create an invite.** Optionally pin it to one email address; the console shows you a one-time, copyable link right after creation. Share it however you'd share any link — chat, email, whatever you already use. The link expires after 7 days and works exactly once.
+- **See your tenant's outstanding invites** and copy a link again if you need to resend it.
+- **Revoke an invite** that should no longer work — it disappears immediately, and the link stops working even if it hasn't expired.
+
+The person you invite opens the link, picks a username and password (and their email, unless you pinned one), and their account is ready immediately — no email round-trip, so it works even on a platform with no outbound mail configured. If something goes wrong partway (their identity-provider account was created but enrolling them into your tenant failed), the page says so plainly and tells them to ask you to finish it, rather than claiming success or failing silently.
+
+An invite to your own tenant is always allowed. Inviting into a **different** tenant is restricted to an OPERATIONS Operator, the same way every other cross-tenant action in this console is — accepting that kind of invite hands out platform-wide access, not just membership in one company's tenant.
+
 ## What still requires Zitadel's own console
 
 This surface is deliberately narrow, not a full admin proxy. Anything beyond enroll/list/deactivate/reactivate and the login/password policy above — role/project configuration inside Zitadel itself, advanced MFA methods, SSO federation, org branding — is still Zitadel's own admin console's job.
@@ -48,10 +63,11 @@ This surface is deliberately narrow, not a full admin proxy. Anything beyond enr
 
 The credential that drives this is Zitadel's **org-owner** service-account token — the most privileged credential the platform's IdP holds, provisioned automatically on every deployment. It never reaches your browser: the console calls erun's own backend, and the backend is the only thing that ever holds it. Every mutation this surface can make is individually audited (see [Operator in the loop](/collaboration/operator-in-the-loop)).
 
-Because that credential is so privileged, this whole surface is restricted to an **OPERATIONS** tenant. A **COMPANY** tenant's Operators do not see these views at all, and the backend refuses the underlying endpoints even if called directly.
+Because that credential is so privileged, the Users/Org settings/Outbound mail surface above is restricted to an **OPERATIONS** tenant. A **COMPANY** tenant's Operators do not see those views at all, and the backend refuses the underlying endpoints even if called directly. [Inviting people](#inviting-people) is the one exception — it never touches that credential (it drives erun's own database and, on acceptance, the same Zitadel identity-creation call enrollment already uses), so it is available to every tenant.
 
 ## See also
 
 - [Agent reference · Identity administration](/agent-reference/identity-administration) — the full endpoint spec.
+- [Agent reference · Invites](/agent-reference/api-protocol#invites) — the invite endpoint spec.
 - [Hosted platform](/concepts/hosted-platform) — the platform this identity provider belongs to.
 - [Operator in the loop](/collaboration/operator-in-the-loop) — the audit trail every mutation here writes to.


### PR DESCRIPTION
Self-registration is open on the production platform — `auth.erunpaas.com`
serves Zitadel's own Register page — and erun **read** the flag governing it
while offering no way to change it. `updateLoginPolicy` took `forceMFA bool` and
mutated exactly one field, so `AllowRegister` round-tripped untouched forever.

That is a capability with no way in (root `AGENTS.md` failure mode 3). To be
precise about severity, as #1482 itself is: erun's authorization is sound and
this is **not a privilege breach** — it is unbounded account creation with no
lever, plus a Users page that misrepresents who is a member.

## The lever

`updateLoginPolicy` is generalised from a single `forceMFA` parameter to a
diff-per-field shape (reusing the `applyBoolField` helper the
password-complexity path already used), so `AllowRegister` threads through
`UpdateOrgSettingsParams` → route → the console's Org Settings panel, beside the
existing MFA toggle.

The single-field signature was the actual trap here: the next field would have
hit the same wall. It no longer can.

An operator reaches it at **Org settings → "Allow anyone to self-register an
account."**

## The default: deliberately unchanged for existing platforms

No code alters a live platform's `allowRegister`. There is **no in-repo path
that provisions a production org's login policy** — only the Playwright
provisioning script pins `allowRegister: false`, for deterministic tests.
`oidc-bootstrap.sh` and the charts are untouched.

So an existing platform keeps whatever value it has until an operator visits the
new toggle. That is the safe direction: a deploy silently closing registration
could lock people out of their own platform.

## The Users page no longer misrepresents membership

`GET /v1/identity/users` now cross-references the IdP's list against erun's
`users` table by external subject and returns `enrolled` / `erunUserId` /
`isMachine`. The console renders **Tenant member**, **IdP only, not enrolled**,
or **Machine account**, and withholds Deactivate/Reactivate entirely for machine
rows (`login-client`, `admin-sa`).

## Invite-only registration

A new `invites` table (RLS, single-use, revocable) backs `POST`/`GET`/`DELETE
/v1/invites`, plus an **unauthenticated** `POST /v1/invites/accept` where the
token is the credential. The token lookup runs through a new
`TxManager.WithinSystemTx` and then rebinds a synthetic `security.Context` to the
invite's target tenant — the same pattern the per-tenant first-user bootstrap
already uses for a caller-less enrolment. Console gets an **Invites** panel and a
standalone `/accept-invite` page that renders before OIDC sign-in starts.

## Deviations, each declared rather than silent

- **No fine-grained "invite into OPERATIONS" permission** — the coarser
  tenant-type gate is reused, matching #1483's own stated fallback. The
  role-assignment layer has since landed, so this is now a carry-over to narrow
  rather than a missing capability, and the docs say so.
- **No passkey on accept** — #1483 permits a password fallback; the invitee sets
  their own rather than receiving a generated one, needing no WebAuthn plumbing.
- **No CLI/MCP surface** — matches #1482's module list.
- **The accept endpoint writes no audit event** — it is unauthenticated, like
  `GET /v1/platform`, so there is no caller identity to attribute a row to.
  `created_by_user_id` plus `consumed_at` is today's record. Documented as a
  known gap.

## Verification

- `TestUpdateOrgSettingsAllowRegisterPreservesOtherLoginFields` — flipping
  `allowRegister` does not disturb `forceMfa` or any other policy field, which is
  exactly what the GET-then-POST round-trip comment exists to protect
- `TestGetOrgSettingsReportsRegistrationOpenAndClosed` — both states
- `TestListUsersDistinguishesEnrolledFromIdPOnly`, plus console
  `InvitesPanel`/`UsersPanel` tests
- invite flow e2e against a **real migrated Postgres** in a throwaway container:
  single-use enforcement, expiry, cross-tenant override, revoke — container
  created and removed by the run
- `make check` → **exit 0** on the rebased tree: golangci-lint clean across every
  Go module, Go tests green including `erun-ui`, `erun-kit`/`erun-console` gates
  (89 tests), all chart tests, integration suite, coverage **76.1%** (≥ 75.8%)

**Nothing touched production and no call was made to the live IdP.** All
verification ran against local throwaway Postgres containers.

Closes #1482
Closes #1483