### PR TITLE
Read the runtime helm release's chart and appVersion from helm list

### DIFF
--- a/erun-common/observe.go
+++ b/erun-common/observe.go
@@ -58,8 +58,9 @@ func RunObservation(ctx Context, req ShellLaunchParams, params ObserveParams) (O
 	limitArgs := observeGetArgs(req, "limitrange")
 	ingressArgs := observeGetArgs(req, "ingress")
 	certArgs := observeGetArgs(req, "certificates.cert-manager.io")
-	helmArgs := observeHelmStatusArgs(req)
 	releaseName := RuntimeReleaseName(req.Tenant)
+	helmArgs := observeHelmStatusArgs(req)
+	helmListArgs := observeHelmListArgs(req, releaseName)
 
 	ctx.TraceCommand("", "kubectl", podArgs...)
 	ctx.TraceCommand("", "kubectl", quotaArgs...)
@@ -67,6 +68,7 @@ func RunObservation(ctx Context, req ShellLaunchParams, params ObserveParams) (O
 	ctx.TraceCommand("", "kubectl", ingressArgs...)
 	ctx.TraceCommand("", "kubectl", certArgs...)
 	ctx.TraceCommand("", "helm", helmArgs...)
+	ctx.TraceCommand("", "helm", helmListArgs...)
 	ctx.Trace("observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason")
 
 	secretArgs := make([][]string, len(params.Secrets))
@@ -99,7 +101,7 @@ func RunObservation(ctx Context, req ShellLaunchParams, params ObserveParams) (O
 		result.Secrets = append(result.Secrets, fetchObservedSecretCheck(secretArgs[i], check))
 	}
 
-	result.HelmRelease = fetchObservedHelmRelease(helmArgs, releaseName, req.Namespace)
+	result.HelmRelease = fetchObservedHelmRelease(helmArgs, helmListArgs, releaseName, req.Namespace)
 	result.Drift = computeObserveDrift(req, result.HelmRelease, result.Pods)
 
 	return result, nil

--- a/erun-common/observe_helm_release.go
+++ b/erun-common/observe_helm_release.go
@@ -154,17 +154,16 @@ func populateObservedChartFields(release *ObservedHelmRelease, listArgs []string
 	}
 	entry := entries[0]
 	release.AppVersion = entry.AppVersion
-	switch {
-	case entry.Chart == "":
+	if entry.Chart == "" {
 		release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("helm list returned an empty chart field for release %q — chart/chartVersion could not be determined", releaseName))
-	default:
-		if name, version, ok := splitHelmChartNameVersion(entry.Chart); ok {
-			release.Chart = name
-			release.ChartVersion = version
-		} else {
-			release.Chart = entry.Chart
-			release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("could not separate release %q's chart name from its version in %q — showing the combined value as chart", releaseName, entry.Chart))
-		}
+		return
+	}
+	if name, version, ok := splitHelmChartNameVersion(entry.Chart); ok {
+		release.Chart = name
+		release.ChartVersion = version
+	} else {
+		release.Chart = entry.Chart
+		release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("could not separate release %q's chart name from its version in %q — showing the combined value as chart", releaseName, entry.Chart))
 	}
 }
 

--- a/erun-common/observe_helm_release.go
+++ b/erun-common/observe_helm_release.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -42,6 +43,22 @@ func observeHelmStatusArgs(req ShellLaunchParams) []string {
 	return append(args, "-o", "json")
 }
 
+// observeHelmListArgs builds a read-only `helm list -o json` invocation
+// filtered to exactly the runtime release. `helm status -o json` carries no
+// chart metadata at all (its top-level keys are apply_method, config, info,
+// manifest, name, namespace, version — no chart), so observe reads chart and
+// appVersion from list instead, which does carry them.
+func observeHelmListArgs(req ShellLaunchParams, releaseName string) []string {
+	args := []string{"list", "--filter", "^" + regexp.QuoteMeta(releaseName) + "$"}
+	if strings.TrimSpace(req.Namespace) != "" {
+		args = append(args, "--namespace", req.Namespace)
+	}
+	if strings.TrimSpace(req.KubernetesContext) != "" {
+		args = append(args, "--kube-context", req.KubernetesContext)
+	}
+	return append(args, "-o", "json")
+}
+
 // helmStatusOutput is a deliberately partial parse of `helm status -o json`,
 // matching the podStatusList idiom elsewhere in observe: unknown fields are
 // ignored so a helm version's extra output does not break observe. Config is
@@ -57,21 +74,34 @@ type helmStatusOutput struct {
 	Info      struct {
 		Status string `json:"status"`
 	} `json:"info"`
-	Chart struct {
-		Metadata struct {
-			Name       string `json:"name"`
-			Version    string `json:"version"`
-			AppVersion string `json:"appVersion"`
-		} `json:"metadata"`
-	} `json:"chart"`
 	Config map[string]interface{} `json:"config"`
+}
+
+// helmListEntry is a deliberately partial parse of one `helm list -o json`
+// entry: chart (rendered as "<name>-<version>") and app_version are the
+// fields helmStatusOutput cannot carry (see observeHelmListArgs).
+type helmListEntry struct {
+	Chart      string `json:"chart"`
+	AppVersion string `json:"app_version"`
+}
+
+// helmChartNameVersionPattern splits a `helm list` chart string such as
+// "erun-devops-1.0.206" into its name and semver-shaped version.
+var helmChartNameVersionPattern = regexp.MustCompile(`^(.+)-(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.]+)*)$`)
+
+func splitHelmChartNameVersion(chart string) (name, version string, ok bool) {
+	match := helmChartNameVersionPattern.FindStringSubmatch(chart)
+	if match == nil {
+		return "", "", false
+	}
+	return match[1], match[2], true
 }
 
 // fetchObservedHelmRelease reads the runtime release's status. A missing
 // release and a failed read are both reported as Found: false, distinguished
 // by Error: a missing release means "confirmed nothing deployed", a non-empty
 // Error means "could not tell" plus what to do about it.
-func fetchObservedHelmRelease(args []string, releaseName, namespace string) *ObservedHelmRelease {
+func fetchObservedHelmRelease(args, listArgs []string, releaseName, namespace string) *ObservedHelmRelease {
 	raw, stderr, err := runObserveHelm(args)
 	if err != nil {
 		if isHelmReleaseNotFound(stderr) {
@@ -84,22 +114,68 @@ func fetchObservedHelmRelease(args []string, releaseName, namespace string) *Obs
 		return &ObservedHelmRelease{Name: releaseName, Error: fmt.Sprintf("observe: could not parse helm status for release %q: %v", releaseName, jsonErr)}
 	}
 	release := &ObservedHelmRelease{
-		Name:         status.Name,
-		Found:        true,
-		Revision:     status.Version,
-		Status:       status.Info.Status,
-		Chart:        status.Chart.Metadata.Name,
-		ChartVersion: status.Chart.Metadata.Version,
-		AppVersion:   status.Chart.Metadata.AppVersion,
+		Name:     status.Name,
+		Found:    true,
+		Revision: status.Version,
+		Status:   status.Info.Status,
 	}
 	if overrides := findNestedStringMap(status.Config, "imageOverrides"); overrides != nil {
 		release.ImageOverrides = overrides
 	}
 	release.RuntimePod = findRuntimePodResourceLimits(status.Config)
+	populateObservedChartFields(release, listArgs, releaseName, namespace)
 	if release.Chart != "" && !strings.Contains(strings.ToLower(release.Chart), "devops") {
-		release.Error = fmt.Sprintf("release %q's chart is %q, which does not look like an erun runtime chart (expected one named like %q) — verify with 'helm get chart %s'", release.Name, release.Chart, DevopsComponentName, release.Name)
+		release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("release %q's chart is %q, which does not look like an erun runtime chart (expected one named like %q) — verify with 'helm get chart %s'", release.Name, release.Chart, DevopsComponentName, release.Name))
 	}
 	return release
+}
+
+// populateObservedChartFields fills Chart/ChartVersion/AppVersion from `helm
+// list`, the only one of observe's two helm reads that carries them. When
+// that read genuinely cannot resolve them, it appends to release.Error
+// instead of leaving Chart/ChartVersion/AppVersion at their zero value: an
+// empty string there must never be read as "the release has no chart" when
+// the truth is "observe could not look" — the same hazard Found/Error already
+// guards against for the release as a whole.
+func populateObservedChartFields(release *ObservedHelmRelease, listArgs []string, releaseName, namespace string) {
+	raw, stderr, err := runObserveHelm(listArgs)
+	if err != nil {
+		release.Error = appendObserveHelmReleaseError(release.Error, "could not determine chart/appVersion: "+observeHelmReadErrorMessage(releaseName, namespace, stderr, err))
+		return
+	}
+	var entries []helmListEntry
+	if jsonErr := json.Unmarshal(raw, &entries); jsonErr != nil {
+		release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("observe: could not parse helm list output for release %q: %v", releaseName, jsonErr))
+		return
+	}
+	if len(entries) == 0 {
+		release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("helm status found release %q but helm list did not — chart/appVersion could not be determined", releaseName))
+		return
+	}
+	entry := entries[0]
+	release.AppVersion = entry.AppVersion
+	switch {
+	case entry.Chart == "":
+		release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("helm list returned an empty chart field for release %q — chart/chartVersion could not be determined", releaseName))
+	default:
+		if name, version, ok := splitHelmChartNameVersion(entry.Chart); ok {
+			release.Chart = name
+			release.ChartVersion = version
+		} else {
+			release.Chart = entry.Chart
+			release.Error = appendObserveHelmReleaseError(release.Error, fmt.Sprintf("could not separate release %q's chart name from its version in %q — showing the combined value as chart", releaseName, entry.Chart))
+		}
+	}
+}
+
+func appendObserveHelmReleaseError(existing, addition string) string {
+	if addition == "" {
+		return existing
+	}
+	if existing == "" {
+		return addition
+	}
+	return existing + "; " + addition
 }
 
 // runObserveHelm runs a read-only `helm` invocation, matching

--- a/erun-common/observe_helm_release_test.go
+++ b/erun-common/observe_helm_release_test.go
@@ -1,0 +1,97 @@
+package eruncommon
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeHelmObserveStub points ERUN_HELM_BIN at a script that dispatches on
+// the subcommand (status vs list), so a test can drive
+// fetchObservedHelmRelease against the real, distinct shapes `helm status
+// -o json` and `helm list -o json` return without a live cluster.
+func writeHelmObserveStub(t *testing.T, statusStdout, listStdout string, exitCode int, stderr string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/helm-stub"
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  status)\n" +
+		"    cat <<'ERUN_TEST_HELM_STATUS'\n" + statusStdout + "\nERUN_TEST_HELM_STATUS\n" +
+		"    ;;\n" +
+		"  list)\n" +
+		"    cat <<'ERUN_TEST_HELM_LIST'\n" + listStdout + "\nERUN_TEST_HELM_LIST\n" +
+		"    ;;\n" +
+		"esac\n"
+	if stderr != "" {
+		script += "cat <<'ERUN_TEST_HELM_STDERR' >&2\n" + stderr + "\nERUN_TEST_HELM_STDERR\n"
+	}
+	script += "exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+	t.Setenv("ERUN_HELM_BIN", path)
+}
+
+// TestFetchObservedHelmReleaseReadsChartFromHelmList locks the parse layer
+// against the real shapes captured from a live cluster: `helm status -o
+// json`'s top-level keys are exactly apply_method/config/info/manifest/
+// name/namespace/version — no "chart" key at all — while `helm list -o
+// json` carries chart ("erun-devops-1.0.206") and app_version ("1.0.206").
+// A golden-file test that only renders an already-parsed ObservedHelmRelease
+// would never catch a bug in this parse step; this test feeds the parser the
+// actual JSON text helm emits.
+func TestFetchObservedHelmReleaseReadsChartFromHelmList(t *testing.T) {
+	statusStdout := `{"name":"erun-devops","namespace":"erun-ux","version":675,` +
+		`"info":{"status":"deployed"},"config":{},"manifest":"","apply_method":"helm"}`
+	listStdout := `[{"name":"erun-devops","namespace":"erun-ux","revision":"675",` +
+		`"updated":"2026-08-28 15:57:27.098572 +0300 +0300","status":"deployed",` +
+		`"chart":"erun-devops-1.0.206","app_version":"1.0.206"}]`
+	writeHelmObserveStub(t, statusStdout, listStdout, 0, "")
+
+	release := fetchObservedHelmRelease([]string{"status", "erun-devops"}, []string{"list"}, "erun-devops", "erun-ux")
+
+	if !release.Found {
+		t.Fatalf("expected release to be found")
+	}
+	if release.Error != "" {
+		t.Fatalf("expected no error, got %q", release.Error)
+	}
+	if release.Chart != "erun-devops" {
+		t.Fatalf("Chart = %q, want %q", release.Chart, "erun-devops")
+	}
+	if release.ChartVersion != "1.0.206" {
+		t.Fatalf("ChartVersion = %q, want %q", release.ChartVersion, "1.0.206")
+	}
+	if release.AppVersion != "1.0.206" {
+		t.Fatalf("AppVersion = %q, want %q", release.AppVersion, "1.0.206")
+	}
+}
+
+// TestFetchObservedHelmReleaseChartUnreadableReportsError is the bug this
+// test file exists to prevent regressing: when helm list cannot resolve
+// chart/appVersion (here, it returns no matching entry even though helm
+// status found the release), Chart/ChartVersion/AppVersion must stay empty
+// and Error must say so — never render the empty string as if it were a
+// real "no chart" reading.
+func TestFetchObservedHelmReleaseChartUnreadableReportsError(t *testing.T) {
+	statusStdout := `{"name":"erun-devops","namespace":"erun-ux","version":675,"info":{"status":"deployed"},"config":{}}`
+	writeHelmObserveStub(t, statusStdout, "[]", 0, "")
+
+	release := fetchObservedHelmRelease([]string{"status", "erun-devops"}, []string{"list"}, "erun-devops", "erun-ux")
+
+	if !release.Found {
+		t.Fatalf("expected release to be found (helm status succeeded)")
+	}
+	if release.Chart != "" || release.ChartVersion != "" || release.AppVersion != "" {
+		t.Fatalf("expected chart fields to stay empty when unreadable, got Chart=%q ChartVersion=%q AppVersion=%q",
+			release.Chart, release.ChartVersion, release.AppVersion)
+	}
+	if release.Error == "" {
+		t.Fatalf("expected a non-empty Error explaining chart/appVersion could not be determined")
+	}
+	if !strings.Contains(release.Error, "could not be determined") {
+		t.Fatalf("Error must explain the field could not be read, got %q", release.Error)
+	}
+}

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -1387,6 +1387,30 @@ func StubKubectlGetJSON(t testing.TB, dir string, responses map[string]string) s
 	return StubBinaryWithScript(t, dir, "kubectl", body.String())
 }
 
+// StubHelmObserve writes a helm stub that dispatches on the subcommand
+// (status or list) to return statusStdout or listStdout, for observe's two
+// distinct real read-only helm calls in one run: `helm status -o json`, which
+// carries no chart metadata at all, and `helm list -o json`, which is where
+// observe actually reads chart/appVersion (see fetchObservedHelmRelease). A
+// call to any other subcommand exits 1 naming the unstubbed argv.
+func StubHelmObserve(t testing.TB, dir, statusStdout, listStdout string) string {
+	t.Helper()
+	body := "case \"$1\" in\n" +
+		"  status)\n" +
+		"    cat <<'ERUN_STUB_HELM_STATUS'\n" +
+		strings.TrimRight(statusStdout, "\n") + "\n" +
+		"ERUN_STUB_HELM_STATUS\n" +
+		"    ;;\n" +
+		"  list)\n" +
+		"    cat <<'ERUN_STUB_HELM_LIST'\n" +
+		strings.TrimRight(listStdout, "\n") + "\n" +
+		"ERUN_STUB_HELM_LIST\n" +
+		"    ;;\n" +
+		"  *) echo \"unstubbed helm call: $*\" >&2; exit 1 ;;\n" +
+		"esac\n"
+	return StubBinaryWithScript(t, dir, "helm", body)
+}
+
 // StubBinaryMergingIntoRemoteOnce writes a stub for name that, on its first
 // invocation only, commits and pushes one commit from repoDir onto origin's
 // branch, then exits 0 like a plain stub. It stands in for a pull request

--- a/erun-integration/observe_test.go
+++ b/erun-integration/observe_test.go
@@ -36,12 +36,26 @@ func observeStubResponses() map[string]string {
 // release that agrees in every field with observeStubResponses' pod and with
 // SeedTenantEnv's recorded runtimeversion (1.0.0) and default runtimepod
 // (DefaultRuntimePodCPU/Memory), so scenarios built on it report no drift
-// unless they deliberately mutate one side.
+// unless they deliberately mutate one side. It carries no "chart" key at all,
+// matching real `helm status -o json` output exactly (see
+// fetchObservedHelmRelease's doc comment) rather than the shape a caller
+// might assume it has.
 func observeHelmStatusStub() string {
 	return `{"name":"team-devops","namespace":"team-dev","version":3,"info":{"status":"deployed"},` +
-		`"chart":{"metadata":{"name":"erun-devops","version":"1.0.0","appVersion":"1.0.0"}},` +
 		`"config":{"imageOverrides":{"erun-devops":"registry.example/test/erun-devops:1.0.0"},` +
 		`"runtime":{"resources":{"limits":{"cpu":"4","memory":"8916Mi"}}}}}`
+}
+
+// observeHelmListStub is a `helm list -o json` body for the "team-devops"
+// release: the one real helm read that carries chart and app_version.
+func observeHelmListStub(chart, appVersion string) string {
+	return `[{"name":"team-devops","namespace":"team-dev","chart":"` + chart + `","app_version":"` + appVersion + `"}]`
+}
+
+// observeHelmListStubDefault is observeHelmListStub for the "erun-devops"
+// chart at the version observeHelmStatusStub/SeedTenantEnv agree on.
+func observeHelmListStubDefault() string {
+	return observeHelmListStub("erun-devops-1.0.0", "1.0.0")
 }
 
 func TestObserve(t *testing.T) {
@@ -105,7 +119,7 @@ func TestObserve(t *testing.T) {
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubKubectlGetJSON(t, stubs, observeStubResponses())
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: observeHelmStatusStub()})
+		fixture.StubHelmObserve(t, stubs, observeHelmStatusStub(), observeHelmListStubDefault())
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -121,7 +135,7 @@ func TestObserve(t *testing.T) {
 		responses := observeStubResponses()
 		responses["secret db-credentials"] = `{"data":{"password":"c2VjcmV0"}}`
 		fixture.StubKubectlGetJSON(t, stubs, responses)
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: observeHelmStatusStub()})
+		fixture.StubHelmObserve(t, stubs, observeHelmStatusStub(), observeHelmListStubDefault())
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe", "--secret", "db-credentials=password", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -139,7 +153,7 @@ func TestObserve(t *testing.T) {
 		responses := observeStubResponses()
 		responses["secret db-credentials"] = `{"data":{"password":"c2VjcmV0"}}`
 		fixture.StubKubectlGetJSON(t, stubs, responses)
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: observeHelmStatusStub()})
+		fixture.StubHelmObserve(t, stubs, observeHelmStatusStub(), observeHelmListStubDefault())
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe", "--secret", "db-credentials=other-key", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -160,7 +174,7 @@ func TestObserve(t *testing.T) {
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubKubectlGetJSON(t, stubs, observeStubResponses())
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: observeHelmStatusStub()})
+		fixture.StubHelmObserve(t, stubs, observeHelmStatusStub(), observeHelmListStubDefault())
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -185,11 +199,10 @@ func TestObserve(t *testing.T) {
 		// found by hand with kubectl/helm.
 		responses["pods"] = `{"items":[{"metadata":{"name":"team-devops-abc123"},"spec":{"containers":[{"name":"erun-devops","resources":{"limits":{"cpu":"4","memory":"8916Mi"}}}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}],"containerStatuses":[{"name":"erun-devops","image":"10.43.0.100:5000/sophium/erun-devops:1.0.0-tini","restartCount":0,"ready":true,"state":{"running":{"startedAt":"2024-01-01T00:00:00Z"}}}]}}]}`
 		fixture.StubKubectlGetJSON(t, stubs, responses)
-		releaseStub := `{"name":"team-devops","namespace":"team-dev","version":5,"info":{"status":"deployed"},` +
-			`"chart":{"metadata":{"name":"erun-devops","version":"1.0.202","appVersion":"1.0.202"}},` +
+		statusStub := `{"name":"team-devops","namespace":"team-dev","version":5,"info":{"status":"deployed"},` +
 			`"config":{"imageOverrides":{"erun-devops":"registry.example/test/erun-devops:1.0.0"},` +
 			`"runtime":{"resources":{"limits":{"cpu":"8","memory":"16384Mi"}}}}}`
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: releaseStub})
+		fixture.StubHelmObserve(t, stubs, statusStub, observeHelmListStub("erun-devops-1.0.202", "1.0.202"))
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -247,9 +260,8 @@ func TestObserve(t *testing.T) {
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubKubectlGetJSON(t, stubs, observeStubResponses())
-		releaseStub := `{"name":"team-devops","namespace":"team-dev","version":1,"info":{"status":"deployed"},` +
-			`"chart":{"metadata":{"name":"unrelated-app","version":"2.3.0","appVersion":"2.3.0"}},"config":{}}`
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: releaseStub})
+		statusStub := `{"name":"team-devops","namespace":"team-dev","version":1,"info":{"status":"deployed"},"config":{}}`
+		fixture.StubHelmObserve(t, stubs, statusStub, observeHelmListStub("unrelated-app-2.3.0", "2.3.0"))
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {
@@ -266,9 +278,8 @@ func TestObserve(t *testing.T) {
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		stubs := setup.Cwd + "/stubs"
 		fixture.StubKubectlGetJSON(t, stubs, observeStubResponses())
-		releaseStub := `{"name":"team-devops","namespace":"team-dev","version":1,"info":{"status":"deployed"},` +
-			`"chart":{"metadata":{"name":"unrelated-app","version":"2.3.0","appVersion":"2.3.0"}},"config":{}}`
-		fixture.StubBinaryAdvanced(t, stubs, "helm", fixture.StubBinarySpec{Stdout: releaseStub})
+		statusStub := `{"name":"team-devops","namespace":"team-dev","version":1,"info":{"status":"deployed"},"config":{}}`
+		fixture.StubHelmObserve(t, stubs, statusStub, observeHelmListStub("unrelated-app-2.3.0", "2.3.0"))
 		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
 		result := erun.Run(t, []string{"observe", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if result.ExitCode != 0 {

--- a/erun-integration/testdata/observe/dry_run.txt
+++ b/erun-integration/testdata/observe/dry_run.txt
@@ -5,4 +5,5 @@ kubectl --context test-context --namespace team-dev get limitrange -o json
 kubectl --context test-context --namespace team-dev get ingress -o json
 kubectl --context test-context --namespace team-dev get certificates.cert-manager.io -o json
 helm status team-devops --namespace team-dev --kube-context test-context -o json
+helm list --filter '^team-devops$' --namespace team-dev --kube-context test-context -o json
 observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason

--- a/erun-integration/testdata/observe/dry_run_with_secret.txt
+++ b/erun-integration/testdata/observe/dry_run_with_secret.txt
@@ -5,5 +5,6 @@ kubectl --context test-context --namespace team-dev get limitrange -o json
 kubectl --context test-context --namespace team-dev get ingress -o json
 kubectl --context test-context --namespace team-dev get certificates.cert-manager.io -o json
 helm status team-devops --namespace team-dev --kube-context test-context -o json
+helm list --filter '^team-devops$' --namespace team-dev --kube-context test-context -o json
 observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason
 kubectl --context test-context --namespace team-dev get secret db-credentials -o json


### PR DESCRIPTION
## Summary

- `helm status <release> -o json`'s top-level keys are exactly `apply_method`, `config`, `info`, `manifest`, `name`, `namespace`, `version` — no `chart` key at all. `ObservedHelmRelease.Chart`/`ChartVersion`/`AppVersion` therefore always parsed as absent and rendered as the Go zero value, which `erun observe`'s text output then printed as `chart none-none, appVersion none` — indistinguishable from real data.
- `helm list -o json` does carry `chart` (rendered as `"<name>-<version>"`) and `app_version`. Observe now issues a second read-only helm call, filtered to the exact release name (`helm list --filter '^<release>$'`), and reads chart/appVersion from there.
- Per the existing `ObservedHelmRelease.Found`/`Error` convention, when the chart fields genuinely cannot be resolved (the list call fails, returns no matching entry, or its `chart` field can't be split into name+version), `Chart`/`ChartVersion`/`AppVersion` stay empty and `Error` explains why — never a silent zero value read as a reading.
- Verified end-to-end against a live cluster (erun/ux, revision 675): before the fix, `erun observe` printed `chart none-none, appVersion none`; after, it prints `chart erun-devops-1.0.206, appVersion 1.0.206`, matching `helm list`'s real values exactly. Drift detection (which depends on `AppVersion`) continues to work correctly.

## Field audit (per the issue's ask)

Audited every field on `ObservedHelmRelease` for the same "zero value rendered as data" hazard:
- `Chart`/`ChartVersion`/`AppVersion` — the bug fixed here.
- `Revision`/`Status` — sourced correctly from `helm status` (already correct in the original bug report: "revision 675, status deployed").
- `ImageOverrides`/`RuntimePod` — safe by construction: the CLI renderer only prints these lines when they're non-empty/non-zero, so an unset value is omitted rather than shown as fake data.

## Test gap addressed

`make check` was green before this fix because the golden-file tests asserted the rendering of an already-parsed `ObservedHelmRelease` struct and never exercised real `helm status`/`helm list` JSON text. Fixed two ways:
- Added `erun-common/observe_helm_release_test.go`, which feeds `fetchObservedHelmRelease` the literal JSON shapes captured from the live cluster (no `chart` key in `helm status`, `chart`/`app_version` in `helm list`) and asserts the fields resolve — plus a case where `helm list` can't resolve them, asserting `Error` is set and fields stay empty.
- The integration suite's `helm` stub previously baked a synthetic `"chart":{"metadata":{...}}}` key into its `helm status -o json` response — a shape real `helm status` never produces. Added `fixture.StubHelmObserve` (dispatches on the `status`/`list` subcommand, mirroring `StubKubectlGetJSON`'s dispatch pattern) and updated `erun-integration/observe_test.go`'s scenarios to stub each helm call with its real, distinct shape.

## Why this stays read-only

`erun observe`'s whole safety property is that it can never mutate anything — that's what lets an orchestrator that must never use `exec raw` be granted it safely. `helm list` is exactly as read-only as the existing `helm status` call (both just read release storage); the new call is filtered to the runtime release's exact name, traced in `--dry-run` like every other observe call, and does not use `--all-namespaces` or any writing flag.

Closes #1535

## Test plan

- [x] `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`, `erun-integration`
- [x] `make check` green (lint, unit/integration tests, coverage gate 76.3% ≥ 75.8%)
- [x] `erun observe --tenant erun --environment ux` against the live cluster prints the real chart/appVersion (verified above)