### PR TITLE
Make long-running gates detach through erun's own job primitive inside agent pods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,33 @@ surface an agent fully controls: its own final turn.
   unfinished, uncommitted, or unrecovered, and the orchestrator believed it
   because nothing in the job's own status said otherwise (erun#1374).
 
+## Long Gates Detach Themselves Inside An Agent Pod
+
+`make check` is a thin front door (`scripts/agent-gate.sh`) around the real
+gate, `check-gate`. Outside an agent pod — a human's terminal, CI, a plain
+`docker build` — it execs `check-gate` directly and behavior is unchanged.
+Inside a coding agent's own pod (`ERUN_ENV_TYPE` `local-agent` or
+`remote-agent`) it instead detaches `check-gate` through `erun exec job
+start` and blocks on `erun exec job await` for a bounded window, because an
+ordinary foreground `make check` run (20-40 minutes) outruns a coding agent's
+own foreground window and gets auto-backgrounded into a bare task handle —
+exactly the case § "One Agent Job Is One Run" above warns about, except here
+the agent never chose to background anything. The fix has to be structural,
+not a prompt reminder: two lanes given opposite instructions ("foreground
+only, never poll" vs. the exact `job start`/`job await` invocations to use)
+both fell into the same turn-per-poll loop anyway, because nothing rejected
+the ordinary foreground invocation either agent actually typed. Whatever the
+caller does — wait once, or re-run the same command after a timeout — the
+cost is a small, bounded number of calls, and the job's real exit code and
+full captured output still reach the caller once it finishes.
+
+Apply the same pattern to any other command whose normal run time can exceed
+an agent's foreground window (see `scripts/agent-gate.sh`'s own header
+comment for the exact mechanics). Run `scripts/agent-gate_test.sh` directly
+after touching it — like `erun-devops/docker/erun-devops/entrypoint_test.sh`,
+it asserts process/argv behavior against a stubbed `erun` and is not wired
+into `make check`.
+
 ## Code Comments
 
 - Keep comments terse and abstract: explain the application behavior and intent behind the code — the "why" — not the mechanics a reader can see in the code itself.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: integration-test lint test-erun-ui test-frontend helm-chart-tests test-postgres-restart check
+.PHONY: integration-test lint test-erun-ui test-frontend helm-chart-tests test-postgres-restart check check-gate
 
 # Go modules linted by the in-build gate: erun-common, erun-cli, erun-mcp,
 # erun-integration, erun-backend/erun-backend-api, and erun-ui. Every entry
@@ -145,9 +145,23 @@ test-postgres-restart:
 integration-test:
 	./erun-integration/scripts/integration-test.sh
 
+# The front door. Everywhere but an agent pod this is check-gate by another
+# name: scripts/agent-gate.sh execs it directly and exits with exactly its
+# status. Inside an agent pod's own coding-agent session (ERUN_ENV_TYPE
+# local-agent or remote-agent) it instead detaches check-gate through erun's
+# job primitive and awaits it for a bounded window, so a 20-40 minute run
+# never sits as an ordinary foreground command for an agent harness to
+# auto-background into a bare task handle -- the caller either gets the real
+# result or a timeout that says to call `make check` again, either way in a
+# small, bounded number of calls. See scripts/agent-gate.sh for why this is
+# the fix and not just documentation.
+check:
+	./scripts/agent-gate.sh check "make check" -- $(MAKE) check-gate
+
 # The full in-build gate: golangci-lint, erun-ui's own Go tests, the frontend
 # kit + console gates, the erun-devops/k8s chart tests, then the integration
-# suite + coverage. The erun-devops image test stage runs this; a failure
-# tags no image. test-postgres-restart is deliberately excluded -- see its
-# own comment above for why.
-check: lint test-erun-ui test-frontend helm-chart-tests integration-test
+# suite + coverage. The erun-devops image test stage runs this (via `check`,
+# which is inert outside an agent pod); a failure tags no image.
+# test-postgres-restart is deliberately excluded -- see its own comment above
+# for why.
+check-gate: lint test-erun-ui test-frontend helm-chart-tests integration-test

--- a/erun-devops/docker/erun-devops/Dockerfile
+++ b/erun-devops/docker/erun-devops/Dockerfile
@@ -68,6 +68,7 @@ RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     npm install -g yarn@1.22.22
 
 COPY Makefile /src/Makefile
+COPY scripts /src/scripts
 COPY package.json yarn.lock /src/
 COPY erun-cli /src/erun-cli
 COPY erun-common /src/erun-common

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env sh
+# Runs a long gate command directly, unless this process is inside an erun
+# agent environment's own pod (ERUN_ENV_TYPE local-agent or remote-agent) --
+# exactly the case where the caller is an in-pod coding agent whose own
+# harness auto-backgrounds a foreground command once it outruns its
+# foreground window, leaving the agent holding a bare task handle it has to
+# poll one turn at a time instead of a result.
+#
+# There, this detaches the real work through erun's own job primitive
+# instead: `erun exec job start` runs it independently of this process, and
+# `erun exec job await` blocks for a bounded window and returns either the
+# finished outcome or a "still running" timeout. Whichever way the caller
+# invokes this script -- once and re-invoked later, or left to time out and
+# re-invoked again -- the cost is a small, bounded number of calls rather than
+# one per poll interval.
+#
+# Usage: agent-gate.sh <job-id> <job-name> -- <command...>
+#
+# Outside an agent pod (a human's terminal, CI, a plain `docker build`, or
+# when AGENT_GATE_DETACHED=1 marks this as the job's own re-exec'd body)
+# the command just runs in place via exec, so behaviour and exit status are
+# unchanged from calling it directly.
+
+set -eu
+
+job_id=$1
+job_name=$2
+shift 2
+if [ "${1:-}" = "--" ]; then
+	shift
+fi
+
+is_agent_pod() {
+	[ "${ERUN_ENV_TYPE:-}" = "local-agent" ] || [ "${ERUN_ENV_TYPE:-}" = "remote-agent" ]
+}
+
+if [ "${AGENT_GATE_DETACHED:-}" = "1" ] || ! is_agent_pod || ! command -v erun >/dev/null 2>&1; then
+	exec "$@"
+fi
+
+: "${ERUN_TENANT:?agent-gate.sh: ERUN_TENANT is not set (expected inside an agent pod)}"
+: "${ERUN_ENVIRONMENT:?agent-gate.sh: ERUN_ENVIRONMENT is not set (expected inside an agent pod)}"
+
+await_timeout="${ERUN_AGENT_GATE_AWAIT_TIMEOUT:-8m}"
+
+start_status=0
+start_output=$(erun exec job start \
+	--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
+	--id "$job_id" --name "$job_name" \
+	--env AGENT_GATE_DETACHED=1 \
+	-- "$@" 2>&1) || start_status=$?
+
+if [ "$start_status" -ne 0 ]; then
+	case "$start_output" in
+	*"is already running"*)
+		# Another invocation of this same command already detached the work;
+		# fall through and await the job already in flight.
+		;;
+	*)
+		printf '%s\n' "$start_output" >&2
+		exit "$start_status"
+		;;
+	esac
+else
+	printf '%s\n' "$start_output" >&2
+fi
+
+await_status=0
+erun exec job await \
+	--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
+	--id "$job_id" --timeout "$await_timeout" >&2 || await_status=$?
+
+if [ "$await_status" -eq 124 ]; then
+	printf 'agent-gate: %s is still running after %s; run this command again to keep waiting\n' "$job_name" "$await_timeout" >&2
+	exit 124
+fi
+
+erun exec job output \
+	--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
+	--id "$job_id" --max-bytes 16777216
+
+exit "$await_status"

--- a/scripts/agent-gate_test.sh
+++ b/scripts/agent-gate_test.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+
+# Tests for agent-gate.sh's own control flow: outside an agent pod (or once
+# the recursion guard is set) it must exec the real command untouched; inside
+# one it must detach through `erun exec job start`/`await`/`output` with the
+# right arguments and propagate the job's real exit status and output.
+#
+# Run directly (not wired into `make check`, same reasoning as
+# erun-devops/docker/erun-devops/entrypoint_test.sh): a stub `erun` on PATH
+# stands in for the real job engine so these assert argv shape and exit-code
+# plumbing, not the job store itself.
+
+set -eu
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+gate="${script_dir}/agent-gate.sh"
+
+work_root="$(mktemp -d 2>/dev/null || mktemp -d -t agent-gate-test)"
+trap 'rm -rf "${work_root}"' EXIT INT TERM
+
+fail() {
+	echo "FAIL: $1" >&2
+	exit 1
+}
+
+# stub_erun writes a fake `erun` on PATH that records every invocation's argv
+# (one line per call) and answers `exec job start`/`await`/`output` per the
+# STUB_* env vars a test case sets, without ever touching a real job store.
+stub_erun() {
+	bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/erun" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$STUB_ARGV_FILE"
+case "$1 $2 $3" in
+"exec job start")
+	if [ -n "${STUB_START_STDERR:-}" ]; then
+		printf '%s' "$STUB_START_STDERR" >&2
+	fi
+	exit "${STUB_START_STATUS:-0}"
+	;;
+"exec job await")
+	exit "${STUB_AWAIT_STATUS:-0}"
+	;;
+"exec job output")
+	printf '%s' "${STUB_JOB_OUTPUT:-}"
+	exit "${STUB_OUTPUT_STATUS:-0}"
+	;;
+*)
+	exit 0
+	;;
+esac
+EOF
+	chmod +x "${bin_dir}/erun"
+}
+
+# run_gate invokes agent-gate.sh with a clean environment plus whatever the
+# caller exported, capturing stdout+stderr and the exit code without letting
+# `set -e` end the test on a nonzero (expected in several cases).
+run_gate() {
+	set +e
+	OUT=$("$gate" "$@" 2>&1)
+	STATUS=$?
+	set -e
+}
+
+# --- outside an agent pod: exec the real command untouched, erun never runs.
+case_dir="${work_root}/outside-agent"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	unset ERUN_ENV_TYPE AGENT_GATE_DETACHED
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	run_gate direct-id "direct name" -- sh -c 'echo direct output; exit 7'
+	[ "$STATUS" -eq 7 ] || fail "outside agent pod: expected exit 7, got $STATUS"
+	case "$OUT" in
+	*"direct output"*) ;;
+	*) fail "outside agent pod: expected the command's own output, got: $OUT" ;;
+	esac
+	if [ -s "$STUB_ARGV_FILE" ]; then
+		fail "outside agent pod: erun must never be invoked, argv was: $(cat "$STUB_ARGV_FILE")"
+	fi
+)
+
+# --- the recursion guard: even inside an agent pod, a job already marked
+# AGENT_GATE_DETACHED=1 must run the real command directly.
+case_dir="${work_root}/detached-guard"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=remote-agent AGENT_GATE_DETACHED=1
+	export ERUN_TENANT=t ERUN_ENVIRONMENT=e
+	run_gate guarded-id "guarded name" -- sh -c 'echo guarded output; exit 3'
+	[ "$STATUS" -eq 3 ] || fail "detached guard: expected exit 3, got $STATUS"
+	case "$OUT" in
+	*"guarded output"*) ;;
+	*) fail "detached guard: expected the command's own output, got: $OUT" ;;
+	esac
+	if [ -s "$STUB_ARGV_FILE" ]; then
+		fail "detached guard: erun must never be invoked, argv was: $(cat "$STUB_ARGV_FILE")"
+	fi
+)
+
+# --- inside an agent pod: detach through start/await/output, with the right
+# tenant/environment/id, and propagate the job's captured output and exit code.
+case_dir="${work_root}/happy-path"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='job output line'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 0 ] || fail "happy path: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"job output line"*) ;;
+	*) fail "happy path: expected the job's captured output, got: $OUT" ;;
+	esac
+	grep -q 'exec job start' "$STUB_ARGV_FILE" || fail "happy path: job start was never called"
+	grep -q -- '--tenant acme' "$STUB_ARGV_FILE" || fail "happy path: tenant was not passed through"
+	grep -q -- '--environment dev' "$STUB_ARGV_FILE" || fail "happy path: environment was not passed through"
+	grep -q -- '--id check' "$STUB_ARGV_FILE" || fail "happy path: job id was not passed through"
+	grep -q -- '--env AGENT_GATE_DETACHED=1' "$STUB_ARGV_FILE" || fail "happy path: recursion guard was not threaded into the job's env"
+	grep -q -- 'make check-gate' "$STUB_ARGV_FILE" || fail "happy path: the real command was not forwarded to job start"
+	grep -q 'exec job await' "$STUB_ARGV_FILE" || fail "happy path: job await was never called"
+	grep -q 'exec job output' "$STUB_ARGV_FILE" || fail "happy path: job output was never read back"
+)
+
+# --- a job already running from a prior invocation: start refuses, and the
+# script must fall through to await rather than treating that as fatal.
+case_dir="${work_root}/already-running"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=remote-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_START_STATUS=1
+	export STUB_START_STDERR='job "check" is already running (pid 123); pass a different id or cancel it first'
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='resumed output'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 0 ] || fail "already running: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"resumed output"*) ;;
+	*) fail "already running: expected the running job's output once it finished, got: $OUT" ;;
+	esac
+	grep -q 'exec job await' "$STUB_ARGV_FILE" || fail "already running: must still await the in-flight job"
+)
+
+# --- an unrelated start failure must be fatal: never silently await a job
+# that was never actually started.
+case_dir="${work_root}/start-fails"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=remote-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_START_STATUS=1
+	export STUB_START_STDERR='some unrelated failure'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 1 ] || fail "start fails: expected exit 1, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"some unrelated failure"*) ;;
+	*) fail "start fails: expected the start error to surface, got: $OUT" ;;
+	esac
+	if grep -q 'exec job await' "$STUB_ARGV_FILE"; then
+		fail "start fails: must not await a job that was never started"
+	fi
+)
+
+# --- await timing out must exit 124 and must not read job output yet.
+case_dir="${work_root}/still-running"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_AWAIT_STATUS=124
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 124 ] || fail "still running: expected exit 124, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"run this command again"*) ;;
+	*) fail "still running: expected the retry hint, got: $OUT" ;;
+	esac
+	if grep -q 'exec job output' "$STUB_ARGV_FILE"; then
+		fail "still running: must not read job output before the job finishes"
+	fi
+)
+
+# --- erun missing from PATH: degrade to running the command directly rather
+# than failing outright.
+case_dir="${work_root}/no-erun"
+mkdir -p "$case_dir"
+(
+	export PATH="/usr/bin:/bin"
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	run_gate check "make check" -- sh -c 'echo no erun on PATH; exit 5'
+	[ "$STATUS" -eq 5 ] || fail "no erun: expected exit 5, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"no erun on PATH"*) ;;
+	*) fail "no erun: expected the command's own output, got: $OUT" ;;
+	esac
+)
+
+echo "ok: agent-gate.sh"


### PR DESCRIPTION
## Summary

- An in-pod coding agent that runs `make check` as an ordinary foreground command gets it auto-backgrounded by its own harness once it outruns the foreground window, leaving the agent to poll a bare output file one turn at a time for the 20-40 minutes the gate takes — often exhausting its turns before it can commit, push, or open a PR.
- Two lanes given opposite instructions (foreground-only vs. the exact `erun exec job start`/`job await` commands to use) both failed the same way, which is why the fix has to be structural rather than a prompt reminder.
- `scripts/agent-gate.sh` makes `make check` self-detach through erun's own job primitive whenever it detects it is running inside an agent pod (`ERUN_ENV_TYPE` `local-agent`/`remote-agent`): `erun exec job start` runs the real gate independently, and `erun exec job await` blocks for a bounded window (default 8m) and returns either the job's real exit code + full captured output, or a "still running" timeout telling the caller to run `make check` again. Whatever the agent types, the cost is a small, bounded number of calls instead of one per poll interval.
- Outside an agent pod (a human's terminal, CI, a plain `docker build`) the wrapper detects it is not in an agent pod and `exec`s the real gate directly with unchanged behavior — verified by running the Docker test stage's exact invocation shape locally.

## Why this design, and what I rejected

The issue proposed three options. I took **option 1 (self-detaching gate)** and rejected the other two:

- **Rejected: make the wrong path fail loudly.** Refusing or warning on a long-running foreground command detected in an agent context still requires the agent to *read* the warning and *choose* to act on it — the exact thing that already failed twice with explicit, correct instructions in the prompt.
- **Rejected: documentation as the fix.** The issue is explicit that prescribing the right commands in a prompt has already failed for two lanes with opposite instructions; documentation is a floor (added to root `AGENTS.md`), never the fix itself.
- **Chosen: self-detaching gate.** `make check` now does the right thing no matter what the agent types — `make check` once, or the same command re-typed after a timeout — because the decision is made by the gate itself, not by the caller.

## What changed

- `scripts/agent-gate.sh` (new): the reusable detach/await wrapper. Recursion-guarded via `AGENT_GATE_DETACHED=1` (not `ERUN_`-prefixed, since `erun exec job start --env` refuses any `ERUN_*` override as its own redirection seam). Falls back to a direct `exec` when `erun` isn't on `PATH`, when the recursion guard is set, or when `ERUN_ENV_TYPE` isn't `local-agent`/`remote-agent`.
- `scripts/agent-gate_test.sh` (new): stubs `erun` on `PATH` (same pattern as `erun-devops/docker/erun-devops/entrypoint_test.sh`) and asserts argv shape, the "already running" fallthrough, the "must not await/read output on a failed start / before the job finishes" negative cases, and the outside-agent-pod / recursion-guard / no-`erun`-on-`PATH` direct-exec paths. Run directly, not wired into `make check` (same reasoning as `entrypoint_test.sh`).
- `Makefile`: `check` is now a thin front door (`agent-gate.sh check "make check" -- $(MAKE) check-gate`); the original prerequisite chain (`lint test-erun-ui test-frontend helm-chart-tests integration-test`) moved to `check-gate`.
- `erun-devops/docker/erun-devops/Dockerfile`: `COPY scripts /src/scripts` so the test stage's `RUN make check` still resolves the wrapper (the Docker build has no `ERUN_ENV_TYPE`, so it takes the direct-exec path unchanged).
- `AGENTS.md`: new "Long Gates Detach Themselves Inside An Agent Pod" section documenting the mechanism and pointing at the pattern for future long-running commands.

## Test plan

- [x] `scripts/agent-gate_test.sh` passes locally (7 scenarios: direct-exec outside an agent pod, recursion guard, happy path start→await→output, "already running" fallthrough, unrelated start failure surfaces and never awaits, await timeout exits 124 without reading output, `erun` missing from `PATH` degrades to direct exec).
- [x] Manually verified end-to-end against the real job engine from inside this PR's own remote-agent pod (`ERUN_ENV_TYPE=remote-agent`): short jobs detach/await/return output correctly, a slow job times out at 124 with the retry hint and no output leak, re-running the same command against an in-flight job reattaches instead of erroring, and the recursion guard runs the real command directly.
- [x] `make check` itself, run from this same pod, self-detached and returned real output/exit 0 in one call — see the last lines below.
- [x] `make -n check` confirms the front door delegates to `check-gate` with `$(MAKE)`, preserving GNU Make's recursive dry-run semantics.

Last 5 lines of `make check` (run from inside this branch's own agent pod, self-detached through the new wrapper):

```
github.com/sophium/erun/main.go:11:						main							100.0%
github.com/sophium/erun/main.go:17:						run							100.0%
total:										(statements)						76.0%

ok  coverage 76.0% (>= 75.8%)
```

Closes #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)