### PR TITLE
Name why the Ports tab has nothing to expose, and scope the titlebar banner locator

### DIFF
--- a/erun-ui/exposure_app.go
+++ b/erun-ui/exposure_app.go
@@ -14,23 +14,24 @@ import (
 // composes the shared expose/unexpose primitives in erun-common; it holds no
 // expose/unexpose planning of its own.
 
-// ListEnvironmentExposures powers the Ports tab's exposure list. An
-// environment whose project carries no platform block reports Configured
-// false -- there is nothing to check against a cluster, so the tab renders
-// "not applicable" rather than an empty list. A listing the caller's
-// Kubernetes credentials cannot make reports Restricted instead of a bare
-// empty list.
+// ListEnvironmentExposures powers the Ports tab's exposure list. Configured
+// is false for either of two distinct reasons, named in NotConfiguredReason
+// so the tab's empty state can tell them apart: a host environment has no
+// pod and no cluster at all, so exposure can never apply; a cluster-backed
+// environment whose project carries no platform block simply hasn't been set
+// up for it yet. A listing the caller's Kubernetes credentials cannot make
+// reports Restricted instead of a bare empty list.
 func (a *App) ListEnvironmentExposures(selection uiSelection) (uiExposureList, error) {
 	selection = normalizeSelection(selection)
 	if selection.Tenant == "" || selection.Environment == "" {
 		return uiExposureList{}, fmt.Errorf("tenant and environment are required")
 	}
-	req, configured, err := a.resolveExposureRequest(selection)
+	req, configured, notConfiguredReason, err := a.resolveExposureRequest(selection)
 	if err != nil {
 		return uiExposureList{}, err
 	}
 	if !configured {
-		return uiExposureList{Services: []uiExposedService{}}, nil
+		return uiExposureList{Services: []uiExposedService{}, NotConfiguredReason: notConfiguredReason}, nil
 	}
 	services, err := eruncommon.ListExposedServices(req)
 	if err != nil {
@@ -101,20 +102,28 @@ func (a *App) UnexposeEnvironment(selection uiSelection) (uiUnexposeResult, erro
 }
 
 // resolveExposureRequest resolves the env's namespace/context (for listing
-// its Ingresses) and whether its project is configured for exposure at all.
-func (a *App) resolveExposureRequest(selection uiSelection) (eruncommon.ShellLaunchParams, bool, error) {
+// its Ingresses), whether it is configured for exposure at all, and -- when
+// it isn't -- which of the two distinct reasons applies. A host environment
+// is checked first and always wins: it has no cluster to check a platform
+// block against, so that reason takes priority over the project's config.
+func (a *App) resolveExposureRequest(selection uiSelection) (req eruncommon.ShellLaunchParams, configured bool, notConfiguredReason string, err error) {
 	config, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
 	if err != nil {
-		return eruncommon.ShellLaunchParams{}, false, err
+		return eruncommon.ShellLaunchParams{}, false, "", err
 	}
-	req := eruncommon.ShellLaunchParams{
+	if config.Type == eruncommon.EnvironmentTypeHost {
+		return eruncommon.ShellLaunchParams{}, false, uiExposureNotConfiguredHostEnvironment, nil
+	}
+	req = eruncommon.ShellLaunchParams{
 		Tenant:            selection.Tenant,
 		Environment:       selection.Environment,
 		Namespace:         eruncommon.KubernetesNamespaceName(selection.Tenant, selection.Environment),
 		KubernetesContext: strings.TrimSpace(config.KubernetesContext),
 	}
-	configured := eruncommon.ProjectHasExposablePlatform(a.exposeProjectRoot())
-	return req, configured, nil
+	if !eruncommon.ProjectHasExposablePlatform(a.exposeProjectRoot()) {
+		return req, false, uiExposureNotConfiguredNoPlatformBlock, nil
+	}
+	return req, true, "", nil
 }
 
 // exposeProjectRoot resolves the currently open project, the same way every

--- a/erun-ui/exposure_app_test.go
+++ b/erun-ui/exposure_app_test.go
@@ -15,7 +15,8 @@ func exposureTestApp(t *testing.T, projectRoot string) *App {
 		deps: erunUIDeps{
 			store: stubUIStore{
 				envs: map[string]eruncommon.EnvConfig{
-					"team/dev": {KubernetesContext: "team-context"},
+					"team/dev":  {KubernetesContext: "team-context"},
+					"team/host": {Type: eruncommon.EnvironmentTypeHost},
 				},
 			},
 			findProjectRoot: func() (string, string, error) {
@@ -70,6 +71,27 @@ func TestListEnvironmentExposuresNotConfiguredWithoutPlatformBlock(t *testing.T)
 	}
 	if len(result.Services) != 0 {
 		t.Fatalf("expected no services, got %+v", result.Services)
+	}
+	if result.NotConfiguredReason != uiExposureNotConfiguredNoPlatformBlock {
+		t.Fatalf("expected NotConfiguredReason %q, got %q", uiExposureNotConfiguredNoPlatformBlock, result.NotConfiguredReason)
+	}
+}
+
+// TestListEnvironmentExposuresNotConfiguredForHostEnvironment locks down that
+// a host environment (no pod, no cluster at all) reports the host-specific
+// reason even when the open project does have a platform block -- exposure
+// can never apply to a host env regardless of the project's configuration.
+func TestListEnvironmentExposuresNotConfiguredForHostEnvironment(t *testing.T) {
+	app := exposureTestApp(t, exposableProjectRoot(t))
+	result, err := app.ListEnvironmentExposures(uiSelection{Tenant: "team", Environment: "host"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Configured {
+		t.Fatal("expected Configured=false for a host environment")
+	}
+	if result.NotConfiguredReason != uiExposureNotConfiguredHostEnvironment {
+		t.Fatalf("expected NotConfiguredReason %q, got %q", uiExposureNotConfiguredHostEnvironment, result.NotConfiguredReason)
 	}
 }
 

--- a/erun-ui/frontend/src/app/documentationThunks.ts
+++ b/erun-ui/frontend/src/app/documentationThunks.ts
@@ -22,3 +22,10 @@ export const openDocumentation = (): AppThunk => () => {
 export const openInstallDocs = (): AppThunk => () => {
   BrowserOpenURL(`${ERUN_DOCS_URL}/getting-started/install`);
 };
+
+// openPlatformBlockDocs deep-links the `platform:` block reference — the
+// recovery the Ports tab's "not available" empty state names for a
+// cluster-backed environment whose project hasn't declared one yet.
+export const openPlatformBlockDocs = (): AppThunk => () => {
+  BrowserOpenURL(`${ERUN_DOCS_URL}/reference/configuration#platform-block`);
+};

--- a/erun-ui/frontend/src/components/app/ManageDialogPortsExposures.tsx
+++ b/erun-ui/frontend/src/components/app/ManageDialogPortsExposures.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import * as React from 'react';
 
+import { openPlatformBlockDocs } from '@/app/documentationThunks';
 import { useAppDispatch } from '@/app/hooks';
 import {
   cancelUnexposeConfirm,
@@ -31,14 +32,15 @@ import { BrowserOpenURL, ClipboardSetText } from '../../../wailsjs/runtime/runti
 
 type ManageDialog = AppState['manageDialog'];
 
-// ExposuresSection is the Ports tab's public-exposure surface (issue #1351):
-// it lists an environment's active exposures and their public hostnames,
-// exposes a new service, and removes the environment's public DNS record
-// behind a two-step confirm. Every reachable state is designed explicitly —
-// loading, three distinct empty states (not applicable / restricted /
-// nothing yet), populated, failed, and the in-flight create/remove states —
-// per erun-ui/AGENTS.md "Degrade by permission" and "Keep the three empty
-// states distinct".
+// ExposuresSection is the Ports tab's public-exposure surface: it lists an
+// environment's active exposures and their public hostnames, exposes a new
+// service, and removes the environment's public DNS record behind a
+// two-step confirm. Every reachable state is designed explicitly — loading,
+// four distinct empty states (host environment type / project not
+// configured for exposure, each named and the fixable one carrying its
+// recovery / restricted / nothing yet), populated, failed, and the in-flight
+// create/remove states — per erun-ui/AGENTS.md "Degrade by permission" and
+// "Keep the three empty states distinct".
 export function ExposuresSection({ dialog }: { dialog: ManageDialog }): React.ReactElement {
   const exposures = dialog.exposures;
   const loading = dialog.exposuresLoading;
@@ -76,11 +78,33 @@ function ExposuresBody({
 }): React.ReactElement {
   const dispatch = useAppDispatch();
   if (!exposures.configured) {
+    if (exposures.notConfiguredReason === 'host-environment') {
+      return (
+        <EmptyState
+          icon={<Globe aria-hidden="true" />}
+          heading="Not available for this environment type"
+          body="Host environments have no pod and no cluster, so there is no public address to show or create here."
+        />
+      );
+    }
     return (
       <EmptyState
         icon={<Globe aria-hidden="true" />}
         heading="Not available for this environment"
-        body="This environment's project isn't set up for hosted deployment, so it has no public address to show."
+        body="This environment's project isn't set up for hosted deployment yet -- it needs a platform: block with a base domain in .erun/config.yaml before it can have a public address."
+        action={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              dispatch(openPlatformBlockDocs());
+            }}
+          >
+            <ExternalLink aria-hidden="true" />
+            View the platform: block reference
+          </Button>
+        }
       />
     );
   }

--- a/erun-ui/frontend/src/uiExposureTypes.ts
+++ b/erun-ui/frontend/src/uiExposureTypes.ts
@@ -6,7 +6,18 @@ export interface UIExposureList {
   restricted: boolean;
   error?: string;
   services: UIExposedService[];
+  // notConfiguredReason distinguishes the two reasons configured can be
+  // false, which call for different copy and different recovery: a host
+  // environment has no cluster and can never be exposed
+  // ("host-environment"), while a cluster-backed environment whose project
+  // has no platform: block yet just hasn't been set up for it
+  // ("no-platform-block", the fixable case). Empty when configured is true.
+  // Bare string to match the Wails binding, which widens the Go string
+  // constant; narrow against UIExposureNotConfiguredReason at the read site.
+  notConfiguredReason?: string;
 }
+
+export type UIExposureNotConfiguredReason = 'host-environment' | 'no-platform-block';
 
 export interface UIExposedService {
   service: string;

--- a/erun-ui/playwright/pages/Titlebar.ts
+++ b/erun-ui/playwright/pages/Titlebar.ts
@@ -1,8 +1,15 @@
 import type { Locator, Page } from '@playwright/test';
 
-// One banner rendered as status or alert depending on the terminalMessage kind.
+// One banner rendered as status or alert depending on the terminalMessage
+// kind. Scoped to the titlebar's own <header> (Titlebar.tsx) because
+// TerminalBusyOverlay renders an unrelated role="status" aria-live="polite"
+// node over the terminal pane with the same signature -- an unscoped
+// selector's .first() can resolve to that overlay's "Opening <tenant> /
+// <environment>..." text instead of the titlebar's own banner whenever a
+// session is mid-open, which is exactly the default env this harness
+// auto-opens on every boot.
 const TITLEBAR_BANNER_SELECTOR =
-  '[role="status"][aria-live="polite"], [role="alert"][aria-live="assertive"]';
+  'header [role="status"][aria-live="polite"], header [role="alert"][aria-live="assertive"]';
 
 export class Titlebar {
   constructor(public readonly page: Page) {}

--- a/erun-ui/playwright/tests/env-init-refresh.spec.ts
+++ b/erun-ui/playwright/tests/env-init-refresh.spec.ts
@@ -72,8 +72,14 @@ test.describe('environment init refresh', () => {
     const environment = 'local';
     await emitWailsEvent(app.page, 'environment-initialized', { tenant, environment });
 
+    // The env never exists, so the handler exhausts its full retry budget
+    // (8 attempts, a getInitialState round trip plus a 400ms delay each)
+    // before raising the error -- on a loaded machine each round trip alone
+    // can take longer than the 400ms delay between them, so the wait here
+    // must clear the retry loop's own worst case with real margin, not just
+    // the fast-path duration a lightly-loaded machine sees.
     await expect(app.titlebar.statusMessage()).toContainText('did not appear in the sidebar', {
-      timeout: 15_000,
+      timeout: 45_000,
     });
     await expect(app.sidebar.envRowButton(tenant, environment)).toHaveCount(0);
     await app.titlebar.dismissStatus();

--- a/erun-ui/playwright/tests/manage-ports-exposures.spec.ts
+++ b/erun-ui/playwright/tests/manage-ports-exposures.spec.ts
@@ -47,7 +47,7 @@ const POPULATED = {
 };
 
 test.describe('manage dialog ports tab — public exposures (#1351)', () => {
-  test('a non-hosted environment reports its public address as not applicable, not an empty list', async ({
+  test('a cluster-backed environment with no platform block names the fix and links to it', async ({
     app,
   }) => {
     await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, SEED_ENV_ALPHA);
@@ -56,12 +56,49 @@ test.describe('manage dialog ports tab — public exposures (#1351)', () => {
     const dialog = app.manageDialog.locator();
 
     await expect(dialog.getByText('Not available for this environment')).toBeVisible();
+    await expect(dialog.getByText(/isn't set up for hosted deployment yet/)).toBeVisible();
     await expect(dialog.getByText('Nothing exposed yet')).toHaveCount(0);
     await expect(dialog.getByRole('button', { name: /Expose a service/ })).toHaveCount(0);
+
+    // The empty state must carry the action that resolves it, not just name
+    // the condition (root AGENTS.md "Smooth, Seamless, No Dead Ends").
+    const docsLink = dialog.getByRole('button', { name: /View the platform: block reference/ });
+    await expect(docsLink).toBeVisible();
 
     await dialog.screenshot({
       path: '/home/erun/.erun/outputs/1351-visual/ports-not-applicable.png',
     });
+
+    const [popup] = await Promise.all([app.page.waitForEvent('popup'), docsLink.click()]);
+    // The browser normalizes a bare path to add a trailing slash before the
+    // fragment (mirrors sidebar-documentation-link.spec.ts's own '/' suffix).
+    await expect
+      .poll(() => popup.url())
+      .toBe('https://docs.erunpaas.com/reference/configuration/#platform-block');
+    await popup.close();
+
+    await app.manageDialog.cancel();
+    await app.manageDialog.waitForClosed();
+  });
+
+  test('a host environment reports its type as never exposable, with no dangling action', async ({
+    app,
+    seededHostEnv,
+  }) => {
+    const { tenant, environment } = seededHostEnv;
+    await app.sidebar.openManageDialogViaKeyboard(tenant, environment);
+    await app.manageDialog.waitForOpen();
+    await app.manageDialog.selectTab('Ports');
+    const dialog = app.manageDialog.locator();
+
+    await expect(dialog.getByText('Not available for this environment type')).toBeVisible();
+    await expect(dialog.getByText(/no pod and no cluster/)).toBeVisible();
+    // Unlike the fixable "no platform block" case, there is nothing to fix
+    // here -- a host env can never be exposed, so no action is offered.
+    await expect(
+      dialog.getByRole('button', { name: /View the platform: block reference/ }),
+    ).toHaveCount(0);
+    await expect(dialog.getByRole('button', { name: /Expose a service/ })).toHaveCount(0);
 
     await app.manageDialog.cancel();
     await app.manageDialog.waitForClosed();

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -504,17 +504,29 @@ type uiPortStatus struct {
 }
 
 // uiExposureList is the Ports tab's read model for an environment's public
-// exposures. Configured is false when the project has no platform block at
-// all, which the tab renders as "not applicable" rather than an empty list —
+// exposures. Configured is false when exposure cannot apply here at all,
+// which the tab renders as "not applicable" rather than an empty list —
 // distinct from Restricted (the caller cannot see the answer) and from a
 // genuinely empty Services list (configured, nothing exposed yet). Error
 // carries a listing failure that is neither of those two named cases.
+// NotConfiguredReason names which of two distinct causes made Configured
+// false, since they call for different copy and different recovery: a host
+// environment has no cluster and can never be exposed, while a cluster-backed
+// environment whose project simply hasn't declared a platform: block yet is
+// the fixable case.
 type uiExposureList struct {
-	Configured bool               `json:"configured"`
-	Restricted bool               `json:"restricted"`
-	Error      string             `json:"error,omitempty"`
-	Services   []uiExposedService `json:"services"`
+	Configured          bool               `json:"configured"`
+	Restricted          bool               `json:"restricted"`
+	Error               string             `json:"error,omitempty"`
+	Services            []uiExposedService `json:"services"`
+	NotConfiguredReason string             `json:"notConfiguredReason,omitempty"`
 }
+
+// uiExposureNotConfiguredReason enumerates uiExposureList.NotConfiguredReason values.
+const (
+	uiExposureNotConfiguredHostEnvironment = "host-environment"
+	uiExposureNotConfiguredNoPlatformBlock = "no-platform-block"
+)
 
 // uiExposedService mirrors eruncommon.ExposedService for the Ports tab list.
 type uiExposedService struct {


### PR DESCRIPTION
Two dead ends on the same surface.

**Ports tab (#1491).** The expose control itself landed separately; what remained was the empty state, which said a flat *"Not available"* for three unrelated situations and offered nothing to do about any of them. Now each names itself, and the one that is fixable carries its fix: an environment whose tenant has no base domain is told it needs a `platform:` block with a base domain in `.erun/config.yaml`, with a link straight to that documentation. No dead end.

**Titlebar banner (#1466).** `TerminalBusyOverlay` renders a `role="status" aria-live="polite"` node with the same signature as the titlebar's own banner, so the page object's `.first()` was resolving to *"Opening tenant/env…"* — the overlay answering a question about the titlebar. The locator is now scoped to the titlebar's `header`. That is the flake's root cause, not its timing; the accompanying timeout raise on `env-init-refresh` only brings the spec's budget in line with the retry budget the code actually spends (8 attempts x round trip + 400ms backoff, which genuinely exceeds 15s under load).

Verified: `manage-ports` and `env-init-refresh` specs, 9 passed.

`make lint` is red on `erun-common/init.go:1576` (`resolveContainerRegistry`, cyclop 11 > 10). That is inherited from `main` — this branch does not touch `erun-common` — and is fixed separately.

Closes #1491
Closes #1466