### PR TITLE
Convert the remaining bare tenant/environment-required errors, and gate the phrase

### DIFF
--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -585,11 +585,11 @@ func normalizeEnvironmentCloudProviderAliasParams(params SetEnvironmentCloudAlia
 	alias := strings.TrimSpace(params.Alias)
 	switch {
 	case tenant == "":
-		return "", "", "", fmt.Errorf("tenant is required")
+		return "", "", "", fmt.Errorf("set cloud provider alias: no tenant given — pass one explicitly (`erun cloud set <tenant> <environment> --alias <alias>`, or the cloud_set tool's tenant field)")
 	case environment == "":
-		return "", "", "", fmt.Errorf("environment is required")
+		return "", "", "", fmt.Errorf("set cloud provider alias for %s: no environment given — pass one explicitly (`erun cloud set %s <environment> --alias <alias>`, or the cloud_set tool's environment field)", tenant, tenant)
 	case alias == "":
-		return "", "", "", fmt.Errorf("cloud provider alias is required")
+		return "", "", "", fmt.Errorf("set cloud provider alias for %s/%s: no alias given — pass one explicitly (`erun cloud set %s %s --alias <alias>`, or the cloud_set tool's alias field)", tenant, environment, tenant, environment)
 	default:
 		return tenant, environment, alias, nil
 	}

--- a/erun-integration/bare_required_input_test.go
+++ b/erun-integration/bare_required_input_test.go
@@ -1,0 +1,184 @@
+package integration
+
+// bare_required_input_test.go is a repo-state structural gate for root
+// AGENTS.md § "Smooth, Seamless, No Dead Ends": a validation failure that
+// names only a generic missing-input phrase, with no operation and no
+// recovery, is exactly failure mode 1 ("advice that cannot work" — here,
+// no advice at all). An audit once found 13 production call sites emitting
+// exactly `fmt.Errorf("tenant is required")`, plus two siblings in the same
+// erun-common function, after an earlier fix addressed one lone producer and
+// closed its own follow-up audit item unperformed. This is the check that
+// closes the gap: it fails the build the next time one of these exact bare
+// phrases reappears in non-test Go source anywhere in the repo. It runs as
+// an ordinary `go test` in this module, so it is part of
+// `make integration-test`/`make check` with no extra wiring — the same
+// precedent as desktop_surface_test.go.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// bareRequiredInputPhrases is the exact set of string literals this gate
+// bars from non-test Go source: a bare "<subject> is required" with no
+// operation and no recovery. The fix that added this gate converted every
+// "tenant is required" producer plus its immediate "environment is
+// required" sibling in the same erun-common function — it deliberately did
+// not chase every "<X> is required" string in the repo (on the order of 150
+// at the time of writing, including several more "cloud provider alias is
+// required" sites this same audit found but left alone). Most of the rest
+// already name their own specific subject (e.g. "review id is required",
+// "target branch is required", "cloud provider alias is required") and are
+// a lower-severity instance of the same class, not the "four words, no
+// operation, no subject beyond a generic noun, no recovery" shape this gate
+// targets. Extend this set only for a phrase that genuinely matches that
+// shape on a reachable path — not for every validation string that happens
+// to end in "is required".
+var bareRequiredInputPhrases = map[string]bool{
+	"tenant is required":      true,
+	"environment is required": true,
+}
+
+// skipDirForBareRequiredInputScan excludes directories that hold no
+// hand-written production Go source: version control, installed JS
+// dependencies, and generated/vendored trees.
+func skipDirForBareRequiredInputScan(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", "dist", "wailsjs", ".claude", ".claude-plugin", ".vscode":
+		return true
+	default:
+		return false
+	}
+}
+
+// bareRequiredInputHit is one banned literal found in production source.
+type bareRequiredInputHit struct {
+	position string
+	value    string
+}
+
+func (h bareRequiredInputHit) Message() string {
+	return fmt.Sprintf("%s: bare required-input error %q reintroduced — name the operation and a recovery instead (see erun-common/open.go's ErrOpenTenantNotProvided for the shape)", h.position, h.value)
+}
+
+// findBareRequiredInputLiterals parses every non-test .go file under root and
+// returns one hit per exact-match banned string literal. AST-based rather
+// than a text grep so a match inside a comment (not reachable at runtime)
+// does not fail the gate.
+func findBareRequiredInputLiterals(t testing.TB, root string) []bareRequiredInputHit {
+	t.Helper()
+	var hits []bareRequiredInputHit
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if path != root && skipDirForBareRequiredInputScan(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			value, unquoteErr := strconv.Unquote(lit.Value)
+			if unquoteErr != nil || !bareRequiredInputPhrases[value] {
+				return true
+			}
+			hits = append(hits, bareRequiredInputHit{position: fset.Position(lit.Pos()).String(), value: value})
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan repo for bare required-input literals: %v", err)
+	}
+	return hits
+}
+
+// TestNoBareRequiredInputError fails when a bare "<subject> is required"
+// string literal (bareRequiredInputPhrases) reappears in non-test Go source
+// anywhere in the repo.
+func TestNoBareRequiredInputError(t *testing.T) {
+	root := repoRoot(t)
+	for _, hit := range findBareRequiredInputLiterals(t, root) {
+		t.Errorf("%s", hit.Message())
+	}
+}
+
+// TestFindBareRequiredInputLiteralsExclusions locks the three ways this
+// scanner must stay quiet on synthetic data: a banned phrase inside a
+// _test.go file (a test asserting the old message during a migration), a
+// banned phrase inside a comment (never reachable at runtime), and an
+// unrelated string that merely ends in "is required". Only a real
+// production-code literal should be reported.
+func TestFindBareRequiredInputLiteralsExclusions(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"production.go": `package fixture
+
+func requireTenant(tenant string) error {
+	if tenant == "" {
+		return fmt.Errorf("tenant is required")
+	}
+	return nil
+}
+`,
+		"production_test.go": `package fixture
+
+// a test migrating off the old bare message still asserts it briefly:
+// "tenant is required"
+func TestOldMessage(t *testing.T) {}
+`,
+		"commented.go": `package fixture
+
+// requireEnvironment used to just say "environment is required" before it
+// named its operation.
+func requireEnvironment(environment string) error {
+	return nil
+}
+`,
+		"unrelated.go": `package fixture
+
+func requireAlias(alias string) error {
+	if alias == "" {
+		return fmt.Errorf("cloud provider alias is required")
+	}
+	return nil
+}
+`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	hits := findBareRequiredInputLiterals(t, dir)
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly one hit (production.go's live literal), got %+v", hits)
+	}
+	if !strings.HasSuffix(hits[0].position, "production.go:5:21") {
+		t.Fatalf("expected the hit to point at production.go's literal, got %q", hits[0].position)
+	}
+	if hits[0].value != "tenant is required" {
+		t.Fatalf("expected the hit to carry the matched phrase, got %q", hits[0].value)
+	}
+}

--- a/erun-integration/cloud_test.go
+++ b/erun-integration/cloud_test.go
@@ -1259,6 +1259,28 @@ func TestCloud(t *testing.T) {
 		golden.Equal(t, "cloud/set_empty_alias_fails", normalize.Apply(result.Combined))
 	})
 
+	t.Run("set_empty_tenant_fails", func(t *testing.T) {
+		// TENANT/ENVIRONMENT are cobra-positional (ExactArgs(2)), so an
+		// explicitly empty value still satisfies the arg-count check and must
+		// be rejected by normalizeEnvironmentCloudProviderAliasParams before
+		// any env lookup runs.
+		setup := env.New(t)
+		result := erun.Run(t, []string{"cloud", "set", "", "dev", "--alias", "team-cloud"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for an empty tenant, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "cloud/set_empty_tenant_fails", normalize.Apply(result.Combined))
+	})
+
+	t.Run("set_empty_environment_fails", func(t *testing.T) {
+		setup := env.New(t)
+		result := erun.Run(t, []string{"cloud", "set", "team", "", "--alias", "team-cloud"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit for an empty environment, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "cloud/set_empty_environment_fails", normalize.Apply(result.Combined))
+	})
+
 	t.Run("refresh_help", func(t *testing.T) {
 		setup := env.New(t)
 		result := erun.Run(t, []string{"cloud", "refresh", "--help"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})

--- a/erun-integration/testdata/cloud/set_empty_alias_fails.txt
+++ b/erun-integration/testdata/cloud/set_empty_alias_fails.txt
@@ -1,2 +1,2 @@
 audit: erun cloud set --alias  team dev
-cloud provider alias is required
+set cloud provider alias for team/dev: no alias given — pass one explicitly (`erun cloud set team dev --alias <alias>`, or the cloud_set tool's alias field)

--- a/erun-integration/testdata/cloud/set_empty_environment_fails.txt
+++ b/erun-integration/testdata/cloud/set_empty_environment_fails.txt
@@ -1,0 +1,2 @@
+audit: erun cloud set --alias team-cloud team
+set cloud provider alias for team: no environment given — pass one explicitly (`erun cloud set team <environment> --alias <alias>`, or the cloud_set tool's environment field)

--- a/erun-integration/testdata/cloud/set_empty_tenant_fails.txt
+++ b/erun-integration/testdata/cloud/set_empty_tenant_fails.txt
@@ -1,0 +1,2 @@
+audit: erun cloud set --alias team-cloud  dev
+set cloud provider alias: no tenant given — pass one explicitly (`erun cloud set <tenant> <environment> --alias <alias>`, or the cloud_set tool's tenant field)

--- a/erun-ui/config_handlers.go
+++ b/erun-ui/config_handlers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -223,9 +222,9 @@ func (a *App) GetCloudProviderBearerToken(alias string) (uiCloudProviderBearerTo
 }
 
 func (a *App) LoadTenantConfig(tenant string) (uiTenantConfig, error) {
-	tenant = strings.TrimSpace(tenant)
-	if tenant == "" {
-		return uiTenantConfig{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("loading tenant settings", tenant)
+	if err != nil {
+		return uiTenantConfig{}, err
 	}
 
 	config, _, err := a.deps.store.LoadTenantConfig(tenant)
@@ -236,9 +235,9 @@ func (a *App) LoadTenantConfig(tenant string) (uiTenantConfig, error) {
 }
 
 func (a *App) SaveTenantConfig(config uiTenantConfig) (uiTenantConfig, error) {
-	tenant := strings.TrimSpace(config.Name)
-	if tenant == "" {
-		return uiTenantConfig{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("saving tenant settings", config.Name)
+	if err != nil {
+		return uiTenantConfig{}, err
 	}
 
 	existing, _, err := a.deps.store.LoadTenantConfig(tenant)

--- a/erun-ui/config_handlers_test.go
+++ b/erun-ui/config_handlers_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestLoadTenantConfigRequiresATenant(t *testing.T) {
+	app := NewApp(erunUIDeps{store: stubUIStore{}})
+	_, err := app.LoadTenantConfig("   ")
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "loading tenant settings") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
+	}
+}
+
+func TestSaveTenantConfigRequiresATenant(t *testing.T) {
+	app := NewApp(erunUIDeps{store: stubUIStore{}})
+	_, err := app.SaveTenantConfig(uiTenantConfig{Name: "  "})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "saving tenant settings") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
+	}
+}

--- a/erun-ui/tenant_dashboard.go
+++ b/erun-ui/tenant_dashboard.go
@@ -12,9 +12,9 @@ import (
 )
 
 func (a *App) LoadTenantDashboard(input uiTenantDashboardInput) (uiTenantDashboard, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiTenantDashboard{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("loading the tenant dashboard", input.Tenant)
+	if err != nil {
+		return uiTenantDashboard{}, err
 	}
 	dashboard := uiTenantDashboard{
 		Tenant:      tenant,

--- a/erun-ui/tenant_input_required.go
+++ b/erun-ui/tenant_input_required.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrTenantNotGiven is the desktop's own tenant-input validation failure: a
+// Wails-exported handler that operates on a tenant received an empty one.
+// Every caller of requireTenant receives tenant from state the frontend
+// already resolved before the call fired — the dashboard's own tenant, a
+// dialog's tenant prop — so hitting this means that state was not resolved
+// yet, not that the operator typed nothing; there is no field for them to
+// fill in, only a surface to reopen.
+var ErrTenantNotGiven = errors.New("no tenant given")
+
+// requireTenant trims tenant and, if empty, reports which desktop operation
+// needed one and the one recovery actually available: reopening the tab or
+// dialog re-resolves the tenant from app state.
+func requireTenant(operation, tenant string) (string, error) {
+	tenant = strings.TrimSpace(tenant)
+	if tenant == "" {
+		return "", fmt.Errorf("%w: %s needs a tenant, and none was given — close and reopen the tab or dialog and try again", ErrTenantNotGiven, operation)
+	}
+	return tenant, nil
+}

--- a/erun-ui/tenant_input_required_test.go
+++ b/erun-ui/tenant_input_required_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRequireTenantTrimsAndPassesThrough(t *testing.T) {
+	tenant, err := requireTenant("loading the tenant dashboard", "  frs  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tenant != "frs" {
+		t.Fatalf("expected a trimmed tenant, got %q", tenant)
+	}
+}
+
+func TestRequireTenantNamesOperationAndRecoveryWhenEmpty(t *testing.T) {
+	_, err := requireTenant("loading the tenant dashboard", "   ")
+	if err == nil {
+		t.Fatal("expected an error for a blank tenant")
+	}
+	if !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "loading the tenant dashboard") {
+		t.Fatalf("error must name the operation: %q", msg)
+	}
+	if !strings.Contains(msg, "reopen the tab or dialog") {
+		t.Fatalf("error must name its recovery: %q", msg)
+	}
+}

--- a/erun-ui/tenant_platform_test.go
+++ b/erun-ui/tenant_platform_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -8,12 +9,17 @@ import (
 )
 
 // TestLoadTenantDashboardRequiresATenant is the null-input case: an empty
-// tenant must fail loudly rather than silently returning null the way the
-// old apiUrl/cloudProviderAlias precondition used to.
+// tenant must fail loudly, naming the operation and its recovery, rather
+// than silently returning null the way the old apiUrl/cloudProviderAlias
+// precondition used to.
 func TestLoadTenantDashboardRequiresATenant(t *testing.T) {
 	app := NewApp(erunUIDeps{store: stubUIStore{}})
-	if _, err := app.LoadTenantDashboard(uiTenantDashboardInput{}); err == nil {
-		t.Fatal("expected an error for a missing tenant")
+	_, err := app.LoadTenantDashboard(uiTenantDashboardInput{})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "loading the tenant dashboard") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }
 

--- a/erun-ui/tenant_review_capability.go
+++ b/erun-ui/tenant_review_capability.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"strings"
 )
 
 // uiTenantReviewCreateCapability reports whether the signed-in user may open
@@ -25,9 +23,9 @@ type uiTenantReviewCreateCapability struct {
 // loading reviews, the merge queue, builds, or audit events the dashboard
 // also reads — this call exists only to gate one button.
 func (a *App) TenantReviewCreateCapability(tenant string) (uiTenantReviewCreateCapability, error) {
-	tenant = strings.TrimSpace(tenant)
-	if tenant == "" {
-		return uiTenantReviewCreateCapability{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("checking whether you can create a review", tenant)
+	if err != nil {
+		return uiTenantReviewCreateCapability{}, err
 	}
 	ctx := a.ctx
 	if ctx == nil {

--- a/erun-ui/tenant_review_capability_test.go
+++ b/erun-ui/tenant_review_capability_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -45,7 +46,10 @@ func TestTenantReviewCreateCapabilityRequiresATenant(t *testing.T) {
 	defer server.Close()
 
 	_, err := tenantDashboardApp(t, server.URL).TenantReviewCreateCapability("")
-	if err == nil || !strings.Contains(err.Error(), "tenant is required") {
-		t.Fatalf("expected a tenant-required error, got %v", err)
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "checking whether you can create a review") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }

--- a/erun-ui/tenant_review_detail.go
+++ b/erun-ui/tenant_review_detail.go
@@ -18,9 +18,9 @@ import (
 // degrades independently, mirroring LoadTenantDashboard's own panels: a
 // caller who cannot read comments still sees the review and its builds.
 func (a *App) LoadReviewDetail(input uiReviewDetailInput) (uiReviewDetail, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiReviewDetail{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("loading review detail", input.Tenant)
+	if err != nil {
+		return uiReviewDetail{}, err
 	}
 	reviewID := strings.TrimSpace(input.ReviewID)
 	if reviewID == "" {
@@ -116,9 +116,9 @@ func loadReviewDetailQueuePosition(ctx context.Context, client *eruncommon.Platf
 // the text preserved" contract: the caller keeps the draft body on error and
 // only clears it once this call actually succeeds.
 func (a *App) CreateReviewReply(input uiCreateReviewReplyInput) (uiReviewComment, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiReviewComment{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("replying to a review comment", input.Tenant)
+	if err != nil {
+		return uiReviewComment{}, err
 	}
 	reviewID := strings.TrimSpace(input.ReviewID)
 	if reviewID == "" {

--- a/erun-ui/tenant_review_detail_test.go
+++ b/erun-ui/tenant_review_detail_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -62,6 +63,16 @@ func loadReviewDetailFrom(t *testing.T, app *App) uiReviewDetail {
 		t.Fatalf("LoadReviewDetail failed: %v", err)
 	}
 	return detail
+}
+
+func TestLoadReviewDetailRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).LoadReviewDetail(uiReviewDetailInput{ReviewID: "review-1"})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "loading review detail") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
+	}
 }
 
 func TestLoadReviewDetailPopulatesTheReviewItself(t *testing.T) {
@@ -130,6 +141,18 @@ func TestCreateReviewReplyCopiesTheParentThreadsAnchor(t *testing.T) {
 	}
 	if comment.CommentID != "comment-3" || comment.ParentCommentID != "comment-1" || comment.Body != "fixed, thanks" {
 		t.Fatalf("unexpected reply: %+v", comment)
+	}
+}
+
+func TestCreateReviewReplyRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).CreateReviewReply(uiCreateReviewReplyInput{
+		ReviewID: "review-1", ParentCommentID: "comment-1", Body: "fixed, thanks",
+	})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "replying to a review comment") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }
 

--- a/erun-ui/tenant_review_write.go
+++ b/erun-ui/tenant_review_write.go
@@ -31,9 +31,9 @@ const (
 // CreateReview opens a review. It is a real, immediate write — there is no
 // dashboard preview path, matching every other side-effecting action here.
 func (a *App) CreateReview(input uiCreateReviewInput) (uiTenantDashboardReview, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiTenantDashboardReview{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("opening a review", input.Tenant)
+	if err != nil {
+		return uiTenantDashboardReview{}, err
 	}
 	name := strings.TrimSpace(input.Name)
 	targetBranch := strings.TrimSpace(input.TargetBranch)
@@ -65,9 +65,9 @@ func (a *App) CreateReview(input uiCreateReviewInput) (uiTenantDashboardReview, 
 // close` and the MCP review_close tool: always a transition to CLOSED, not a
 // general status setter.
 func (a *App) CloseReview(input uiCloseReviewInput) (uiTenantDashboardReview, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiTenantDashboardReview{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("closing a review", input.Tenant)
+	if err != nil {
+		return uiTenantDashboardReview{}, err
 	}
 	reviewID := strings.TrimSpace(input.ReviewID)
 	if reviewID == "" {
@@ -98,9 +98,9 @@ func (a *App) CloseReview(input uiCloseReviewInput) (uiTenantDashboardReview, er
 // let the caller route the operator to the threads, or to
 // OverrideAdvanceMergeQueue, instead of hitting a dead end.
 func (a *App) AdvanceMergeQueue(input uiAdvanceMergeQueueInput) (uiTenantDashboardReview, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiTenantDashboardReview{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("advancing the merge queue", input.Tenant)
+	if err != nil {
+		return uiTenantDashboardReview{}, err
 	}
 	targetBranch := strings.TrimSpace(input.TargetBranch)
 	if targetBranch == "" {
@@ -133,9 +133,9 @@ func (a *App) AdvanceMergeQueue(input uiAdvanceMergeQueueInput) (uiTenantDashboa
 // gate. Reason is required — the backend refuses a blank one — and is
 // recorded in the platform's audit trail alongside the caller's identity.
 func (a *App) OverrideAdvanceMergeQueue(input uiOverrideAdvanceMergeQueueInput) (uiTenantDashboardReview, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiTenantDashboardReview{}, fmt.Errorf("tenant is required")
+	tenant, err := requireTenant("overriding the merge queue's unresolved-thread gate", input.Tenant)
+	if err != nil {
+		return uiTenantDashboardReview{}, err
 	}
 	targetBranch := strings.TrimSpace(input.TargetBranch)
 	if targetBranch == "" {
@@ -167,8 +167,8 @@ func (a *App) OverrideAdvanceMergeQueue(input uiOverrideAdvanceMergeQueueInput) 
 // trimmed input, kept apart from the call itself so that function's own
 // branching stays under the module's cyclomatic-complexity cap.
 func validateCreateReviewCommentInput(tenant, reviewID, commitID, filePath, body string) error {
-	if strings.TrimSpace(tenant) == "" {
-		return fmt.Errorf("tenant is required")
+	if _, err := requireTenant("commenting on a review", tenant); err != nil {
+		return err
 	}
 	if reviewID == "" {
 		return fmt.Errorf("review id is required")
@@ -233,9 +233,13 @@ func (a *App) UnresolveReviewComment(input uiUpdateReviewCommentStatusInput) (ui
 }
 
 func (a *App) updateReviewCommentStatus(input uiUpdateReviewCommentStatusInput, status string) (uiReviewComment, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	if tenant == "" {
-		return uiReviewComment{}, fmt.Errorf("tenant is required")
+	operation := "resolving a review comment"
+	if status == "OPEN" {
+		operation = "reopening a review comment"
+	}
+	tenant, err := requireTenant(operation, input.Tenant)
+	if err != nil {
+		return uiReviewComment{}, err
 	}
 	reviewID := strings.TrimSpace(input.ReviewID)
 	if reviewID == "" {

--- a/erun-ui/tenant_review_write_test.go
+++ b/erun-ui/tenant_review_write_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -112,6 +113,18 @@ func TestCreateReviewOpensAReviewFromThePushedBranch(t *testing.T) {
 	}
 }
 
+func TestCreateReviewRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).CreateReview(uiCreateReviewInput{
+		Name: "Open the review", TargetBranch: "main", SourceBranch: "feature/1348-x",
+	})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "opening a review") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
+	}
+}
+
 func TestCreateReviewRequiresNameAndBothBranches(t *testing.T) {
 	server := reviewWriteAPI(t, nil)
 	defer server.Close()
@@ -135,6 +148,16 @@ func TestCreateReviewSurfacesForbiddenAsAnError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected the refused write to surface as an error")
+	}
+}
+
+func TestCloseReviewRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).CloseReview(uiCloseReviewInput{ReviewID: "review-1"})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "closing a review") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }
 
@@ -162,6 +185,16 @@ func TestCloseReviewSurfacesForbiddenAsAnError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected the refused write to surface as an error")
+	}
+}
+
+func TestAdvanceMergeQueueRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).AdvanceMergeQueue(uiAdvanceMergeQueueInput{TargetBranch: "main"})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "advancing the merge queue") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }
 
@@ -215,6 +248,18 @@ func TestAdvanceMergeQueueReportsUnresolvedThreadsAsABlockNotAnError(t *testing.
 	}
 }
 
+func TestOverrideAdvanceMergeQueueRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).OverrideAdvanceMergeQueue(uiOverrideAdvanceMergeQueueInput{
+		TargetBranch: "blocked", Reason: "hotfix, reviewers unavailable",
+	})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "overriding the merge queue's unresolved-thread gate") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
+	}
+}
+
 func TestOverrideAdvanceMergeQueueBypassesTheGate(t *testing.T) {
 	server := reviewWriteAPI(t, nil)
 	defer server.Close()
@@ -239,6 +284,18 @@ func TestOverrideAdvanceMergeQueueRequiresAReason(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(err.Error(), "a reason is required") {
 		t.Fatalf("expected a reason-required error, got %v", err)
+	}
+}
+
+func TestCreateReviewCommentRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).CreateReviewComment(uiCreateReviewCommentInput{
+		ReviewID: "review-1", CommitID: "abc123", FilePath: "main.go", Line: 10, Body: "why this line?",
+	})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "commenting on a review") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }
 
@@ -325,5 +382,34 @@ func TestReviewDetailReportsCanCloseAlongsideCanComment(t *testing.T) {
 
 	if !detail.CanClose {
 		t.Fatalf("expected an unknown capability set to leave closing attemptable, got %+v", detail)
+	}
+}
+
+// TestResolveReviewCommentRequiresATenant and
+// TestUnresolveReviewCommentRequiresATenant both route through
+// updateReviewCommentStatus, which names a different operation for each
+// direction (resolving vs reopening) — both are locked here so neither
+// branch regresses to the shared bare message.
+func TestResolveReviewCommentRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).ResolveReviewComment(uiUpdateReviewCommentStatusInput{
+		ReviewID: "review-1", CommentID: "comment-1",
+	})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "resolving a review comment") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
+	}
+}
+
+func TestUnresolveReviewCommentRequiresATenant(t *testing.T) {
+	_, err := NewApp(erunUIDeps{store: stubUIStore{}}).UnresolveReviewComment(uiUpdateReviewCommentStatusInput{
+		ReviewID: "review-1", CommentID: "comment-1",
+	})
+	if err == nil || !errors.Is(err, ErrTenantNotGiven) {
+		t.Fatalf("expected ErrTenantNotGiven, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "reopening a review comment") {
+		t.Fatalf("expected the error to name its operation, got %v", err)
 	}
 }


### PR DESCRIPTION
`tenant is required` was still reaching the operator. #1432 fixed **one**
producer and closed; **13 remained** in production code, and its scope item 2 —
count the class and put the count in the PR — was skipped.

Two process failures produced that, and the second is the instructive one:
**#1432 scoped the audit to `erun-common`, but twelve of the thirteen live in
`erun-ui`.** Anyone following that instruction literally would have found exactly
one hit and concluded the class was small. The boundary was wrong before anyone
ran it.

## The count — the item that was missed

Re-derived independently at the branch point, not taken on trust: **13
producers**, matching the reported table exactly.

```
erun-common/cloud.go:588
erun-ui/config_handlers.go:228, 241
erun-ui/tenant_dashboard.go:17
erun-ui/tenant_review_capability.go:30
erun-ui/tenant_review_detail.go:23, 121
erun-ui/tenant_review_write.go:36, 70, 103, 138, 171, 238
```

All 13 converted. `git grep` for the bare phrase across the repo now returns
**zero** production hits.

## The recovery text is honest about what it does not know

The twelve `erun-ui` sites go through a shared `requireTenant(operation, tenant)`
wrapping sentinel `ErrTenantNotGiven`, each naming its own operation — "loading
the tenant dashboard", "advancing the merge queue", "resolving a review
comment", and so on.

The recovery deserves comment. Checking the **actual frontend call sites**
showed `tenant` always arrives from state the frontend already resolved before
the call fired — a dialog's prop, the dashboard's own tenant. So an empty value
means that state was not ready, **not** that the operator has a field to fill in.
The message says so: *"close and reopen the tab or dialog."*

Inventing a plausible-sounding "pass a tenant" remedy would have been failure
mode 1 — a confident remedy for a cause nobody checked.

`erun-common/cloud.go` differs because it genuinely is caller-supplied, so it
names both routes: `` set cloud provider alias for team: no environment given —
pass one explicitly (`erun cloud set team <environment> --alias <alias>`, or the
cloud_set tool's environment field) ``.

## Near-misses left alone, stated rather than implied

- **7 more `"cloud provider alias is required"` sites** — same bare shape,
  different noun, never audited by either issue. The one inside the function
  already being rewritten was converted; the rest are a legitimate follow-up.
- **`erun-cli/cmd/init.go:161,164`** — a qualified variant
  (`"...for non-local-agent envs"`), so it matched neither audit's exact phrase
  and already names its constraint.
- **~150 other `"<X> is required"` sites** — these already name their own
  specific subject, which is materially less severe than a bare, generic
  `tenant is required` in a multi-tenant product. A distinct and much larger
  effort.

## The gate, so the fourteenth cannot land

`erun-integration/bare_required_input_test.go` — an ordinary `go test` in
`erun-integration`, so `make check` already runs it. Same precedent as
`desktop_surface_test.go`; no new entry point invented.

It parses every non-test `.go` file with `go/parser` and fails on an exact-match
`*ast.BasicLit` equal to `"tenant is required"` or `"environment is required"`.
**AST-based rather than grep**, so the same phrase inside a comment does not fail
the build — and the exclusion logic is itself tested against synthetic data (a
live literal, the phrase in a `_test.go`, the phrase in a comment, and an
adjacent-but-different string).

Scope is deliberately the two phrases this audit actually converted, not the
~150-site broader class. Widening it is one line, whenever a future audit
actually converts another class — a gate that fails on work nobody has done yet
would just be turned off.

**Red-then-green:** run in a throwaway `git worktree` against unmodified
`origin/main` → **14 failures** at exactly the coordinates above (13 plus the
`environment is required` sibling). Run against this branch → clean. Worktree
removed.

## Gates

- `golangci-lint` → **0 issues** across all six modules
- `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui`,
  `erun-integration`
- 15 new/updated `erun-ui` tests asserting `errors.Is(err, ErrTenantNotGiven)`
  and that each message carries its operation; 2 new integration scenarios
- `make check` → **exit 0**, coverage **76.1%** (≥ 75.8%)

Closes #1488