### PR TITLE
Fix writerIsTerminal misreading /dev/null as a terminal

### DIFF
--- a/erun-cli/cmd/plain_prompt.go
+++ b/erun-cli/cmd/plain_prompt.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 
 	"github.com/manifoldco/promptui"
+	"golang.org/x/term"
 )
 
 // A single shared reader is deliberate: each bufio.Reader buffers ahead, so
@@ -23,6 +24,11 @@ var plainPromptInput = sync.OnceValue(func() *bufio.Reader {
 	return bufio.NewReader(os.Stdin)
 })
 
+// writerIsTerminal asks whether w is a real terminal, not merely a character
+// device: os.ModeCharDevice is also set for /dev/null, /dev/zero, and
+// /dev/random, so a stat-based check misreads "command < /dev/null" — the
+// conventional way to run a command non-interactively — as an interactive
+// terminal.
 func writerIsTerminal(w io.Writer) bool {
 	if os.Getenv("ERUN_FORCE_TTY") == "1" {
 		return true
@@ -31,8 +37,7 @@ func writerIsTerminal(w io.Writer) bool {
 	if !ok {
 		return false
 	}
-	info, err := file.Stat()
-	return err == nil && (info.Mode()&os.ModeCharDevice) != 0
+	return term.IsTerminal(int(file.Fd()))
 }
 
 // runPlainPrompt is the non-TTY fallback for promptui.Prompt, mirroring its

--- a/erun-integration/internal/erun/erun.go
+++ b/erun-integration/internal/erun/erun.go
@@ -141,6 +141,13 @@ type RunOptions struct {
 	Env     []string
 	Stdin   string
 	Timeout time.Duration
+	// StdinFromDevNull binds the subprocess's stdin directly to the OS null
+	// device instead of the default in-memory pipe. A piped Stdin buffer is
+	// never a character device, so it cannot exercise a stat-based TTY check
+	// the same way the null device does — the null device is a character
+	// device but not a terminal, which is exactly the input a stat-based
+	// check confuses for one. Mutually exclusive with Stdin.
+	StdinFromDevNull bool
 }
 
 // requireIsolatedEnv guards the harness boundary: a scenario that runs the
@@ -198,11 +205,21 @@ func Run(t testing.TB, args []string, opts RunOptions) Result {
 	cmd.Env = env
 	// Always feed stdin from a buffer (empty when the scenario passes no
 	// Stdin) so the subprocess never inherits the developer's terminal. This
-	// keeps stdin a non-terminal pipe locally, matching CI's /dev/null stdin,
-	// so stdin-TTY-gated branches (e.g. the interactive-gh-auth gate)
-	// behave the same everywhere. Scenarios that need the interactive branch
-	// opt in explicitly via the ERUN_FORCE_TTY seam.
-	cmd.Stdin = bytes.NewBufferString(opts.Stdin)
+	// keeps stdin a non-terminal pipe locally, so stdin-TTY-gated branches
+	// (e.g. the interactive-gh-auth gate) behave the same everywhere.
+	// Scenarios that need the interactive branch opt in explicitly via the
+	// ERUN_FORCE_TTY seam. A scenario that needs stdin bound to the real null
+	// device (StdinFromDevNull) gets that instead — see the field doc.
+	if opts.StdinFromDevNull {
+		devNull, err := os.Open(os.DevNull)
+		if err != nil {
+			t.Fatalf("open %s: %v", os.DevNull, err)
+		}
+		defer devNull.Close()
+		cmd.Stdin = devNull
+	} else {
+		cmd.Stdin = bytes.NewBufferString(opts.Stdin)
+	}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/erun-integration/internal/erun/erun.go
+++ b/erun-integration/internal/erun/erun.go
@@ -215,7 +215,7 @@ func Run(t testing.TB, args []string, opts RunOptions) Result {
 		if err != nil {
 			t.Fatalf("open %s: %v", os.DevNull, err)
 		}
-		defer devNull.Close()
+		defer func() { _ = devNull.Close() }()
 		cmd.Stdin = devNull
 	} else {
 		cmd.Stdin = bytes.NewBufferString(opts.Stdin)

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -254,6 +254,23 @@ func TestOpen(t *testing.T) {
 		golden.Equal(t, "open/no_tty_dry_run_falls_back_to_no_shell", normalize.Apply(result.Combined))
 	})
 
+	t.Run("no_tty_dry_run_falls_back_to_no_shell_stdin_dev_null", func(t *testing.T) {
+		// The scenario above already runs with stdin unset, which erun.Run
+		// binds to an in-memory pipe — never a character device, so it cannot
+		// reproduce a stat-based TTY check confusing a non-terminal character
+		// device for a terminal. Binding stdin to the real OS null device
+		// (StdinFromDevNull) is what actually exercises that: /dev/null is a
+		// character device but not a terminal, and a `command < /dev/null`
+		// invocation is the conventional way callers make a command
+		// non-interactive. Same assertion as the scenario above; the point of
+		// this one is the stdin source, not a different resolved plan.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlNotFound(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-alias-prompt", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars, StdinFromDevNull: true})
+		golden.Equal(t, "open/no_tty_dry_run_falls_back_to_no_shell", normalize.Apply(result.Combined))
+	})
+
 	// zshAliasLine is the exact alias production appends for team/dev under
 	// zsh; the tests assert the startup file gains this line verbatim.
 	const zshAliasLine = `alias team-dev='eval "$(erun open team dev --no-shell)"'`


### PR DESCRIPTION
## Summary
- `writerIsTerminal` (`erun-cli/cmd/plain_prompt.go`) used `os.ModeCharDevice` to decide "is this a terminal". `/dev/null` (and `/dev/zero`, `/dev/random`) is a character device but not a terminal, so `command < /dev/null` — the conventional way to run something non-interactively — was misread as an interactive terminal. This made #1522's non-TTY branch in `erun open` a no-op for exactly the callers it was written for, so a doomed interactive shell still launched.
- Switched the predicate to `golang.org/x/term.IsTerminal`, keeping the existing `ERUN_FORCE_TTY` escape hatch. `writerIsTerminal` has four call sites, all fixed by this one change: `stdinIsTerminal`/`stdoutIsTerminalForAliasSetup` in `open.go`, and the promptui-vs-plain-prompt switch in `root.go`.
- Added `erun.RunOptions.StdinFromDevNull` to the integration harness so a scenario can bind the subprocess's stdin to the real null device instead of an in-memory pipe, and added `open_test.go::no_tty_dry_run_falls_back_to_no_shell_stdin_dev_null`, which reuses the existing golden. A piped stdin is never a character device, so the pre-existing `no_tty_dry_run_falls_back_to_no_shell` scenario passed under both the old and new predicate and could not have caught this regression; the new scenario fails against the old `os.ModeCharDevice` check (verified by hand: reverting just the predicate reproduces the shell-launch trace instead of the no-shell fallback) and passes with the fix.

Closes #1523

## Confirmation of the /dev/null behaviour
`os.Stat("/dev/null").Mode()&os.ModeCharDevice != 0` prints `true` — confirmed locally before making any change, per the issue's repro.

## Other callers
All four callers of `writerIsTerminal` shared the same bug (root.go's `runPrompt`/`runSelect` promptui-vs-plain switch on stdout, `open.go`'s `stdinIsTerminal` and `stdoutIsTerminalForAliasSetup`), so the single predicate fix covers all of them — no caller-specific changes were needed.

## Test plan
- [x] `go build ./...` / `go vet ./...` in `erun-cli` and `erun-integration`
- [x] `go test ./cmd -run TestZZManualCheckStdinTerminal < /dev/null` (ad hoc, removed) confirmed `writerIsTerminal(os.Stdin)` now returns `false` under `/dev/null`
- [x] New integration scenario verified to fail against the pre-fix predicate and pass with the fix
- [x] `make check` (detached job, full gate incl. lint/coverage) — green, coverage 76.0% (>= 75.8%)