### PR TITLE
Make non-interactive erun open skip the shell it cannot keep alive

### DIFF
--- a/erun-cli/cmd/api_port_forward.go
+++ b/erun-cli/cmd/api_port_forward.go
@@ -69,7 +69,7 @@ func ensureAPIPortForward(ctx common.Context, result common.OpenResult) (int, er
 
 	ctx.TraceCommand("", "kubectl", args...)
 
-	return startAPIPortForward(statePath, expectedState, args, localPort)
+	return startAPIPortForward(ctx, statePath, expectedState, args, localPort)
 }
 
 // ensureAPIPortForwardDryRun previews the port-forward without a live cluster
@@ -141,7 +141,7 @@ func checkAPIDeploymentPresent(args []string) (bool, error) {
 	return false, fmt.Errorf("failed to check API deployment: %w: %s", err, strings.TrimSpace(string(output)))
 }
 
-func startAPIPortForward(statePath string, expectedState mcpPortForwardState, args []string, localPort int) (int, error) {
+func startAPIPortForward(ctx common.Context, statePath string, expectedState mcpPortForwardState, args []string, localPort int) (int, error) {
 	logPath := mcpPortForwardLogPath(statePath)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return 0, err
@@ -157,16 +157,17 @@ func startAPIPortForward(statePath string, expectedState mcpPortForwardState, ar
 	cmd := common.Command("kubectl", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	detachBackgroundProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return 0, err
 	}
 	expectedState.ProcessID = cmd.Process.Pid
 	if err := saveMCPPortForwardState(statePath, expectedState); err != nil {
-		_ = cmd.Process.Kill()
+		releaseUnreachablePortForward(ctx, "api", cmd.Process, localPort, err)
 		return 0, err
 	}
 	if err := waitForAPIPortForward(localPort, logPath); err != nil {
-		_ = cmd.Process.Kill()
+		releaseUnreachablePortForward(ctx, "api", cmd.Process, localPort, err)
 		return 0, err
 	}
 	return localPort, nil

--- a/erun-cli/cmd/background_process_unix.go
+++ b/erun-cli/cmd/background_process_unix.go
@@ -11,8 +11,15 @@ import (
 	eruncommon "github.com/sophium/erun/erun-common"
 )
 
+// detachBackgroundProcess puts a port-forward in its own session, mirroring
+// detachEnvironmentJobSupervisor (erun-common/job_process_unix.go): a session
+// leader has no controlling terminal to be hung up with and is not in the
+// caller's process group, which is what lets it survive `erun open` exiting
+// (a doomed non-interactive shell, or a normal --no-shell return) without the
+// caller wrapping anything in setsid itself. Setpgid alone still shares that
+// session and does not give the same guarantee.
 func detachBackgroundProcess(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 }
 
 func isPortForwardProcess(pid int) bool {

--- a/erun-cli/cmd/background_process_windows.go
+++ b/erun-cli/cmd/background_process_windows.go
@@ -2,9 +2,24 @@
 
 package cmd
 
-import "os/exec"
+import (
+	"os/exec"
+	"syscall"
+)
 
-func detachBackgroundProcess(*exec.Cmd) {}
+// createNewProcessGroup detaches a child from the console control events the
+// caller's group receives — the closest Windows equivalent to a new session
+// (see erun-common/job_process_windows.go, which uses the same flag for the
+// same reason). Without it, closing the console that started `erun open`
+// takes its port-forwards down with it.
+const createNewProcessGroup = 0x00000200
+
+func detachBackgroundProcess(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createNewProcessGroup
+}
 
 func isPortForwardProcess(int) bool {
 	return false

--- a/erun-cli/cmd/mcp_port_forward.go
+++ b/erun-cli/cmd/mcp_port_forward.go
@@ -67,7 +67,7 @@ func ensureMCPPortForward(ctx common.Context, result common.OpenResult) (int, er
 
 	ctx.TraceCommand("", "kubectl", args...)
 
-	return startMCPPortForward(statePath, expectedState, args, localPort)
+	return startMCPPortForward(ctx, statePath, expectedState, args, localPort)
 }
 
 // adoptForeignMCPPortForward reuses a pre-existing kubectl port-forward already
@@ -128,7 +128,7 @@ func stopStaleMCPPortForward(state, expectedState mcpPortForwardState, localPort
 	waitForLocalPortToClose(localPort)
 }
 
-func startMCPPortForward(statePath string, expectedState mcpPortForwardState, args []string, localPort int) (int, error) {
+func startMCPPortForward(ctx common.Context, statePath string, expectedState mcpPortForwardState, args []string, localPort int) (int, error) {
 	logPath := mcpPortForwardLogPath(statePath)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return 0, err
@@ -156,9 +156,24 @@ func startMCPPortForward(statePath string, expectedState mcpPortForwardState, ar
 	}
 
 	if err := waitForMCPPortForward(localPort, logPath); err != nil {
+		releaseUnreachablePortForward(ctx, "mcp", cmd.Process, localPort, err)
 		return 0, err
 	}
 	return localPort, nil
+}
+
+// releaseUnreachablePortForward stops a forward that was just started but
+// never became reachable within its startup wait, so a slow or failed
+// kubectl port-forward does not sit bound to the port claiming to be there —
+// the "held but the edge never answers" shape that looks identical to a
+// genuinely stale forward to the next caller. Best-effort: the process may
+// already be gone, and the caller's own error already reports the failure.
+func releaseUnreachablePortForward(ctx common.Context, kind string, process *os.Process, localPort int, cause error) {
+	ctx.Trace(fmt.Sprintf("%s: releasing port-forward for 127.0.0.1:%d — it never became reachable: %s", kind, localPort, strings.TrimSpace(cause.Error())))
+	if process != nil {
+		_ = process.Kill()
+	}
+	waitForLocalPortToClose(localPort)
 }
 
 func waitForMCPPortForward(localPort int, logPath string) error {

--- a/erun-cli/cmd/open.go
+++ b/erun-cli/cmd/open.go
@@ -22,6 +22,11 @@ const (
 
 var currentHostOS = func() common.HostOS { return common.DetectHost().OS }
 
+// stdinIsTerminal decides whether open may safely block on an interactive
+// shell. A var (like currentHostOS above) so tests can force the TTY branch
+// via ERUN_FORCE_TTY, the same seam writerIsTerminal already honors.
+var stdinIsTerminal = func() bool { return writerIsTerminal(os.Stdin) }
+
 // refuseOpenForHostEnvironment refuses `open` against a host env: it has no
 // pod and no cluster to open a kubectl-exec shell into. Its worktree is
 // already the operator's own directory, so the resolution here is to open
@@ -101,7 +106,10 @@ func newOpenCmd(prepareContext func(common.Context) common.Context, resolveOpen 
 			"`erun deploy` first, or pass --deploy to deploy before opening (the operator-convenience " +
 			"shortcut: builds-here envs build→push→deploy, runtime envs install the current version). " +
 			"Use --vscode or --intellij to open an IDE instead, or --no-shell to print the setup " +
-			"commands for your current shell.\n\n" +
+			"commands for your current shell. Without a TTY on stdin (an MCP client, an " +
+			"orchestrator, a script) open skips the shell automatically and behaves like " +
+			"--no-shell instead: the port-forwards still come up, but open never launches a " +
+			"shell that would read EOF and exit immediately.\n\n" +
 			"Opening is also how you start an environment you stopped with `erun stop`. That makes " +
 			"open an operator gesture: anything that respawns it automatically to re-establish a " +
 			"dropped session must pass --reconnect, which reattaches without starting a stopped " +
@@ -382,6 +390,16 @@ func (r *resolvedOpenRunner) run() error {
 	}
 	if r.options.NoShell {
 		r.ctx.Trace("open: --no-shell selected, emitting setup commands instead of launching shell")
+		return r.emitNoShellSetup()
+	}
+	if !stdinIsTerminal() {
+		// A non-interactive caller (an MCP client, an orchestrator, a script) is
+		// exactly the shape that hits this: kubectl exec -it reads EOF on a
+		// non-TTY stdin and returns almost instantly, so open would exit right
+		// behind it having done nothing to keep the port-forwards it just started
+		// alive or supervised. Falling back to the --no-shell behavior keeps them
+		// up without gambling a shell that cannot stay open.
+		r.ctx.Trace("open: stdin is not a TTY, so an interactive shell would read EOF and exit immediately; keeping the port-forwards up and emitting setup commands instead of a shell that cannot stay open")
 		return r.emitNoShellSetup()
 	}
 

--- a/erun-cli/cmd/sshd_port_forward.go
+++ b/erun-cli/cmd/sshd_port_forward.go
@@ -65,7 +65,7 @@ func ensureSSHDPortForward(ctx common.Context, result common.OpenResult) (common
 
 	ctx.TraceCommand("", "kubectl", args...)
 
-	return startSSHDPortForward(statePath, expectedState, args, info)
+	return startSSHDPortForward(ctx, statePath, expectedState, args, info)
 }
 
 // adoptForeignSSHDPortForward mirrors adoptForeignMCPPortForward for the
@@ -105,7 +105,7 @@ func stopStaleSSHDPortForward(state, expectedState sshdPortForwardState, localPo
 	}
 }
 
-func startSSHDPortForward(statePath string, expectedState sshdPortForwardState, args []string, info common.SSHConnectionInfo) (common.SSHConnectionInfo, error) {
+func startSSHDPortForward(ctx common.Context, statePath string, expectedState sshdPortForwardState, args []string, info common.SSHConnectionInfo) (common.SSHConnectionInfo, error) {
 	logPath := sshdPortForwardLogPath(statePath)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
 		return common.SSHConnectionInfo{}, err
@@ -133,6 +133,7 @@ func startSSHDPortForward(statePath string, expectedState sshdPortForwardState, 
 	}
 
 	if err := waitForSSHDPortForward(info.Port, logPath); err != nil {
+		releaseUnreachablePortForward(ctx, "sshd", cmd.Process, info.Port, err)
 		return common.SSHConnectionInfo{}, err
 	}
 	return info, nil

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -238,6 +238,22 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/no_shell_dry_run", normalize.Apply(result.Combined))
 	})
 
+	t.Run("no_tty_dry_run_falls_back_to_no_shell", func(t *testing.T) {
+		// The stale-forward recovery advice names bare `erun open <tenant>
+		// <env>`, which a non-interactive caller (an MCP client, an
+		// orchestrator, a script) runs with no TTY on stdin — this harness's
+		// default piped stdin stands in for that. Without --no-shell on the
+		// command line, open must still take the no-shell branch on its own:
+		// a real kubectl exec -it there would read EOF and return almost
+		// instantly, exiting before anything supervises the port-forwards
+		// just started.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		golden.Equal(t, "open/no_tty_dry_run_falls_back_to_no_shell", normalize.Apply(result.Combined))
+	})
+
 	// zshAliasLine is the exact alias production appends for team/dev under
 	// zsh; the tests assert the startup file gains this line verbatim.
 	const zshAliasLine = `alias team-dev='eval "$(erun open team dev --no-shell)"'`
@@ -640,7 +656,12 @@ func TestOpen(t *testing.T) {
 		// runs, which holds the tab until the runtime is reachable.
 		setup := env.New(t)
 		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1 mirrors the desktop's real invocation: an --app-session
+		// tab runs inside a dtach-allocated pty, so stdin really is a TTY there,
+		// unlike this harness's piped default. Without it open would now take the
+		// non-interactive no-shell branch instead of the shell preview this
+		// scenario exists to lock.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "open-0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_dry_run_pure_open_does_not_deploy", normalize.Apply(result.Combined))
 	})
@@ -774,7 +795,8 @@ func TestOpen(t *testing.T) {
 		// model rather than the agent's own default.
 		setup := env.New(t)
 		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "ai", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_ai_dry_run_wraps_dtach_and_launches_claude", normalize.Apply(result.Combined))
 	})
@@ -793,7 +815,8 @@ func TestOpen(t *testing.T) {
 				"  defaultmodel: fable\n"+
 				"  verbosedebug: true\n"+
 				"  effort: high\n")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "ai", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_ai_dry_run_launches_claude_with_model_and_verbose_debug", normalize.Apply(result.Combined))
 	})
@@ -807,7 +830,8 @@ func TestOpen(t *testing.T) {
 			"claude:\n"+
 				"  models: [opus]\n"+
 				"  defaultmodel: fable\n")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "ai", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_ai_dry_run_falls_back_to_available_when_default_dropped", normalize.Apply(result.Combined))
 	})
@@ -823,7 +847,8 @@ func TestOpen(t *testing.T) {
 		fixture.SeedRemoteTenantEnvWithClaude(t, setup, "team", "dev",
 			"claude:\n"+
 				"  usemantle: true\n")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "ai", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_ai_dry_run_gateway_auth_disables_remote_control", normalize.Apply(result.Combined))
 	})
@@ -834,7 +859,8 @@ func TestOpen(t *testing.T) {
 		// no claude launch and no contribute prelude in the launcher body.
 		setup := env.New(t)
 		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "open-0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_shell_dry_run_wraps_dtach", normalize.Apply(result.Combined))
 	})
@@ -847,7 +873,8 @@ func TestOpen(t *testing.T) {
 		// reattachable session.
 		setup := env.New(t)
 		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
-		envVars := stubKubectlNotFound(t, setup)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy.
+		envVars := append(stubKubectlNotFound(t, setup), "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "contribute-ai", "--contribute", "--ai", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		golden.Equal(t, "open/app_session_contribute_ai_dry_run_preludes_clone", normalize.Apply(result.Combined))
 	})
@@ -1517,6 +1544,10 @@ func TestOpen(t *testing.T) {
 			ExecExitCodes:  []int{0},
 		})...)
 		envVars = append(envVars, openHostOSOverride)
+		// ERUN_FORCE_TTY=1: this scenario locks the interactive shell path (the
+		// form an operator at a real terminal runs); without it, stdin's
+		// non-TTY default in this harness would take the no-shell branch instead.
+		envVars = append(envVars, "ERUN_FORCE_TTY=1")
 		holderPID := fixture.StartStalePortHolder(t, 26100)
 		stubAdoptHolderProbes(t, setup, adoptHolder{port: 26100, pid: holderPID,
 			argv: "kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 26100:26100 --address 127.0.0.1"})
@@ -1661,6 +1692,10 @@ func TestOpen(t *testing.T) {
 			ExecExitCodes:  []int{0},
 			SeedKeyFile:    seededKeyFile,
 		})...)
+		// ERUN_FORCE_TTY=1: locks the interactive shell path an operator at a
+		// real terminal takes; this harness's stdin is otherwise non-TTY, which
+		// would now take the no-shell branch instead.
+		envVars = append(envVars, "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -1684,6 +1719,43 @@ func TestOpen(t *testing.T) {
 		}
 	})
 
+	t.Run("no_tty_real_run_keeps_forwards_without_a_shell", func(t *testing.T) {
+		// The reported failure, end to end and for real (not a dry-run trace):
+		// a non-interactive `erun open` must never drop into an interactive
+		// shell that reads EOF and exits almost instantly, taking the
+		// port-forwards it just started down with it. This harness's default
+		// stdin is already non-TTY, standing in for the MCP client/orchestrator/
+		// script that hits this in practice. The kubectl port-forward stub
+		// really binds 127.0.0.1:26100, so dialing it again after open has
+		// already exited is the proof that the forward outlived the command —
+		// not just that no error was printed.
+		skipIfPortsBusy(t, 26100, 26133)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithPortRange(t, setup, "team", "dev", 26100)
+		stubsDir := filepath.Join(setup.Cwd, "stubs")
+		envVars := append(setup.Env(), fixture.StubKubectlDeployed(t, stubsDir, fixture.KubectlDeployedStubSpec{
+			DeploymentName: "team-devops",
+			ContainerName:  "team-devops",
+			RepoPath:       "/home/erun/git/team",
+			MCPPort:        26100,
+			SSHPort:        26122,
+			ExecExitCodes:  []int{0},
+		})...)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "open/no_tty_real_run_keeps_forwards_without_a_shell", normalize.Apply(result.Combined))
+		if _, err := os.Stat(filepath.Join(stubsDir, "exec-calls")); err == nil {
+			t.Fatal("a non-interactive open must never invoke the interactive shell exec")
+		}
+		conn, err := netDialTimeout("tcp", "127.0.0.1:26100", time.Second)
+		if err != nil {
+			t.Fatalf("MCP port-forward must still be listening after open returns without a shell: %v", err)
+		}
+		_ = conn.Close()
+	})
+
 	t.Run("shell_real_run_session_taken_over_exits_with_notice", func(t *testing.T) {
 		// Takeover handover, end to end: the persistent session's exec
 		// wrapper exits 76 when another ERun window re-attaches the session.
@@ -1705,6 +1777,9 @@ func TestOpen(t *testing.T) {
 			SSHPort:        26122,
 			ExecExitCodes:  []int{76},
 		})...)
+		// ERUN_FORCE_TTY=1: see app_session_dry_run_pure_open_does_not_deploy —
+		// an --app-session tab runs inside a real dtach pty.
+		envVars = append(envVars, "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev", "--app-session", "open-0"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("takeover must end the shell loop cleanly, exit %d: %s", result.ExitCode, result.Combined)
@@ -1797,6 +1872,9 @@ func TestOpen(t *testing.T) {
 			PodsJSON:       podsJSON,
 			EventsJSON:     eventsJSON,
 		})...)
+		// ERUN_FORCE_TTY=1: locks the interactive shell path an operator at a
+		// real terminal takes; this harness's stdin is otherwise non-TTY.
+		envVars = append(envVars, "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 1 {
 			t.Fatalf("expected exit 1 from the failed rollout wait, got %d: %s", result.ExitCode, result.Combined)
@@ -1832,6 +1910,9 @@ func TestOpen(t *testing.T) {
 		// the seam confirms erun-devops published so it installs it instead of
 		// refusing.
 		envVars = append(envVars, "ERUN_PUBLISHED_CHART_PROBE_OVERRIDE=erun-devops:1.0.0")
+		// ERUN_FORCE_TTY=1: locks the interactive shell path an operator at a
+		// real terminal takes; this harness's stdin is otherwise non-TTY.
+		envVars = append(envVars, "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
@@ -1883,6 +1964,9 @@ func TestOpen(t *testing.T) {
 			ExecExitCodes:  []int{137, 0},
 			PodsJSON:       healthyPodsJSON,
 		})...)
+		// ERUN_FORCE_TTY=1: locks the interactive shell path an operator at a
+		// real terminal takes; this harness's stdin is otherwise non-TTY.
+		envVars = append(envVars, "ERUN_FORCE_TTY=1")
 		result := erun.Run(t, []string{"open", "team", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
 			t.Fatalf("pod replacement must reattach cleanly, exit %d: %s", result.ExitCode, result.Combined)

--- a/erun-integration/testdata/open/help.txt
+++ b/erun-integration/testdata/open/help.txt
@@ -1,6 +1,6 @@
 Open a shell in the tenant environment.
 
-open is a pure primitive: it starts the port-forwards and drops you into a shell against the runtime that is already deployed. It does not deploy on its own — run `erun deploy` first, or pass --deploy to deploy before opening (the operator-convenience shortcut: builds-here envs build→push→deploy, runtime envs install the current version). Use --vscode or --intellij to open an IDE instead, or --no-shell to print the setup commands for your current shell.
+open is a pure primitive: it starts the port-forwards and drops you into a shell against the runtime that is already deployed. It does not deploy on its own — run `erun deploy` first, or pass --deploy to deploy before opening (the operator-convenience shortcut: builds-here envs build→push→deploy, runtime envs install the current version). Use --vscode or --intellij to open an IDE instead, or --no-shell to print the setup commands for your current shell. Without a TTY on stdin (an MCP client, an orchestrator, a script) open skips the shell automatically and behaves like --no-shell instead: the port-forwards still come up, but open never launches a shell that would read EOF and exit immediately.
 
 Opening is also how you start an environment you stopped with `erun stop`. That makes open an operator gesture: anything that respawns it automatically to re-establish a dropped session must pass --reconnect, which reattaches without starting a stopped environment or discarding the recorded stop.
 

--- a/erun-integration/testdata/open/no_tty_dry_run_falls_back_to_no_shell.txt
+++ b/erun-integration/testdata/open/no_tty_dry_run_falls_back_to_no_shell.txt
@@ -1,0 +1,19 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --dry-run --no-alias-prompt team dev
+config: would assign localportrangestart=17000 to team/dev
+trace-log: would append the full trace to <TMP>
+open: tenant=team environment=dev kubernetes-context=test-context remote=false no-shell=false ide=shell
+open: pure primitive — not deploying (run `erun deploy` first, or pass --deploy to deploy before opening)
+kubectl --context test-context --namespace team-dev get deployment team-devops -o name
+kubectl --context test-context --namespace team-dev get deployment team-devops -o 'jsonpath={.spec.replicas}/{.status.readyReplicas}'
+runtime run state: deployment team-devops is absent from namespace team-dev
+open: team-devops is not deployed, so there is nothing to wake
+kubectl --context test-context --namespace team-dev port-forward deployment/team-devops 17000:17000 --address <LOOPBACK>
+kubectl --context test-context --namespace team-dev get deployment team-api -o name
+open: port-forwarding service/team-api if the check above finds the deployment present
+open: stdin is not a TTY, so an interactive shell would read EOF and exit immediately; keeping the port-forwards up and emitting setup commands instead of a shell that cannot stay open
+kubectl config use-context test-context
+kubectl config set-context --current --namespace=team-dev
+cd <TMP>

--- a/erun-integration/testdata/open/no_tty_real_run_keeps_forwards_without_a_shell.txt
+++ b/erun-integration/testdata/open/no_tty_real_run_keeps_forwards_without_a_shell.txt
@@ -1,0 +1,9 @@
+kubectl config use-context 'test-context' >/dev/null &&
+kubectl config set-context --current --namespace='team-dev' >/dev/null &&
+cd '<TMP>'
+audit: erun open --no-alias-prompt team dev
+trace-log: appending the full trace to <TMP>
+open: tenant=team environment=dev kubernetes-context=test-context remote=true no-shell=false ide=shell
+open: pure primitive — not deploying (run `erun deploy` first, or pass --deploy to deploy before opening)
+runtime run state: deployment team-devops wants 1 replica(s), 0 ready
+open: stdin is not a TTY, so an interactive shell would read EOF and exit immediately; keeping the port-forwards up and emitting setup commands instead of a shell that cannot stay open


### PR DESCRIPTION
## Summary

- `erun open` defaulted to `no-shell=false` (`ide=shell`) with no check on whether stdin is a terminal, so a non-interactive caller's `kubectl exec -it` read EOF and returned almost instantly; `open` exited right behind it having done nothing to keep the MCP/API/SSHD port-forwards it had just started alive or supervised — exactly the gap the job subsystem (`erun-common/job_process_unix.go`) was already hardened against with `Setsid`.
- `open` now detects a non-terminal stdin and falls back to the `--no-shell` behavior automatically: the port-forwards still come up, but it never launches a shell that would read EOF and exit immediately. The stale-forward recovery message (`erun mcp call`'s `mcpEdgeError`) already names bare `erun open <tenant> <env>`, and that invocation is now correct for the non-interactive audience that hits it, so no message text needed to change.
- Hardened the port-forward child processes to actually survive the caller's session ending: Unix now uses `Setsid` (matching the job subsystem's `detachEnvironmentJobSupervisor`) instead of `Setpgid` alone, and Windows' previously no-op `detachBackgroundProcess` now sets `CREATE_NEW_PROCESS_GROUP` (matching `job_process_windows.go`). Also found and fixed the API port-forward starting completely undetached (no `Setpgid`/`Setsid` at all).
- A forward that never becomes reachable within its startup wait is now released (killed, trace line "releasing port-forward for ...") instead of being left running and bound to the port — the "held but the edge never answers" shape that's indistinguishable from a genuinely stale forward on the next attempt.

## Test plan

- [x] `erun-cli`: `go build ./...`, `go test ./...`, `golangci-lint run ./...`
- [x] `erun-integration`: `go test ./...` (full suite green); added `open/no_tty_dry_run_falls_back_to_no_shell` and `open/no_tty_real_run_keeps_forwards_without_a_shell` (the latter dials the real port-forward simulator after `open` has already exited, proving the forward outlives the command); added `ERUN_FORCE_TTY=1` to the existing `app_session_*` and `shell_real_run_*` scenarios that intentionally exercise the interactive-shell path (a real desktop `--app-session` tab, or an operator at a real terminal, genuinely has a TTY)
- [x] `make check` (full repo gate, run as a detached `erun exec job`): green, coverage 76.0% (>= 75.8%)

Closes #1504