### PR TITLE
Show why the orchestrator env picker excludes an environment

### DIFF
--- a/erun-ui/frontend/src/components/app/OrchestratorDialog.Environments.helpers.ts
+++ b/erun-ui/frontend/src/components/app/OrchestratorDialog.Environments.helpers.ts
@@ -1,0 +1,19 @@
+export interface EnvCandidate {
+  tenant: string;
+  environment: string;
+  // An ineligible env (e.g. runtime — no worktree to review, no in-pod agent
+  // to delegate to) is still listed, disabled, with ineligibleReason set,
+  // rather than silently dropped: an operator who knows the env exists must
+  // be able to see that it was considered and why it can't be linked.
+  eligible: boolean;
+  defaultDirectory: string;
+  // A mirrored env is reviewed in a synced copy the operator may place anywhere;
+  // otherwise the review directory is the env's own worktree on this machine and
+  // its path is derived from the env, not chosen here.
+  mirrored: boolean;
+  ineligibleReason: string;
+}
+
+export function envKey(tenant: string, environment: string): string {
+  return `${tenant} ${environment}`;
+}

--- a/erun-ui/frontend/src/components/app/OrchestratorDialog.Environments.tsx
+++ b/erun-ui/frontend/src/components/app/OrchestratorDialog.Environments.tsx
@@ -1,0 +1,178 @@
+import { Button, Checkbox, Input, Label } from 'erun-kit';
+import { Ban, FolderOpen } from 'lucide-react';
+import * as React from 'react';
+
+import type { OrchestratorEnvRef } from '@/app/slices/orchestratorsSlice';
+import {
+  type EnvCandidate,
+  envKey,
+} from '@/components/app/OrchestratorDialog.Environments.helpers';
+
+import { ChooseLocalRepoPath } from '../../../wailsjs/go/main/App';
+
+// EnvironmentsFieldStatus distinguishes the three states the field can be in,
+// so "no environments configured" never reads the same as "you have several,
+// none eligible" — the empty state itself must say which case applies and
+// what to do next, rather than leaving an operator who knows an env exists to
+// wonder whether erun even noticed it.
+function EnvironmentsFieldStatus({
+  totalCount,
+  eligibleCount,
+}: {
+  totalCount: number;
+  eligibleCount: number;
+}): React.ReactElement | null {
+  if (totalCount === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No environments yet. Initialize one to orchestrate it.
+      </p>
+    );
+  }
+  if (eligibleCount === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {totalCount} environment{totalCount === 1 ? '' : 's'} found, but none can be linked to an
+        orchestrator — see the reason listed under each one below.
+      </p>
+    );
+  }
+  return null;
+}
+
+export function EnvironmentsField({
+  candidates,
+  selected,
+  onToggle,
+  onDirectoryChange,
+}: {
+  candidates: EnvCandidate[];
+  selected: OrchestratorEnvRef[];
+  onToggle: (candidate: EnvCandidate, checked: boolean) => void;
+  onDirectoryChange: (ref: OrchestratorEnvRef, directory: string) => void;
+}): React.ReactElement {
+  const eligibleCount = candidates.filter((candidate) => candidate.eligible).length;
+  return (
+    <div className="space-y-1.5">
+      <Label>Environments</Label>
+      <EnvironmentsFieldStatus totalCount={candidates.length} eligibleCount={eligibleCount} />
+      {candidates.length > 0 ? (
+        <div className="max-h-56 space-y-2 overflow-y-auto">
+          {candidates.map((candidate) => {
+            const ref = selected.find(
+              (entry) =>
+                envKey(entry.tenant, entry.environment) ===
+                envKey(candidate.tenant, candidate.environment),
+            );
+            return (
+              <EnvironmentRow
+                key={envKey(candidate.tenant, candidate.environment)}
+                candidate={candidate}
+                selectedRef={ref}
+                onToggle={onToggle}
+                onDirectoryChange={onDirectoryChange}
+              />
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// IneligibleEnvironmentRow renders an env the picker considered and rejected:
+// a disabled checkbox so it reads as unavailable rather than merely unchecked,
+// and the reason as a first-class, always-visible line rather than a tooltip
+// an operator has to go hunting for.
+function IneligibleEnvironmentRow({ candidate }: { candidate: EnvCandidate }): React.ReactElement {
+  return (
+    <div className="rounded-sm border border-border/60 bg-muted/20 px-2 py-1.5">
+      <label className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Checkbox
+          checked={false}
+          disabled
+          aria-label={`${candidate.tenant} / ${candidate.environment} can't be linked`}
+        />
+        {candidate.tenant} / {candidate.environment}
+      </label>
+      <p className="mt-1 flex items-start gap-1.5 pl-6 text-xs text-muted-foreground">
+        <Ban aria-hidden="true" className="mt-px size-3 shrink-0" />
+        <span>{candidate.ineligibleReason}</span>
+      </p>
+    </div>
+  );
+}
+
+function EnvironmentRow({
+  candidate,
+  selectedRef,
+  onToggle,
+  onDirectoryChange,
+}: {
+  candidate: EnvCandidate;
+  selectedRef: OrchestratorEnvRef | undefined;
+  onToggle: (candidate: EnvCandidate, checked: boolean) => void;
+  onDirectoryChange: (ref: OrchestratorEnvRef, directory: string) => void;
+}): React.ReactElement {
+  if (!candidate.eligible) {
+    return <IneligibleEnvironmentRow candidate={candidate} />;
+  }
+  const browse = (): void => {
+    if (!selectedRef) {
+      return;
+    }
+    void ChooseLocalRepoPath(selectedRef.directory).then((dir) => {
+      if (dir.trim() !== '') {
+        onDirectoryChange(selectedRef, dir.trim());
+      }
+    });
+  };
+  return (
+    <div className="rounded-sm border border-border/60 px-2 py-1.5">
+      <label className="flex items-center gap-2 text-sm">
+        <Checkbox
+          checked={Boolean(selectedRef)}
+          onCheckedChange={(checked) => {
+            onToggle(candidate, checked === true);
+          }}
+        />
+        {candidate.tenant} / {candidate.environment}
+        <span className="text-xs text-muted-foreground">
+          {candidate.mirrored ? 'synced mirror' : 'worktree on this machine'}
+        </span>
+      </label>
+      {selectedRef ? (
+        <div className="mt-1.5 flex items-center gap-1.5 pl-6">
+          {candidate.mirrored ? (
+            <>
+              <Input
+                className="h-7 font-mono text-xs"
+                value={selectedRef.directory}
+                onChange={(event) => {
+                  onDirectoryChange(selectedRef, event.target.value);
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-xs"
+                className="size-7 flex-none"
+                aria-label={`Choose sync directory for ${candidate.tenant} / ${candidate.environment}`}
+                onClick={browse}
+              >
+                <FolderOpen aria-hidden="true" />
+              </Button>
+            </>
+          ) : (
+            // Derived from the env's repository path, so it is shown rather than
+            // offered for editing: there is no mirror to place, and the operator
+            // moves it by changing the env's repository path.
+            <p className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+              {candidate.defaultDirectory}
+            </p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/OrchestratorDialog.tsx
+++ b/erun-ui/frontend/src/components/app/OrchestratorDialog.tsx
@@ -1,5 +1,4 @@
 import { Button } from 'erun-kit';
-import { Checkbox } from 'erun-kit';
 import {
   Dialog,
   DialogContent,
@@ -10,7 +9,7 @@ import {
 } from 'erun-kit';
 import { Input } from 'erun-kit';
 import { Label } from 'erun-kit';
-import { AlertTriangle, FolderOpen, LoaderCircle, RotateCcw, Trash2 } from 'lucide-react';
+import { AlertTriangle, LoaderCircle, RotateCcw, Trash2 } from 'lucide-react';
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
@@ -26,23 +25,14 @@ import {
   type OrchestratorInfo,
 } from '@/app/slices/orchestratorsSlice';
 import { OrchestratorConversationsSection } from '@/components/app/OrchestratorDialog.Conversations';
+import { EnvironmentsField } from '@/components/app/OrchestratorDialog.Environments';
+import {
+  type EnvCandidate,
+  envKey,
+} from '@/components/app/OrchestratorDialog.Environments.helpers';
 import { OrchestratorGuidanceSection } from '@/components/app/OrchestratorDialog.Guidance';
 
-import { ChooseLocalRepoPath, ListOrchestratorEnvCandidates } from '../../../wailsjs/go/main/App';
-
-interface EnvCandidate {
-  tenant: string;
-  environment: string;
-  defaultDirectory: string;
-  // A mirrored env is reviewed in a synced copy the operator may place anywhere;
-  // otherwise the review directory is the env's own worktree on this machine and
-  // its path is derived from the env, not chosen here.
-  mirrored: boolean;
-}
-
-function envKey(tenant: string, environment: string): string {
-  return `${tenant} ${environment}`;
-}
+import { ListOrchestratorEnvCandidates } from '../../../wailsjs/go/main/App';
 
 // OrchestratorDialog creates or edits a persisted orchestrator: a name and the
 // agent environments it links, each with the host directory it reviews read-only.
@@ -405,118 +395,5 @@ function OrchestratorDeleteConfirm({
         </Button>
       </DialogFooter>
     </>
-  );
-}
-
-function EnvironmentsField({
-  candidates,
-  selected,
-  onToggle,
-  onDirectoryChange,
-}: {
-  candidates: EnvCandidate[];
-  selected: OrchestratorEnvRef[];
-  onToggle: (candidate: EnvCandidate, checked: boolean) => void;
-  onDirectoryChange: (ref: OrchestratorEnvRef, directory: string) => void;
-}): React.ReactElement {
-  return (
-    <div className="space-y-1.5">
-      <Label>Environments</Label>
-      {candidates.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No agent environments yet. Initialize one to orchestrate it.
-        </p>
-      ) : (
-        <div className="max-h-56 space-y-2 overflow-y-auto">
-          {candidates.map((candidate) => {
-            const ref = selected.find(
-              (entry) =>
-                envKey(entry.tenant, entry.environment) ===
-                envKey(candidate.tenant, candidate.environment),
-            );
-            return (
-              <EnvironmentRow
-                key={envKey(candidate.tenant, candidate.environment)}
-                candidate={candidate}
-                selectedRef={ref}
-                onToggle={onToggle}
-                onDirectoryChange={onDirectoryChange}
-              />
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function EnvironmentRow({
-  candidate,
-  selectedRef,
-  onToggle,
-  onDirectoryChange,
-}: {
-  candidate: EnvCandidate;
-  selectedRef: OrchestratorEnvRef | undefined;
-  onToggle: (candidate: EnvCandidate, checked: boolean) => void;
-  onDirectoryChange: (ref: OrchestratorEnvRef, directory: string) => void;
-}): React.ReactElement {
-  const browse = (): void => {
-    if (!selectedRef) {
-      return;
-    }
-    void ChooseLocalRepoPath(selectedRef.directory).then((dir) => {
-      if (dir.trim() !== '') {
-        onDirectoryChange(selectedRef, dir.trim());
-      }
-    });
-  };
-  return (
-    <div className="rounded-sm border border-border/60 px-2 py-1.5">
-      <label className="flex items-center gap-2 text-sm">
-        <Checkbox
-          checked={Boolean(selectedRef)}
-          onCheckedChange={(checked) => {
-            onToggle(candidate, checked === true);
-          }}
-        />
-        {candidate.tenant} / {candidate.environment}
-        <span className="text-xs text-muted-foreground">
-          {candidate.mirrored ? 'synced mirror' : 'worktree on this machine'}
-        </span>
-      </label>
-      {selectedRef ? (
-        <div className="mt-1.5 flex items-center gap-1.5 pl-6">
-          {candidate.mirrored ? (
-            <>
-              <Input
-                className="h-7 font-mono text-xs"
-                value={selectedRef.directory}
-                onChange={(event) => {
-                  onDirectoryChange(selectedRef, event.target.value);
-                }}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="icon-xs"
-                className="size-7 flex-none"
-                aria-label={`Choose sync directory for ${candidate.tenant} / ${candidate.environment}`}
-                onClick={browse}
-              >
-                <FolderOpen aria-hidden="true" />
-              </Button>
-            </>
-          ) : (
-            // Derived from the env's repository path, so it is shown rather than
-            // offered for editing: there is no mirror to place, and the operator
-            // moves it by changing the env's repository path.
-            <p className="min-w-0 truncate font-mono text-xs text-muted-foreground">
-              {candidate.defaultDirectory}
-            </p>
-          )}
-        </div>
-      ) : null}
-    </div>
   );
 }

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -95,15 +95,19 @@ type orchestratorEnvInput struct {
 	Directory   string `json:"directory"`
 }
 
-// orchestratorEnvCandidate is an agent env the operator can link, with the host
-// directory the orchestrator reviews it in. Mirrored distinguishes the two kinds
-// of review directory: a workspace-sync mirror the operator may place anywhere,
-// or the env's own worktree on this machine, whose path is derived and fixed.
+// orchestratorEnvCandidate is an env the operator considered linking, eligible
+// or not. Mirrored distinguishes the two kinds of review directory an eligible
+// env carries: a workspace-sync mirror the operator may place anywhere, or the
+// env's own worktree on this machine, whose path is derived and fixed. An
+// ineligible env carries no directory — IneligibleReason explains, in
+// operator language, why it cannot be linked instead.
 type orchestratorEnvCandidate struct {
 	Tenant           string `json:"tenant"`
 	Environment      string `json:"environment"`
+	Eligible         bool   `json:"eligible"`
 	DefaultDirectory string `json:"defaultDirectory"`
 	Mirrored         bool   `json:"mirrored"`
+	IneligibleReason string `json:"ineligibleReason"`
 }
 
 // orchestratorEnvInfo is the JSON-safe view of one linked environment.
@@ -230,6 +234,19 @@ func orchestratableEnv(env eruncommon.EnvConfig) bool {
 	default:
 		return false
 	}
+}
+
+// orchestratorIneligibilityReason explains, in the operator's language, why an
+// env orchestratableEnv rejects cannot be linked — reusing that function's own
+// reasoning rather than restating it. Returns "" for an eligible env.
+func orchestratorIneligibilityReason(env eruncommon.EnvConfig) string {
+	if orchestratableEnv(env) {
+		return ""
+	}
+	if env.ResolvedType() == eruncommon.EnvironmentTypeRuntime {
+		return "Runtime environments have no worktree to review and no in-pod agent to delegate to, so they can't be linked to an orchestrator."
+	}
+	return "This environment's type isn't recognized, so it can't be linked to an orchestrator."
 }
 
 // orchestratorReviewDirectory resolves where an orchestrator reviews an env on
@@ -1243,10 +1260,14 @@ func (a *App) findOrchestratorConfig(id string) (eruncommon.OrchestratorConfig, 
 	return eruncommon.OrchestratorConfig{}, fmt.Errorf("orchestrator %q not found", id)
 }
 
-// ListOrchestratorEnvCandidates returns the agent environments the operator can
-// link, each with the host directory the orchestrator reviews it in: a mirror the
-// sync fills for a remote-agent env, or the worktree itself for a local-agent env,
-// which is already on this machine because the pod hostPath-mounts it.
+// ListOrchestratorEnvCandidates returns every environment the operator could
+// consider linking, eligible or not — an env orchestratableEnv rejects is
+// still listed, disabled, with IneligibleReason explaining why, rather than
+// silently dropped: an operator who knows an env exists must be able to see
+// that it was considered. An eligible env also carries the host directory the
+// orchestrator reviews it in: a mirror the sync fills for a remote-agent env,
+// or the worktree itself for a local-agent env, which is already on this
+// machine because the pod hostPath-mounts it.
 func (a *App) ListOrchestratorEnvCandidates() ([]orchestratorEnvCandidate, error) {
 	tenants, err := a.deps.store.ListTenantConfigs()
 	if err != nil {
@@ -1259,16 +1280,17 @@ func (a *App) ListOrchestratorEnvCandidates() ([]orchestratorEnvCandidate, error
 			continue
 		}
 		for _, env := range envs {
-			if !orchestratableEnv(env) {
-				continue
+			candidate := orchestratorEnvCandidate{
+				Tenant:      tenant.Name,
+				Environment: env.Name,
+				Eligible:    orchestratableEnv(env),
 			}
-			directory, mirrored := orchestratorReviewDirectory(tenant.Name, env)
-			out = append(out, orchestratorEnvCandidate{
-				Tenant:           tenant.Name,
-				Environment:      env.Name,
-				DefaultDirectory: directory,
-				Mirrored:         mirrored,
-			})
+			if candidate.Eligible {
+				candidate.DefaultDirectory, candidate.Mirrored = orchestratorReviewDirectory(tenant.Name, env)
+			} else {
+				candidate.IneligibleReason = orchestratorIneligibilityReason(env)
+			}
+			out = append(out, candidate)
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -102,11 +102,12 @@ func orchestratorTestAppWithReachability(t *testing.T, reachable func(int) bool)
 	return app, laptopRepo
 }
 
-// TestListOrchestratorEnvCandidatesCoversBothAgentTypes locks the capability: an
-// orchestrator can link either agent type, and each candidate carries where that
-// env is reviewed — a mirror the operator may place anywhere, or the local-agent
-// worktree already on this machine. A runtime env is still listed, disabled,
-// with a reason rather than dropped without trace.
+// The three TestListOrchestratorEnvCandidates* tests below lock the
+// capability: an orchestrator can link either agent type, and each candidate
+// carries where that env is reviewed — a mirror the operator may place
+// anywhere, or the local-agent worktree already on this machine. A runtime
+// env is still listed, disabled, with a reason rather than dropped without
+// trace.
 // TestOrchestratableEnvCoversHost locks in that a host env links like
 // local-agent and remote-agent — the issue's own recommendation (#1380): a
 // host env's worktree is already the operator's own checkout, so the
@@ -143,8 +144,12 @@ func TestOrchestratorReviewDirectoryReviewsAHostEnvInPlace(t *testing.T) {
 	}
 }
 
-func TestListOrchestratorEnvCandidatesCoversBothAgentTypes(t *testing.T) {
-	app, laptopRepo := orchestratorTestAppWithLocalRepo(t)
+// listOrchestratorTestCandidates is the shared fixture read for the
+// candidate-shape assertions below: dev (remote-agent), laptop (local-agent),
+// runtime (ineligible), in that sorted order.
+func listOrchestratorTestCandidates(t *testing.T) (dev, laptop, rt orchestratorEnvCandidate, laptopRepo string) {
+	t.Helper()
+	app, repo := orchestratorTestAppWithLocalRepo(t)
 	defer app.shutdown(context.Background())
 
 	candidates, err := app.ListOrchestratorEnvCandidates()
@@ -154,22 +159,38 @@ func TestListOrchestratorEnvCandidatesCoversBothAgentTypes(t *testing.T) {
 	if len(candidates) != 3 {
 		t.Fatalf("expected both agent envs plus the ineligible runtime env, got %+v", candidates)
 	}
-	dev, laptop, rt := candidates[0], candidates[1], candidates[2]
+	dev, laptop, rt = candidates[0], candidates[1], candidates[2]
 	if dev.Environment != "dev" || laptop.Environment != "laptop" || rt.Environment != "runtime" {
 		t.Fatalf("expected dev, laptop, runtime in that order, got %+v", candidates)
 	}
+	return dev, laptop, rt, repo
+}
+
+func TestListOrchestratorEnvCandidatesReviewsARemoteAgentEnvInAMirror(t *testing.T) {
+	dev, _, _, _ := listOrchestratorTestCandidates(t)
 	if !dev.Eligible || !dev.Mirrored {
 		t.Fatalf("expected the remote-agent env to be eligible and reviewed in a mirror, got %+v", dev)
 	}
 	if !strings.HasSuffix(dev.DefaultDirectory, "orchestrators"+string(os.PathSeparator)+"frs-dev") {
 		t.Fatalf("unexpected mirror directory: %q", dev.DefaultDirectory)
 	}
+}
+
+func TestListOrchestratorEnvCandidatesReviewsALocalAgentEnvInPlace(t *testing.T) {
+	_, laptop, _, laptopRepo := listOrchestratorTestCandidates(t)
 	if !laptop.Eligible || laptop.Mirrored {
 		t.Fatalf("expected the local-agent env to be eligible and reviewed in place, got %+v", laptop)
 	}
 	if laptop.DefaultDirectory != laptopRepo {
 		t.Fatalf("local-agent review directory = %q, want the env worktree %q", laptop.DefaultDirectory, laptopRepo)
 	}
+}
+
+// TestListOrchestratorEnvCandidatesKeepsARuntimeEnvListedButIneligible locks
+// the fix: a runtime env stays in the list, disabled, with an operator-facing
+// reason, rather than being dropped without trace.
+func TestListOrchestratorEnvCandidatesKeepsARuntimeEnvListedButIneligible(t *testing.T) {
+	_, _, rt, _ := listOrchestratorTestCandidates(t)
 	if rt.Eligible {
 		t.Fatalf("expected the runtime env to stay ineligible, got %+v", rt)
 	}

--- a/erun-ui/orchestrator_test.go
+++ b/erun-ui/orchestrator_test.go
@@ -105,7 +105,8 @@ func orchestratorTestAppWithReachability(t *testing.T, reachable func(int) bool)
 // TestListOrchestratorEnvCandidatesCoversBothAgentTypes locks the capability: an
 // orchestrator can link either agent type, and each candidate carries where that
 // env is reviewed — a mirror the operator may place anywhere, or the local-agent
-// worktree already on this machine. A runtime env stays out: nothing to review.
+// worktree already on this machine. A runtime env is still listed, disabled,
+// with a reason rather than dropped without trace.
 // TestOrchestratableEnvCoversHost locks in that a host env links like
 // local-agent and remote-agent — the issue's own recommendation (#1380): a
 // host env's worktree is already the operator's own checkout, so the
@@ -150,24 +151,60 @@ func TestListOrchestratorEnvCandidatesCoversBothAgentTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOrchestratorEnvCandidates failed: %v", err)
 	}
-	if len(candidates) != 2 {
-		t.Fatalf("expected both agent envs and no runtime env, got %+v", candidates)
+	if len(candidates) != 3 {
+		t.Fatalf("expected both agent envs plus the ineligible runtime env, got %+v", candidates)
 	}
-	dev, laptop := candidates[0], candidates[1]
-	if dev.Environment != "dev" || laptop.Environment != "laptop" {
-		t.Fatalf("expected dev then laptop, got %+v", candidates)
+	dev, laptop, rt := candidates[0], candidates[1], candidates[2]
+	if dev.Environment != "dev" || laptop.Environment != "laptop" || rt.Environment != "runtime" {
+		t.Fatalf("expected dev, laptop, runtime in that order, got %+v", candidates)
 	}
-	if !dev.Mirrored {
-		t.Fatalf("expected the remote-agent env to be reviewed in a mirror, got %+v", dev)
+	if !dev.Eligible || !dev.Mirrored {
+		t.Fatalf("expected the remote-agent env to be eligible and reviewed in a mirror, got %+v", dev)
 	}
 	if !strings.HasSuffix(dev.DefaultDirectory, "orchestrators"+string(os.PathSeparator)+"frs-dev") {
 		t.Fatalf("unexpected mirror directory: %q", dev.DefaultDirectory)
 	}
-	if laptop.Mirrored {
-		t.Fatalf("expected the local-agent env to be reviewed in place, got %+v", laptop)
+	if !laptop.Eligible || laptop.Mirrored {
+		t.Fatalf("expected the local-agent env to be eligible and reviewed in place, got %+v", laptop)
 	}
 	if laptop.DefaultDirectory != laptopRepo {
 		t.Fatalf("local-agent review directory = %q, want the env worktree %q", laptop.DefaultDirectory, laptopRepo)
+	}
+	if rt.Eligible {
+		t.Fatalf("expected the runtime env to stay ineligible, got %+v", rt)
+	}
+	if rt.DefaultDirectory != "" || rt.Mirrored {
+		t.Fatalf("expected the ineligible runtime env to carry no review directory, got %+v", rt)
+	}
+	if rt.IneligibleReason == "" {
+		t.Fatalf("expected the runtime env to carry an operator-facing reason, got %+v", rt)
+	}
+}
+
+// TestOrchestratorIneligibilityReasonExplainsEachRejectedType locks the
+// operator-facing copy: an eligible env carries no reason, a runtime env
+// names the concrete gap (no worktree, no in-pod agent), and an unresolved
+// type still gets an actionable — if generic — explanation rather than "".
+func TestOrchestratorIneligibilityReasonExplainsEachRejectedType(t *testing.T) {
+	cases := []struct {
+		envType    eruncommon.EnvironmentType
+		wantEmpty  bool
+		wantSubstr string
+	}{
+		{eruncommon.EnvironmentTypeLocalAgent, true, ""},
+		{eruncommon.EnvironmentTypeRemoteAgent, true, ""},
+		{eruncommon.EnvironmentTypeHost, true, ""},
+		{eruncommon.EnvironmentTypeRuntime, false, "no worktree"},
+		{"", false, "type"},
+	}
+	for _, tc := range cases {
+		got := orchestratorIneligibilityReason(eruncommon.EnvConfig{Type: tc.envType})
+		if tc.wantEmpty && got != "" {
+			t.Errorf("orchestratorIneligibilityReason(type=%q) = %q, want empty", tc.envType, got)
+		}
+		if !tc.wantEmpty && !strings.Contains(got, tc.wantSubstr) {
+			t.Errorf("orchestratorIneligibilityReason(type=%q) = %q, want substring %q", tc.envType, got, tc.wantSubstr)
+		}
 	}
 }
 

--- a/erun-ui/playwright/pages/OrchestratorDialog.ts
+++ b/erun-ui/playwright/pages/OrchestratorDialog.ts
@@ -60,6 +60,31 @@ export class OrchestratorDialog {
     });
   }
 
+  // An ineligible env (e.g. runtime) is still listed, disabled, with its
+  // reason as a first-class line under the checkbox row rather than a
+  // tooltip. The checkbox carries an accessible name naming both the env and
+  // that it can't be linked, so it never collides with an eligible row's
+  // plain "<tenant> / <environment>" checkbox name.
+  ineligibleEnvCheckbox(tenant: string, environment: string): Locator {
+    return this.locator().getByRole('checkbox', {
+      name: `${tenant} / ${environment} can't be linked`,
+    });
+  }
+
+  envIneligibleReason(tenant: string, environment: string): Locator {
+    return this.envBlock(tenant, environment).locator('p');
+  }
+
+  // Distinguishes "nothing configured yet" from "several environments, none
+  // eligible" — the two empty states the Environments field must not conflate.
+  environmentsEmptyMessage(): Locator {
+    return this.locator().getByText('No environments yet. Initialize one to orchestrate it.');
+  }
+
+  environmentsAllIneligibleMessage(): Locator {
+    return this.locator().getByText(/environments? found, but none can be linked/);
+  }
+
   // Takes the mode for the same reason locator/waitForOpen/waitForClosed do:
   // defaulting to 'New orchestrator' silently aimed at a dialog that is not
   // open, so an Edit-mode caller waited out the full timeout on a Cancel

--- a/erun-ui/playwright/tests/orchestrator-env-picker-ineligible.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-env-picker-ineligible.spec.ts
@@ -1,0 +1,137 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// The orchestrator's Environments picker used to drop a runtime env (and any
+// other ineligible env) without a trace: it simply was not in the list, which
+// an operator who knows the env exists cannot distinguish from "erun has not
+// noticed it" or "this is a bug". The picker now lists every env it
+// considered, disabled with its reason when ineligible, and the empty state
+// names which of the two ways it can be empty applies.
+//
+// Go coverage for the underlying data (which types are eligible, what the
+// reason text says) lives in TestOrchestratableEnvCoversHost,
+// TestListOrchestratorEnvCandidatesCoversBothAgentTypes, and
+// TestOrchestratorIneligibilityReasonExplainsEachRejectedType in
+// erun-ui/orchestrator_test.go. This spec drives the frontend rendering the
+// backend's response produces.
+test.describe('orchestrator Environments picker accounts for ineligible envs', () => {
+  test('a runtime environment is listed disabled with its reason, and cannot be linked', async ({
+    app,
+    seededRuntimeEnv,
+  }) => {
+    await app.sidebar.newOrchestratorButton().click();
+    await app.orchestratorDialog.waitForOpen();
+
+    // The eligible baseline env still offers a plain, checkable row.
+    await expect(app.orchestratorDialog.envRow(SEED_TENANT, SEED_ENV_ALPHA)).toBeVisible();
+    await expect(app.orchestratorDialog.envCheckbox(SEED_TENANT, SEED_ENV_ALPHA)).toBeEnabled();
+
+    // The runtime env is considered and shown, not silently omitted: its
+    // checkbox is disabled and its reason is a first-class visible line, not
+    // hidden behind a tooltip.
+    const runtimeCheckbox = app.orchestratorDialog.ineligibleEnvCheckbox(
+      SEED_TENANT,
+      seededRuntimeEnv.environment,
+    );
+    await expect(runtimeCheckbox).toBeVisible();
+    await expect(runtimeCheckbox).toBeDisabled();
+    await expect(runtimeCheckbox).not.toBeChecked();
+
+    const reason = app.orchestratorDialog.envIneligibleReason(
+      SEED_TENANT,
+      seededRuntimeEnv.environment,
+    );
+    await expect(reason).toContainText('no worktree to review');
+    await expect(reason).toContainText('no in-pod agent to delegate to');
+
+    // A genuinely disabled checkbox refuses a real (non-forced) click outright
+    // — Playwright's actionability check is itself the assertion that it
+    // never becomes selectable through the UI.
+    await expect(runtimeCheckbox.click({ timeout: 1_000 })).rejects.toThrow();
+    await expect(runtimeCheckbox).not.toBeChecked();
+
+    await app.orchestratorDialog.cancel();
+    await app.orchestratorDialog.waitForClosed();
+  });
+});
+
+// stubEnvCandidates replaces ListOrchestratorEnvCandidates's response so the
+// "several environments, none eligible" empty state is reachable without
+// mutating the shared seeded baseline (which always carries eligible
+// local-agent envs) — the sanctioned way to stage state the baseline itself
+// cannot carry (see erun-ui/playwright/AGENTS.md "Isolated config root and
+// seeded baseline").
+async function stubEnvCandidates(
+  page: Page,
+  candidates: {
+    tenant: string;
+    environment: string;
+    eligible: boolean;
+    defaultDirectory: string;
+    mirrored: boolean;
+    ineligibleReason: string;
+  }[],
+): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'ListOrchestratorEnvCandidates') {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: candidates }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+}
+
+test.describe('orchestrator Environments picker empty states', () => {
+  test('no candidates at all says so and names the remedy', async ({ app, page }) => {
+    await stubEnvCandidates(page, []);
+
+    await app.sidebar.newOrchestratorButton().click();
+    await app.orchestratorDialog.waitForOpen();
+
+    await expect(app.orchestratorDialog.environmentsEmptyMessage()).toBeVisible();
+    await expect(app.orchestratorDialog.environmentsAllIneligibleMessage()).toHaveCount(0);
+
+    await app.orchestratorDialog.cancel();
+    await app.orchestratorDialog.waitForClosed();
+  });
+
+  test('every candidate ineligible reads differently from no candidates at all', async ({
+    app,
+    page,
+  }) => {
+    await stubEnvCandidates(page, [
+      {
+        tenant: SEED_TENANT,
+        environment: 'prod',
+        eligible: false,
+        defaultDirectory: '',
+        mirrored: false,
+        ineligibleReason:
+          "Runtime environments have no worktree to review and no in-pod agent to delegate to, so they can't be linked to an orchestrator.",
+      },
+    ]);
+
+    await app.sidebar.newOrchestratorButton().click();
+    await app.orchestratorDialog.waitForOpen();
+
+    await expect(app.orchestratorDialog.environmentsAllIneligibleMessage()).toBeVisible();
+    await expect(app.orchestratorDialog.environmentsAllIneligibleMessage()).toContainText('1');
+    await expect(app.orchestratorDialog.environmentsEmptyMessage()).toHaveCount(0);
+
+    const checkbox = app.orchestratorDialog.ineligibleEnvCheckbox(SEED_TENANT, 'prod');
+    await expect(checkbox).toBeVisible();
+    await expect(checkbox).toBeDisabled();
+    await expect(app.orchestratorDialog.envIneligibleReason(SEED_TENANT, 'prod')).toContainText(
+      'no worktree to review',
+    );
+
+    await app.orchestratorDialog.cancel();
+    await app.orchestratorDialog.waitForClosed();
+  });
+});


### PR DESCRIPTION
## Summary
- The orchestrator dialog's Environments picker used to drop ineligible envs (e.g. `runtime` type) without a trace, leaving an operator unable to tell whether erun noticed their env, ignored it, or hit a bug.
- `ListOrchestratorEnvCandidates` now returns every considered env, each carrying `eligible` and, for an ineligible one, an operator-facing `ineligibleReason` reusing `orchestratableEnv`'s own documented reasoning — never the raw type token.
- The dialog renders an ineligible env as a disabled row with the reason as a first-class, always-visible line (never a bare tooltip), and distinguishes the two empty states: "no environments yet" vs "N environments found, but none can be linked."

## UX Impact Review Checklist (root AGENTS.md)
1. **Affected paths:** New/Edit orchestrator dialog → Environments field (`OrchestratorDialog.tsx` → `OrchestratorDialog.Environments.tsx`), backed by `App.ListOrchestratorEnvCandidates` (`erun-ui/orchestrator.go`).
2. **User-visible sequence:** Operator opens the orchestrator dialog → Environments field lists every tenant/env pair the backend knows about → eligible rows are checkable as before; ineligible rows render disabled with the reason directly under them → the field's top line explains which of the two empty states applies when relevant.
3. **State-without-affordance:** N/A — this only adds render paths for data already fetched; no new mutable app state.
4. **Visibility of system status:** The reason and empty-state copy are always-visible text, not a transient overlay.
5. **Success/failure feedback:** N/A — read-only listing, no side effect.
6. **Consistency with comparable flows:** Reuses the existing disabled-checkbox + first-class reason-line pattern already used for degrade-by-permission empty states (root AGENTS.md "Degrade by permission").
7. **Heuristic pass:** Visibility of system status — met (reason always visible). Recognition over recall — met (operator doesn't need to read code comments to know why an env is missing). Others not implicated by this change.
8. **Playwright coverage:** New spec `erun-ui/playwright/tests/orchestrator-env-picker-ineligible.spec.ts`, extending the existing `OrchestratorDialog` page object — covers a real ineligible (`runtime`) env rendering disabled with its reason, and (via RPC stub, per playwright/AGENTS.md's sanctioned staging technique — the shared seeded baseline always carries eligible envs so the all-ineligible state can't be reached any other way) the "no environments" vs "none eligible" empty-state distinction.

## Test plan
- [x] `make check` (root gate: build, lint, all module tests) — green
- [x] `erun-ui/playwright/run.sh --build -- orchestrator-env-picker-ineligible orchestrator-link-local-agent` — 4/4 passed

Closes #1441