### PR TITLE
Probe the hosted registry on its port, not on a status it must never return

### DIFF
--- a/erun-devops/k8s/erun-oci-registry-chart_test.sh
+++ b/erun-devops/k8s/erun-oci-registry-chart_test.sh
@@ -102,4 +102,17 @@ printf '%s\n' "$(document "${overridden}" Deployment)" | grep -q 'image: ghcr.io
 printf '%s\n' "${service}" | grep -q 'port: 5000' || fail "the Service must expose port 5000"
 printf '%s\n' "${service}" | grep -q 'targetPort: registry' || fail "the Service must target the named registry port"
 
+# --- 9. No probe asserts a status this registry must never return ---
+# An unauthenticated GET /v2/ is 401 here by design — that is the bearer
+# challenge the whole auth model rests on — and kubelet counts only 2xx/3xx as
+# success. An httpGet probe therefore inverts the contract: the better the auth
+# is configured, the more certainly the pod never goes ready and its own startup
+# probe kills a container that is working. Nothing on the pod answers 2xx
+# unauthenticated, so there is no path to aim one at.
+if printf '%s\n' "${deployment}" | grep -q 'httpGet:'; then
+    fail "no probe may use httpGet: an unauthenticated GET against this registry is 401 by design, which kubelet treats as a failed probe"
+fi
+printf '%s\n' "${deployment}" | grep -q 'tcpSocket:' ||
+    fail "the container must be probed on its port: readiness for a registry whose authorization is delegated is that the port serves"
+
 echo "OK: erun-oci-registry chart"

--- a/erun-devops/k8s/erun-oci-registry/templates/registry.yaml
+++ b/erun-devops/k8s/erun-oci-registry/templates/registry.yaml
@@ -122,15 +122,23 @@ spec:
           ports:
             - containerPort: 5000
               name: registry
+          # tcpSocket, not httpGet. This registry delegates every request to the
+          # bearer token service, so an unauthenticated GET /v2/ answers 401 by
+          # design — and kubelet counts only 2xx/3xx as success. An HTTP probe
+          # here therefore asserts the opposite of correct behaviour: the better
+          # the registry is configured, the more certainly it never goes ready,
+          # and the startup probe eventually kills a container that is working.
+          # Nothing on the pod answers 2xx unauthenticated (/v2/ and
+          # /v2/_catalog are 401, /metrics is 404), so there is no path to point
+          # an HTTP probe at either. Readiness for a component whose
+          # authorization lives elsewhere is "the port serves".
           readinessProbe:
-            httpGet:
-              path: /v2/
+            tcpSocket:
               port: registry
             periodSeconds: 5
             timeoutSeconds: 2
           startupProbe:
-            httpGet:
-              path: /v2/
+            tcpSocket:
               port: registry
             periodSeconds: 2
             timeoutSeconds: 2


### PR DESCRIPTION
The `erun-oci-registry` component could not become ready in any correctly configured deployment.

Part of #1499 (the probe half; the image-never-published half is separate).

## What happened

Deploying it for #1494, the pod pulled, started, and was then killed by its own startup probe:

```
frs-oci-registry-9bfb6fb89-4n8ps   0/1   Running   1 (100s ago)
```

zot was completely healthy the whole time, and its log shows it answering the probe exactly as it should:

```json
{"level":"info","message":"HTTP API","path":"/v2/","statusCode":401,"User-Agent":["kube-probe/1.34"]}
```

## Why it can never work

Both probes were `httpGet: /v2/`. An unauthenticated `GET /v2/` against a token-authenticated registry is **401 by design** — it is the bearer challenge the entire auth model rests on — and kubelet counts only 2xx/3xx as success.

So the probe asserted the opposite of correct behaviour: the better the registry's auth was configured, the more certainly it never went ready. And there is no path to point an HTTP probe at instead — nothing on the pod answers 2xx unauthenticated:

| path | status |
|---|---|
| `/v2/` | 401 |
| `/v2/_catalog` | 401 |
| `/metrics` | 404 |

## Fix

`tcpSocket` on the named `registry` port. Readiness for a component whose authorization is delegated elsewhere is that the port serves; an `exec` probe accepting 401 would also work and buys nothing over this.

Test 9 in the chart test locks both halves — no `httpGet` anywhere in the Deployment, and the container is probed on its port — so the next edit cannot quietly restore a probe that inverts the contract.

## Validation

Confirmed against the running deployment before writing the fix, by patching the live probes as a throwaway diagnostic (helm reverts it; the chart is the real fix):

```
READY: 1/1 Running          # instantly, with tcpSocket
```

and the public endpoint then served correctly through its Ingress and certificate:

```
HTTP/2 401
www-authenticate: Bearer realm="https://api.erunpaas.com/v2/token",service="registry.erunpaas.com"
```

`make helm-chart-tests` passes, including the new assertion:

```
>> erun-devops/k8s/erun-oci-registry-chart_test.sh
OK: erun-oci-registry chart
```