### PR TITLE
Name a recovery for an unresolved tenant/environment, and gate handlers whose required inputs their schema cannot express

### DIFF
--- a/erun-integration/bare_required_input_test.go
+++ b/erun-integration/bare_required_input_test.go
@@ -8,11 +8,20 @@ package integration
 // exactly `fmt.Errorf("tenant is required")`, plus two siblings in the same
 // erun-common function, after an earlier fix addressed one lone producer and
 // closed its own follow-up audit item unperformed. This is the check that
-// closes the gap: it fails the build the next time one of these exact bare
+// closes the gap: it fails the build the next time one of these bare
 // phrases reappears in non-test Go source anywhere in the repo. It runs as
 // an ordinary `go test` in this module, so it is part of
 // `make integration-test`/`make check` with no extra wiring — the same
 // precedent as desktop_surface_test.go.
+//
+// erun-mcp's exec_agent shipped uncallable because its target-resolution
+// failure used a THIRD phrasing, "tenant and environment are required" —
+// the original gate matched only the two literal strings above, so this
+// exact defect walked straight through it. Matching against a fixed set of
+// literals will always be one phrasing behind; bareRequiredInputPattern
+// below matches the *shape* instead (any bare combination of "tenant"
+// and/or "environment", singular or plural, in either order), so a future
+// reordering or pluralization cannot slip through the same way.
 
 import (
 	"fmt"
@@ -21,29 +30,76 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-// bareRequiredInputPhrases is the exact set of string literals this gate
-// bars from non-test Go source: a bare "<subject> is required" with no
-// operation and no recovery. The fix that added this gate converted every
+// bareRequiredInputPattern matches a bare "<subject> is/are required" with no
+// operation and no recovery, for the closed set of generic nouns this gate
+// tracks: "tenant" and "environment", alone or combined via "and". This is a
+// deliberately narrow generalization -- from an enumeration of exact
+// literals to a shape covering their permutations -- not a blanket "any
+// subject is required" scanner. The fix that added this gate converted every
 // "tenant is required" producer plus its immediate "environment is
-// required" sibling in the same erun-common function — it deliberately did
+// required" sibling in the same erun-common function, and deliberately did
 // not chase every "<X> is required" string in the repo (on the order of 150
 // at the time of writing, including several more "cloud provider alias is
-// required" sites this same audit found but left alone). Most of the rest
+// required" sites that same audit found but left alone). Most of the rest
 // already name their own specific subject (e.g. "review id is required",
 // "target branch is required", "cloud provider alias is required") and are
 // a lower-severity instance of the same class, not the "four words, no
 // operation, no subject beyond a generic noun, no recovery" shape this gate
-// targets. Extend this set only for a phrase that genuinely matches that
-// shape on a reachable path — not for every validation string that happens
-// to end in "is required".
-var bareRequiredInputPhrases = map[string]bool{
-	"tenant is required":      true,
-	"environment is required": true,
+// targets. Widen this pattern's subject set only for a phrase that
+// genuinely matches that shape on a reachable path — not for every
+// validation string that happens to end in "is required".
+var bareRequiredInputPattern = regexp.MustCompile(`^(?:tenant|environment)(?: and (?:tenant|environment))? (?:is|are) required$`)
+
+// bareRequiredInputBaseline is a shrink-only baseline (the same pattern as
+// KnownUnsurfacedRoutes in erun-backend-api/internal/routes/route_audit.go)
+// for the "tenant and environment are required" hits that widening the
+// pattern above newly caught: 65 pre-existing call sites across erun-cli,
+// erun-common, and erun-ui, none of them reachable from the exec_agent bug
+// this gate change was made for. Rewriting all of them to name their own
+// operation and recovery is a distinct, large effort of its own (tracked at
+// https://github.com/sophium/erun/issues/1506), not something to rush inline
+// with a one-tool schema fix. This baseline may only shrink: fixing a site
+// and forgetting to remove its entry here fails TestBareRequiredInputBaselineIsCurrent
+// below, the same way a stale KnownUnsurfacedRoutes entry fails its own gate.
+// The key is the file path relative to the repo root; the value is the exact
+// count of matching literals still in that file.
+var bareRequiredInputBaseline = map[string]int{
+	"erun-cli/cmd/activity.go":         3,
+	"erun-cli/cmd/activity_lease.go":   1,
+	"erun-cli/cmd/activity_proxy.go":   1,
+	"erun-cli/cmd/delete.go":           1,
+	"erun-cli/cmd/job.go":              1,
+	"erun-common/activity.go":          3,
+	"erun-common/delete.go":            1,
+	"erun-common/env_trace.go":         1,
+	"erun-common/idle_stop_pending.go": 4,
+	"erun-common/job_supervisor.go":    1,
+	"erun-common/unexpose.go":          1,
+	"erun-ui/contribute_mode.go":       2,
+	"erun-ui/contribute_sessions.go":   2,
+	"erun-ui/deploy_components.go":     1,
+	"erun-ui/environment_config.go":    4,
+	"erun-ui/environment_health.go":    1,
+	"erun-ui/environment_jobs.go":      1,
+	"erun-ui/environment_stop.go":      1,
+	"erun-ui/env_trace_handlers.go":    1,
+	"erun-ui/exec_write_push.go":       2,
+	"erun-ui/exposure_app.go":          3,
+	"erun-ui/host_open_path.go":        1,
+	"erun-ui/host_workspace.go":        4,
+	"erun-ui/idle_status.go":           3,
+	"erun-ui/outputs.go":               2,
+	"erun-ui/pin_version.go":           3,
+	"erun-ui/runtime_activity.go":      2,
+	"erun-ui/runtime_sizing.go":        2,
+	"erun-ui/runtime_usage.go":         1,
+	"erun-ui/terminal_sessions.go":     11,
 }
 
 // skipDirForBareRequiredInputScan excludes directories that hold no
@@ -61,6 +117,7 @@ func skipDirForBareRequiredInputScan(name string) bool {
 // bareRequiredInputHit is one banned literal found in production source.
 type bareRequiredInputHit struct {
 	position string
+	file     string // path relative to the scan root, forward-slash separated
 	value    string
 }
 
@@ -69,9 +126,9 @@ func (h bareRequiredInputHit) Message() string {
 }
 
 // findBareRequiredInputLiterals parses every non-test .go file under root and
-// returns one hit per exact-match banned string literal. AST-based rather
-// than a text grep so a match inside a comment (not reachable at runtime)
-// does not fail the gate.
+// returns one hit per string literal matching bareRequiredInputPattern.
+// AST-based rather than a text grep so a match inside a comment (not
+// reachable at runtime) does not fail the gate.
 func findBareRequiredInputLiterals(t testing.TB, root string) []bareRequiredInputHit {
 	t.Helper()
 	var hits []bareRequiredInputHit
@@ -93,16 +150,21 @@ func findBareRequiredInputLiterals(t testing.TB, root string) []bareRequiredInpu
 		if parseErr != nil {
 			return fmt.Errorf("parse %s: %w", path, parseErr)
 		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return fmt.Errorf("relativize %s: %w", path, relErr)
+		}
+		rel = filepath.ToSlash(rel)
 		ast.Inspect(file, func(n ast.Node) bool {
 			lit, ok := n.(*ast.BasicLit)
 			if !ok || lit.Kind != token.STRING {
 				return true
 			}
 			value, unquoteErr := strconv.Unquote(lit.Value)
-			if unquoteErr != nil || !bareRequiredInputPhrases[value] {
+			if unquoteErr != nil || !bareRequiredInputPattern.MatchString(value) {
 				return true
 			}
-			hits = append(hits, bareRequiredInputHit{position: fset.Position(lit.Pos()).String(), value: value})
+			hits = append(hits, bareRequiredInputHit{position: fset.Position(lit.Pos()).String(), file: rel, value: value})
 			return true
 		})
 		return nil
@@ -113,13 +175,40 @@ func findBareRequiredInputLiterals(t testing.TB, root string) []bareRequiredInpu
 	return hits
 }
 
-// TestNoBareRequiredInputError fails when a bare "<subject> is required"
-// string literal (bareRequiredInputPhrases) reappears in non-test Go source
-// anywhere in the repo.
+// TestNoBareRequiredInputError fails when a bare tenant/environment
+// required-input literal (bareRequiredInputPattern) reappears in non-test Go
+// source anywhere in the repo, beyond what bareRequiredInputBaseline already
+// carries for a given file. A file with no baseline entry gets zero
+// tolerance -- any hit there is a brand new instance of the bug. A file with
+// a baseline entry may not exceed it: that would be a new call site added
+// next to the tracked ones, not fixing them.
 func TestNoBareRequiredInputError(t *testing.T) {
 	root := repoRoot(t)
+	counts := map[string]int{}
 	for _, hit := range findBareRequiredInputLiterals(t, root) {
-		t.Errorf("%s", hit.Message())
+		counts[hit.file]++
+		if counts[hit.file] > bareRequiredInputBaseline[hit.file] {
+			t.Errorf("%s", hit.Message())
+		}
+	}
+}
+
+// TestBareRequiredInputBaselineIsCurrent fails when a baselined file's actual
+// hit count has dropped below what bareRequiredInputBaseline still claims --
+// the same shrink-only enforcement FindStaleBaselineEntries applies to
+// KnownUnsurfacedRoutes. A fix that lowers a file's count without lowering
+// its baseline entry here would otherwise let the debt silently look larger
+// than it is forever.
+func TestBareRequiredInputBaselineIsCurrent(t *testing.T) {
+	root := repoRoot(t)
+	counts := map[string]int{}
+	for _, hit := range findBareRequiredInputLiterals(t, root) {
+		counts[hit.file]++
+	}
+	for file, baseline := range bareRequiredInputBaseline {
+		if actual := counts[file]; actual < baseline {
+			t.Errorf("%s: bareRequiredInputBaseline claims %d hit(s) but only %d remain -- lower the baseline entry (see https://github.com/sophium/erun/issues/1506)", file, baseline, actual)
+		}
 	}
 }
 
@@ -180,5 +269,35 @@ func requireAlias(alias string) error {
 	}
 	if hits[0].value != "tenant is required" {
 		t.Fatalf("expected the hit to carry the matched phrase, got %q", hits[0].value)
+	}
+	if hits[0].file != "production.go" {
+		t.Fatalf("expected the hit to carry the relative file path, got %q", hits[0].file)
+	}
+}
+
+// TestBareRequiredInputPatternCatchesShapeVariants is the regression for the
+// bug this gate widening exists to fix: exec_agent's target resolution
+// failed with "tenant and environment are required", a third phrasing the
+// old literal-enumeration gate did not know about. This locks that the
+// pattern generalizes over conjunction order and singular/plural, not just
+// the two original literals, while still leaving an unrelated
+// specifically-named subject alone.
+func TestBareRequiredInputPatternCatchesShapeVariants(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"tenant is required", true},
+		{"environment is required", true},
+		{"tenant and environment are required", true},
+		{"environment and tenant are required", true},
+		{"tenant and environment is required", true},
+		{"review id is required", false},
+		{"cloud provider alias is required", false},
+		{"tenant and environment are required to deploy", false},
+	} {
+		if got := bareRequiredInputPattern.MatchString(tc.value); got != tc.want {
+			t.Errorf("bareRequiredInputPattern.MatchString(%q) = %v, want %v", tc.value, got, tc.want)
+		}
 	}
 }

--- a/erun-mcp/delete.go
+++ b/erun-mcp/delete.go
@@ -26,7 +26,9 @@ func deleteTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 		}
 		expected := eruncommon.DeleteEnvironmentConfirmation(tenant, environment)
 		if expected == "" {
-			return nil, JobEnvelopeOutput{}, fmt.Errorf("tenant and environment are required")
+			return nil, JobEnvelopeOutput{}, fmt.Errorf(
+				"tenant/environment not resolved: this MCP server was not started bound to a tenant/environment, and the call did not supply them either -- pass tenant and environment explicitly in the call, or run this edge for an environment that has them configured",
+			)
 		}
 		if !input.Preview && strings.TrimSpace(input.Confirmation) != expected {
 			return nil, JobEnvelopeOutput{}, fmt.Errorf("delete confirmation must match %q", expected)

--- a/erun-mcp/delete.go
+++ b/erun-mcp/delete.go
@@ -26,9 +26,7 @@ func deleteTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReques
 		}
 		expected := eruncommon.DeleteEnvironmentConfirmation(tenant, environment)
 		if expected == "" {
-			return nil, JobEnvelopeOutput{}, fmt.Errorf(
-				"tenant/environment not resolved: this MCP server was not started bound to a tenant/environment, and the call did not supply them either -- pass tenant and environment explicitly in the call, or run this edge for an environment that has them configured",
-			)
+			return nil, JobEnvelopeOutput{}, errMissingLocalTarget(tenant == "", environment == "")
 		}
 		if !input.Preview && strings.TrimSpace(input.Confirmation) != expected {
 			return nil, JobEnvelopeOutput{}, fmt.Errorf("delete confirmation must match %q", expected)

--- a/erun-mcp/exec_agent_callable_test.go
+++ b/erun-mcp/exec_agent_callable_test.go
@@ -1,0 +1,41 @@
+package erunmcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestExecAgentIsCallableWithOnlyAgentAndPrompt is the end-to-end regression
+// for the bug where exec_agent's handler demanded a tenant/environment its own
+// JSON schema could not carry (additionalProperties: false, no tenant/
+// environment property): every call failed, one way or another, no matter
+// what the caller sent. This drives a real MCP session over HTTP -- the same
+// path a client actually uses, including the SDK's own schema validation --
+// rather than calling the Go handler directly, since a direct call bypasses
+// exactly the validation layer that rejected the extra properties.
+func TestExecAgentIsCallableWithOnlyAgentAndPrompt(t *testing.T) {
+	t.Setenv("ERUN_CLAUDE_BIN", "true")
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "acme", Environment: "dev", RepoPath: t.TempDir()}}
+	session := connectTestMCPSession(t, eruncommon.BuildInfo{Version: "1.2.3"}, runtime)
+
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "exec_agent",
+		Arguments: map[string]any{"agent": "claude", "prompt": "probe", "preview": true},
+	})
+	if err != nil {
+		t.Fatalf("exec_agent rejected a call carrying only its own required+documented properties: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("exec_agent returned a tool-level error for its own minimal input: %v", result.Content)
+	}
+
+	encoded, marshalErr := json.MarshalIndent(result.StructuredContent, "", "  ")
+	if marshalErr != nil {
+		t.Fatalf("marshal exec_agent's response: %v", marshalErr)
+	}
+	t.Logf("exec_agent({agent:claude, prompt:probe, preview:true}) resolved:\n%s", encoded)
+}

--- a/erun-mcp/local_target_test.go
+++ b/erun-mcp/local_target_test.go
@@ -1,6 +1,7 @@
 package erunmcp
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -60,12 +61,51 @@ func TestResolveLocalTargetAcceptsItsOwnScope(t *testing.T) {
 }
 
 // A server with no scope of its own still needs both values from the caller.
+// The error itself must not be the bare "tenant and environment are
+// required" dead end that made exec_agent's failure unrecoverable: it must
+// name what is missing and what the caller can do about it.
 func TestResolveLocalTargetRequiresBothWhenTheServerHasNoScope(t *testing.T) {
 	runtime := RuntimeConfig{}
-	if _, _, err := resolveLocalTarget(runtime, "", ""); err == nil {
-		t.Error("expected an error when neither the server nor the caller names a target")
+	_, _, err := resolveLocalTarget(runtime, "", "")
+	if err == nil {
+		t.Fatal("expected an error when neither the server nor the caller names a target")
 	}
-	if _, _, err := resolveLocalTarget(runtime, "tenant-a", ""); err == nil {
-		t.Error("expected an error when the environment is missing entirely")
+	assertNamesMissingAndRecovery(t, err, "tenant/environment")
+
+	_, _, err = resolveLocalTarget(runtime, "tenant-a", "")
+	if err == nil {
+		t.Fatal("expected an error when the environment is missing entirely")
 	}
+	assertNamesMissingAndRecovery(t, err, "environment")
+}
+
+// assertNamesMissingAndRecovery insists a target-resolution error names the
+// missing subject and a concrete recovery ("pass ... explicitly"), not just
+// that an error occurred -- a bare "tenant and environment are required"
+// would pass a plain err != nil check but is exactly the dead end this
+// guards against.
+func assertNamesMissingAndRecovery(t *testing.T, err error, wantSubject string) {
+	t.Helper()
+	if err.Error() == "tenant and environment are required" || err.Error() == "tenant is required" || err.Error() == "environment is required" {
+		t.Fatalf("error regressed to a bare required-input message with no recovery: %v", err)
+	}
+	if !strings.Contains(err.Error(), wantSubject) {
+		t.Errorf("error should name %q, got: %v", wantSubject, err)
+	}
+	if !strings.Contains(err.Error(), "pass") {
+		t.Errorf("error should tell the caller to pass the missing value explicitly, got: %v", err)
+	}
+}
+
+// delete's own tenant/environment resolution (scopedTenantEnv, not
+// resolveLocalTarget) hit the identical bare "tenant and environment are
+// required" dead end when neither the server nor the caller named a target.
+// It carries the same fix and deserves the same regression coverage.
+func TestDeleteRefusesWithNamedRecoveryWhenNeitherSideNamesATarget(t *testing.T) {
+	runtime := RuntimeConfig{}
+	_, _, err := deleteTool(runtime)(context.Background(), nil, DeleteInput{Preview: true})
+	if err == nil {
+		t.Fatal("expected an error when neither the server nor the caller names a target")
+	}
+	assertNamesMissingAndRecovery(t, err, "tenant/environment")
 }

--- a/erun-mcp/required_input_schema_test.go
+++ b/erun-mcp/required_input_schema_test.go
@@ -1,0 +1,240 @@
+package erunmcp
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// toolsExcludedFromRequiredInputAudit are tools TestEveryToolsRequiredInputIsExpressibleInItsOwnSchema
+// does not call: each mutates real, non-sandboxed state (a lease file under
+// the real activity cache, injected AWS credentials, a recorded idle-stop
+// marker) with no preview mode that would make the call side-effect free.
+// erun-mcp's test suite has no HOME-sandboxing harness the way
+// erun-integration's env.New gives the CLI suite, so there is no contained
+// place for that mutation to land. This is a documented gap, not a silent
+// one: if one of these ever grows this same bug (a required input its own
+// schema cannot carry), this audit will not catch it.
+var toolsExcludedFromRequiredInputAudit = map[string]bool{
+	"activity_lease_release":       true,
+	"activity_lease_take":          true,
+	"cloud_clear_aws_credentials":  true,
+	"cloud_inject_aws_credentials": true,
+	"idle_stop_cancel":             true,
+	"idle_stop_record":             true,
+}
+
+// requiredSubjectPattern matches a message that, in its ENTIRETY, is a bare
+// "<subject> is/are required" -- the same anchored shape
+// erun-integration/bare_required_input_test.go's bareRequiredInputPattern
+// checks for tenant/environment specifically, generalized to any subject.
+// Anchoring to the whole message (not just a substring anywhere in it) is
+// what keeps this from firing on a message that merely ends in that phrase
+// after real context, e.g. "a platform block with a base domain is required
+// in .erun/config.yaml (...)" -- that names its own operation and location,
+// so it is not the dead end this check targets.
+var requiredSubjectPattern = regexp.MustCompile(`(?i)^([a-z][a-z ]*?) (?:is|are) required$`)
+
+// camelCaseBoundary finds the position just before a capital letter that
+// follows a lowercase one, e.g. in "leaseTtlSeconds" -- used to split a
+// schema property name into words for the overlap check below.
+var camelCaseBoundary = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+
+// TestEveryToolsRequiredInputIsExpressibleInItsOwnSchema is the mechanical
+// check for the exec_agent class of bug: a handler that reads a required
+// input its own JSON schema has no property for. exec_agent shipped
+// uncallable because its handler demanded tenant/environment while its
+// schema (additionalProperties: false, no tenant/environment property)
+// could not carry them -- no input satisfied it. This drives every tool
+// (except the excluded ones above) with only the properties its own schema
+// marks required, populated with placeholder values, over a real MCP
+// session -- the same schema-validating path a real client uses -- and
+// fails if the tool complains about a property its schema does not define,
+// or if its error names something "required" that is not one of its own
+// schema properties.
+func TestEveryToolsRequiredInputIsExpressibleInItsOwnSchema(t *testing.T) {
+	t.Setenv("ERUN_CLAUDE_BIN", "true")
+	t.Setenv("ERUN_CODEX_BIN", "true")
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "acme", Environment: "dev", RepoPath: t.TempDir()}}
+	session := connectTestMCPSession(t, eruncommon.BuildInfo{Version: "1.2.3"}, runtime)
+
+	tools, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	if len(tools.Tools) == 0 {
+		t.Fatal("no tools listed; the rest of this test would pass vacuously")
+	}
+
+	for _, tool := range tools.Tools {
+		tool := tool
+		t.Run(tool.Name, func(t *testing.T) {
+			if toolsExcludedFromRequiredInputAudit[tool.Name] {
+				t.Skip("excluded: mutates real state with no preview mode -- see toolsExcludedFromRequiredInputAudit")
+			}
+			props, required := schemaPropertiesAndRequired(t, tool)
+			readOnly := tool.Annotations != nil && tool.Annotations.ReadOnlyHint
+			_, hasPreview := props["preview"]
+			if !readOnly && !hasPreview {
+				t.Skip("excluded: not read-only and has no preview mode to call it side-effect free")
+			}
+
+			args := map[string]any{}
+			for _, name := range required {
+				args[name] = placeholderFor(props[name])
+			}
+			if hasPreview {
+				args["preview"] = true
+			}
+
+			result, callErr := session.CallTool(context.Background(), &mcp.CallToolParams{Name: tool.Name, Arguments: args})
+			if callErr != nil {
+				assertErrorNamesOnlyOwnSchemaProperties(t, tool.Name, props, callErr.Error())
+				return
+			}
+			if result.IsError {
+				assertErrorNamesOnlyOwnSchemaProperties(t, tool.Name, props, resultText(result))
+			}
+		})
+	}
+}
+
+// schemaPropertiesAndRequired reads a tool's wire-shaped InputSchema
+// (map[string]any, per mcp.Tool's documented client-side shape) into its
+// property definitions and required-property names.
+func schemaPropertiesAndRequired(t *testing.T, tool *mcp.Tool) (map[string]any, []string) {
+	t.Helper()
+	schema, ok := tool.InputSchema.(map[string]any)
+	if !ok {
+		t.Fatalf("%s: InputSchema is %T, not map[string]any", tool.Name, tool.InputSchema)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if props == nil {
+		props = map[string]any{}
+	}
+	var required []string
+	if raw, ok := schema["required"].([]any); ok {
+		for _, r := range raw {
+			if name, ok := r.(string); ok {
+				required = append(required, name)
+			}
+		}
+	}
+	return props, required
+}
+
+// placeholderFor synthesizes a minimal value matching a JSON schema
+// property's declared type -- just enough to satisfy the SDK's own schema
+// validation, not to be meaningful domain input. A domain-level rejection of
+// a placeholder (e.g. "review not found") is an expected, healthy outcome;
+// this test only cares whether the tool's OWN schema can carry what its
+// handler demands.
+func placeholderFor(propSchema any) any {
+	m, ok := propSchema.(map[string]any)
+	if !ok {
+		return "x"
+	}
+	if enum, ok := m["enum"].([]any); ok && len(enum) > 0 {
+		return enum[0]
+	}
+	switch schemaType(m["type"]) {
+	case "integer", "number":
+		return 1
+	case "boolean":
+		return false
+	case "array":
+		return []any{}
+	case "object":
+		return map[string]any{}
+	default:
+		return "x"
+	}
+}
+
+// schemaType normalizes a JSON schema "type" keyword, which may be a bare
+// string or a union array (e.g. ["string", "null"]) -- the first non-null
+// entry is what a placeholder should match.
+func schemaType(raw any) string {
+	switch v := raw.(type) {
+	case string:
+		return v
+	case []any:
+		for _, entry := range v {
+			if s, ok := entry.(string); ok && s != "null" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// assertErrorNamesOnlyOwnSchemaProperties fails when a tool's error, for a
+// call carrying only its own required properties, blames a property its
+// schema does not define -- either the SDK's own extra-property complaint
+// (which should never fire here, since nothing extra was sent) or a bare
+// "<subject> is required" whose subject shares no word with any of the
+// tool's own schema properties, which is exactly the exec_agent defect: a
+// handler-required input the schema has no way to carry. Sharing at least
+// one word (e.g. "raw command is required" against a schema property named
+// "command") is treated as the schema expressing the subject -- the
+// complaint is then a domain-level validation (the placeholder value this
+// audit sent was empty/unusable), not a schema-expressiveness gap.
+func assertErrorNamesOnlyOwnSchemaProperties(t *testing.T, toolName string, props map[string]any, message string) {
+	t.Helper()
+	if strings.Contains(strings.ToLower(message), "additional propert") {
+		t.Errorf("%s: rejected its own minimal required-only input as carrying extra properties: %s", toolName, message)
+	}
+	match := requiredSubjectPattern.FindStringSubmatch(strings.TrimSpace(message))
+	if match == nil {
+		return
+	}
+	schemaWords := propertyWords(props)
+	considered, orphaned := 0, 0
+	for _, word := range strings.Fields(strings.ToLower(match[1])) {
+		if word == "and" {
+			continue
+		}
+		considered++
+		if !schemaWords[word] {
+			orphaned++
+		}
+	}
+	// Every word in the subject is unrepresented anywhere in the schema: the
+	// schema has no property this error could possibly be about.
+	if considered > 0 && orphaned == considered {
+		t.Errorf("%s: error says %q is required, but none of that subject's words are a property of this tool's own schema: %s", toolName, strings.TrimSpace(match[1]), message)
+	}
+}
+
+// propertyWords splits every schema property name into lowercased words on
+// camelCase boundaries (e.g. "leaseTtlSeconds" -> "lease", "ttl", "seconds"),
+// so a message subject sharing any one of those words is treated as the
+// schema representing it.
+func propertyWords(props map[string]any) map[string]bool {
+	words := map[string]bool{}
+	for name := range props {
+		split := camelCaseBoundary.ReplaceAllString(name, "$1 $2")
+		for _, word := range strings.Fields(strings.ToLower(split)) {
+			words[word] = true
+		}
+	}
+	return words
+}
+
+// resultText concatenates a CallToolResult's text content, which is where a
+// ToolHandlerFor-returned error's message ends up (see mcp.CallToolResult's
+// IsError doc).
+func resultText(result *mcp.CallToolResult) string {
+	var sb strings.Builder
+	for _, c := range result.Content {
+		if text, ok := c.(*mcp.TextContent); ok {
+			fmt.Fprint(&sb, text.Text)
+		}
+	}
+	return sb.String()
+}

--- a/erun-mcp/required_input_schema_test.go
+++ b/erun-mcp/required_input_schema_test.go
@@ -74,33 +74,43 @@ func TestEveryToolsRequiredInputIsExpressibleInItsOwnSchema(t *testing.T) {
 	for _, tool := range tools.Tools {
 		tool := tool
 		t.Run(tool.Name, func(t *testing.T) {
-			if toolsExcludedFromRequiredInputAudit[tool.Name] {
-				t.Skip("excluded: mutates real state with no preview mode -- see toolsExcludedFromRequiredInputAudit")
-			}
-			props, required := schemaPropertiesAndRequired(t, tool)
-			readOnly := tool.Annotations != nil && tool.Annotations.ReadOnlyHint
-			_, hasPreview := props["preview"]
-			if !readOnly && !hasPreview {
-				t.Skip("excluded: not read-only and has no preview mode to call it side-effect free")
-			}
-
-			args := map[string]any{}
-			for _, name := range required {
-				args[name] = placeholderFor(props[name])
-			}
-			if hasPreview {
-				args["preview"] = true
-			}
-
-			result, callErr := session.CallTool(context.Background(), &mcp.CallToolParams{Name: tool.Name, Arguments: args})
-			if callErr != nil {
-				assertErrorNamesOnlyOwnSchemaProperties(t, tool.Name, props, callErr.Error())
-				return
-			}
-			if result.IsError {
-				assertErrorNamesOnlyOwnSchemaProperties(t, tool.Name, props, resultText(result))
-			}
+			auditToolRequiredInputAgainstItsOwnSchema(t, session, tool)
 		})
+	}
+}
+
+// auditToolRequiredInputAgainstItsOwnSchema calls one tool with only its own
+// schema-required properties (skipping tools this audit cannot call
+// side-effect free) and checks the outcome names no property its schema
+// cannot carry. Split out of TestEveryToolsRequiredInputIsExpressibleInItsOwnSchema
+// to keep that test's own branching within the module's complexity budget.
+func auditToolRequiredInputAgainstItsOwnSchema(t *testing.T, session *mcp.ClientSession, tool *mcp.Tool) {
+	t.Helper()
+	if toolsExcludedFromRequiredInputAudit[tool.Name] {
+		t.Skip("excluded: mutates real state with no preview mode -- see toolsExcludedFromRequiredInputAudit")
+	}
+	props, required := schemaPropertiesAndRequired(t, tool)
+	readOnly := tool.Annotations != nil && tool.Annotations.ReadOnlyHint
+	_, hasPreview := props["preview"]
+	if !readOnly && !hasPreview {
+		t.Skip("excluded: not read-only and has no preview mode to call it side-effect free")
+	}
+
+	args := map[string]any{}
+	for _, name := range required {
+		args[name] = placeholderFor(props[name])
+	}
+	if hasPreview {
+		args["preview"] = true
+	}
+
+	result, callErr := session.CallTool(context.Background(), &mcp.CallToolParams{Name: tool.Name, Arguments: args})
+	if callErr != nil {
+		assertErrorNamesOnlyOwnSchemaProperties(t, tool.Name, props, callErr.Error())
+		return
+	}
+	if result.IsError {
+		assertErrorNamesOnlyOwnSchemaProperties(t, tool.Name, props, resultText(result))
 	}
 }
 

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -211,20 +211,28 @@ func resolveLocalTarget(runtime RuntimeConfig, tenant, environment string) (stri
 	resolvedTenant := firstNonEmpty(requestedTenant, serverTenant)
 	resolvedEnvironment := firstNonEmpty(requestedEnvironment, serverEnvironment)
 	if resolvedTenant == "" || resolvedEnvironment == "" {
-		var missing []string
-		if resolvedTenant == "" {
-			missing = append(missing, "tenant")
-		}
-		if resolvedEnvironment == "" {
-			missing = append(missing, "environment")
-		}
-		what := strings.Join(missing, "/")
-		return "", "", fmt.Errorf(
-			"%s not resolved: this MCP server was not started bound to a %s, and the call did not supply %s either -- pass %s explicitly in the call, or run this edge for an environment that has it configured",
-			what, what, what, strings.Join(missing, " and "),
-		)
+		return "", "", errMissingLocalTarget(resolvedTenant == "", resolvedEnvironment == "")
 	}
 	return resolvedTenant, resolvedEnvironment, nil
+}
+
+// errMissingLocalTarget names exactly what is missing (tenant, environment,
+// or both) and what the caller can do about it, instead of the bare "tenant
+// and environment are required" dead end this replaced: that message named
+// no operation, no subject, and no recovery.
+func errMissingLocalTarget(missingTenant, missingEnvironment bool) error {
+	var missing []string
+	if missingTenant {
+		missing = append(missing, "tenant")
+	}
+	if missingEnvironment {
+		missing = append(missing, "environment")
+	}
+	what := strings.Join(missing, "/")
+	return fmt.Errorf(
+		"%s not resolved: this MCP server was not started bound to a %s, and the call did not supply %s either -- pass %s explicitly in the call, or run this edge for an environment that has it configured",
+		what, what, what, strings.Join(missing, " and "),
+	)
 }
 
 func firstNonEmpty(values ...string) string {

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -211,7 +211,18 @@ func resolveLocalTarget(runtime RuntimeConfig, tenant, environment string) (stri
 	resolvedTenant := firstNonEmpty(requestedTenant, serverTenant)
 	resolvedEnvironment := firstNonEmpty(requestedEnvironment, serverEnvironment)
 	if resolvedTenant == "" || resolvedEnvironment == "" {
-		return "", "", fmt.Errorf("tenant and environment are required")
+		var missing []string
+		if resolvedTenant == "" {
+			missing = append(missing, "tenant")
+		}
+		if resolvedEnvironment == "" {
+			missing = append(missing, "environment")
+		}
+		what := strings.Join(missing, "/")
+		return "", "", fmt.Errorf(
+			"%s not resolved: this MCP server was not started bound to a %s, and the call did not supply %s either -- pass %s explicitly in the call, or run this edge for an environment that has it configured",
+			what, what, what, strings.Join(missing, " and "),
+		)
 	}
 	return resolvedTenant, resolvedEnvironment, nil
 }


### PR DESCRIPTION
### Root cause: a space-separated bool flag silently dropped every later flag

`erun-devops/docker/erun-devops/entrypoint.sh`'s `exec_runtime_mcp()` launched
`emcp` with:

```
--metrics-enabled "${ERUN_METRICS_ENABLED:-true}" \
```

Go's `flag` package sets a bool flag from its own presence; it does not
consume the next token as that flag's value. The bare `true` that followed
became the first *non-flag* argument, and `flag.Parse` stops at the first
non-flag argument — every flag after it (`--tenant`, `--environment`,
`--repo-path`, `--kubernetes-context`, `--namespace`) was silently dropped
into `flags.Args()` and never applied. The environment's MCP edge then served
with an **empty `RuntimeContext`**, so every tool that resolves its target
from server context failed with "tenant and environment are required" —
`exec_agent`'s schema/handler mismatch below is what made that failure
user-visible, but the flag bug is why it happened in *every* deployed
environment regardless of that fix.

Reproduced on the deployed 1.0.203 binary, same argv except the one flag's
form (auth off, no trusted issuers configured):

```
$ emcp ... --metrics-enabled true  --tenant erun --environment build ...
erun mcp listening on 127.0.0.1:18904/mcp tenant="" environment="" namespace=""
exec_agent{agent,prompt,preview} -> isError=true "tenant and environment are required"

$ emcp ... --metrics-enabled=true --tenant erun --environment build ...
erun mcp listening on 127.0.0.1:18905/mcp tenant="erun" environment="build" namespace="erun-build"
exec_agent{agent,prompt,preview} -> isError=none, tenant=erun environment=build, job resolved
```

**Fix:**
- `entrypoint.sh`: write the flag as one token, `--metrics-enabled="${ERUN_METRICS_ENABLED:-true}"`. It's the only bool flag in the argv builder (and the only `emcp` launch site with a bool flag) — every other flag is a string.
- `erun-mcp/cmd/emcp/main.go`: close the class, not just the instance. After `flags.Parse`, refuse to start when `flags.NArg() > 0`, naming the first unparsed argument and telling the caller to write bool flags as `--flag=value`. An empty tenant/environment is still accepted — a bare edge is legitimate now that callers may pass a target explicitly — only leftover positional arguments are refused.
- `erun-mcp/cmd/emcp/main_test.go`: `TestRunRefusesSpaceSeparatedBoolFlagValue` proves the space-separated form is refused and the `=` form still honors every later flag. The existing test (`TestRunPassesResolvedFlags`) already used `--metrics-enabled=false` — the safe form — which is exactly why this gate never caught the space-separated form the entrypoint was actually using.
- `erun-devops/docker/erun-devops/entrypoint_test.sh`: asserts the captured `emcp` argv actually parses through — walks it the same way `flag.Parse` would and fails if any bare positional token (including a space-separated bool value) would stop parsing before `--tenant`/`--environment` are applied.

### Also in this PR: the exec_agent schema/handler mismatch (#1502's direct symptom)

**The error was a dead end.** `tenant and environment are required` named no operation, no subject, and no recovery. It now names which of the two failed to resolve, why (the edge was not started bound to one and the call did not supply one), and what to do about it. `delete.go` raised the same bare string and now shares the one message.

**The gate for this class had a hole.** `erun-integration/bare_required_input_test.go` (#1495) matched the literal strings `"tenant is required"` and `"environment is required"`. The message here was `"tenant and environment are required"` — a third phrasing that walked straight through a gate built to catch exactly it. Enumerating phrasings cannot work; the gate now matches the *shape* of a bare required-input error.

**A whole class of bug was undetectable.** A handler that requires an input its own schema cannot express is unsatisfiable by construction, and nothing checked for it. `erun-mcp/required_input_schema_test.go` now drives every registered tool over a real MCP session with only its schema-declared required properties, and asserts the failure is never a complaint about a property the schema does not define. `exec_agent_callable_test.go` is the direct regression for this instance, driven over HTTP so the SDK's own validation layer is in the path — a direct handler call would bypass exactly the validation that rejected the extra properties.

Note: the schema/handler fix itself landed on `main` earlier via `3b8ec910` (#1493) — `AgentInput` carries `Tenant`/`Environment` and `agentTool` resolves through `resolveLocalTarget`. That fix is ahead of `v1.0.203` and not contained in `v1.0.204`, so it needs a release, not a code change, to reach deployed environments. Even once released, `exec_agent` would still have failed in every deployed environment until the flag bug above is fixed too — a caller-supplied target would satisfy the schema but the edge's own empty context would still poison any tool relying on server-side resolution.

Verified: `make check` green, coverage 76.0%.

Closes #1502
