### PR TITLE
Keep the orchestrator hover card's environment state live

### DIFF
--- a/erun-ui/frontend/src/app/orchestratorEnvActivitySync.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvActivitySync.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { configureStore } from '@reduxjs/toolkit';
+
+import { environmentIndicator } from '@/components/app/Sidebar.helpers';
+
+import { orchestratorEnvironmentLine } from './orchestratorEnvironmentActivity';
+import envStatusReducer from './slices/envStatusSlice';
+import orchestratorsReducer, { setOrchestrators } from './slices/orchestratorsSlice';
+import type { AppDispatch } from './store';
+import { selectionKey } from './versionSuggestions';
+import { handleEnvActivity } from './wailsEventThunks';
+
+// This is the bug from the reported card/row contradiction: the sidebar row
+// (envStatusSlice, driven by the env-activity event) and the orchestrator
+// card (orchestratorsSlice, joined onto env refs at read-model build time)
+// are two different feeds of the same poller observation. The fix routes one
+// event to both; this test drives that event through the real thunk and
+// reads both surfaces back, rather than asserting the reducer was called.
+function buildStore(orchestratorId: string, tenant: string, environment: string) {
+  const store = configureStore({
+    reducer: { envStatus: envStatusReducer, orchestrators: orchestratorsReducer },
+  });
+  store.dispatch(
+    setOrchestrators([
+      {
+        id: orchestratorId,
+        name: orchestratorId,
+        environments: [{ tenant, environment, directory: '/tmp/a' }],
+        tenants: [tenant],
+        directories: ['/tmp/a'],
+        sessionId: 1,
+        status: 'running',
+        busy: false,
+        transient: false,
+        shellRunning: false,
+        shellCommand: '',
+        shellStartedAtUnix: 0,
+        nudgeCount: 0,
+        nudgeCapped: false,
+        restartRequired: false,
+      },
+    ]),
+  );
+  return store;
+}
+
+// isFailure asks the one question the reported bug got wrong for: does this
+// surface currently read as a failure? Deriving it identically for both
+// surfaces from their own state is what proves they agree, rather than
+// re-testing each derivation function in isolation.
+function rowIsFailure(store: ReturnType<typeof buildStore>, key: string): boolean {
+  const activity = store.getState().envStatus.activityByEnv[key];
+  const indicator = environmentIndicator({
+    name: key,
+    envState: '',
+    isOpen: true,
+    reachable: activity?.reachable ?? false,
+    outage: activity?.outage ?? false,
+    busy: activity?.busy ?? false,
+    detail: activity?.detail ?? '',
+  });
+  return indicator.dot === 'failed';
+}
+
+function cardIsFailure(store: ReturnType<typeof buildStore>, orchestratorId: string): boolean {
+  const orchestrator = store
+    .getState()
+    .orchestrators.items.find((item) => item.id === orchestratorId);
+  const ref = orchestrator?.environments[0];
+  if (!ref) {
+    throw new Error('expected a seeded env ref');
+  }
+  return orchestratorEnvironmentLine(ref).state === 'outage';
+}
+
+test('an env-activity event updates the orchestrator card, not just the sidebar row', () => {
+  const tenant = 'frs';
+  const environment = 'local';
+  const store = buildStore('orch', tenant, environment);
+  const dispatch = store.dispatch as unknown as AppDispatch;
+
+  dispatch(
+    handleEnvActivity({
+      tenant,
+      environment,
+      reachable: false,
+      observed: false,
+      outage: true,
+      busy: false,
+    }),
+  );
+  assert.equal(cardIsFailure(store, 'orch'), true, 'card should show the outage once reported');
+
+  // This is the transition the bug lost: the card kept the stale outage after
+  // the poller recovered, because nothing routed the recovery event to it.
+  dispatch(
+    handleEnvActivity({
+      tenant,
+      environment,
+      reachable: true,
+      observed: true,
+      outage: false,
+      busy: false,
+    }),
+  );
+  assert.equal(
+    cardIsFailure(store, 'orch'),
+    false,
+    'card should clear the outage once the poller recovers',
+  );
+});
+
+test('no combination of the poller observation makes the row and the card disagree', () => {
+  const tenant = 'frs';
+  const environment = 'local';
+  const store = buildStore('orch', tenant, environment);
+  const dispatch = store.dispatch as unknown as AppDispatch;
+  const key = selectionKey({ tenant, environment });
+
+  const booleans = [false, true];
+  for (const reachable of booleans) {
+    for (const observed of booleans) {
+      for (const outage of booleans) {
+        for (const busy of booleans) {
+          dispatch(handleEnvActivity({ tenant, environment, reachable, observed, outage, busy }));
+          assert.equal(
+            rowIsFailure(store, key),
+            cardIsFailure(store, 'orch'),
+            `row and card disagreed for reachable=${String(reachable)} observed=${String(observed)} outage=${String(outage)} busy=${String(busy)}`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('a clean boot seeds the card from the fetch alone, before any event arrives', () => {
+  const store = configureStore({
+    reducer: { envStatus: envStatusReducer, orchestrators: orchestratorsReducer },
+  });
+  store.dispatch(
+    setOrchestrators([
+      {
+        id: 'orch',
+        name: 'orch',
+        environments: [
+          {
+            tenant: 'frs',
+            environment: 'local',
+            directory: '/tmp/a',
+            activity: { reachable: false, observed: false, outage: true, busy: false },
+          },
+        ],
+        tenants: ['frs'],
+        directories: ['/tmp/a'],
+        sessionId: 1,
+        status: 'running',
+        busy: false,
+        transient: false,
+        shellRunning: false,
+        shellCommand: '',
+        shellStartedAtUnix: 0,
+        nudgeCount: 0,
+        nudgeCapped: false,
+        restartRequired: false,
+      },
+    ]),
+  );
+
+  assert.equal(cardIsFailure(store, 'orch'), true);
+});

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.test.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import reducer, {
+  type OrchestratorInfo,
+  type OrchestratorsState,
+  setEnvActivityForOrchestratorEnvs,
+  setOrchestrators,
+} from './orchestratorsSlice';
+
+function orchestrator(overrides: Partial<OrchestratorInfo> = {}): OrchestratorInfo {
+  return {
+    id: 'orch',
+    name: 'orch',
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: 0,
+    status: 'stopped',
+    busy: false,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+    nudgeCount: 0,
+    nudgeCapped: false,
+    restartRequired: false,
+    ...overrides,
+  };
+}
+
+function stateWith(items: OrchestratorInfo[]): OrchestratorsState {
+  return reducer(undefined, setOrchestrators(items));
+}
+
+test('a live env-activity patch replaces a stale snapshot on the matching ref', () => {
+  const state = stateWith([
+    orchestrator({
+      id: 'orch-a',
+      environments: [
+        {
+          tenant: 'frs',
+          environment: 'local',
+          directory: '/tmp/a',
+          activity: { reachable: false, observed: false, outage: true, busy: false },
+        },
+      ],
+    }),
+  ]);
+
+  const next = reducer(
+    state,
+    setEnvActivityForOrchestratorEnvs({
+      tenant: 'frs',
+      environment: 'local',
+      activity: { reachable: true, observed: true, outage: false, busy: false },
+    }),
+  );
+
+  assert.deepEqual(next.items[0]?.environments[0]?.activity, {
+    reachable: true,
+    observed: true,
+    outage: false,
+    busy: false,
+  });
+});
+
+test('a patch for a different environment leaves an unrelated ref untouched', () => {
+  const staleActivity = { reachable: false, observed: false, outage: true, busy: false };
+  const state = stateWith([
+    orchestrator({
+      id: 'orch-a',
+      environments: [
+        { tenant: 'frs', environment: 'local', directory: '/tmp/a', activity: staleActivity },
+      ],
+    }),
+  ]);
+
+  const next = reducer(
+    state,
+    setEnvActivityForOrchestratorEnvs({
+      tenant: 'frs',
+      environment: 'other',
+      activity: { reachable: true, observed: true, outage: false, busy: false },
+    }),
+  );
+
+  assert.deepEqual(next.items[0]?.environments[0]?.activity, staleActivity);
+});
+
+test('one environment linked from two orchestrators updates on both refs', () => {
+  const state = stateWith([
+    orchestrator({
+      id: 'orch-a',
+      environments: [
+        {
+          tenant: 'frs',
+          environment: 'local',
+          directory: '/tmp/a',
+          activity: { reachable: false, observed: false, outage: true, busy: false },
+        },
+      ],
+    }),
+    orchestrator({
+      id: 'orch-b',
+      environments: [
+        {
+          tenant: 'frs',
+          environment: 'local',
+          directory: '/tmp/b',
+          activity: { reachable: false, observed: false, outage: true, busy: false },
+        },
+      ],
+    }),
+  ]);
+
+  const next = reducer(
+    state,
+    setEnvActivityForOrchestratorEnvs({
+      tenant: 'frs',
+      environment: 'local',
+      activity: { reachable: true, observed: true, outage: false, busy: false },
+    }),
+  );
+
+  assert.equal(next.items[0]?.environments[0]?.activity?.outage, false);
+  assert.equal(next.items[1]?.environments[0]?.activity?.outage, false);
+});
+
+// A clean fetch (setOrchestrators) is the build-time join and must keep
+// carrying whatever activity the read model resolved, independent of the live
+// patch reducer above — this is what makes a page reload correct without
+// waiting on the next poller transition.
+test('a fresh fetch still reflects the joined snapshot with no event required', () => {
+  const state = stateWith([
+    orchestrator({
+      environments: [
+        {
+          tenant: 'frs',
+          environment: 'local',
+          directory: '/tmp/a',
+          activity: {
+            reachable: true,
+            observed: true,
+            outage: false,
+            busy: true,
+            detail: 'holding: x',
+          },
+        },
+      ],
+    }),
+  ]);
+
+  assert.deepEqual(state.items[0]?.environments[0]?.activity, {
+    reachable: true,
+    observed: true,
+    outage: false,
+    busy: true,
+    detail: 'holding: x',
+  });
+});

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -105,6 +105,31 @@ export const orchestratorsSlice = createSlice({
       state.busy = false;
       state.error = action.payload;
     },
+    // setEnvActivityForOrchestratorEnvs is the live half of the activity join:
+    // a fetch (setOrchestrators) joins the poller's snapshot onto each env ref
+    // at that instant, but nothing previously kept it current between fetches,
+    // so a card could still show an outage the poller had already cleared. This
+    // patches every ref across every orchestrator that names the given
+    // tenant/environment, driven by the same env-activity event that already
+    // updates the sidebar row (see envStatusSlice.setEnvActivityForEnv), so the
+    // two never read from inputs of different ages again.
+    setEnvActivityForOrchestratorEnvs(
+      state,
+      action: PayloadAction<{
+        tenant: string;
+        environment: string;
+        activity: UIEnvironmentActivity;
+      }>,
+    ) {
+      const { tenant, environment, activity } = action.payload;
+      for (const orchestrator of state.items) {
+        for (const ref of orchestrator.environments) {
+          if (ref.tenant === tenant && ref.environment === environment) {
+            ref.activity = activity;
+          }
+        }
+      }
+    },
   },
 });
 
@@ -114,5 +139,6 @@ export const {
   closeOrchestratorDialog,
   setOrchestratorsBusy,
   setOrchestratorsError,
+  setEnvActivityForOrchestratorEnvs,
 } = orchestratorsSlice.actions;
 export default orchestratorsSlice.reducer;

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -33,6 +33,7 @@ import { setAIBusyForEnv, setAIBusyForSession } from './slices/aiActivitySlice';
 import { recordDoctorOutcome } from './slices/doctorSlice';
 import { setEnvActivityForEnv, setEnvStatusForEnv } from './slices/envStatusSlice';
 import { setShellActivityForSession } from './slices/orchestratorShellActivitySlice';
+import { setEnvActivityForOrchestratorEnvs } from './slices/orchestratorsSlice';
 import { appendReconnectLine } from './slices/reviewSlice';
 import {
   clearPendingOpenAfterDeploy,
@@ -119,6 +120,13 @@ export const handleEnvStatus =
 // answering, and whether work is in flight — so a row driven from the CLI or by
 // an in-pod agent shows its condition instead of rendering blank (Nielsen #1,
 // visibility of system status).
+//
+// It also patches every orchestrator env ref for this tenant/environment, not
+// just the sidebar row's own copy: an orchestrator card joins the same
+// activity onto its linked envs at read-model build time, and nothing kept
+// that joined copy current between builds — so a card could keep reporting an
+// outage the row had already recovered from. Driving both off this one event
+// is what keeps the two surfaces from disagreeing about one environment.
 export const handleEnvActivity =
   (payload: EnvActivityPayload): AppThunk =>
   (dispatch) => {
@@ -127,19 +135,16 @@ export const handleEnvActivity =
     if (!tenant || !environment) {
       return;
     }
+    const activity = {
+      reachable: payload.reachable,
+      observed: payload.observed,
+      outage: payload.outage === true,
+      busy: payload.busy,
+      detail: (payload.detail ?? '').trim(),
+    };
     const key = selectionKey({ tenant, environment });
-    dispatch(
-      setEnvActivityForEnv({
-        key,
-        activity: {
-          reachable: payload.reachable,
-          observed: payload.observed,
-          outage: payload.outage === true,
-          busy: payload.busy,
-          detail: (payload.detail ?? '').trim(),
-        },
-      }),
-    );
+    dispatch(setEnvActivityForEnv({ key, activity }));
+    dispatch(setEnvActivityForOrchestratorEnvs({ tenant, environment, activity }));
   };
 
 // handleAppStatus surfaces a backend status line to the user.

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -255,6 +255,11 @@ export class Sidebar {
     await this.orchestratorRowButton(name).click();
   }
 
+  // The hover card raised by hovering orchestratorRowButton, mirroring envHoverCard().
+  orchestratorHoverCard(name: string): Locator {
+    return this.page.getByRole('dialog', { name: `${name} details` });
+  }
+
   // The tenant name button that opens its dashboard, carrying aria-current
   // when the dashboard is the sidebar's focused row (#1204).
   tenantDashboardButton(tenant: string): Locator {

--- a/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
@@ -327,4 +327,105 @@ test.describe('orchestrator hover card environment and pacing state', () => {
     await expect(dialog).toBeVisible();
     await expect(dialog).not.toContainText('Nudges');
   });
+
+  // Linked through a stubbed ListOrchestrators (like the tests above) rather
+  // than the suite's static pw/alpha link: alpha is the desktop's own
+  // auto-opened default environment, whose real idle/activity polling would
+  // keep overwriting the injected event underneath this test. A seededEnv is
+  // never opened, so nothing but the driven event touches its activity.
+  test('a card holding an outage clears it once the same environment recovers, and the row agrees', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+    await stubOrchestratorList(
+      page,
+      snapshot({ environments: [{ tenant, environment, directory: '/tmp/a' }] }),
+    );
+    await app.reboot();
+
+    const dot = app.sidebar.envOpenDot(tenant, environment);
+    const dialog = app.sidebar.orchestratorHoverCard(SEED_ORCHESTRATOR);
+
+    // A retry that re-hovers a row the pointer never left is a no-op — the
+    // browser only fires mouseenter on a genuine boundary crossing, so a
+    // popover that closed for any other reason (e.g. the screenshot below
+    // scrolling it out of view) would then never reopen. Moving off first
+    // guarantees every retry re-triggers a real enter.
+    async function rehover(): Promise<void> {
+      await page.mouse.move(0, 0);
+      await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+    }
+
+    // This is the transition the bug lost: a card that already rendered once
+    // must pick up a later event, not just whatever the fetch it booted from
+    // handed it.
+    await driveEnvActivity(
+      page,
+      { tenant, environment, reachable: false, observed: false, outage: true, busy: false },
+      async () => {
+        await rehover();
+        await expect(dialog).toBeVisible({ timeout: 1_000 });
+        await expect(dialog).toContainText('Lost connection', { timeout: 1_000 });
+        await expect(dot).toHaveAttribute('data-env-state', 'failed', { timeout: 1_000 });
+        // Taken while still converged and hovered — a screenshot outside this
+        // callback can race the popover's own close-on-mouse-leave timer.
+        await dialog.screenshot({
+          path: '/home/erun/.erun/outputs/orchestrator-card-live-state/card-outage.png',
+        });
+      },
+    );
+
+    await driveEnvActivity(
+      page,
+      { tenant, environment, reachable: true, observed: true, outage: false, busy: false },
+      async () => {
+        await rehover();
+        await expect(dialog).toContainText('Idle', { timeout: 1_000 });
+        await expect(dialog).not.toContainText('Lost connection', { timeout: 1_000 });
+        await expect(dot).toHaveAttribute('data-env-state', 'running', { timeout: 1_000 });
+        await dialog.screenshot({
+          path: '/home/erun/.erun/outputs/orchestrator-card-live-state/card-recovered.png',
+        });
+      },
+    );
+  });
 });
+
+interface EnvActivityEvent {
+  tenant: string;
+  environment: string;
+  reachable: boolean;
+  observed: boolean;
+  outage?: boolean;
+  busy: boolean;
+  detail?: string;
+}
+
+// Mirrors erun-ui/environment_activity.go's env-activity event. The backend's
+// own sweep also runs on a timer against this seeded (inert) env and can
+// overwrite the injected value with its own "unreachable" observation, so
+// every assertion driven by this helper is re-driven until it converges,
+// bounded by a real timeout rather than a guessed delay.
+async function driveEnvActivity(
+  page: Page,
+  event: EnvActivityEvent,
+  assertions: () => Promise<void>,
+): Promise<void> {
+  await expect(async () => {
+    await emitEnvActivity(page, event);
+    await assertions();
+  }).toPass({ timeout: 20_000 });
+}
+
+async function emitEnvActivity(page: Page, payload: EnvActivityEvent): Promise<void> {
+  await page.evaluate((event) => {
+    const runtime = (
+      window as unknown as {
+        runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+      }
+    ).runtime;
+    runtime.EventsEmit('env-activity', event);
+  }, payload);
+}


### PR DESCRIPTION
## Summary

- The orchestrator hover card joined each linked environment's activity (reachable/observed/outage/busy) onto its read model once, at build time (`orchestratorInfoFor`/`envInfos`), and nothing refreshed that joined copy afterward. The sidebar row already consumes the `env-activity` Wails event live; the orchestrator card did not, so a recovered environment could keep showing "Lost connection" on the card while its own row read green.
- Adds `setEnvActivityForOrchestratorEnvs` to `orchestratorsSlice` and routes the existing `env-activity` event (`handleEnvActivity` in `wailsEventThunks.ts`) to patch every orchestrator env ref matching that tenant/environment, in addition to the sidebar row's own slice. The build-time join (`setOrchestrators` from a fresh fetch) is unchanged — it still seeds a clean boot correctly; this only adds the live path between fetches.
- Checked the other read-model builders that join `envActivitySnapshot()`/`a.envActivity` onto `orchestratorInfoFor` (7 call sites in `erun-ui/orchestrator.go`): all of them are builders (fetch/boot/list), none is a second "joined but never refreshed" copy distinct from the one this PR fixes — the live half is entirely a frontend concern (one event, two consumers), so no Go change was needed.
- `#1476` (usage across environment-listing surfaces) is **not** included here — see below.

## Why #1476 is a separate change

`#1475` and `#1476` looked like they might share a data path (both touch the orchestrator card / environment lists), but they turned out to be independent:
- `#1475` is a narrow frontend fix: wire an *existing* event (`env-activity`) into an *existing* field (`OrchestratorEnvRef.activity`) that nothing was refreshing.
- `#1476` is materially larger: a new Go-side usage-collection cadence (CPU/mem/disk via `LoadRuntimeUsage`, on a sweep rather than per-hover), a cache with staleness/age tracking, rendering across three different surfaces (env hover card, orchestrator card, sidebar considered-and-rejected), and its own docs update.

Doing both in one PR would have meant either half-shipping #1476's backend cadence work or bundling an unrelated, much larger feature into a bug-fix PR. #1475 is done completely here; #1476 is left for its own change.

## UX Impact Review Checklist

1. **Affected paths.** Orchestrator sidebar hover card (`Sidebar.OrchestratorHoverCard.tsx` via `orchestratorEnvironmentLine`), driven by the `env-activity` Wails event.
2. **User-visible sequence.** Operator hovers an orchestrator row → card shows each linked environment's line (e.g. "Lost connection", "Busy — ...", "Idle"). Before: that line was frozen at whatever the last fetch/boot saw. After: the same `env-activity` event that already updates the environment's own sidebar row now also updates the card's copy, so hovering later shows the current state.
3. **State-without-affordance.** N/A — this only makes an existing rendered field track its real source instead of going stale.
4. **Visibility of system status (Nielsen #1).** Directly fixes a visibility-of-system-status defect: the card was showing an outage that had already cleared.
5. **Success/failure feedback.** N/A — no new operation, no new failure mode.
6. **Consistency with comparable flows.** Now consistent with the sidebar row, which already lives off this event (`envStatusSlice.setEnvActivityForEnv`) — the fix literally reuses that same event.
7. **Heuristic pass.** Nielsen #1 (visibility of system status) is the one this fixes; the rest are unaffected (no new control, no new error state, no accessibility change).
8. **Playwright coverage.** Extended `sidebar-orchestrator-hover-card-activity.spec.ts` with a new test that drives the environment through outage → recovery via the same `env-activity` event and asserts the card and the row agree at each step (with screenshots), using a `seededEnv` (never opened by the desktop) rather than the suite's default env, since the default env's own real activity polling would otherwise race the injected event.

## Test plan

- [x] `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn test` — new unit tests in `orchestratorsSlice.test.ts` (reducer patches matching refs across orchestrators, leaves others untouched) and `orchestratorEnvActivitySync.test.ts` (drives the real `handleEnvActivity` thunk through a store with both slices; asserts outage→recovery on the card, an exhaustive boolean matrix where the row and the card never disagree, and that a clean boot still seeds correctly with no event required).
- [x] `erun-ui`: `go test ./...` (via `make check`) — no Go changes in this PR.
- [x] `erun-ui/playwright`: `./run.sh` (targeted spec run x3 for stability, full suite run in progress) — new/extended spec in `sidebar-orchestrator-hover-card-activity.spec.ts`.
- [x] `make check` — green.

Closes #1475