### PR TITLE
Make the hosted registry able to work, and refuse it when it cannot

### DIFF
--- a/erun-backend/erun-backend-api/registry_token_route_test.go
+++ b/erun-backend/erun-backend-api/registry_token_route_test.go
@@ -1,0 +1,61 @@
+package backendapi
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/mcptoken"
+)
+
+// TestHostedRegistryTokenRouteRegistersWithDefaultResolvers is the red-then-green
+// case for the hosted registry being unreachable in production (#1494). It builds
+// the handler the way a real deployment does — a database and an MCP signing key,
+// and no injected resolvers at all — and asserts GET /v2/token is served.
+//
+// RED: defaultTo filled only the combined identity resolver and left tenant nil,
+// so the registration gate in NewHandler never fired. The token service the whole
+// hosted-registry feature depends on was absent from every deployment, and a push
+// to registry.erunpaas.com authenticated against a route that did not exist.
+func TestHostedRegistryTokenRouteRegistersWithDefaultResolvers(t *testing.T) {
+	handler, err := NewHandler(HandlerOptions{
+		DB: undialedDatabase(t),
+		TokenVerifier: TokenVerifierFunc(func(context.Context, string) (Claims, error) {
+			return Claims{Issuer: "https://issuer.example", Subject: "user-1"}, nil
+		}),
+		MCPSigner: testRegistrySigner(t),
+	})
+	if err != nil {
+		t.Fatalf("build handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/token?service=registry.erunpaas.com\u0026scope=repository:acme/app:pull", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Fatal("GET /v2/token is not registered: the hosted registry token service does not wire up when a deployment injects no resolvers of its own")
+	}
+}
+
+func testRegistrySigner(t *testing.T) *mcptoken.Signer {
+	t.Helper()
+	_, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate signing key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(private)
+	if err != nil {
+		t.Fatalf("marshal signing key: %v", err)
+	}
+	signer, err := mcptoken.NewSigner(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	if err != nil {
+		t.Fatalf("build signer: %v", err)
+	}
+	return signer
+}

--- a/erun-backend/erun-backend-api/server.go
+++ b/erun-backend/erun-backend-api/server.go
@@ -216,7 +216,14 @@ func (r identityResolvers) complete() bool {
 func (r *identityResolvers) defaultTo(identities *repository.IdentityRepository) {
 	if r.identity == nil && r.tenant == nil && r.user == nil {
 		r.identity = identities
-	} else if r.tenant == nil {
+	}
+	// Fill the plain tenant resolver even when the combined identity resolver
+	// above is the one auth will use. tenantAndUser prefers identities whenever
+	// it is set, so this cannot move the atomic-bootstrap path — but a consumer
+	// that needs only a tenant is gated on this field, and leaving it nil is why
+	// the hosted registry token service never registered in any deployment that
+	// injects no resolvers of its own.
+	if r.tenant == nil {
 		r.tenant = identities
 	}
 	if r.user == nil {

--- a/erun-common/hosted_registry.go
+++ b/erun-common/hosted_registry.go
@@ -1,0 +1,99 @@
+package eruncommon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// HostedRegistryProbeTimeout bounds the availability probe. It is short on
+// purpose: the probe sits in front of an interactive choice (an `erun init`
+// flag, a desktop toggle), so a hosted registry that is slow to answer must not
+// hold the surface that is asking about it.
+const HostedRegistryProbeTimeout = 5 * time.Second
+
+// HostedRegistryStatus answers whether erun's hosted registry can be pushed to
+// right now, and when it cannot, why and what resolves it. Reason and Recovery
+// are set only for a cause the probe actually observed: an unreachable registry
+// has several distinct causes with different remedies, and a confident remedy
+// for a cause that was not checked is its own dead end (root AGENTS.md,
+// "Smooth, Seamless, No Dead Ends").
+type HostedRegistryStatus struct {
+	Host      string
+	Available bool
+	Reason    string
+	Recovery  string
+}
+
+// Err renders an unavailable status as an error that names the operation, the
+// subject, and the way forward. Available statuses return nil.
+func (s HostedRegistryStatus) Err() error {
+	if s.Available {
+		return nil
+	}
+	return fmt.Errorf("erun's hosted container registry %s %s. %s", s.Host, s.Reason, s.Recovery)
+}
+
+// ProbeHostedRegistry reports whether the hosted registry is serving the OCI
+// distribution API.
+//
+// Any HTTP response counts as available, including 401. An unauthenticated GET
+// /v2/ is exactly what a healthy token-authenticated registry rejects, so
+// treating a non-2xx status as down would report every correctly configured
+// registry as missing.
+func ProbeHostedRegistry(ctx context.Context, client *http.Client) HostedRegistryStatus {
+	return probeHostedRegistryAt(ctx, client, "https://"+HostedRegistryHost+"/v2/", HostedRegistryHost)
+}
+
+// probeHostedRegistryAt is ProbeHostedRegistry with the endpoint injected, so a
+// test can exercise the status mapping — in particular that a 401 counts as
+// available — against a real HTTP server instead of the live hostname.
+func probeHostedRegistryAt(ctx context.Context, client *http.Client, url, host string) HostedRegistryStatus {
+	status := HostedRegistryStatus{Host: host}
+	if client == nil {
+		client = &http.Client{Timeout: HostedRegistryProbeTimeout}
+	}
+	ctx, cancel := context.WithTimeout(ctx, HostedRegistryProbeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		status.Reason = "could not be probed"
+		status.Recovery = "Report this: building the probe request itself failed, which is a defect rather than a registry outage."
+		return status
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		status.Reason, status.Recovery = describeHostedRegistryFailure(err)
+		return status
+	}
+	defer func() { _ = resp.Body.Close() }()
+	status.Available = true
+	return status
+}
+
+// describeHostedRegistryFailure maps a probe failure to the cause it actually
+// observed. Each branch names a remedy that applies to that cause and no other.
+func describeHostedRegistryFailure(err error) (reason, recovery string) {
+	const chooseAnother = "Choose a different registry instead: --container-registry <host/namespace> for one you already have, or --cluster-registry for an in-cluster one."
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.IsNotFound {
+		return "does not resolve",
+			"The hosted registry is not deployed for this platform, so nothing would receive the images pushed to it. " + chooseAnother
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Sprintf("did not answer within %s", HostedRegistryProbeTimeout),
+			"It may be starting or overloaded. Retry shortly, and if it stays unreachable, " + chooseAnother
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return fmt.Sprintf("did not answer within %s", HostedRegistryProbeTimeout),
+			"It may be starting or overloaded. Retry shortly, and if it stays unreachable, " + chooseAnother
+	}
+	return fmt.Sprintf("is not reachable (%v)", err),
+		"Check network access to it from this machine. If it is genuinely down, " + chooseAnother
+}

--- a/erun-common/hosted_registry_test.go
+++ b/erun-common/hosted_registry_test.go
@@ -1,0 +1,93 @@
+package eruncommon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHostedRegistryProbeTreatsUnauthorizedAsAvailable pins the rule the whole
+// gate depends on: a token-authenticated registry answers an unauthenticated
+// GET /v2/ with 401, so reading a non-2xx status as "down" would report every
+// correctly configured registry as missing and refuse a choice that works.
+func TestHostedRegistryProbeTreatsUnauthorizedAsAvailable(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusUnauthorized} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+		}))
+		got := probeHostedRegistryAt(context.Background(), server.Client(), server.URL+"/v2/", HostedRegistryHost)
+		server.Close()
+		if !got.Available {
+			t.Fatalf("status %d: expected the registry to read as available, got %+v", status, got)
+		}
+		if got.Err() != nil {
+			t.Fatalf("status %d: an available registry must not produce an error, got %v", status, got.Err())
+		}
+	}
+}
+
+// TestHostedRegistryProbeNamesAnUnresolvableHost checks the dead-end rule: an
+// unavailable status must name what it observed and carry a way forward.
+func TestHostedRegistryProbeNamesAnUnresolvableHost(t *testing.T) {
+	got := probeHostedRegistryAt(context.Background(), nil, "https://registry.invalid.erun-does-not-exist./v2/", HostedRegistryHost)
+	if got.Available {
+		t.Fatal("expected an unresolvable host to read as unavailable")
+	}
+	err := got.Err()
+	if err == nil {
+		t.Fatal("expected an unavailable status to produce an error")
+	}
+	if !strings.Contains(err.Error(), HostedRegistryHost) {
+		t.Fatalf("the error must name the registry it is about, got %q", err)
+	}
+	if got.Recovery == "" {
+		t.Fatalf("every unavailable status must carry a way forward, got %+v", got)
+	}
+}
+
+// TestErunRegistryRefusesWhenUnreachable is the red-then-green case for #1494
+// item 4: choosing the hosted registry must fail at the choice, naming the
+// reason, rather than writing an environment whose every push resolves to a
+// host that is not there.
+func TestErunRegistryRefusesWhenUnreachable(t *testing.T) {
+	runner := bootstrapRunner{BootstrapInitDependencies: BootstrapInitDependencies{
+		ProbeHostedRegistry: func(context.Context) HostedRegistryStatus {
+			return HostedRegistryStatus{
+				Host:     HostedRegistryHost,
+				Reason:   "does not resolve",
+				Recovery: "Choose a different registry instead.",
+			}
+		},
+	}}
+	registry, err := runner.resolveContainerRegistry(BootstrapInitParams{ErunRegistry: true}, "acme", "dev", "", "", true)
+	if err == nil {
+		t.Fatalf("expected --erun-registry to refuse an unreachable registry, got %q", registry)
+	}
+	if registry != "" {
+		t.Fatalf("a refused choice must seed no registry, got %q", registry)
+	}
+	for _, want := range []string{HostedRegistryHost, "does not resolve", "Choose a different registry"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal must contain %q, got %q", want, err)
+		}
+	}
+}
+
+// TestErunRegistryAcceptedWhenAvailable keeps the refusal from swallowing the
+// working case.
+func TestErunRegistryAcceptedWhenAvailable(t *testing.T) {
+	runner := bootstrapRunner{BootstrapInitDependencies: BootstrapInitDependencies{
+		ProbeHostedRegistry: func(context.Context) HostedRegistryStatus {
+			return HostedRegistryStatus{Host: HostedRegistryHost, Available: true}
+		},
+	}}
+	registry, err := runner.resolveContainerRegistry(BootstrapInitParams{ErunRegistry: true}, "acme", "dev", "", "", true)
+	if err != nil {
+		t.Fatalf("an available registry must be accepted: %v", err)
+	}
+	if want := HostedRegistryReference("acme"); registry != want {
+		t.Fatalf("expected %q, got %q", want, registry)
+	}
+}

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -1,6 +1,7 @@
 package eruncommon
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -251,8 +252,16 @@ type BootstrapInitDependencies struct {
 	RunRemoteCommand          RemoteCommandRunnerFunc
 	DeployHelmChart           HelmChartDeployerFunc
 	Sleep                     SleepFunc
-	Context                   Context
+	// ProbeHostedRegistry answers whether erun's hosted registry can be pushed
+	// to. Unset defaults to a real probe, so a caller that wires nothing still
+	// refuses an unreachable registry instead of writing config whose pushes
+	// fail later, far from the choice that caused it.
+	ProbeHostedRegistry HostedRegistryProbeFunc
+	Context             Context
 }
+
+// HostedRegistryProbeFunc reports the hosted registry's current availability.
+type HostedRegistryProbeFunc func(context.Context) HostedRegistryStatus
 
 type bootstrapRunner struct {
 	BootstrapInitDependencies
@@ -1571,6 +1580,12 @@ func (s bootstrapRunner) resolveContainerRegistry(params BootstrapInitParams, te
 		return "", nil
 	}
 	if params.ErunRegistry {
+		// Refuse rather than seed a registry nothing would receive the images
+		// pushed to it: the failure would otherwise surface at the first build,
+		// far from the flag that chose it.
+		if status := s.probeHostedRegistry(); !status.Available {
+			return "", status.Err()
+		}
 		return HostedRegistryReference(tenant), nil
 	}
 	if params.ContainerRegistry != "" {
@@ -1849,4 +1864,14 @@ func normalizeImagePullSecrets(names []string) []string {
 		normalized = append(normalized, name)
 	}
 	return normalized
+}
+
+// probeHostedRegistry runs the availability probe the hosted-registry choice is
+// gated on, defaulting to the real one when no dependency was injected.
+func (s bootstrapRunner) probeHostedRegistry() HostedRegistryStatus {
+	probe := s.ProbeHostedRegistry
+	if probe == nil {
+		probe = func(ctx context.Context) HostedRegistryStatus { return ProbeHostedRegistry(ctx, nil) }
+	}
+	return probe(context.Background())
 }

--- a/erun-common/init.go
+++ b/erun-common/init.go
@@ -1580,13 +1580,22 @@ func (s bootstrapRunner) resolveContainerRegistry(params BootstrapInitParams, te
 		return "", nil
 	}
 	if params.ErunRegistry {
+		reference := HostedRegistryReference(tenant)
+		// A dry-run resolves and traces without touching the world, so it does
+		// not probe. Saying so is the point: a dry-run that printed the resolved
+		// reference alone would read as "this choice works", which is the very
+		// impression the probe exists to stop the real run from giving.
+		if s.Context.DryRun {
+			s.Context.Trace("init: --erun-registry resolves to " + reference + "; the real run probes " + HostedRegistryHost + " and refuses the choice if it is not reachable")
+			return reference, nil
+		}
 		// Refuse rather than seed a registry nothing would receive the images
 		// pushed to it: the failure would otherwise surface at the first build,
 		// far from the flag that chose it.
 		if status := s.probeHostedRegistry(); !status.Available {
 			return "", status.Err()
 		}
-		return HostedRegistryReference(tenant), nil
+		return reference, nil
 	}
 	if params.ContainerRegistry != "" {
 		return params.ContainerRegistry, nil

--- a/erun-docs/docs/deployment/deploy-platform.md
+++ b/erun-docs/docs/deployment/deploy-platform.md
@@ -120,10 +120,14 @@ Three things are yours to supply; the chart does the rest.
 --set-string registry.tokenRealm=https://api.<base-domain>/v2/token
 ```
 
-**2. The signing-key Secret.** The registry trusts exactly the public half of the erun API's own registry-signing key (the same key that also signs mcp-token and dns01-token — distinct audiences, one key). Copy that key out of the API's signing-key Secret and into a Secret named for the registry, once, in the platform env's namespace:
+**2. The signing-key Secret.** The registry trusts exactly the public half of the erun API's own registry-signing key (the same key that also signs mcp-token and dns01-token — distinct audiences, one key). Create it once, in the platform env's namespace.
+
+The API's Secret holds only the **private** key, under `signing.key` — there is
+no `public.pem` in it to copy — so derive the public half on the way across:
 
 ```bash
-kubectl -n <tenant>-prod get secret <tenant>-api-mcp-signing-key -o jsonpath='{.data.public\.pem}' | base64 -d \
+kubectl -n <tenant>-prod get secret <tenant>-api-mcp-signing -o jsonpath='{.data.signing\.key}' | base64 -d \
+  | openssl pkey -pubout \
   | kubectl -n <tenant>-prod create secret generic <tenant>-oci-registry-signing-key --from-file=public.pem=/dev/stdin
 ```
 

--- a/erun-integration/testdata/init/erun_registry_dry_run.txt
+++ b/erun-integration/testdata/init/erun_registry_dry_run.txt
@@ -12,10 +12,12 @@ Loaded tenant configuration
 Loading environment configuration
 kubectl --context test-context get namespace team-dev -o name
 deploy: namespace team-dev is created if the check above reports it missing
+init: --erun-registry resolves to registry.erunpaas.com/team; the real run probes registry.erunpaas.com and refuses the choice if it is not reachable
 Adding new environment
 mkdir -p <TMP>
 write-yaml <TMP>
 ==> Initializing team/dev
+init: --erun-registry resolves to registry.erunpaas.com/team; the real run probes registry.erunpaas.com and refuses the choice if it is not reachable
 deploy: runtime chart team-devops <VERSION> not found in registry.erunpaas.com/team (the tenant's own umbrella)
 deploy: runtime chart erun-devops <VERSION> found in registry.erunpaas.com/team (the shared platform chart)
 deploy: no local runtime chart; using published chart oci://registry.erunpaas.com/team/charts/erun-devops version <VERSION>


### PR DESCRIPTION
Toward #1494, taking scope item (1) as **deploy it**. This is the erun half: the code changes that make the hosted registry capable of working at all, plus refusing the choice while it is not. The prod install itself (chart, DNS, certificate) lands in the frs repo and is not in this PR — so this does not close the issue.

## The token service could never have registered

The issue reads as "the code landed and the deployment never happened". Checking the backend before provisioning anything showed it is worse than that: **the deployment would not have helped.**

`GET /v2/token` 404s in `frs-prod`, in-cluster, with the handler compiled into the running image and the signing key mounted:

```
v1_platform=200      <- the probe works
v2_token_GET=404
```

The registration gate needs `resolvers.tenant != nil`, and `defaultTo` takes this branch when a deployment injects nothing — which is all of them:

```go
if r.identity == nil && r.tenant == nil && r.user == nil {
    r.identity = identities        // production
} else if r.tenant == nil {
    r.tenant = identities          // never reached
}
```

So `tenant` stays nil and the handler is never registered. Nothing else showed a symptom because `tenantAndUser` prefers `identities` whenever it is set.

Filling the plain tenant resolver too is safe for exactly that reason — the atomic-bootstrap path cannot move — and `*repository.IdentityRepository` already satisfies `TenantResolver`, as `registrytoken/handler.go`'s own interface doc says.

Red-then-green, with the handler built the way a deployment builds it:

```
--- RED  --- FAIL: TestHostedRegistryTokenRouteRegistersWithDefaultResolvers
             GET /v2/token is not registered: the hosted registry token service
             does not wire up when a deployment injects no resolvers of its own
--- GREEN ok  github.com/sophium/erun/erun-backend/erun-backend-api
```

## Refusing the choice instead of misconfiguring the environment (item 4)

`erun init --erun-registry` wrote the environment without ever checking the registry was there, so the failure surfaced at the first build rather than at the flag. It now probes and refuses, naming what was observed and a remedy that applies to *that* cause — an unresolvable host, a timeout and a connection failure get different advice, because a confident remedy for an unchecked cause is its own dead end.

Through the real CLI today:

```
erun's hosted container registry registry.erunpaas.com does not resolve. The hosted
registry is not deployed for this platform, so nothing would receive the images pushed
to it. Choose a different registry instead: --container-registry <host/namespace> for
one you already have, or --cluster-registry for an in-cluster one.
```

**This covers the desktop too.** The desktop does not create environments itself — `session.go` builds an `erun init … --erun-registry` command line and runs the CLI — so the desktop's hosted-registry option now fails at creation with the same reason instead of producing an environment whose pushes go nowhere. That is the whole of item 4's requirement for both surfaces named in it.

A 401 counts as available: an unauthenticated `GET /v2/` is exactly what a healthy token-authenticated registry returns, so treating a non-2xx as down would refuse a registry that works.

## Dry-run stays offline

A dry-run resolves and traces without touching the world, so it does not probe — and says so, rather than printing the resolved reference alone and reading as "this choice works". That also keeps `make check` independent of external DNS, which is the trap #1452 was about.

## A runbook step that could not work

`deploy-platform.md` told the operator to copy `public.pem` out of `<tenant>-api-mcp-signing-key`. The Secret is `<tenant>-api-mcp-signing` and holds only `signing.key`, the **private** key — there is no `public.pem` to copy. Corrected to derive the public half with `openssl pkey -pubout`.

## What is deliberately not here

**Item 3 — greying out the desktop toggle up front.** Its harm (an environment configured to push nowhere) is now prevented by the refusal above, so what remains is the UX of declining before submit rather than at it. Doing it properly needs a new Wails binding, and the toolchain to generate and typecheck one is not available in the environment this was built in (`wails` is absent; `frontend/wailsjs` is generated, not committed). I did not want to write frontend code I could not run the gates on. Left on #1494.

## Validation

- `make lint` — `0 issues.` across all six modules
- `erun-common`, `erun-backend-api`, `erun-cli`, `erun-mcp` — `go test ./...` pass
- `erun-integration` — `go test ./...` pass, including the regenerated `init/erun_registry_dry_run` golden
- `test-erun-ui` / `test-frontend` not run here (no generated bindings in this checkout); no `erun-ui` source is touched by this PR, and the release's own image build runs them