### PR TITLE
Add a structural gate against issue references in code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,21 @@ test-erun-ui:
 # dependency `yarn install`'s package-registry fetch does not already impose
 # on this gate. Run it locally before a PR that touches a shadcn primitive
 # (see erun-kit/AGENTS.md); it is not re-verified on every image build.
+#
+# The issue-reference gate runs here rather than as a per-package ESLint
+# rule: scripts/check-issue-references.mjs is the TypeScript-side twin of
+# erun-integration/issue_reference_test.go (see that file's header), and one
+# script scanning all three source roots in a single pass gives it the same
+# repo-wide shrink-only baseline the Go gate uses, which a rule duplicated
+# across three separate flat configs could not do on its own. It needs only
+# the `typescript` package this step's own `yarn install` already resolves,
+# not each package's full type-aware lint setup.
 test-frontend:
 	@echo ">> yarn install (root workspace: erun-kit, erun-console, erun-ui/frontend)"
 	@yarn install --frozen-lockfile
+	@echo ">> issue-reference gate (erun-kit, erun-ui/frontend, erun-console)"
+	@node --test scripts/check-issue-references.test.mjs
+	@node scripts/check-issue-references.mjs erun-kit/src erun-ui/frontend/src erun-console/src
 	@echo ">> erun-kit gates"
 	@(cd erun-kit && yarn typecheck && yarn lint && yarn format:check && yarn build)
 	@echo ">> erun-console gates"

--- a/erun-integration/bare_required_input_test.go
+++ b/erun-integration/bare_required_input_test.go
@@ -62,9 +62,9 @@ var bareRequiredInputPattern = regexp.MustCompile(`^(?:tenant|environment)(?: an
 // pattern above newly caught: 65 pre-existing call sites across erun-cli,
 // erun-common, and erun-ui, none of them reachable from the exec_agent bug
 // this gate change was made for. Rewriting all of them to name their own
-// operation and recovery is a distinct, large effort of its own (tracked at
-// https://github.com/sophium/erun/issues/1506), not something to rush inline
-// with a one-tool schema fix. This baseline may only shrink: fixing a site
+// operation and recovery is a distinct, large effort of its own (tracked in
+// a separate GitHub issue), not something to rush inline with a one-tool
+// schema fix. This baseline may only shrink: fixing a site
 // and forgetting to remove its entry here fails TestBareRequiredInputBaselineIsCurrent
 // below, the same way a stale KnownUnsurfacedRoutes entry fails its own gate.
 // The key is the file path relative to the repo root; the value is the exact

--- a/erun-integration/issue_reference_test.go
+++ b/erun-integration/issue_reference_test.go
@@ -1,0 +1,522 @@
+package integration
+
+// issue_reference_test.go is a repo-state structural gate for root
+// AGENTS.md § "Code Comments", which asks that a tracker reference never
+// reach a comment because provenance lives in the git history (git blame),
+// not the source. Eleven separate agent lanes wrote a tracker reference into a
+// comment or a subtest name in one session, every one of them given that
+// rule verbatim in its prompt, because the rule lived only in a prompt: it
+// depended on every dispatcher restating it and every author following it.
+// This is the structural fix, the same shape as bare_required_input_test.go
+// and desktop_surface_test.go: an AST walk that fails the build the next
+// time the defect reappears, rather than another instruction to ignore.
+//
+// A prior gate for a different defect class was written against two exact
+// literal phrasings and was walked through by a third phrasing within
+// hours (see bare_required_input_test.go's own history). issueReferencePattern
+// below is written against the *shape* of a tracker reference instead: a
+// bare "#" followed by digits, an "issue #" prefix, an "owner/repo#" cross-
+// repo form, or a full GitHub issue/pull URL -- so a new prefix word or a
+// different repo does not slip past it the way a fixed string would.
+//
+// Scope is deliberately narrow: comments, function/method declaration names,
+// and t.Run/b.Run subtest names -- "comments... and test names" is the
+// defect this was filed for. An arbitrary string literal (a t.Errorf/t.Skip
+// diagnostic message, a user-facing error string) is not scanned; those are
+// runtime output, not source documentation, and a blanket string-literal
+// scan would flag legitimate content (a URL quoted in a fixture, a golden
+// value) far more often than it would catch a real instance of this defect.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// issueReferencePattern matches a GitHub issue/PR reference by shape, not by
+// one fixed phrasing:
+//   - a bare hash sign directly followed by a number
+//   - the word "issue" (any case) before a hash-number, whitespace-tolerant
+//   - a cross-repo "owner/repo" path directly followed by a hash-number
+//   - a full GitHub issue or pull-request URL ("github.com/<owner>/<repo>/issues/<n>"
+//     or ".../pull/<n>")
+//
+// The bare hash-number alternative is intentionally the widest of the four:
+// it is what actually catches a new prefix wording this pattern was never
+// told about, at the cost of also matching a rare non-issue use of "#" next
+// to digits (e.g. a numeric hex color in a comment). That tradeoff mirrors
+// bareRequiredInputPattern's own "generalize the shape, accept the rare
+// coincidental match" choice, because the alternative -- enumerating
+// phrasings -- is the exact failure this gate exists to not repeat.
+var issueReferencePattern = regexp.MustCompile(`(?i)issue\s*#\s*\d+|[\w][\w.-]*/[\w][\w.-]*#\d+|(?:^|[^\w#])(#\d{2,6})\b|github\.com/[\w.-]+/[\w.-]+/(?:issues|pull)/\d+`)
+
+// matchIssueReference returns the offending substring issueReferencePattern
+// matched in text, or "" if it did not match. The bare hash-number
+// alternative above must consume the character before the "#" to enforce a
+// word boundary (RE2 has no lookbehind), so it captures just the "#NNN"
+// portion in group 1; every other alternative's own match is already exactly
+// the reference text, so group 1 being empty falls back to the whole match.
+func matchIssueReference(text string) string {
+	m := issueReferencePattern.FindStringSubmatch(text)
+	if m == nil {
+		return ""
+	}
+	if m[1] != "" {
+		return m[1]
+	}
+	return m[0]
+}
+
+// issueReferenceIdentPattern matches the identifier-shape variant of the
+// same defect: a function or method name that spells out "issue" next to a
+// number (e.g. a test named TestIssue1470Regression). Go identifiers cannot
+// contain "#" or "/", so the bare-hash and URL shapes above do not apply
+// here; a plain number embedded in a name (e.g. Test1470) is not enough on
+// its own to flag; too many legitimately numbered identifiers exist for
+// that to be a useful signal. Requiring the word "issue" keeps this to the
+// same "this identifier literally names a tracker reference" shape.
+var issueReferenceIdentPattern = regexp.MustCompile(`(?i)issue[_]?\d{2,6}`)
+
+// skipDirForIssueReferenceScan excludes directories that hold no
+// hand-written production or test Go source: version control, installed JS
+// dependencies, generated/vendored trees, and per-command golden fixtures
+// (testdata/ captures real command output, which may legitimately include
+// operator-authored text containing a "#"; it holds no .go source of its
+// own in this repo today, but is excluded on principle rather than by
+// accident of the current tree).
+func skipDirForIssueReferenceScan(name string) bool {
+	switch name {
+	case ".git", "node_modules", "vendor", "dist", "wailsjs", ".claude", ".claude-plugin", ".vscode", "testdata":
+		return true
+	default:
+		return false
+	}
+}
+
+// issueReferenceHit is one tracker reference found in Go source.
+type issueReferenceHit struct {
+	position string
+	file     string // path relative to the scan root, forward-slash separated
+	kind     string // "comment", "function name", or "subtest name"
+	value    string
+}
+
+func (h issueReferenceHit) Message() string {
+	return fmt.Sprintf("%s: %s contains a tracker reference %q -- issue references belong in the PR body, not in code (root AGENTS.md § \"Code Comments\")", h.position, h.kind, h.value)
+}
+
+// findIssueReferenceHits parses every .go file under root (production and
+// test files alike -- test names are an explicit target of this gate) and
+// returns one hit per comment matching issueReferencePattern, per function
+// or method declaration matching issueReferenceIdentPattern, and per
+// t.Run/b.Run subtest name literal matching issueReferencePattern.
+// AST-based rather than a text grep so a match inside an unrelated string
+// literal (a t.Errorf message, a golden value) does not fail the gate --
+// only source that is genuinely a comment, a declared name, or a subtest
+// title counts.
+func findIssueReferenceHits(t testing.TB, root string) []issueReferenceHit {
+	t.Helper()
+	var hits []issueReferenceHit
+	fset := token.NewFileSet()
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if path != root && skipDirForIssueReferenceScan(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return fmt.Errorf("parse %s: %w", path, parseErr)
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return fmt.Errorf("relativize %s: %w", path, relErr)
+		}
+		rel = filepath.ToSlash(rel)
+
+		for _, cg := range file.Comments {
+			for _, c := range cg.List {
+				if m := matchIssueReference(c.Text); m != "" {
+					hits = append(hits, issueReferenceHit{
+						position: fset.Position(c.Pos()).String(),
+						file:     rel,
+						kind:     "comment",
+						value:    m,
+					})
+				}
+			}
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.FuncDecl:
+				if issueReferenceIdentPattern.MatchString(node.Name.Name) {
+					hits = append(hits, issueReferenceHit{
+						position: fset.Position(node.Name.Pos()).String(),
+						file:     rel,
+						kind:     "function name",
+						value:    node.Name.Name,
+					})
+				}
+			case *ast.CallExpr:
+				sel, ok := node.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Run" || len(node.Args) == 0 {
+					return true
+				}
+				lit, ok := node.Args[0].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				value, unquoteErr := strconv.Unquote(lit.Value)
+				if unquoteErr != nil {
+					return true
+				}
+				if m := matchIssueReference(value); m != "" {
+					hits = append(hits, issueReferenceHit{
+						position: fset.Position(lit.Pos()).String(),
+						file:     rel,
+						kind:     "subtest name",
+						value:    m,
+					})
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan repo for issue reference hits: %v", err)
+	}
+	return hits
+}
+
+// issueReferenceBaseline is a shrink-only baseline (the same pattern as
+// bareRequiredInputBaseline above and KnownUnsurfacedRoutes in
+// erun-backend-api/internal/routes/route_audit.go) for the pre-existing
+// tracker references this gate found on adoption: 345 hits across 145
+// files, almost all of them explanatory comments written before this rule
+// was enforceable structurally. Rewriting all of them is a distinct, large
+// cleanup with no behavior change of its own, not something to rush inline
+// with the gate that now prevents new ones. This baseline may only shrink:
+// fixing a site and forgetting to remove its entry here fails
+// TestIssueReferenceBaselineIsCurrent below, the same way a stale
+// KnownUnsurfacedRoutes entry fails its own gate. The key is the file path
+// relative to the repo root; the value is the exact count of matching hits
+// still in that file.
+var issueReferenceBaseline = map[string]int{
+	"erun-backend/erun-backend-api/cmd/eapi/main.go":                                2,
+	"erun-backend/erun-backend-api/comments_e2e_test.go":                            1,
+	"erun-backend/erun-backend-api/env_deploy_e2e_test.go":                          2,
+	"erun-backend/erun-backend-api/environment_delete_e2e_test.go":                  4,
+	"erun-backend/erun-backend-api/env_provisioner_rbac_e2e_test.go":                8,
+	"erun-backend/erun-backend-api/internal/deployexec/job.go":                      4,
+	"erun-backend/erun-backend-api/internal/deployexec/job_test.go":                 1,
+	"erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go":            4,
+	"erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go":       1,
+	"erun-backend/erun-backend-api/internal/deployexec/placement.go":                3,
+	"erun-backend/erun-backend-api/internal/deployexec/placement_test.go":           1,
+	"erun-backend/erun-backend-api/internal/mergeexec/job_test.go":                  1,
+	"erun-backend/erun-backend-api/internal/model/context.go":                       1,
+	"erun-backend/erun-backend-api/internal/model/environment.go":                   3,
+	"erun-backend/erun-backend-api/internal/model/invite.go":                        1,
+	"erun-backend/erun-backend-api/internal/model/tenant_quota.go":                  1,
+	"erun-backend/erun-backend-api/internal/model/usage_event.go":                   1,
+	"erun-backend/erun-backend-api/internal/provision/delete.go":                    2,
+	"erun-backend/erun-backend-api/internal/provision/delete_reconciler.go":         6,
+	"erun-backend/erun-backend-api/internal/provision/delete_reconciler_test.go":    4,
+	"erun-backend/erun-backend-api/internal/provision/environments.go":              1,
+	"erun-backend/erun-backend-api/internal/provision/environments_test.go":         1,
+	"erun-backend/erun-backend-api/internal/provision/lifecycle.go":                 6,
+	"erun-backend/erun-backend-api/internal/provision/lifecycle_test.go":            4,
+	"erun-backend/erun-backend-api/internal/provision/registry_credentials_test.go": 1,
+	"erun-backend/erun-backend-api/internal/repository/environments.go":             14,
+	"erun-backend/erun-backend-api/internal/repository/invites_e2e_test.go":         3,
+	"erun-backend/erun-backend-api/internal/repository/invites.go":                  1,
+	"erun-backend/erun-backend-api/internal/repository/reviews_e2e_test.go":         1,
+	"erun-backend/erun-backend-api/internal/repository/tenant_quotas.go":            3,
+	"erun-backend/erun-backend-api/internal/repository/tenant_quotas_test.go":       3,
+	"erun-backend/erun-backend-api/internal/routes/config_test.go":                  3,
+	"erun-backend/erun-backend-api/internal/routes/contexts.go":                     1,
+	"erun-backend/erun-backend-api/internal/routes/contexts_test.go":                1,
+	"erun-backend/erun-backend-api/internal/routes/environments.go":                 21,
+	"erun-backend/erun-backend-api/internal/routes/environments_test.go":            13,
+	"erun-backend/erun-backend-api/internal/routes/identity.go":                     5,
+	"erun-backend/erun-backend-api/internal/routes/identity_test.go":                4,
+	"erun-backend/erun-backend-api/internal/routes/invites.go":                      4,
+	"erun-backend/erun-backend-api/internal/routes/invites_test.go":                 2,
+	"erun-backend/erun-backend-api/internal/routes/provision.go":                    3,
+	"erun-backend/erun-backend-api/internal/routes/tenant_quotas.go":                2,
+	"erun-backend/erun-backend-api/internal/routes/tenant_quotas_test.go":           1,
+	"erun-backend/erun-backend-api/internal/service/environments.go":                3,
+	"erun-backend/erun-backend-api/internal/service/environments_test.go":           3,
+	"erun-backend/erun-backend-api/internal/service/identity.go":                    2,
+	"erun-backend/erun-backend-api/internal/service/identity_test.go":               1,
+	"erun-backend/erun-backend-api/internal/service/invites_test.go":                2,
+	"erun-backend/erun-backend-api/internal/zitadel/client_e2e_test.go":             2,
+	"erun-backend/erun-backend-api/internal/zitadel/client.go":                      1,
+	"erun-backend/erun-backend-api/internal/zitadel/client_test.go":                 1,
+	"erun-backend/erun-backend-api/internal/zitadel/policies_test.go":               1,
+	"erun-backend/erun-backend-api/internal/zitadel/smtp.go":                        2,
+	"erun-backend/erun-backend-api/merge_queue_e2e_test.go":                         1,
+	"erun-backend/erun-backend-api/registry_token_route_test.go":                    1,
+	"erun-backend/erun-backend-api/server.go":                                       8,
+	"erun-cli/cmd/doctor_host_credentials.go":                                       1,
+	"erun-cli/cmd/job.go":                                 1,
+	"erun-cli/cmd/mcp_proxy.go":                           2,
+	"erun-cli/cmd/review.go":                              1,
+	"erun-common/activity_lease_test.go":                  3,
+	"erun-common/build_run.go":                            1,
+	"erun-common/build_run_test.go":                       1,
+	"erun-common/cloud_erun_test.go":                      1,
+	"erun-common/deploy.go":                               1,
+	"erun-common/deploy_image_pull_secret.go":             1,
+	"erun-common/environment_type_test.go":                1,
+	"erun-common/ghcr_credential_preflight.go":            1,
+	"erun-common/ghcr_credential_preflight_test.go":       1,
+	"erun-common/hosted_registry_test.go":                 1,
+	"erun-common/init_remote.go":                          1,
+	"erun-common/job_supervisor.go":                       2,
+	"erun-common/job_test.go":                             1,
+	"erun-common/kubernetes_namespace_conditions_test.go": 1,
+	"erun-common/kubernetes_namespace.go":                 2,
+	"erun-common/kubernetes_resource_quota.go":            1,
+	"erun-common/kubernetes_resource_quota_test.go":       1,
+	"erun-common/mcp_capabilities.go":                     1,
+	"erun-common/mcp_reachability.go":                     1,
+	"erun-common/mcp_tools.go":                            5,
+	"erun-common/mcp_tools_test.go":                       1,
+	"erun-common/observe_drift.go":                        1,
+	"erun-common/platform_client.go":                      2,
+	"erun-common/platform_client_reviews.go":              1,
+	"erun-common/platform_commands.go":                    1,
+	"erun-common/published_devops_chart.go":               3,
+	"erun-common/published_devops_chart_test.go":          2,
+	"erun-common/runtime_resources.go":                    4,
+	"erun-common/runtime_usage.go":                        1,
+	"erun-common/runtime_usage_test.go":                   1,
+	"erun-common/upgrade_resolver_test.go":                6,
+	"erun-devops/dns01-webhook/solver.go":                 1,
+	"erun-devops/dns01-webhook/solver_test.go":            1,
+	"erun-integration/activity_test.go":                   1,
+	"erun-integration/build_test.go":                      1,
+	"erun-integration/delete_test.go":                     3,
+	"erun-integration/deploy_test.go":                     6,
+	"erun-integration/doctor_test.go":                     6,
+	"erun-integration/environment_half_scenarios_test.go": 5,
+	"erun-integration/exec_test.go":                       1,
+	"erun-integration/init_test.go":                       3,
+	"erun-integration/observe_test.go":                    5,
+	"erun-integration/push_test.go":                       8,
+	"erun-integration/release_test.go":                    3,
+	"erun-integration/usage_test.go":                      1,
+	"erun-integration/version_test.go":                    2,
+	"erun-mcp/agent.go":                                   1,
+	"erun-mcp/capabilities.go":                            1,
+	"erun-mcp/capabilities_test.go":                       1,
+	"erun-mcp/exec.go":                                    1,
+	"erun-mcp/job_envelope.go":                            1,
+	"erun-mcp/job_target_test.go":                         1,
+	"erun-mcp/mcp_overview_doc_test.go":                   1,
+	"erun-mcp/platform.go":                                1,
+	"erun-mcp/runtime.go":                                 1,
+	"erun-mcp/server.go":                                  5,
+	"erun-mcp/server_test.go":                             3,
+	"erun-mcp/tool_metadata_test.go":                      1,
+	"erun-ui/api_log_test.go":                             1,
+	"erun-ui/app_test.go":                                 5,
+	"erun-ui/config_handlers.go":                          1,
+	"erun-ui/env_ensure_test.go":                          2,
+	"erun-ui/environment_activity_observed_test.go":       1,
+	"erun-ui/host_open_path.go":                           1,
+	"erun-ui/host_open_path_test.go":                      1,
+	"erun-ui/mcp_errors.go":                               1,
+	"erun-ui/orchestrator.go":                             4,
+	"erun-ui/orchestrator_guidance_test.go":               1,
+	"erun-ui/orchestrator_mcp.go":                         2,
+	"erun-ui/orchestrator_mcp_test.go":                    2,
+	"erun-ui/orchestrator_pacing.go":                      1,
+	"erun-ui/orchestrator_pacing_test.go":                 1,
+	"erun-ui/orchestrator_role_file_test.go":              1,
+	"erun-ui/orchestrator_shell_activity.go":              1,
+	"erun-ui/orchestrator_shell_activity_test.go":         1,
+	"erun-ui/orchestrator_test.go":                        3,
+	"erun-ui/restart_control_test.go":                     1,
+	"erun-ui/session_heartbeat_test.go":                   1,
+	"erun-ui/tenant_dashboard.go":                         3,
+	"erun-ui/tenant_dashboard_test.go":                    1,
+	"erun-ui/tenant_review_detail.go":                     1,
+	"erun-ui/tenant_review_detail_test.go":                1,
+	"erun-ui/terminal_repaint_input_test.go":              4,
+	"erun-ui/terminal_sessions.go":                        3,
+	"erun-ui/ui_model.go":                                 2,
+}
+
+// TestNoIssueReferenceInCode fails when a tracker reference matching
+// issueReferencePattern or issueReferenceIdentPattern reappears in Go
+// source anywhere in the repo, beyond what issueReferenceBaseline already
+// carries for a given file. A file with no baseline entry gets zero
+// tolerance -- any hit there is a brand new instance of the bug. A file
+// with a baseline entry may not exceed it: that would be a new reference
+// added next to the pre-existing ones, not cleaning them up.
+func TestNoIssueReferenceInCode(t *testing.T) {
+	root := repoRoot(t)
+	counts := map[string]int{}
+	for _, hit := range findIssueReferenceHits(t, root) {
+		counts[hit.file]++
+		if counts[hit.file] > issueReferenceBaseline[hit.file] {
+			t.Errorf("%s", hit.Message())
+		}
+	}
+}
+
+// TestIssueReferenceBaselineIsCurrent fails when a baselined file's actual
+// hit count has dropped below what issueReferenceBaseline still claims --
+// the same shrink-only enforcement FindStaleBaselineEntries applies to
+// KnownUnsurfacedRoutes and TestBareRequiredInputBaselineIsCurrent applies
+// above. A cleanup that removes a reference without lowering its baseline
+// entry here would otherwise let the debt silently look larger than it is
+// forever.
+func TestIssueReferenceBaselineIsCurrent(t *testing.T) {
+	root := repoRoot(t)
+	counts := map[string]int{}
+	for _, hit := range findIssueReferenceHits(t, root) {
+		counts[hit.file]++
+	}
+	for file, baseline := range issueReferenceBaseline {
+		if actual := counts[file]; actual < baseline {
+			t.Errorf("%s: issueReferenceBaseline claims %d hit(s) but only %d remain -- lower the baseline entry", file, baseline, actual)
+		}
+	}
+}
+
+// TestFindIssueReferenceHitsExclusions locks the scope this scanner must
+// respect: a tracker reference inside a real comment is caught (including
+// inside a _test.go file, since test files are not excluded), a reference
+// inside a t.Run subtest name is caught, a reference inside an unrelated
+// string literal (a t.Errorf diagnostic) is not, and a markdown-style "#"
+// heading with no digit is not. Every reference value below is a
+// deliberately-constructed fixture using a number and repo name that do not
+// correspond to any real GitHub issue, written into a temp directory rather
+// than committed source.
+func TestFindIssueReferenceHitsExclusions(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"production.go": `package fixture
+
+// FIXTURE: deliberately-constructed violation for this test only.
+// see #9999's precedent for how this used to resolve.
+func doWork() error {
+	return nil
+}
+`,
+		"production_test.go": `package fixture
+
+import "testing"
+
+// FIXTURE: deliberately-constructed violation -- subtest names are in scope.
+func TestSomething(t *testing.T) {
+	t.Run("fixed in example-org/example-repo#9999", func(t *testing.T) {})
+}
+`,
+		"unrelated.go": `package fixture
+
+import "fmt"
+
+// A markdown-style heading inside a comment, not a tracker reference.
+// # Overview
+
+func errFatalMessage() error {
+	return fmt.Errorf("see https://github.com/example-org/example-repo/issues/9999 for docs")
+}
+`,
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	hits := findIssueReferenceHits(t, dir)
+	if len(hits) != 2 {
+		t.Fatalf("expected exactly two hits (production.go's comment, production_test.go's subtest name), got %+v", hits)
+	}
+
+	byFile := map[string]issueReferenceHit{}
+	for _, h := range hits {
+		byFile[h.file] = h
+	}
+
+	commentHit, ok := byFile["production.go"]
+	if !ok || commentHit.kind != "comment" || commentHit.value != "#9999" {
+		t.Fatalf("expected production.go's comment hit %q, got %+v", "#9999", commentHit)
+	}
+	subtestHit, ok := byFile["production_test.go"]
+	if !ok || subtestHit.kind != "subtest name" || subtestHit.value != "example-org/example-repo#9999" {
+		t.Fatalf("expected production_test.go's subtest hit %q, got %+v", "example-org/example-repo#9999", subtestHit)
+	}
+	if _, ok := byFile["unrelated.go"]; ok {
+		t.Fatalf("expected unrelated.go to have no hits (its reference sits inside an Errorf string, not a comment/name/subtest), got %+v", hits)
+	}
+}
+
+// TestIssueReferencePatternCatchesShapeVariants is the regression for the
+// design goal this gate exists to hold: match the shape of a tracker
+// reference, not one fixed phrasing. Every "true" case here uses a
+// deliberately fake org/repo and issue number.
+func TestIssueReferencePatternCatchesShapeVariants(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"#9999", true},
+		{"see #9999 for context", true},
+		{"issue #9999", true},
+		{"Issue #9999", true},
+		{"issue#9999", true},
+		{"example-org/example-repo#9999", true},
+		{"https://github.com/example-org/example-repo/issues/9999", true},
+		{"https://github.com/example-org/example-repo/pull/9999", true},
+		{"# Overview", false},
+		{"C# is a language", false},
+		{"go 1.9999 is not a real toolchain version", false},
+	} {
+		if got := issueReferencePattern.MatchString(tc.value); got != tc.want {
+			t.Errorf("issueReferencePattern.MatchString(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestIssueReferenceIdentPatternCatchesShapeVariants locks the
+// identifier-shape variant: a declared name must spell out "issue" next to
+// a number. A bare number in a name (Test1234) is not enough on its own --
+// too many legitimately numbered identifiers exist for that to be useful.
+func TestIssueReferenceIdentPatternCatchesShapeVariants(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{"TestIssue9999Regression", true},
+		{"handleIssue1234", true},
+		{"issue_9999_fix", true},
+		{"TestSomethingElse", false},
+		{"Test1234", false},
+	} {
+		if got := issueReferenceIdentPattern.MatchString(tc.value); got != tc.want {
+			t.Errorf("issueReferenceIdentPattern.MatchString(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}

--- a/scripts/check-issue-references.mjs
+++ b/scripts/check-issue-references.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+// check-issue-references.mjs is the TypeScript half of the repo-state
+// structural gate for root AGENTS.md § "Code Comments": a tracker reference
+// must not reach a code comment, because provenance lives in the git
+// history, not the source. The Go half lives in
+// erun-integration/issue_reference_test.go and follows the same design;
+// this file mirrors its regex shape and its shrink-only baseline pattern so
+// the two halves cannot silently drift apart in what they consider a hit.
+//
+// Why the TypeScript compiler package instead of a plain grep or a custom
+// ESLint rule: `typescript` is already a devDependency hoisted to this
+// repo's root node_modules (every frontend workspace member depends on it),
+// so no new tool is introduced. ts.getLeadingCommentRanges/
+// getTrailingCommentRanges is the same tokenizer the compiler itself uses to
+// separate comments from string/template literal content, so a reference
+// quoted inside a string constant is never mistaken for a comment the way a
+// line-based `#` grep would. An ESLint rule was the other option considered:
+// rejected because a rule runs once per package (three separate flat
+// configs to keep in sync) and ESLint has no natural mechanism for the
+// cross-file shrink-only baseline this gate needs, whereas one script
+// scanning all frontend source roots in a single pass gives both properties
+// for free and needs no type information (a plain syntactic scan), so it
+// does not depend on each package's own tsconfig/project service.
+//
+// Scope is comments only, not string literals or identifiers: TypeScript
+// test titles are string arguments to describe/it/test, not declared names,
+// and a blanket string-literal scan would flag far more legitimate content
+// (URLs in fixtures, golden values) than it would catch real instances of
+// this defect. Comments are exactly what the filed defect was about.
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+// issueReferencePattern mirrors erun-integration/issue_reference_test.go's
+// issueReferencePattern exactly: a bare hash-number, an "issue #" prefix, a
+// cross-repo "owner/repo#" form, or a full GitHub issue/pull URL. Group 1
+// captures just the "#NNN" portion of the bare-hash alternative (JS regex
+// has no lookbehind either, so the boundary character before "#" must be
+// consumed by the match); every other alternative's match is already exactly
+// the reference text.
+export const issueReferencePattern =
+  /issue\s*#\s*\d+|[\w][\w.-]*\/[\w][\w.-]*#\d+|(?:^|[^\w#])(#\d{2,6})\b|github\.com\/[\w.-]+\/[\w.-]+\/(?:issues|pull)\/\d+/i;
+
+export function matchIssueReference(text) {
+  const m = issueReferencePattern.exec(text);
+  if (!m) return null;
+  return m[1] || m[0];
+}
+
+const skipDirs = new Set(['.git', 'node_modules', 'vendor', 'dist', 'wailsjs', '.claude', '.claude-plugin', '.vscode', 'testdata']);
+
+function walkSourceFiles(dir, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (skipDirs.has(entry.name)) continue;
+      walkSourceFiles(join(dir, entry.name), out);
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      out.push(join(dir, entry.name));
+    }
+  }
+}
+
+// commentRangesIn returns every leading-comment-range text found scanning
+// forward through `text`, using the same ts.getLeadingCommentRanges the
+// compiler itself uses to tokenize comments -- so a "#" inside a string or
+// template literal is never treated as comment content.
+function commentRangesIn(text) {
+  const ranges = [];
+  let pos = 0;
+  while (pos < text.length) {
+    const found = ts.getLeadingCommentRanges(text, pos) || [];
+    for (const r of found) {
+      ranges.push(text.slice(r.pos, r.end));
+    }
+    if (found.length === 0) {
+      pos++;
+    } else {
+      pos = found[found.length - 1].end;
+    }
+  }
+  return ranges;
+}
+
+// findIssueReferenceHits scans every .ts/.tsx file under each given root and
+// returns one hit per comment matching issueReferencePattern. File paths in
+// each hit are relative to the repo root, so callers can key a baseline
+// consistently regardless of which root a file was reached through.
+export function findIssueReferenceHits(roots) {
+  const hits = [];
+  for (const root of roots) {
+    const full = isAbsolute(root) ? root : join(repoRoot, root);
+    let isDir;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+    const files = [];
+    walkSourceFiles(full, files);
+    for (const file of files) {
+      const text = readFileSync(file, 'utf8');
+      const rel = relative(repoRoot, file).split('\\').join('/');
+      for (const comment of commentRangesIn(text)) {
+        const value = matchIssueReference(comment);
+        if (value) {
+          hits.push({ file: rel, value });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+// checkBaseline applies the same shrink-only enforcement as
+// TestNoIssueReferenceInCode / TestIssueReferenceBaselineIsCurrent in the Go
+// gate: a file with no baseline entry gets zero tolerance for a new hit, a
+// baselined file may not exceed its recorded count, and a baselined file
+// whose real count has dropped below what the baseline claims must have its
+// baseline entry lowered in the same change.
+export function checkBaseline(hits, baseline) {
+  const counts = new Map();
+  const violations = [];
+  for (const hit of hits) {
+    const next = (counts.get(hit.file) || 0) + 1;
+    counts.set(hit.file, next);
+    if (next > (baseline[hit.file] || 0)) {
+      violations.push(hit);
+    }
+  }
+  const staleEntries = [];
+  for (const [file, allowed] of Object.entries(baseline)) {
+    const actual = counts.get(file) || 0;
+    if (actual < allowed) {
+      staleEntries.push({ file, allowed, actual });
+    }
+  }
+  return { violations, staleEntries };
+}
+
+function messageFor(hit) {
+  return `${hit.file}: comment contains a tracker reference "${hit.value}" -- issue references belong in the PR body, not in code (root AGENTS.md § "Code Comments")`;
+}
+
+// issueReferenceBaseline is the TypeScript-side shrink-only baseline, same
+// pattern as issueReferenceBaseline in erun-integration/issue_reference_test.go:
+// a record of pre-existing hits found when this gate was added, not a
+// design decision -- it may only shrink.
+export const issueReferenceBaseline = {
+  'erun-console/src/App.tsx': 3,
+  'erun-console/src/app/api/identityApi.ts': 2,
+  'erun-console/src/auth/auth.ts': 1,
+  'erun-console/src/auth/identity.ts': 1,
+  'erun-console/src/config/ConfigView.test.tsx': 1,
+  'erun-console/src/config/ConfigView.tsx': 1,
+  'erun-console/src/config/platform.ts': 1,
+  'erun-console/src/environments/EnvironmentsPanel.test.tsx': 1,
+  'erun-console/src/environments/EnvironmentsPanel.tsx': 1,
+  'erun-console/src/identity/AcceptInvitePage.tsx': 2,
+  'erun-console/src/identity/InvitesPanel.tsx': 2,
+  'erun-console/src/identity/OrgSettingsPanel.tsx': 1,
+  'erun-console/src/identity/SmtpSettingsPanel.tsx': 1,
+  'erun-console/src/identity/UsersPanel.tsx': 3,
+  'erun-console/src/identity/controller.ts': 1,
+  'erun-console/src/shell/AppShell.tsx': 2,
+  'erun-console/src/shell/ConsoleSidebar.tsx': 1,
+  'erun-console/src/shell/PreShellScreens.tsx': 1,
+  'erun-console/src/shell/landingContent.ts': 1,
+  'erun-console/src/shell/sections.ts': 3,
+  'erun-kit/src/models/platformConfig.ts': 1,
+  'erun-ui/frontend/src/app/TerminalController.ts': 3,
+  'erun-ui/frontend/src/app/TerminalSessionRegistry.test.ts': 2,
+  'erun-ui/frontend/src/app/TerminalSessionRegistry.ts': 1,
+  'erun-ui/frontend/src/app/clipboard.test.ts': 1,
+  'erun-ui/frontend/src/app/cloudProviderThunks.ts': 1,
+  'erun-ui/frontend/src/app/createReviewDialogThunks.ts': 1,
+  'erun-ui/frontend/src/app/diagnosticsReport.test.ts': 1,
+  'erun-ui/frontend/src/app/diagnosticsReport.ts': 1,
+  'erun-ui/frontend/src/app/mergeQueueThunks.ts': 1,
+  'erun-ui/frontend/src/app/middleware/terminalDisplayMiddleware.ts': 1,
+  'erun-ui/frontend/src/app/orchestratorBusyLabel.test.ts': 1,
+  'erun-ui/frontend/src/app/orchestratorBusyLabel.ts': 2,
+  'erun-ui/frontend/src/app/orchestratorBusySeed.ts': 1,
+  'erun-ui/frontend/src/app/orchestratorThunks.test.ts': 1,
+  'erun-ui/frontend/src/app/orchestratorThunks.ts': 1,
+  'erun-ui/frontend/src/app/reconnectCopy.test.ts': 1,
+  'erun-ui/frontend/src/app/reconnectCopy.ts': 2,
+  'erun-ui/frontend/src/app/reviewDetailThunks.ts': 4,
+  'erun-ui/frontend/src/app/reviewEnvTargets.test.ts': 1,
+  'erun-ui/frontend/src/app/reviewThunks.ts': 3,
+  'erun-ui/frontend/src/app/selectors.ts': 4,
+  'erun-ui/frontend/src/app/sessionThunks.ts': 1,
+  'erun-ui/frontend/src/app/sidebarFocus.test.ts': 1,
+  'erun-ui/frontend/src/app/slices/aiActivitySlice.ts': 1,
+  'erun-ui/frontend/src/app/slices/orchestratorsSlice.ts': 1,
+  'erun-ui/frontend/src/app/slices/reviewSlice.errorKind.test.ts': 2,
+  'erun-ui/frontend/src/app/slices/reviewSlice.test.ts': 3,
+  'erun-ui/frontend/src/app/slices/reviewSlice.ts': 3,
+  'erun-ui/frontend/src/app/state.ts': 3,
+  'erun-ui/frontend/src/app/tenantDashboardPanels.ts': 2,
+  'erun-ui/frontend/src/app/terminalFocus.test.ts': 2,
+  'erun-ui/frontend/src/app/terminalFocus.ts': 2,
+  'erun-ui/frontend/src/app/terminalOrigin.ts': 1,
+  'erun-ui/frontend/src/app/terminalPathLinkProvider.ts': 1,
+  'erun-ui/frontend/src/app/terminalPathLinks.test.ts': 1,
+  'erun-ui/frontend/src/app/terminalPathLinks.ts': 1,
+  'erun-ui/frontend/src/app/terminalReattachRepaint.test.ts': 2,
+  'erun-ui/frontend/src/app/terminalReattachRepaint.ts': 2,
+  'erun-ui/frontend/src/app/terminalUrlLinks.ts': 1,
+  'erun-ui/frontend/src/app/useEnvDiffSlot.test.ts': 1,
+  'erun-ui/frontend/src/app/useEnvDiffSlot.ts': 1,
+  'erun-ui/frontend/src/components/app/DebugPanel.tsx': 1,
+  'erun-ui/frontend/src/components/app/DiffList.CommentAction.tsx': 1,
+  'erun-ui/frontend/src/components/app/DiffList.tsx': 5,
+  'erun-ui/frontend/src/components/app/InlineAlert.tsx': 1,
+  'erun-ui/frontend/src/components/app/ManageDialogJobsTab.tsx': 1,
+  'erun-ui/frontend/src/components/app/OrchestratorDialog.Guidance.tsx': 1,
+  'erun-ui/frontend/src/components/app/PlatformSignInAlert.tsx': 4,
+  'erun-ui/frontend/src/components/app/ReviewDetailDialog.Comments.tsx': 4,
+  'erun-ui/frontend/src/components/app/ReviewPanel.ChangedFiles.tsx': 2,
+  'erun-ui/frontend/src/components/app/ReviewPanel.EnvLabel.tsx': 1,
+  'erun-ui/frontend/src/components/app/ReviewPanel.tsx': 2,
+  'erun-ui/frontend/src/components/app/Sidebar.EnvironmentRow.tsx': 1,
+  'erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx': 1,
+  'erun-ui/frontend/src/components/app/TenantDashboardMessage.tsx': 2,
+  'erun-ui/frontend/src/components/app/TenantDashboardPanels.Reviews.tsx': 3,
+  'erun-ui/frontend/src/components/app/TerminalTabStrip.tsx': 1,
+  'erun-ui/frontend/src/components/app/Titlebar.Controls.tsx': 2,
+  'erun-ui/frontend/src/components/app/Titlebar.Status.tsx': 3,
+  'erun-ui/frontend/src/components/app/UsageMeter.helpers.test.ts': 1,
+  'erun-ui/frontend/src/uiExposureTypes.ts': 1,
+};
+
+function main() {
+  const roots = process.argv.slice(2);
+  if (roots.length === 0) {
+    console.error('usage: node scripts/check-issue-references.mjs <root> [<root> ...]');
+    process.exit(2);
+  }
+  const hits = findIssueReferenceHits(roots);
+  const { violations, staleEntries } = checkBaseline(hits, issueReferenceBaseline);
+
+  for (const hit of violations) {
+    console.error(messageFor(hit));
+  }
+  for (const entry of staleEntries) {
+    console.error(
+      `${entry.file}: issueReferenceBaseline claims ${entry.allowed} hit(s) but only ${entry.actual} remain -- lower the baseline entry in scripts/check-issue-references.mjs`,
+    );
+  }
+  if (violations.length > 0 || staleEntries.length > 0) {
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-issue-references.test.mjs
+++ b/scripts/check-issue-references.test.mjs
@@ -1,0 +1,93 @@
+// Self-test for check-issue-references.mjs, the TypeScript half of the
+// issue-reference gate (see that file's header for the design rationale).
+// Run with `node --test scripts/check-issue-references.test.mjs`. Every
+// example below uses a fake org/repo/number; none corresponds to a real
+// GitHub issue.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { checkBaseline, findIssueReferenceHits, issueReferencePattern, matchIssueReference } from './check-issue-references.mjs';
+
+test('issueReferencePattern catches the shape, not one phrasing', () => {
+  const cases = [
+    ['#8888', true],
+    ['see #8888 for context', true],
+    ['issue #8888', true],
+    ['Issue #8888', true],
+    ['issue#8888', true],
+    ['acme/widgets#8888', true],
+    ['https://github.com/acme/widgets/issues/8888', true],
+    ['https://github.com/acme/widgets/pull/8888', true],
+    ['# Overview', false],
+    ['C# is a language', false],
+    ['no hash sign here at all', false],
+  ];
+  for (const [value, want] of cases) {
+    assert.equal(issueReferencePattern.test(value), want, `pattern.test(${JSON.stringify(value)})`);
+  }
+});
+
+test('matchIssueReference strips the boundary character from the bare-hash shape', () => {
+  assert.equal(matchIssueReference('see #8888 for context'), '#8888');
+  assert.equal(matchIssueReference('issue #8888'), 'issue #8888');
+  assert.equal(matchIssueReference('acme/widgets#8888'), 'acme/widgets#8888');
+  assert.equal(matchIssueReference('no reference here'), null);
+});
+
+test('findIssueReferenceHits reads real comments and ignores string-literal content', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'issue-ref-test-'));
+  try {
+    writeFileSync(
+      join(dir, 'production.ts'),
+      [
+        '// FIXTURE: deliberately-constructed violation for this test only.',
+        "// see #8889's precedent for how this used to resolve.",
+        'export function doWork(): void {',
+        '  // this string is not a comment reference: "acme/widgets#8890"',
+        '  const message = "acme/widgets#8890";',
+        '  console.log(message);',
+        '}',
+        '',
+      ].join('\n'),
+    );
+    const hits = findIssueReferenceHits([dir]);
+    // production.ts has exactly one real comment matching the pattern; the
+    // second comment line quotes the reference to explain why the string on
+    // the next line is NOT a hit (string literals are out of scope), so it
+    // legitimately matches too -- both are real comments.
+    assert.equal(hits.length, 2);
+    assert.ok(hits.every((h) => h.file.endsWith('production.ts')));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkBaseline enforces zero tolerance for an unbaselined file', () => {
+  const hits = [{ file: 'new-file.ts', value: '#8891' }];
+  const { violations, staleEntries } = checkBaseline(hits, {});
+  assert.equal(violations.length, 1);
+  assert.equal(staleEntries.length, 0);
+});
+
+test('checkBaseline allows exactly the baselined count and rejects one more', () => {
+  const hits = [
+    { file: 'existing.ts', value: '#8892' },
+    { file: 'existing.ts', value: '#8893' },
+    { file: 'existing.ts', value: '#8894' },
+  ];
+  const { violations } = checkBaseline(hits, { 'existing.ts': 2 });
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].value, '#8894');
+});
+
+test('checkBaseline fails a stale baseline entry that claims more than actually remains', () => {
+  const hits = [{ file: 'cleaned-up.ts', value: '#8895' }];
+  const { violations, staleEntries } = checkBaseline(hits, { 'cleaned-up.ts': 3 });
+  assert.equal(violations.length, 0);
+  assert.equal(staleEntries.length, 1);
+  assert.deepEqual(staleEntries[0], { file: 'cleaned-up.ts', allowed: 3, actual: 1 });
+});


### PR DESCRIPTION
## Summary

Eleven separate agent lanes wrote a GitHub issue/PR reference into a code comment or test name in one session, every one of them given the instruction "NO issue numbers in code, comments, or test names" verbatim in its prompt. A prompt-only rule depends on every dispatcher restating it and every author following it — eleven for eleven says that lever doesn't work. This replaces it with a structural gate, following the same AST-gate + shrink-only-baseline pattern already in this repo (`erun-integration/bare_required_input_test.go`, `erun-integration/desktop_surface_test.go`).

- **Go** (`erun-integration/issue_reference_test.go`): parses every `.go` file in the repo with `go/parser` and flags a tracker reference in a comment, a function/method declaration name, or a `t.Run`/`b.Run` subtest name.
- **TypeScript** (`scripts/check-issue-references.mjs` + self-test): scans `erun-kit/src`, `erun-ui/frontend/src`, `erun-console/src` for comments containing the same reference shape, using the already-vendored `typescript` compiler package's comment tokenizer (`ts.getLeadingCommentRanges`) rather than a byte-level grep, so a `#` inside a string/template literal is never mistaken for a comment. An ESLint rule was considered and rejected: a rule runs per-package (three flat configs to keep in sync) and has no natural cross-file shrink-only baseline mechanism, whereas one script scanning all three roots in a single pass gets both for free and needs no type information. Wired into `make check` via `test-frontend` (root `node_modules` already carries `typescript` from the Yarn workspace hoist, resolved by the same `yarn install` that step already runs).

**Shape, not phrasing.** Both matchers catch `#1234`, `issue #1234`, `owner/repo#1234`, and a full `github.com/owner/repo/issues|pull/1234` URL via one regex per language (kept in sync by design, documented in each file) — the same "generalize the shape" fix `bareRequiredInputPattern` used after a prior gate enumerating exact literals was walked through by a new phrasing within hours.

**Scope / exemptions.** Both scanners look only at comments (Go also covers function/test names, since those are explicitly named in the filed defect). Arbitrary string literals (`t.Errorf`/`t.Skip` messages, user-facing error strings) are out of scope — those are runtime output, not source documentation, and scanning them would flag far more legitimate content (URLs in fixtures, golden values) than real instances of this defect. Standard non-source directories are skipped (`.git`, `node_modules`, `vendor`, `dist`, `wailsjs`, `testdata`, editor/tooling dirs). `erun-docs/` prose and `testdata/` goldens are exempt by construction (only `.go`/`.ts`/`.tsx` files are scanned, so markdown prose is untouched).

**Pre-existing occurrences.** Counted before writing the baseline: **345 hits across 145 Go files**, **135 hits across 82 TypeScript files** — both far too large to clean up in this PR without a large, unrelated diff, so both use the repo's established shrink-only baseline (same shape as `bareRequiredInputBaseline`/`KnownUnsurfacedRoutes`): a file with no baseline entry gets zero tolerance, a baselined file may not exceed its recorded count, and a baselined file whose count has genuinely dropped must have its entry lowered in the same change (enforced by `TestIssueReferenceBaselineIsCurrent` / the TS script's stale-entry check) — cleanup only ever shrinks the list, it can't rot into a silent amnesty. Also fixed the one pre-existing violation the new Go gate found sitting right next to it: an issue-URL in `bare_required_input_test.go`'s own comment.

**Proof it catches things.** Injected a real violation of each of the four phrasings into both a scratch Go file and a real TS source file (`erun-kit/src/models/platformConfig.ts`), confirmed `TestNoIssueReferenceInCode` / `check-issue-references.mjs` failed on each with the exact file/line/text, then reverted. Also injected a Go function-name and `t.Run` subtest-name violation and confirmed both are caught. See the PR conversation/commit for full output.

## Test plan

- [x] `go test ./...` in `erun-integration` — green, including the new `TestNoIssueReferenceInCode`, `TestIssueReferenceBaselineIsCurrent`, exclusion, and shape-variant tests
- [x] `node --test scripts/check-issue-references.test.mjs` — green
- [x] Deliberately injected all 4 phrasings (bare `#N`, `issue #N`, `owner/repo#N`, GitHub URL) into scratch Go and real TS source, confirmed the gate fails on each with a clear message, then reverted
- [x] Deliberately injected a Go function-name and subtest-name violation, confirmed both caught
- [x] `make check` — green (lint, `erun-ui` tests, frontend gates incl. this gate, helm chart tests, integration suite, coverage 76.2% ≥ 75.8%)
- [x] `make integration-test` — green (coverage 76.3% ≥ 75.8%)
- [x] `git diff --stat origin/main...HEAD` — only the 5 intended files, no `yarn.lock`

Closes #1539