### PR TITLE
Report a probe that hit its own deadline as a timeout, not as a kill signal

### DIFF
--- a/erun-ui/playwright/tests/manage-runtime-activity.spec.ts
+++ b/erun-ui/playwright/tests/manage-runtime-activity.spec.ts
@@ -27,9 +27,19 @@ test.describe('manage dialog runtime activity panel', () => {
     // cannot read a pod. Visibility of system status (Nielsen #1) requires the
     // panel to say so rather than render empty, which would read as "nothing is
     // running" — the exact false-negative this work exists to remove.
+    //
+    // The stub kubectl fails fast, so this exercises the classifier's "keep the
+    // raw cause" branch (erun-ui/runtime_probe_error.go), not the
+    // deadline-vs-external-kill classification -- this offline harness cannot
+    // make a probe actually time out or get signal-killed. Those branches are
+    // covered by the Go suite instead (erun-ui/runtime_probe_error_test.go and
+    // TestLoadRuntimeActivityReportsOwnTimeoutNotSignalKilled /
+    // TestLoadRuntimeActivityReportsExternalKillDistinctFromTimeout in
+    // erun-ui/runtime_activity_test.go).
     await expect(panel).toContainText(
       /Cannot read what the runtime is running|Open the environment to see what it is running/,
     );
+    await expect(panel).not.toContainText('signal:');
 
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();

--- a/erun-ui/playwright/tests/manage-runtime-sizing.spec.ts
+++ b/erun-ui/playwright/tests/manage-runtime-sizing.spec.ts
@@ -130,4 +130,34 @@ test.describe('manage dialog sizing recommendation panel', () => {
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();
   });
+
+  // Unlike the two tests above, this one does not stub LoadRuntimeSizing, so
+  // the seeded (inert, never-deployed) env's real probe runs against the
+  // harness's stub kubectl and fails for real.
+  //
+  // The stub kubectl fails fast, so this exercises the classifier's "keep the
+  // raw cause" branch, not the deadline-vs-external-kill classification --
+  // this offline harness cannot make a probe actually time out or get
+  // signal-killed. Those branches are covered by the Go suite instead
+  // (erun-ui/runtime_probe_error_test.go and
+  // TestLoadRuntimeSizingReportsOwnTimeoutNotSignalKilled /
+  // TestLoadRuntimeSizingReportsExternalKillDistinctFromTimeout in
+  // erun-ui/runtime_sizing_test.go).
+  test('an unreachable pod fails soft with a stated reason, never a blank panel', async ({
+    app,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+    await app.sidebar.openManageDialogViaKeyboard(tenant, environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+
+    const panel = app.manageDialog.runtimeSizingPanel();
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Cannot read this environment's sizing recommendation");
+    await expect(panel).not.toContainText('signal:');
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
 });

--- a/erun-ui/playwright/tests/manage-runtime-usage.spec.ts
+++ b/erun-ui/playwright/tests/manage-runtime-usage.spec.ts
@@ -177,4 +177,34 @@ test.describe('manage dialog runtime usage panel', () => {
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();
   });
+
+  // The seeded env is inert and never deployed, so the harness's stub kubectl
+  // (unmocked here, unlike the two tests above) fails the probe for real
+  // rather than through a stubbed response. Visibility of system status
+  // (Nielsen #1) requires the panel to say so rather than render blank.
+  //
+  // The stub kubectl fails fast, so this exercises the classifier's "keep the
+  // raw cause" branch, not the deadline-vs-external-kill classification --
+  // this offline harness cannot make a probe actually time out or get
+  // signal-killed. Those branches are covered by the Go suite instead
+  // (erun-ui/runtime_probe_error_test.go and
+  // TestLoadRuntimeUsageReportsOwnTimeoutNotSignalKilled in
+  // erun-ui/runtime_usage_test.go).
+  test('an unreachable pod fails soft with a stated reason, never a blank panel', async ({
+    app,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+    await app.sidebar.openManageDialogViaKeyboard(tenant, environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Runtime');
+
+    const panel = app.manageDialog.runtimeUsagePanel();
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Cannot read this environment's resource usage");
+    await expect(panel).not.toContainText('signal:');
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
 });

--- a/erun-ui/runtime_activity.go
+++ b/erun-ui/runtime_activity.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -105,7 +106,7 @@ func (a *App) probeRuntimeActivity(selection uiSelection) (uiRuntimeActivity, er
 	output, err := a.execInRuntimePod(ctx, selection,
 		eruncommon.RemoteAppSessionHeartbeatScript(selection.Tenant, selection.Environment)+"\n"+runtimeProcessSnapshotScript())
 	if err != nil {
-		return uiRuntimeActivity{}, err
+		return uiRuntimeActivity{}, errors.New(runtimeProbeFailureMessage(ctx, runtimeActivityTimeout, err, func(e error) string { return e.Error() }))
 	}
 	return runtimeActivityFromProbe(selection, output), nil
 }

--- a/erun-ui/runtime_activity_test.go
+++ b/erun-ui/runtime_activity_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"reflect"
 	goruntime "runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestRuntimeActivityGroupsResourceHoldingProcesses covers the leftover case
@@ -81,6 +83,69 @@ func TestLoadRuntimeActivityFailsSoft(t *testing.T) {
 	}
 	if !strings.Contains(activity.Message, "Cannot read what the runtime is running") {
 		t.Fatalf("the reason must be visible, got %q", activity.Message)
+	}
+}
+
+// TestLoadRuntimeActivityReportsOwnTimeoutNotSignalKilled is the reported
+// defect for the "Running in this environment" panel: with the app's own
+// context already past its deadline, probeRuntimeActivity's derived ctx reads
+// as already timed out (context.WithTimeout on an expired parent inherits its
+// Err() immediately), so the panel must name that timeout rather than the
+// "signal: killed" text the mocked exec below deliberately returns.
+func TestLoadRuntimeActivityReportsOwnTimeoutNotSignalKilled(t *testing.T) {
+	app := NewApp(erunUIDeps{
+		execRuntimePod: func(context.Context, uiSelection, string) (string, error) {
+			return "", errors.New("signal: killed")
+		},
+	})
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+	app.ctx = ctx
+
+	activity, err := app.LoadRuntimeActivity(uiSelection{Tenant: "petios", Environment: "local"})
+	if err != nil {
+		t.Fatalf("LoadRuntimeActivity must not surface a probe failure as an error: %v", err)
+	}
+	if activity.Available {
+		t.Fatalf("a timed-out probe must not be reported as an available reading: %+v", activity)
+	}
+	if !strings.Contains(activity.Message, "timed out") {
+		t.Fatalf("expected the panel to name its own timeout, got %q", activity.Message)
+	}
+	if strings.Contains(activity.Message, "signal:") {
+		t.Fatalf("the panel must never repeat the raw kill signal on a timeout, got %q", activity.Message)
+	}
+}
+
+// TestLoadRuntimeActivityReportsExternalKillDistinctFromTimeout covers a kill
+// this probe did not cause: ctx has not expired, but the pod exec still
+// terminated by signal (an OOM kill, an evicted pod, most likely). That is a
+// different situation from the self-inflicted timeout above and must read
+// differently, without ever naming the bare signal either.
+func TestLoadRuntimeActivityReportsExternalKillDistinctFromTimeout(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("signal-terminated exec is a POSIX concept")
+	}
+	app := NewApp(erunUIDeps{
+		execRuntimePod: func(context.Context, uiSelection, string) (string, error) {
+			cmd := exec.Command("/bin/sh", "-c", "kill -9 $$")
+			return "", cmd.Run()
+		},
+	})
+	app.ctx = context.Background()
+
+	activity, err := app.LoadRuntimeActivity(uiSelection{Tenant: "petios", Environment: "local"})
+	if err != nil {
+		t.Fatalf("LoadRuntimeActivity must not surface a probe failure as an error: %v", err)
+	}
+	if strings.Contains(activity.Message, "timed out") {
+		t.Fatalf("a kill this probe did not cause must not be read as its own timeout, got %q", activity.Message)
+	}
+	if strings.Contains(activity.Message, "signal:") {
+		t.Fatalf("the panel must never repeat the raw kill signal, got %q", activity.Message)
+	}
+	if !strings.Contains(activity.Message, "killed") {
+		t.Fatalf("expected the panel to name an external kill, got %q", activity.Message)
 	}
 }
 

--- a/erun-ui/runtime_probe_error.go
+++ b/erun-ui/runtime_probe_error.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// runtimeProbeFailureMessage is the one translator all three Runtime-tab
+// probes (usage, activity, sizing) route a failed read through. Each probe
+// binds its own kubectl exec to a context it created and cancels on a fixed
+// deadline, so when that call fails, ctx.Err() tells the cause with certainty
+// -- there is nothing to infer, because erun is the one that set the deadline
+// and enforced it. Reporting the "signal: killed" os/exec used to carry out
+// that enforcement, instead of the deadline itself, discards a cause erun
+// already knows and reads (in a panel about memory) as an OOM kill that never
+// happened. A kill this probe did not cause -- the kernel OOM-killing the
+// exec'd process, the pod getting evicted -- is a different situation with a
+// different next action, so it is named as an external kill rather than
+// folded into the timeout message. Anything else falls through to fallback,
+// which lets a caller keep its own domain-specific extraction (e.g. the
+// resize command's own refusal text) for errors that were never about the
+// deadline at all.
+func runtimeProbeFailureMessage(ctx context.Context, timeout time.Duration, err error, fallback func(error) string) string {
+	switch {
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return fmt.Sprintf(
+			"timed out after %s waiting on the runtime pod. This probe enforces its own bound rather than hanging the tab; if it keeps happening, the environment may be overloaded or wedged -- open a shell to check what it is running, or try Reclaim.",
+			timeout)
+	case ctx.Err() != nil:
+		return fmt.Sprintf("canceled before it finished: %s", ctx.Err())
+	case isRuntimeProbeExternalKill(err):
+		return "the runtime pod's process was killed for a reason other than this probe's own timeout -- most likely an out-of-memory kill or the pod being evicted. Check the environment's recent events."
+	default:
+		return fallback(err)
+	}
+}
+
+// isRuntimeProbeExternalKill reports whether err is a process that terminated
+// by signal rather than by exiting. It uses os/exec's own distinction
+// (ProcessState.Exited()) rather than matching "signal: killed" in the error
+// text, so it cannot mistake a real message that happens to contain that
+// phrase for a kill, and it never needs to reproduce the phrase itself.
+func isRuntimeProbeExternalKill(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ProcessState == nil {
+		return false
+	}
+	return !exitErr.Exited()
+}

--- a/erun-ui/runtime_probe_error_test.go
+++ b/erun-ui/runtime_probe_error_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	goruntime "runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRuntimeProbeFailureMessageNamesOwnDeadlineAsTimeout is the reported
+// defect itself: when the ctx that bounded the probe is the one that expired,
+// the message must name that timeout and its bound rather than repeating
+// whatever kill-signal text os/exec used to enforce it.
+func TestRuntimeProbeFailureMessageNamesOwnDeadlineAsTimeout(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+
+	msg := runtimeProbeFailureMessage(ctx, 10*time.Second, errors.New("signal: killed"), func(e error) string { return e.Error() })
+
+	if !strings.Contains(msg, "timed out") || !strings.Contains(msg, "10s") {
+		t.Fatalf("expected the message to name a timeout and its bound, got %q", msg)
+	}
+	if strings.Contains(msg, "signal:") {
+		t.Fatalf("a self-inflicted deadline must never surface the raw kill signal, got %q", msg)
+	}
+}
+
+// TestRuntimeProbeFailureMessageNamesExternalKillDistinctFromTimeout covers a
+// kill this probe did not cause: ctx has not expired, but the process still
+// terminated by signal. That is a different situation (an OOM kill, an
+// evicted pod) with a different next action, so it must read differently from
+// the timeout branch above, and must not name a bare signal either.
+func TestRuntimeProbeFailureMessageNamesExternalKillDistinctFromTimeout(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("signal-terminated exec is a POSIX concept")
+	}
+	cmd := exec.Command("/bin/sh", "-c", "kill -9 $$")
+	killErr := cmd.Run()
+	if killErr == nil {
+		t.Fatalf("expected the self-kill to produce a signal-terminated exec error")
+	}
+
+	msg := runtimeProbeFailureMessage(context.Background(), 10*time.Second, killErr, func(e error) string { return e.Error() })
+
+	if strings.Contains(msg, "timed out") {
+		t.Fatalf("a kill this probe did not cause must not be read as its own timeout, got %q", msg)
+	}
+	if strings.Contains(msg, "signal:") {
+		t.Fatalf("an external kill must not surface the raw kill signal either, got %q", msg)
+	}
+	if !strings.Contains(msg, "killed") || !strings.Contains(msg, "other than this probe") {
+		t.Fatalf("expected the message to name an external kill distinct from this probe's own timeout, got %q", msg)
+	}
+}
+
+// TestRuntimeProbeFailureMessageKeepsRawCauseForUnclassifiedFailure covers
+// everything that is neither this probe's own deadline nor a signal-terminated
+// process: the raw cause is kept (via the caller's own fallback), never dressed
+// up as either specific case.
+func TestRuntimeProbeFailureMessageKeepsRawCauseForUnclassifiedFailure(t *testing.T) {
+	err := errors.New("kubectl: unable to connect to the server")
+
+	msg := runtimeProbeFailureMessage(context.Background(), 10*time.Second, err, func(e error) string {
+		return "fallback: " + e.Error()
+	})
+
+	if msg != "fallback: kubectl: unable to connect to the server" {
+		t.Fatalf("expected the fallback's own text to survive unchanged, got %q", msg)
+	}
+}

--- a/erun-ui/runtime_sizing.go
+++ b/erun-ui/runtime_sizing.go
@@ -70,7 +70,7 @@ func (a *App) LoadRuntimeSizing(selection uiSelection) (uiRuntimeSizingRecommend
 		return uiRuntimeSizingRecommendation{
 			Tenant:      selection.Tenant,
 			Environment: selection.Environment,
-			Message:     "Cannot read this environment's sizing recommendation: " + friendlyRuntimeResizeError(err),
+			Message:     "Cannot read this environment's sizing recommendation: " + runtimeProbeFailureMessage(ctx, runtimeSizingTimeout, err, friendlyRuntimeResizeError),
 		}, nil
 	}
 	return runtimeSizingFromOutput(selection, output), nil
@@ -91,7 +91,7 @@ func (a *App) ResizeRuntimeToRecommendation(selection uiSelection, overrideLease
 	defer cancel()
 	output, err := a.execInRuntimePod(ctx, selection, resizeCommandScript(selection, true, overrideLease))
 	if err != nil {
-		return uiRuntimeSizingRecommendation{}, fmt.Errorf("%s", friendlyRuntimeResizeError(err))
+		return uiRuntimeSizingRecommendation{}, fmt.Errorf("%s", runtimeProbeFailureMessage(ctx, runtimeReclaimTimeout, err, friendlyRuntimeResizeError))
 	}
 	result := runtimeSizingFromOutput(selection, output)
 	result.Available = true

--- a/erun-ui/runtime_sizing_test.go
+++ b/erun-ui/runtime_sizing_test.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"os/exec"
 	"reflect"
+	goruntime "runtime"
+	"strings"
 	"testing"
+	"time"
 )
 
 // TestRuntimeSizingFromOutputParsesActions covers the happy path: the resize
@@ -86,3 +92,63 @@ func TestFriendlyRuntimeResizeErrorStripsWrapper(t *testing.T) {
 type wrappedError struct{ msg string }
 
 func (e *wrappedError) Error() string { return e.msg }
+
+// TestLoadRuntimeSizingReportsOwnTimeoutNotSignalKilled is the reported defect
+// for the sizing panel: with the app's own context already past its deadline,
+// LoadRuntimeSizing's derived ctx reads as already timed out, so the panel
+// must name that timeout rather than the "signal: killed" text the mocked
+// exec below deliberately returns.
+func TestLoadRuntimeSizingReportsOwnTimeoutNotSignalKilled(t *testing.T) {
+	app := NewApp(erunUIDeps{
+		execRuntimePod: func(context.Context, uiSelection, string) (string, error) {
+			return "", errors.New("signal: killed")
+		},
+	})
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+	app.ctx = ctx
+
+	recommendation, err := app.LoadRuntimeSizing(uiSelection{Tenant: "myapp", Environment: "prod"})
+	if err != nil {
+		t.Fatalf("LoadRuntimeSizing must not surface a probe failure as an error: %v", err)
+	}
+	if recommendation.Available {
+		t.Fatalf("a timed-out probe must not be reported as an available reading: %+v", recommendation)
+	}
+	if !strings.Contains(recommendation.Message, "timed out") {
+		t.Fatalf("expected the panel to name its own timeout, got %q", recommendation.Message)
+	}
+	if strings.Contains(recommendation.Message, "signal:") {
+		t.Fatalf("the panel must never repeat the raw kill signal on a timeout, got %q", recommendation.Message)
+	}
+}
+
+// TestLoadRuntimeSizingReportsExternalKillDistinctFromTimeout covers a kill
+// this probe did not cause, which must read differently from the
+// self-inflicted timeout above and must never name the bare signal either.
+func TestLoadRuntimeSizingReportsExternalKillDistinctFromTimeout(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("signal-terminated exec is a POSIX concept")
+	}
+	app := NewApp(erunUIDeps{
+		execRuntimePod: func(context.Context, uiSelection, string) (string, error) {
+			cmd := exec.Command("/bin/sh", "-c", "kill -9 $$")
+			return "", cmd.Run()
+		},
+	})
+	app.ctx = context.Background()
+
+	recommendation, err := app.LoadRuntimeSizing(uiSelection{Tenant: "myapp", Environment: "prod"})
+	if err != nil {
+		t.Fatalf("LoadRuntimeSizing must not surface a probe failure as an error: %v", err)
+	}
+	if strings.Contains(recommendation.Message, "timed out") {
+		t.Fatalf("a kill this probe did not cause must not be read as its own timeout, got %q", recommendation.Message)
+	}
+	if strings.Contains(recommendation.Message, "signal:") {
+		t.Fatalf("the panel must never repeat the raw kill signal, got %q", recommendation.Message)
+	}
+	if !strings.Contains(recommendation.Message, "killed") {
+		t.Fatalf("expected the panel to name an external kill, got %q", recommendation.Message)
+	}
+}

--- a/erun-ui/runtime_usage.go
+++ b/erun-ui/runtime_usage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -66,7 +67,7 @@ func loadRuntimeUsageViaKubectl(parent context.Context, store erunUIStore, selec
 
 	reading, err := eruncommon.RunRuntimeUsage(quietOutputsContext(), runtimeUsageRunner(ctx), req, eruncommon.RuntimeUsageParams{})
 	if err != nil {
-		return uiRuntimeUsage{}, err
+		return uiRuntimeUsage{}, errors.New(runtimeProbeFailureMessage(ctx, runtimeUsageTimeout, err, func(e error) string { return e.Error() }))
 	}
 	return uiRuntimeUsageFromReading(reading), nil
 }

--- a/erun-ui/runtime_usage_test.go
+++ b/erun-ui/runtime_usage_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	eruncommon "github.com/sophium/erun/erun-common"
 )
@@ -125,5 +128,42 @@ func TestRuntimeUsageFromReadingMixedAvailability(t *testing.T) {
 	}
 	if len(usage.Warnings) != 1 {
 		t.Fatalf("warnings must be carried through verbatim, got %+v", usage.Warnings)
+	}
+}
+
+// TestLoadRuntimeUsageReportsOwnTimeoutNotSignalKilled is the reported defect,
+// reproduced through the real production wiring (loadRuntimeUsageViaKubectl is
+// not mocked): with the app's own context already past its deadline, the
+// probe's internal runtimeUsageTimeout bound reads as already exceeded before
+// the kubectl exec even runs, so no kubectl binary is required for this test
+// to reach the same classification a real timeout would. The memory panel's
+// message must say so instead of "signal: killed" -- the exact phrase this
+// panel would otherwise misread as an OOM kill.
+func TestLoadRuntimeUsageReportsOwnTimeoutNotSignalKilled(t *testing.T) {
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{
+			"petios": {Name: "petios", DefaultEnvironment: "local"},
+		},
+		envs: map[string]eruncommon.EnvConfig{
+			"petios/local": {Name: "local", LocalRepoPath: t.TempDir(), KubernetesContext: "test-context"},
+		},
+	}
+	app := NewApp(erunUIDeps{store: store})
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+	defer cancel()
+	app.ctx = ctx
+
+	usage, err := app.LoadRuntimeUsage(uiSelection{Tenant: "petios", Environment: "local"})
+	if err != nil {
+		t.Fatalf("LoadRuntimeUsage must not surface a probe failure as an error: %v", err)
+	}
+	if usage.Available {
+		t.Fatalf("a timed-out probe must not be reported as an available reading: %+v", usage)
+	}
+	if !strings.Contains(usage.Message, "timed out") {
+		t.Fatalf("expected the memory panel to name its own timeout, got %q", usage.Message)
+	}
+	if strings.Contains(usage.Message, "signal:") {
+		t.Fatalf("the memory panel must never say anything that reads as an OOM kill on a timeout, got %q", usage.Message)
 	}
 }


### PR DESCRIPTION
All three Runtime-tab panels reported their own 10-second deadline as:

```
⚠ Cannot read this environment's resource usage: signal: killed
```

`signal: killed` is the **kill mechanism, not the cause** — and erun is the one
that did the killing, via a deadline it set itself. In a panel about **memory**,
"killed" reads as an **OOM kill**, sending the operator to hunt a memory problem
that does not exist.

This is the same root error as several defects fixed today (#1444, #1474,
#1471): reporting a state that was never observed. Here it is starker — the
cause was not even unknown. erun set the deadline, enforced it, and then
discarded that knowledge in favour of the signal `os/exec` used to carry the
enforcement out.

## One translator, not three panels patched

`runtimeProbeFailureMessage` (new `erun-ui/runtime_probe_error.go`) is the single
path all three probes — usage, activity, sizing — route a failed read through:

| Cause | Reported as |
|---|---|
| `ctx.Err() == DeadlineExceeded` | timed out after *N*, naming the bound, **with a next action** |
| context cancelled otherwise | cancelled before it finished, with the reason |
| killed by something **erun did not do** | named as an external kill — OOM or eviction — pointing at the environment's recent events |
| anything else | falls through to the caller's own fallback |

Two details worth calling out:

**It keys on `ctx.Err()`, not on error text.** Each probe binds its kubectl exec
to a context it created and cancels on a fixed deadline, so `ctx.Err()` states
the cause with certainty. There is nothing to infer.

**`isRuntimeProbeExternalKill` uses `os/exec`'s own `ProcessState.Exited()`**
rather than matching `"signal: killed"` in the error string. So it cannot
mistake a genuine message that happens to contain that phrase for a kill, and it
never has to reproduce the phrase itself. Matching the text would have
reintroduced the same class of guess this PR removes.

**An external kill stays distinct from a timeout**, because the operator's next
action is completely different — one is "your environment is busy", the other is
"your process was killed by the kernel". Flattening them was half the original
defect.

## Verification

- new unit tests per branch in `runtime_probe_error_test.go`, plus updated tests
  for all three panels (`runtime_usage_test.go`, `runtime_activity_test.go`,
  `runtime_sizing_test.go`)
- three Playwright specs updated (`manage-runtime-usage`, `-activity`,
  `-sizing`) — **12 passed**
- `make check` → **exit 0**: golangci-lint **0 issues** across all six modules,
  Go tests, frontend gates, all chart tests, integration suite, coverage
  **76.1%** (≥ 75.8%)

Closes #1478