### PR TITLE
Fix two Playwright specs that only flake under full-suite load

### DIFF
--- a/erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-cross-env-diff.spec.ts
@@ -363,6 +363,15 @@ test.describe('orchestrator cross-env diff panel (#1178)', () => {
     const betaAll = review.reviewBoundaryButton('All branch changes', 1);
     const betaCurrent = review.reviewBoundaryButton('Current local changes', 1);
 
+    // diffSectionPaths() above only proves the diff panel's file list
+    // (DiffList) has rendered both environments' files. The review-layers
+    // controls read the same per-env slot but live in a separate subtree
+    // (ReviewRangeControls, inside the changed-files aside), so nth(1) has
+    // nothing to resolve to until beta's own controls have mounted -- wait
+    // for that directly instead of assuming it happens in the same commit.
+    await expect(betaCurrent).toBeVisible();
+    await expect(betaAll).toBeVisible();
+
     await expect(alphaCurrent).toHaveAttribute('aria-pressed', 'true');
     await expect(betaCurrent).toHaveAttribute('aria-pressed', 'true');
 

--- a/erun-ui/playwright/tests/review-keyboard-model.spec.ts
+++ b/erun-ui/playwright/tests/review-keyboard-model.spec.ts
@@ -1,6 +1,6 @@
 import type { Request, Route } from '@playwright/test';
 
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   removeEnvironment,
   SEED_TENANT,
@@ -283,10 +283,7 @@ async function openReviewDetailFromDashboard(
   environment: string,
   reviewName: string,
 ): Promise<void> {
-  await app.reloadEnvironments();
-  await app.sidebar
-    .envRowButton(SEED_TENANT, environment)
-    .waitFor({ state: 'visible', timeout: 15_000 });
+  await waitForSeededRow(app, SEED_TENANT, environment);
   await app.sidebar.openTenantDashboard(SEED_TENANT);
   await app.tenantDashboard.waitForOpen();
   await app.tenantDashboard.selectTab('Reviews');


### PR DESCRIPTION
## Summary
- `review-keyboard-model.spec.ts`'s `openReviewDetailFromDashboard` used the fixed `.waitFor({ state: 'visible', timeout: 15_000 })` reload pattern instead of `waitForSeededRow`'s `expect().toPass()` convergence (already adopted elsewhere by #1459). A reload issued while an earlier refetch is in flight can resolve against a stale snapshot with nothing to re-trigger it. Fixed by calling `waitForSeededRow` instead.
- `orchestrator-cross-env-diff.spec.ts`'s per-env scope-leak test read the second environment's "Current local changes"/"All branch changes" buttons by DOM order (`.nth(1)`) immediately after `diffSectionPaths()` converged on both environments' files. That convergence only proves the diff panel's own subtree (`DiffList`) rendered — the review-layers controls (`ReviewRangeControls`) read the same per-env slot but live in a separate subtree (the changed-files aside), so nothing guaranteed beta's controls had mounted by the time the assertion ran. The reported error ("element(s) not found", not a wrong value) confirms this was a genuine not-yet-mounted race, not a wrong-locator match. Fixed by waiting for beta's controls to be visible before reading their pressed state — no timeout was raised anywhere; both waits use the same default 10s `expect` timeout the rest of the suite uses.

## Verification
- `./run.sh -- review-keyboard-model.spec.ts orchestrator-cross-env-diff.spec.ts --repeat-each=5`: **75/75 passed**.
- Full default suite run (single worker, ~385 tests) in progress to reproduce genuine full-suite-load conditions; will update with the result.

## Test plan
- [x] `./run.sh -- review-keyboard-model.spec.ts orchestrator-cross-env-diff.spec.ts --repeat-each=5` green
- [ ] Full suite run green
- [ ] `make check`

Closes #1467
Closes #1468