### PR TITLE
Detach the playwright and integration-test gates the same way make check does

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,20 @@ after touching it — like `erun-devops/docker/erun-devops/entrypoint_test.sh`,
 it asserts process/argv behavior against a stubbed `erun` and is not wired
 into `make check`.
 
+The criterion for wrapping a command this way is "long enough that a harness
+will background it", never the target's name — `make check` was simply the
+first one found this way. `erun-ui/playwright/run.sh` (longer than `make
+check` itself; see `erun-ui/playwright/AGENTS.md` § "Headless Launch") and
+`make integration-test` (routinely run standalone per § "Integration Test
+Gate" below, and the single longest component of `check-gate`) are wired
+through the same wrapper for that reason. `erun release` / `erun build
+--release` were checked and are not: the merge queue already runs a release
+as a detached job in an agent env (see § "Integration Test Gate" below), and
+nothing tells an agent to run either directly as routine, foreground,
+per-change validation the way `make check`, `make integration-test`, and the
+playwright suite are. Re-check this list when a new command earns that same
+routine-and-long status.
+
 ## Code Comments
 
 - Keep comments terse and abstract: explain the application behavior and intent behind the code — the "why" — not the mechanics a reader can see in the code itself.
@@ -249,7 +263,7 @@ Probe artifacts the agent leaves behind during verification (injected files, man
 
 - `make integration-test` must be green on `main` at all times. Do not merge a PR that leaves any scenario red, including scenarios that were already failing before your branch — if you discover a preexisting red, either fix it in the same PR or open a tracking issue and a follow-up PR before merging anything else that touches the suite. "Some tests were already broken" is not a license to add more.
 - This repository intentionally has no hosted CI (#521): GitHub-hosted runners are ephemeral, which defeats erun's daemon-centric build caching, and erun provides its own build system and merge queue instead. Both halves of that queue now exist in `erun-backend-api`: promoting a review to `MERGE` dispatches `internal/mergeexec` to build the prospective merge of the review's source onto its *current* target and gate it with a real `erun build`, pushing only on green — so `MERGED` means a merge actually happened and a build actually passed, not a caller's assertion — and an accepted (now actually-merged) review then enqueues a release, run by a per-tenant serial queue as a Job in an agent env with warm caches. It is opt-in per control plane and is not yet a required status check, so the gate is still enforced where it always was for this repository's own PRs: run it locally before merging, and every erun-driven build anywhere re-runs it via the image's test stage (see `erun-devops/AGENTS.md` § "Build Workflow"). Do not reintroduce GitHub Actions workflows for build or test gating.
-- Run `go test ./...` (or `make integration-test`) under `erun-integration/` before pushing any change that touches `erun-cli`, `erun-common`, the runtime entrypoint, the chart deploy plumbing, or any integration golden. If a scenario is red on your machine but you believe it is "platform-dependent" or "flaky", that is a defect to fix (see the host-OS pinning guidance in `erun-integration/AGENTS.md`), not a reason to ship.
+- Run `go test ./...` (or `make integration-test`) under `erun-integration/` before pushing any change that touches `erun-cli`, `erun-common`, the runtime entrypoint, the chart deploy plumbing, or any integration golden. If a scenario is red on your machine but you believe it is "platform-dependent" or "flaky", that is a defect to fix (see the host-OS pinning guidance in `erun-integration/AGENTS.md`), not a reason to ship. `make integration-test` is itself wired through `scripts/agent-gate.sh` (see § "Long Gates Detach Themselves Inside An Agent Pod" above) since it is routinely run standalone and is long enough on its own to hit the same foreground-timeout failure; `make check-gate` depends on the underlying `integration-test-gate` target directly so a `make check` run never nests one detached job inside another.
 - The integration suite runs the compiled binary as a subprocess against per-command `--dry-run` goldens. The contract for `--dry-run` is therefore a hard public-surface boundary: every action and every decision the command would take must appear as a trace line, regardless of whether downstream input resolution succeeds. Treat a missing trace as a bug, not a documentation gap.
 - Coverage is gated on `erun-cli` + `erun-common` only, and the integration suite is the single source of truth for that coverage — unit tests in those packages do not count toward the gate, so write the integration scenario for new `erun-cli`/`erun-common` behavior and delete unit tests that overlap one. Other modules (`erun-mcp`, `erun-backend`, `erun-ui`) are validated by their own per-module suites.
 - Do not skip integration scenarios to make the suite green. If a regression is discovered, leave the failing scenario in place so the gate fails until the regression is fixed; that is the suite working as designed.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: integration-test lint test-erun-ui test-frontend helm-chart-tests test-postgres-restart check check-gate
+.PHONY: integration-test integration-test-gate lint test-erun-ui test-frontend helm-chart-tests test-postgres-restart check check-gate
 
 # Go modules linted by the in-build gate: erun-common, erun-cli, erun-mcp,
 # erun-integration, erun-backend/erun-backend-api, and erun-ui. Every entry
@@ -142,7 +142,17 @@ test-postgres-restart:
 # directly with --update-golden (./erun-integration/scripts/integration-test.sh
 # --update-golden) — gate mode refuses outright if UPDATE_GOLDEN is set in the
 # environment, so it cannot be reseeded via `make check UPDATE_GOLDEN=1`.
+#
+# Detaches through the same wrapper as `check` below, since root AGENTS.md
+# tells contributors to run this standalone before pushing and it is long
+# enough on its own to hit the same foreground-timeout failure inside an
+# agent pod. check-gate depends on integration-test-gate directly rather than
+# on this target, so a `make check` run never nests one detached job inside
+# another.
 integration-test:
+	./scripts/agent-gate.sh integration-test "make integration-test" -- $(MAKE) integration-test-gate
+
+integration-test-gate:
 	./erun-integration/scripts/integration-test.sh
 
 # The front door. Everywhere but an agent pod this is check-gate by another
@@ -164,4 +174,4 @@ check:
 # which is inert outside an agent pod); a failure tags no image.
 # test-postgres-restart is deliberately excluded -- see its own comment above
 # for why.
-check-gate: lint test-erun-ui test-frontend helm-chart-tests integration-test
+check-gate: lint test-erun-ui test-frontend helm-chart-tests integration-test-gate

--- a/erun-ui/playwright/AGENTS.md
+++ b/erun-ui/playwright/AGENTS.md
@@ -28,6 +28,7 @@ The suite owns its config root (issue #483). `fixtures/seedRoot.ts` is the singl
 
 There is only one supported way to run the suite. The shell script `run.sh` in this directory is the single entry point — `yarn` scripts call it for convenience, and the desktop build/packaging flow invokes it too.
 
+- `run.sh` is wired through `scripts/agent-gate.sh`, the same wrapper `make check` uses (root `AGENTS.md` § "Long Gates Detach Themselves Inside An Agent Pod"): outside an agent pod it behaves exactly as documented below, but inside one it detaches the whole run — build, lint, and the suite itself — through erun's own job primitive and awaits it for a bounded window, so this suite (longer than `make check`) never sits as an ordinary foreground command for an agent's harness to auto-background. A timeout says to run the same `run.sh` invocation again to keep waiting.
 - One-shot from this directory:
   ```sh
   ./run.sh

--- a/erun-ui/playwright/run.sh
+++ b/erun-ui/playwright/run.sh
@@ -30,6 +30,20 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 ERUN_UI_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 BIN_PATH="$ERUN_UI_DIR/bin/erun-app"
 
+# Detach the whole run through scripts/agent-gate.sh, the same wrapper `make
+# check` uses, so this suite (longer than `make check` itself) never sits as
+# an ordinary foreground command for an in-pod coding agent's harness to
+# auto-background into a bare task handle. Outside an agent pod agent-gate.sh
+# execs straight through with no behaviour change. RUN_SH_AGENT_GATED marks
+# that this invocation already made that one pass, so the re-exec of this
+# same script (either agent-gate.sh's own straight-through, or the job body
+# it starts) does not route through here again.
+if [ -z "${AGENT_GATE_DETACHED:-}" ] && [ "${RUN_SH_AGENT_GATED:-0}" != "1" ]; then
+	RUN_SH_AGENT_GATED=1
+	export RUN_SH_AGENT_GATED
+	exec "$ERUN_UI_DIR/../scripts/agent-gate.sh" ui-playwright "erun-ui/playwright/run.sh $*" -- "$SCRIPT_DIR/run.sh" "$@"
+fi
+
 FORCE_BUILD=0
 HEADED=0
 PORT=34123

--- a/scripts/agent-gate_test.sh
+++ b/scripts/agent-gate_test.sh
@@ -3,7 +3,8 @@
 # Tests for agent-gate.sh's own control flow: outside an agent pod (or once
 # the recursion guard is set) it must exec the real command untouched; inside
 # one it must detach through `erun exec job start`/`await`/`output` with the
-# right arguments and propagate the job's real exit status and output.
+# right arguments and propagate the job's real exit status and output. It also
+# covers erun-ui/playwright/run.sh's wiring into that same wrapper.
 #
 # Run directly (not wired into `make check`, same reasoning as
 # erun-devops/docker/erun-devops/entrypoint_test.sh): a stub `erun` on PATH
@@ -227,4 +228,124 @@ mkdir -p "$case_dir"
 	esac
 )
 
+# --- erun-ui/playwright/run.sh: wired through the same agent-gate.sh wrapper
+# as `make check`. run.sh's own body needs yarn/node/playwright to actually
+# run the suite, so these cases stub only `erun` and assert on what reaches
+# `erun exec job start` -- the start/await/output plumbing itself is already
+# covered above; this section only checks that run.sh routes into it
+# correctly and forwards its own arguments faithfully.
+playwright_run_sh="${script_dir}/../erun-ui/playwright/run.sh"
+
+run_playwright() {
+	set +e
+	OUT=$("$playwright_run_sh" "$@" 2>&1)
+	STATUS=$?
+	set -e
+}
+
+# --- outside an agent pod: run.sh must behave exactly as before. --port with
+# no value fails fast inside run.sh's own flag parsing, well before it would
+# ever reach yarn/playwright, so this proves both "no erun call happened" and
+# "the real script body still ran in place".
+case_dir="${work_root}/playwright-outside-agent"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	unset ERUN_ENV_TYPE AGENT_GATE_DETACHED RUN_SH_AGENT_GATED
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	run_playwright --port
+	[ "$STATUS" -eq 2 ] || fail "playwright outside agent pod: expected exit 2, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"--port requires a value"*) ;;
+	*) fail "playwright outside agent pod: expected run.sh's own error, got: $OUT" ;;
+	esac
+	if [ -s "$STUB_ARGV_FILE" ]; then
+		fail "playwright outside agent pod: erun must never be invoked, argv was: $(cat "$STUB_ARGV_FILE")"
+	fi
+)
+
+# --- the recursion guard: already inside the detached job body
+# (AGENT_GATE_DETACHED=1), run.sh must not wrap itself again.
+case_dir="${work_root}/playwright-detached-guard"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent AGENT_GATE_DETACHED=1
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	unset RUN_SH_AGENT_GATED
+	run_playwright --port
+	[ "$STATUS" -eq 2 ] || fail "playwright detached guard: expected exit 2, got $STATUS ($OUT)"
+	if [ -s "$STUB_ARGV_FILE" ]; then
+		fail "playwright detached guard: erun must never be invoked, argv was: $(cat "$STUB_ARGV_FILE")"
+	fi
+)
+
+# --- inside an agent pod: detach through the same start/await/output flow as
+# make check, with every original argument forwarded to the re-invoked run.sh
+# faithfully, and the job's captured output/exit status returned untouched.
+case_dir="${work_root}/playwright-happy-path"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=remote-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='playwright job output'
+	unset RUN_SH_AGENT_GATED
+	run_playwright --build --skip-lint -- --grep "manage dialog sizing" --reporter=list
+	[ "$STATUS" -eq 0 ] || fail "playwright happy path: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"playwright job output"*) ;;
+	*) fail "playwright happy path: expected the job's captured output, got: $OUT" ;;
+	esac
+	grep -q 'exec job start' "$STUB_ARGV_FILE" || fail "playwright happy path: job start was never called"
+	grep -q -- '--id ui-playwright' "$STUB_ARGV_FILE" || fail "playwright happy path: job id was not passed through"
+	grep -q -- '--env AGENT_GATE_DETACHED=1' "$STUB_ARGV_FILE" || fail "playwright happy path: recursion guard was not threaded into the job's env"
+	grep -q -- 'playwright/run.sh --build --skip-lint -- --grep manage dialog sizing --reporter=list' "$STUB_ARGV_FILE" \
+		|| fail "playwright happy path: original arguments were not forwarded intact, argv was: $(cat "$STUB_ARGV_FILE")"
+	grep -q 'exec job await' "$STUB_ARGV_FILE" || fail "playwright happy path: job await was never called"
+	grep -q 'exec job output' "$STUB_ARGV_FILE" || fail "playwright happy path: job output was never read back"
+)
+
+# --- the job id stays stable across invocations even as the arguments
+# change, so a caller re-invoking run.sh with the same command after a
+# timeout keeps awaiting the same job rather than starting a new one.
+case_dir="${work_root}/playwright-stable-id"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_AWAIT_STATUS=0
+
+	unset RUN_SH_AGENT_GATED
+	export STUB_JOB_OUTPUT=first
+	run_playwright --grep "spec one" >/dev/null
+
+	unset RUN_SH_AGENT_GATED
+	export STUB_JOB_OUTPUT=second
+	run_playwright --headed --grep "spec two" >/dev/null
+
+	starts=$(grep -c -- 'exec job start.*--id ui-playwright' "$STUB_ARGV_FILE" || true)
+	[ "$starts" -eq 2 ] || fail "playwright stable id: expected both invocations to start a job with the same id, argv was: $(cat "$STUB_ARGV_FILE")"
+	grep -q -- 'spec one' "$STUB_ARGV_FILE" || fail "playwright stable id: first invocation's arguments were lost"
+	grep -q -- 'spec two' "$STUB_ARGV_FILE" || fail "playwright stable id: second invocation's arguments were lost"
+)
+
 echo "ok: agent-gate.sh"
+echo "ok: erun-ui/playwright/run.sh detachment wiring"


### PR DESCRIPTION
## Summary

- `scripts/agent-gate.sh` (from #1435/#1525) only wrapped `make check`. `erun-ui/playwright/run.sh` — the longer of the two gates, and the one agents are told to run directly (`cd erun-ui && ./playwright/run.sh --build -- <spec>`) — was still an ordinary foreground command inside an agent pod, so a harness could still auto-background it into a bare task handle once it outran the foreground window, leaving completed work uncommitted.
- Wired `run.sh` through the same wrapper: it re-execs itself once through `scripts/agent-gate.sh` before doing any real work, using a stable job id (`ui-playwright`) so a retry after a timeout keeps awaiting the same job, and forwarding every original argument (`--build`, `--skip-lint`, a spec grep, `--reporter=`, etc.) intact. Outside an agent pod `agent-gate.sh` execs straight through, so a human's terminal / CI / the desktop build see no change.
- Audited what else an in-pod agent is routinely told to run standalone that can take minutes (per the issue's own framing: the criterion is "long enough to be backgrounded," not the target's name):
  - **`make integration-test`** — root `AGENTS.md` explicitly tells contributors to run this standalone before pushing, and it's the single longest component of `check-gate`. Wired it through the same wrapper (`integration-test` now calls `agent-gate.sh` around a new `integration-test-gate` target; `check-gate` depends on `integration-test-gate` directly so a `make check` run never nests one detached job inside another).
  - **`erun release` / `erun build --release`** — considered and left unwired. The merge queue already runs a release as a detached Job in an agent env (see root `AGENTS.md` § "Integration Test Gate"), and nothing tells an agent to run either directly as routine, foreground, per-change validation the way `make check`/`make integration-test`/the playwright suite are.
  - **`erun-console/playwright/run.sh`** — considered and left unwired. It's opt-in (`ERUN_E2E_CONSOLE_OIDC=1`) and only required for changes to the console's auth lifecycle, the same narrow-scope shape as `erun-ui`'s already-excluded `--e2e-k3d` mode — not something an agent runs routinely.
- Extended `scripts/agent-gate_test.sh` to cover `run.sh`'s wiring specifically: outside an agent pod it runs in place with no `erun` call at all; the recursion guard holds once already inside the detached job body; inside an agent pod it detaches with every original argument forwarded intact and the job's real exit status/output returned faithfully; and the job id stays stable across invocations with different arguments.
- Documented the wiring in `erun-ui/playwright/AGENTS.md` § "Headless Launch" and in root `AGENTS.md` § "Long Gates Detach Themselves Inside An Agent Pod" / § "Integration Test Gate".

## Test plan

- [x] `sh scripts/agent-gate_test.sh` passes (`ok: agent-gate.sh` / `ok: erun-ui/playwright/run.sh detachment wiring`)
- [x] Manually verified outside an agent pod `./run.sh --port` still fails exactly as before (exit 2, no `erun` invoked)
- [x] Manually verified inside an agent pod (stubbed `erun`) the job id stays stable across two different argument sets while the forwarded command differs
- [ ] `make check` (full gate)

Closes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)