### PR TITLE
Resolve the job target in the two detached entry points that skipped it, and name a removed tool's replacement

### DIFF
--- a/erun-common/mcp_tools.go
+++ b/erun-common/mcp_tools.go
@@ -161,11 +161,15 @@ var mcpToolDescriptors = map[string]MCPToolDescriptor{
 	"expose":                 {Family: "", CLIPath: []string{"expose"}, Title: "Publish a service through the platform edge", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
 	"unexpose":               {Family: "", CLIPath: []string{"unexpose"}, Title: "Withdraw a published service", ReadOnly: false, Destructive: true, Idempotent: true, OpenWorld: true},
 	"terraform":              {Family: "", CLIPath: nil, Title: "Run the environment's Terraform root", ReadOnly: false, Destructive: true, Idempotent: false, OpenWorld: true},
-	"doctor":                 {Family: "", CLIPath: []string{"doctor"}, Title: "Diagnose an environment", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
-	"observe":                {Family: "", CLIPath: []string{"observe"}, Title: "Observe an environment's live state", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},
-	"usage":                  {Family: "", CLIPath: []string{"usage"}, Title: "Report an environment's live resource usage", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},
-	"resize":                 {Family: "", CLIPath: []string{"resize"}, Title: "Resize the runtime pod's CPU/memory limits", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
-	"delete":                 {Family: "", CLIPath: []string{"delete"}, Title: "Delete an environment and its namespace", ReadOnly: false, Destructive: true, Idempotent: true, OpenWorld: true},
+	// job_start has no working handler: it is a removed-tool stub (see
+	// mcpRemovedTools) whose only behavior is to name the tool that took over
+	// its capability.
+	"job_start": {Family: "exec", CLIPath: nil, Title: "Removed: use exec_raw or exec_agent", ReadOnly: true, Destructive: false, Idempotent: true, OpenWorld: false, AgentFacing: true},
+	"doctor":    {Family: "", CLIPath: []string{"doctor"}, Title: "Diagnose an environment", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
+	"observe":   {Family: "", CLIPath: []string{"observe"}, Title: "Observe an environment's live state", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},
+	"usage":     {Family: "", CLIPath: []string{"usage"}, Title: "Report an environment's live resource usage", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},
+	"resize":    {Family: "", CLIPath: []string{"resize"}, Title: "Resize the runtime pod's CPU/memory limits", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"delete":    {Family: "", CLIPath: []string{"delete"}, Title: "Delete an environment and its namespace", ReadOnly: false, Destructive: true, Idempotent: true, OpenWorld: true},
 }
 
 // MCPToolDescriptorFor returns a tool's descriptor. The second result is false
@@ -249,4 +253,31 @@ func MCPToolCurrentName(tool string) string {
 		return current
 	}
 	return trimmed
+}
+
+// mcpRemovedTools maps a tool this server no longer runs to the guidance a
+// caller needs once it is gone: which live tool now covers its capability.
+// This is deliberately separate from mcpToolRenames: a rename's replacement
+// shares the retired tool's schema and behavior, so aliasing it costs
+// nothing. A removal's capability can split across replacements with
+// incompatible schemas -- job_start's command mode became exec_raw's
+// wait:false path and its agent mode became the separate exec_agent tool, so
+// no single alias could carry both without lying about its own input shape.
+// A tool named here still gets a registration under its retired name (see
+// erun-mcp's registerRemovedTools), so calling it fails with the guidance
+// below rather than the SDK's bare "unknown tool", which names a problem and
+// no action the caller can take.
+var mcpRemovedTools = map[string]string{
+	"job_start": "exec_raw with wait:false for a plain command, or exec_agent for an AI tool",
+}
+
+// MCPRemovedTools returns the retired-to-guidance mapping, so a transport can
+// register a stub under each retired name and a test can assert every stub
+// names a real, described replacement.
+func MCPRemovedTools() map[string]string {
+	removed := make(map[string]string, len(mcpRemovedTools))
+	for name, guidance := range mcpRemovedTools {
+		removed[name] = guidance
+	}
+	return removed
 }

--- a/erun-common/mcp_tools_test.go
+++ b/erun-common/mcp_tools_test.go
@@ -24,11 +24,11 @@ func TestToolNameEqualsItsCLIPath(t *testing.T) {
 }
 
 // TestMCPOnlyToolsAreTheKnownSet pins the tools with no erun command behind
-// them. #1186 assumed there were none beyond the five renames; there are
-// eleven now (ten wire-level primitives the CLI deliberately expresses
-// differently for a human, plus exec_agent, whose capability the CLI already
-// covers via `erun exec job start --agent`). Pinning the set makes adding a
-// twelfth a decision rather than an accident.
+// them: ten wire-level primitives the CLI deliberately expresses differently
+// for a human, exec_agent (whose capability the CLI already covers via `erun
+// exec job start --agent`), and job_start (a removed-tool stub with no
+// handler at all, see MCPRemovedTools). Pinning the set makes adding another
+// one a decision rather than an accident.
 func TestMCPOnlyToolsAreTheKnownSet(t *testing.T) {
 	want := map[string]struct{}{
 		"activity_lease_list":          {},
@@ -42,6 +42,7 @@ func TestMCPOnlyToolsAreTheKnownSet(t *testing.T) {
 		"cloud_clear_aws_credentials":  {},
 		"terraform":                    {},
 		"exec_agent":                   {},
+		"job_start":                    {},
 	}
 	for _, name := range MCPToolNames() {
 		_, expected := want[name]
@@ -120,6 +121,27 @@ func TestReadOnlyToolsAreNotAlsoDestructive(t *testing.T) {
 		descriptor, _ := MCPToolDescriptorFor(name)
 		if descriptor.ReadOnly && descriptor.Destructive {
 			t.Errorf("%s claims to be both read-only and destructive", name)
+		}
+	}
+}
+
+// TestRemovedToolsAreDistinctFromRenames: a rename keeps a working handler
+// under the old name; a removed tool never does. The two tables must never
+// share a key, or a caller's retired name would resolve to two different
+// meanings depending on which table looked it up first. Each removed name
+// also needs a descriptor (registering it would otherwise panic) and
+// non-empty guidance naming what replaced it.
+func TestRemovedToolsAreDistinctFromRenames(t *testing.T) {
+	renames := MCPToolRenames()
+	for name, guidance := range MCPRemovedTools() {
+		if _, ok := renames[name]; ok {
+			t.Errorf("%s is in both MCPToolRenames and MCPRemovedTools", name)
+		}
+		if _, ok := mcpToolDescriptors[name]; !ok {
+			t.Errorf("%s has no descriptor, so registering its removed-tool stub would panic", name)
+		}
+		if strings.TrimSpace(guidance) == "" {
+			t.Errorf("%s has no guidance naming its replacement", name)
 		}
 	}
 }

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -193,7 +193,7 @@ Take an activity lease before **detaching** long work in the env — a build, a 
 | `exec_job_output` | Read a page of a job's output, including while it runs. |
 | `exec_job_cancel` | Signal a running job's work by its recorded process. |
 
-`job`'s five query verbs moved under `exec` (`job_attach`/`job_status`/`job_await`/`job_output`/`job_cancel` are retired aliases, kept callable for one release). The command-starting tool did not move with them: `job_start` is gone outright, split across the two tools that actually start a job now — **`exec_raw` with `wait: false`** for a plain command (see [The escape hatch](#raw--the-escape-hatch)), and **`exec_agent`** for an AI tool. Splitting them means each tool's schema only carries the fields its own mode needs, instead of `job_start`'s single schema carrying both a `command` and an `agent`/`prompt` that excluded each other.
+`job`'s five query verbs moved under `exec` (`job_attach`/`job_status`/`job_await`/`job_output`/`job_cancel` are retired aliases, kept callable for one release). The command-starting tool did not move with them: `job_start`'s capability split across the two tools that actually start a job now — **`exec_raw` with `wait: false`** for a plain command (see [The escape hatch](#raw--the-escape-hatch)), and **`exec_agent`** for an AI tool. `job_start` itself stays registered as a stub: calling it always fails, naming both replacements, so a caller still shaped for the old tool learns what to call instead of seeing a bare "unknown tool". Splitting the capability means each tool's schema only carries the fields its own mode needs, instead of `job_start`'s single schema carrying both a `command` and an `agent`/`prompt` that excluded each other; both new tools also take the optional `tenant`/`environment` pair described above, the same as every other job tool.
 
 **Reach for a backgrounded job instead of a foreground `exec_raw` call for anything you will need to come back to.** A foreground call is request/response: it returns when the process exits, so observing long work through it means re-implementing job bookkeeping in shell — detach the work, redirect it to a log, poll in a loop, invent a sentinel token because the real signal is buffered until exit, and parse that token back out of this envelope. Each of those is a place to get it wrong, and none of them is the interesting problem.
 
@@ -392,6 +392,7 @@ Every tool the server can register, one row each, grouped by `_meta.family` and 
 | exec | `exec_job_await` | `erun exec job await` | Read |
 | exec | `exec_job_output` | `erun exec job output` | Read |
 | exec | `exec_job_cancel` | `erun exec job cancel` | Work |
+| exec | `job_start` | *(removed; see `exec_raw` `wait: false` / `exec_agent`)* | Read |
 | cloud | `cloud_list` | *(MCP-only)* | Read |
 | cloud | `cloud_init_aws` | `erun cloud init aws` | Work |
 | cloud | `cloud_init_cloudflare` | `erun cloud init cloudflare` | Work |

--- a/erun-mcp/agent.go
+++ b/erun-mcp/agent.go
@@ -17,6 +17,8 @@ import (
 type AgentInput struct {
 	Agent           string            `json:"agent" jsonschema:"AI tool to run: claude or codex. erun invokes it in its streaming mode, so exec_job_output returns events while it works and exec_job_status reports its current activity rather than only running"`
 	Prompt          string            `json:"prompt" jsonschema:"what the agent should do"`
+	Tenant          string            `json:"tenant,omitempty" jsonschema:"tenant whose environment runs the job; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment     string            `json:"environment,omitempty" jsonschema:"environment to run the job in; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Dir             string            `json:"dir,omitempty" jsonschema:"working directory to run from; defaults to the runtime repo root"`
 	Env             map[string]string `json:"env,omitempty" jsonschema:"additional KEY=VALUE environment for the agent's own process, on top of what it inherits from the runtime pod -- e.g. raising CLAUDE_CODE_MAX_OUTPUT_TOKENS for one run. Values land in the job supervisor's argv, visible to anything that can list processes in this environment, so this is not where secrets belong. PATH, LD_PRELOAD, and a few other names that could redirect what the job executes are refused, as is any ERUN_ name"`
 	Name            string            `json:"name,omitempty" jsonschema:"what the run is, shown wherever the environment reports as busy; defaults to agent"`
@@ -28,8 +30,11 @@ type AgentInput struct {
 
 func agentTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, AgentInput) (*mcp.CallToolResult, JobResult, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input AgentInput) (*mcp.CallToolResult, JobResult, error) {
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, JobResult{}, err
+		}
 		dir := strings.TrimSpace(input.Dir)
-		var err error
 		if dir == "" {
 			if dir, err = runtimeRepoPath(runtime.Context); err != nil {
 				return nil, JobResult{}, err
@@ -45,8 +50,8 @@ func agentTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest
 		trace := new(bytes.Buffer)
 		ctx := runtimeCallContext(input.Preview, 0, nil, trace, trace)
 		job, err := eruncommon.StartEnvironmentJob(ctx, eruncommon.StartEnvironmentJobParams{
-			Tenant:         runtime.Context.Tenant,
-			Environment:    runtime.Context.Environment,
+			Tenant:         tenant,
+			Environment:    environment,
 			Name:           firstNonEmpty(strings.TrimSpace(input.Name), "agent"),
 			ID:             strings.TrimSpace(input.ID),
 			Agent:          input.Agent,
@@ -61,8 +66,8 @@ func agentTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest
 			return nil, JobResult{}, err
 		}
 		return nil, JobResult{
-			Tenant:      runtime.Context.Tenant,
-			Environment: runtime.Context.Environment,
+			Tenant:      tenant,
+			Environment: environment,
 			Job:         job,
 			Trace:       normalizeTraceLines(trace.String()),
 			Executed:    !input.Preview,

--- a/erun-mcp/exec.go
+++ b/erun-mcp/exec.go
@@ -22,8 +22,11 @@ type RawInput struct {
 	Stdin   string            `json:"stdin,omitempty" jsonschema:"optional stdin to pass to the command; only used in the foreground (wait true)"`
 	Dir     string            `json:"dir,omitempty" jsonschema:"working directory to run from, absolute or relative to the runtime repo root; defaults to the runtime repo root"`
 	Env     map[string]string `json:"env,omitempty" jsonschema:"additional KEY=VALUE environment for the command, on top of what it inherits from the runtime pod; only valid with wait false, since a foreground call already runs in this process's own environment with nothing to extend it with. Values land in the job supervisor's argv, visible to anything that can list processes in this environment, so this is not where secrets belong; PATH, LD_PRELOAD, and a few other names that could redirect what the job executes are refused, as is any ERUN_ name"`
-	// Name/ID address a backgrounded command the way job_start's did; ignored
-	// in the foreground, where there is no handle to address.
+	// Tenant/Environment, and Name/ID, address a backgrounded command the way
+	// job_start's did; ignored in the foreground, where there is no handle to
+	// address and this server's own context already applies.
+	Tenant          string `json:"tenant,omitempty" jsonschema:"tenant whose environment runs the backgrounded command; only used with wait false. Defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment     string `json:"environment,omitempty" jsonschema:"environment to run the backgrounded command in; only used with wait false. Defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Name            string `json:"name,omitempty" jsonschema:"what the backgrounded command is, shown wherever the environment reports as busy; only used with wait false. Defaults to exec_raw"`
 	ID              string `json:"id,omitempty" jsonschema:"handle to address the backgrounded command by; only used with wait false. Defaults to name, so re-running the same named command keeps one stable handle"`
 	MaxOutputBytes  int64  `json:"maxOutputBytes,omitempty" jsonschema:"cap on captured output in bytes for a backgrounded command; past it output is dropped and the job reports outputTruncated. Only used with wait false. Defaults to 16777216"`
@@ -71,6 +74,10 @@ func execRawForeground(runtime RuntimeConfig, input RawInput) (JobEnvelopeOutput
 // that engine rather than the in-process task job the rest of the
 // job-envelope surface uses, which has no subprocess to detach.
 func execRawBackground(runtime RuntimeConfig, input RawInput) (JobEnvelopeOutput, error) {
+	tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+	if err != nil {
+		return JobEnvelopeOutput{}, err
+	}
 	dir, err := execRawResolveDir(runtime, input.Dir)
 	if err != nil {
 		return JobEnvelopeOutput{}, err
@@ -83,8 +90,8 @@ func execRawBackground(runtime RuntimeConfig, input RawInput) (JobEnvelopeOutput
 	trace := new(bytes.Buffer)
 	ctx := runtimeCallContext(input.Preview, input.Verbosity, nil, trace, trace)
 	job, err := eruncommon.StartEnvironmentJob(ctx, eruncommon.StartEnvironmentJobParams{
-		Tenant:         runtime.Context.Tenant,
-		Environment:    runtime.Context.Environment,
+		Tenant:         tenant,
+		Environment:    environment,
 		Name:           firstNonEmpty(strings.TrimSpace(input.Name), "exec_raw"),
 		ID:             strings.TrimSpace(input.ID),
 		Command:        input.Command,

--- a/erun-mcp/job_target_test.go
+++ b/erun-mcp/job_target_test.go
@@ -32,6 +32,16 @@ func TestJobLeaseAndIdleToolsRefuseAForeignEnvironment(t *testing.T) {
 
 	_, _, err = idleStopHistoryTool(runtime)(ctx, nil, IdleStopHistoryInput{Tenant: "tenant-b", Environment: "prod"})
 	assertRefusedForeignTarget(t, "idle_stop_history", err)
+
+	_, _, err = rawTool(runtime)(ctx, nil, RawInput{
+		Command: []string{"true"}, Wait: boolPtr(false), Tenant: "tenant-b", Environment: "prod",
+	})
+	assertRefusedForeignTarget(t, "exec_raw (wait:false)", err)
+
+	_, _, err = agentTool(runtime)(ctx, nil, AgentInput{
+		Agent: "claude", Prompt: "x", Tenant: "tenant-b", Environment: "prod",
+	})
+	assertRefusedForeignTarget(t, "exec_agent", err)
 }
 
 // assertRefusedForeignTarget insists the tool refused BECAUSE the target is not
@@ -61,5 +71,45 @@ func TestJobToolsAcceptTheirOwnScope(t *testing.T) {
 	}
 	if _, _, err := jobStatusTool(runtime)(ctx, nil, JobStatusInput{}); err != nil {
 		t.Errorf("job_status refused an omitted scope: %v", err)
+	}
+}
+
+// TestExecRawBackgroundAndExecAgentResolveTenantEnvironmentLikeOtherJobTools
+// guards against exec_raw's wait:false path and exec_agent reading
+// runtime.Context.Tenant/Environment directly again, with no field a caller
+// could use to supply or restate them and no foreign-target refusal --
+// unlike every sibling job tool, which resolves through resolveLocalTarget.
+// Preview mode and a placeholder supervisor path (never exec'd, since preview
+// short-circuits before the process would start) let this exercise the same
+// resolution the live call makes without spawning anything.
+func TestExecRawBackgroundAndExecAgentResolveTenantEnvironmentLikeOtherJobTools(t *testing.T) {
+	t.Setenv("ERUN_ERUN_BIN", "erun-test-supervisor-stub")
+	runtime := normalizeRuntimeConfig(RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev", RepoPath: t.TempDir()}})
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"omitted", "", ""},
+		{"restated", "tenant-a", "dev"},
+	} {
+		t.Run("exec_raw/"+tc.name, func(t *testing.T) {
+			if _, _, err := rawTool(runtime)(ctx, nil, RawInput{
+				Command: []string{"true"}, Wait: boolPtr(false), Preview: true,
+				Tenant: tc.tenant, Environment: tc.environment,
+			}); err != nil {
+				t.Errorf("exec_raw (wait:false) refused %s scope: %v", tc.name, err)
+			}
+		})
+		t.Run("exec_agent/"+tc.name, func(t *testing.T) {
+			if _, _, err := agentTool(runtime)(ctx, nil, AgentInput{
+				Agent: "claude", Prompt: "x", Preview: true,
+				Tenant: tc.tenant, Environment: tc.environment,
+			}); err != nil {
+				t.Errorf("exec_agent refused %s scope: %v", tc.name, err)
+			}
+		})
 	}
 }

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -190,8 +190,32 @@ func newServer(info eruncommon.BuildInfo, runtime RuntimeConfig, identity authId
 	registerReviewTools(reg, runtime)
 	registerDeliveryTools(reg, runtime)
 	registerInspectionTools(reg, runtime)
+	registerRemovedTools(reg)
 
 	return server
+}
+
+// registerRemovedTools gives every retired tool name in erun-common's
+// removed-tool table a stub, instead of leaving the name unregistered. An
+// unregistered name fails at the SDK's own routing layer with a bare "unknown
+// tool", which names a problem and no action the caller can take; the stub
+// registered here instead fails with the guidance naming the tool that took
+// over its capability. The input type accepts any arguments so a caller still
+// shaped for the retired tool's own schema reaches this handler rather than
+// failing schema validation first.
+func registerRemovedTools(reg toolRegistrar) {
+	for name, guidance := range eruncommon.MCPRemovedTools() {
+		addTool(reg, &mcp.Tool{
+			Name:        name,
+			Description: fmt.Sprintf("Removed; use %s instead.", guidance),
+		}, removedTool(name, guidance))
+	}
+}
+
+func removedTool(name, guidance string) func(context.Context, *mcp.CallToolRequest, map[string]any) (*mcp.CallToolResult, any, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, _ map[string]any) (*mcp.CallToolResult, any, error) {
+		return nil, nil, fmt.Errorf("%s was removed; use %s instead", name, guidance)
+	}
 }
 
 func registerReadModelTools(reg toolRegistrar, info eruncommon.BuildInfo, runtime RuntimeConfig) {

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -174,23 +174,19 @@ var wantRegisteredTools = []string{
 	"review_unresolve", "terraform", "unexpose", "upgrade", "usage", "version", "whip", "write",
 }
 
-func TestHTTPHandlerExposesVersionTool(t *testing.T) {
-	// newHTTPHandler resolves its auth trust anchor from the ambient environment,
-	// so running this test inside an erun runtime pod (which sets
-	// ERUN_MCP_TRUSTED_ISSUER) would enable auth and reject the unauthenticated
-	// client. Clear the anchors so the tool surface is what is under test.
+// connectTestMCPSession clears the ambient auth anchors (set when this test
+// runs inside an erun runtime pod, which would otherwise reject the
+// unauthenticated test client) and connects a client session to a freshly
+// built handler, so each caller gets a clean session without repeating the
+// setup and its own defer-cleanup.
+func connectTestMCPSession(t *testing.T, info eruncommon.BuildInfo, runtime RuntimeConfig) *mcp.ClientSession {
+	t.Helper()
 	for _, key := range []string{envMCPTrustedIssuers, envMCPTrustedIssuer, envMCPAudience, envTenant} {
 		t.Setenv(key, "")
 	}
 	cfg := HTTPConfig{Path: "/mcp"}
-	info := eruncommon.BuildInfo{
-		Version: "1.2.3",
-		Commit:  "abcdef",
-		Date:    "2024-01-01",
-	}
-
-	httpServer := httptest.NewServer(newHTTPHandler(info, cfg, RuntimeConfig{}, nil))
-	defer httpServer.Close()
+	httpServer := httptest.NewServer(newHTTPHandler(info, cfg, runtime, nil))
+	t.Cleanup(httpServer.Close)
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
 	session, err := client.Connect(context.Background(), &mcp.StreamableClientTransport{
@@ -200,9 +196,16 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Connect failed: %v", err)
 	}
-	defer func() {
-		_ = session.Close()
-	}()
+	t.Cleanup(func() { _ = session.Close() })
+	return session
+}
+
+func TestHTTPHandlerExposesVersionTool(t *testing.T) {
+	session := connectTestMCPSession(t, eruncommon.BuildInfo{
+		Version: "1.2.3",
+		Commit:  "abcdef",
+		Date:    "2024-01-01",
+	}, RuntimeConfig{})
 
 	tools, err := session.ListTools(context.Background(), nil)
 	if err != nil {
@@ -229,10 +232,16 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if got := version["version"]; got != "1.2.3" {
 		t.Fatalf("unexpected structured content: %+v", version)
 	}
+}
 
-	// job_start is registered (it appears in gotTools above) but has no
-	// working handler: the call must fail as a tool error naming its
-	// replacement, not as a protocol-level "unknown tool".
+// TestCallingARemovedToolNamesItsReplacement calls job_start over a real MCP
+// round trip: it is registered (TestHTTPHandlerExposesVersionTool's
+// wantRegisteredTools pins that) but has no working handler, so the call must
+// fail as a tool error naming its replacements, not as a protocol-level
+// "unknown tool" that names a problem and no action the caller can take.
+func TestCallingARemovedToolNamesItsReplacement(t *testing.T) {
+	session := connectTestMCPSession(t, eruncommon.BuildInfo{}, RuntimeConfig{})
+
 	removed, err := session.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      "job_start",
 		Arguments: map[string]any{"command": []string{"echo", "hi"}},

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -148,9 +148,11 @@ func TestEndpointURL(t *testing.T) {
 var wantRegisteredTools = []string{
 	// Sorted. The four exec_* names joined the surface with #1186's rename;
 	// diff/raw/write/commit remain as deprecated aliases for one release.
-	// #1246 moved job's five query verbs to exec_job_* (job_* remain as
-	// deprecated aliases for one release) and added exec_agent; job_start is
-	// gone outright, split between exec_raw's wait:false mode and exec_agent.
+	// job's five query verbs moved to exec_job_* (job_* remain as deprecated
+	// aliases for one release) and exec_agent joined the surface; job_start's
+	// capability split between exec_raw's wait:false mode and exec_agent, so
+	// it keeps a registered stub that fails, naming both, rather than
+	// disappearing outright.
 	"activity_lease_list", "activity_lease_release", "activity_lease_take",
 	"build", "cloud_clear_aws_credentials", "cloud_init_aws",
 	"cloud_init_cloudflare", "cloud_init_erun", "cloud_inject_aws_credentials",
@@ -160,7 +162,7 @@ var wantRegisteredTools = []string{
 	"exec_diff", "exec_job_attach", "exec_job_await", "exec_job_cancel", "exec_job_output", "exec_job_status",
 	"exec_push", "exec_raw", "exec_write", "expose", "idle", "idle_stop_cancel",
 	"idle_stop_history", "idle_stop_record", "init", "job_attach", "job_await",
-	"job_cancel", "job_output", "job_status", "list", "observe",
+	"job_cancel", "job_output", "job_start", "job_status", "list", "observe",
 	"outputs_download", "outputs_list", "pin", "platform_context_create",
 	"platform_context_get", "platform_context_list", "platform_env_delete",
 	"platform_env_deploy", "platform_env_get", "platform_env_list",
@@ -227,6 +229,34 @@ func TestHTTPHandlerExposesVersionTool(t *testing.T) {
 	if got := version["version"]; got != "1.2.3" {
 		t.Fatalf("unexpected structured content: %+v", version)
 	}
+
+	// job_start is registered (it appears in gotTools above) but has no
+	// working handler: the call must fail as a tool error naming its
+	// replacement, not as a protocol-level "unknown tool".
+	removed, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "job_start",
+		Arguments: map[string]any{"command": []string{"echo", "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(job_start) failed at the protocol level: %v", err)
+	}
+	if !removed.IsError {
+		t.Fatalf("expected job_start to report a tool error, got: %+v", removed)
+	}
+	if got := removedToolText(t, removed); !strings.Contains(got, "exec_raw") || !strings.Contains(got, "exec_agent") {
+		t.Fatalf("job_start error should name both replacements, got: %q", got)
+	}
+}
+
+func removedToolText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, content := range result.Content {
+		if text, ok := content.(*mcp.TextContent); ok {
+			sb.WriteString(text.Text)
+		}
+	}
+	return sb.String()
 }
 
 func TestActivityHTTPMiddlewareSkipsRecordingForIdleProbe(t *testing.T) {


### PR DESCRIPTION
`exec_raw` with `wait: false` and `exec_agent` both failed with:

```
tenant and environment are required
```

while **neither schema declared `tenant` or `environment`** and both are
`additionalProperties: false` — so the caller could not satisfy the
requirement. Together these are the complete replacement for the removed
`job_start`, so on an affected runtime there was **no MCP route to start any
detached work at all**.

## Root cause — and the lead I gave was wrong

I pointed this at `erun-common/activity.go:254`/`:371`, which raise that exact
string. **That was wrong**, and the investigation says so with evidence: those
lines belong to `ResolveStoredEnvironmentIdleStatus` (the `idle` tool) and
`RecordEnvironmentActivity` (request-logging middleware, whose error is
discarded with `_ =`). Neither is on the job-starting path.

The real cause: `execRawBackground` (`erun-mcp/exec.go`) and `agentTool`
(`erun-mcp/agent.go`) read `runtime.Context.Tenant`/`Environment` **directly**
and passed them into `StartEnvironmentJobParams` — with no `Tenant`/`Environment`
field on `RawInput`/`AgentInput` and **no call to `resolveLocalTarget`**.

Every sibling job tool — `jobStatusTool`, `jobAwaitTool`,
`activityLeaseTakeTool`, `idleStopHistoryTool` — resolves through
`resolveLocalTarget(runtime, input.Tenant, input.Environment)`, which defaults to
the server context and refuses a foreign one. `StartEnvironmentJob`'s
`normalize()` then raises the error at `job_supervisor.go:138-141` whenever
either is empty.

**The convention was already established and already tested.**
`job_target_test.go` carries a regression test from #1195 enforcing exactly this
pattern on every job tool — *except these two*, which sat outside its reach. This
PR brings them in, and extends that test to cover them so they cannot drift back
out.

## Proved by calling it, not by reading the schema

The fixed `emcp` binary, run standalone and then over a real MCP session:

- `exec_raw` `wait:false` → `{"executed":true,"jobId":"probe-bg","state":"running"}`,
  later confirmed `exited 0` via `exec_job_status`
- `exec_agent` → a full job record with real `pid`/`childPid`, `state:"running"`
- `job_start` → `job_start was removed; use exec_raw with wait:false for a plain
  command, or exec_agent for an AI tool instead`

All probe artifacts cleaned up afterwards.

## Naming a removed tool's replacement

A general **removed-tool table** (`mcpRemovedTools`/`MCPRemovedTools`),
parallel to but distinct from `mcpToolRenames`. `registerRemovedTools`
registers a stub for each entry whose handler errors with the guidance — so the
name still appears in `tools/list` and is discoverable, rather than vanishing
into a bare "unknown tool".

Two alternatives were rejected with reasons rather than passed over:

- **Aliasing `job_start` in `mcpToolRenames`** — its capability genuinely split
  into two incompatible schemas (command vs agent mode), which is precisely why
  it was never aliased.
- **Pattern-matching "unknown tool" at the routing layer** — would also fire for
  typos and never-shipped names, a far broader surface than "a tool erun once
  shipped and retired", and would not make the name discoverable.

This matters beyond tidiness: I filed the original report on the false premise
that `job_start` was *missing* rather than replaced, and had to correct it. A
bare "unknown tool" is what made that mistake available.

## Gates

- `go build` / `go test` green in `erun-common`, `erun-mcp`, `erun-cli`,
  `erun-integration`, `erun-ui`
- `golangci-lint` green — one self-inflicted `cyclop` finding fixed by extracting
  a shared test helper and splitting the assertion into its own test, **not** by
  raising the threshold
- `make check` → **exit 0**: all module lints 0 issues, chart tests, integration
  suite, coverage **76.1%** (≥ 75.8%)

Also updated to keep existing gates green: the pinned MCP-only-tools set, the
registered-tools list, and `erun-docs/docs/mcp/overview.md`'s tool index
(enforced by `TestMCPOverviewDocumentsEveryTool`).

Closes #1455
Closes #1446