### PR TITLE
Compare observe's drift check against what the config recorded, not a manufactured default

### DIFF
--- a/erun-common/observe_drift.go
+++ b/erun-common/observe_drift.go
@@ -91,23 +91,29 @@ func runningImageDrift(release *ObservedHelmRelease, pods []ObservedPod) []strin
 // runtimePodDrift compares the env config's recorded runtime pod sizing
 // against what the release actually rendered. Both sides are the release's
 // own record of intent, not a live cgroup read, so this stays a plain
-// `helm status` comparison rather than reaching into the pod.
+// `helm status` comparison rather than reaching into the pod. Unlike deploy,
+// which must resolve a concrete value to pass to helm and so normalizes an
+// unset field to NormalizeRuntimePodResources' package default, a config field
+// left empty here asserts nothing about the environment's shape — the same
+// reasoning the recordedVersion/runtimeImage checks above already apply — so
+// each field compares only when the config actually recorded one, instead of
+// diffing the release against a manufactured default nobody configured.
 func runtimePodDrift(req ShellLaunchParams, release *ObservedHelmRelease) []string {
 	if release.RuntimePod == (RuntimePodResources{}) {
 		return nil
 	}
-	recorded := NormalizeRuntimePodResources(req.RuntimePod)
+	recorded := req.RuntimePod
 	live := release.RuntimePod
 	var findings []string
-	if recorded.CPU != live.CPU {
+	if cpu := strings.TrimSpace(recorded.CPU); cpu != "" && cpu != live.CPU {
 		findings = append(findings, fmt.Sprintf(
 			"env config runtimepod CPU limit (%s) does not match the release's runtime.resources.limits.cpu (%s)",
-			recorded.CPU, live.CPU))
+			cpu, live.CPU))
 	}
-	if recorded.Memory != live.Memory {
+	if memory := strings.TrimSpace(recorded.Memory); memory != "" && memory != live.Memory {
 		findings = append(findings, fmt.Sprintf(
 			"env config runtimepod memory limit (%s) does not match the release's runtime.resources.limits.memory (%s)",
-			recorded.Memory, live.Memory))
+			memory, live.Memory))
 	}
 	return findings
 }

--- a/erun-integration/observe_test.go
+++ b/erun-integration/observe_test.go
@@ -187,10 +187,14 @@ func TestObserve(t *testing.T) {
 	// release's own recorded values disagreeing with the running container
 	// (a hand-patched, out-of-band image) and with the env config's recorded
 	// runtimeversion/runtimepod must be named, not left for the reader to spot
-	// by comparing dumps by eye.
+	// by comparing dumps by eye. The env config records an explicit runtimepod
+	// (rather than leaving it unset) so the runtimepod drift below reflects a
+	// real configured value disagreeing with the release, not silence compared
+	// against a manufactured default.
 	t.Run("real_run_reports_release_drift", func(t *testing.T) {
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		appendEnvConfig(t, setup, "team", "dev", "runtimepod:\n  cpu: \"4\"\n  memory: 8916Mi\n")
 		stubs := setup.Cwd + "/stubs"
 		responses := observeStubResponses()
 		// The running container's image and resource limits diverge from what
@@ -209,6 +213,58 @@ func TestObserve(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "observe/real_run_reports_release_drift", normalize.Apply(result.Combined))
+	})
+
+	// real_run_runtime_pod_silent_config_reports_no_drift is the false-positive
+	// regression this scenario exists for: an env config that never recorded a
+	// runtimepod (the SeedTenantEnv default, and the in-pod reality per
+	// runtime_resources.go's NormalizeRuntimePodResources doc) asserts nothing
+	// about the pod's shape, so a release sized well above the package's
+	// DefaultRuntimePodCPU/Memory (4 / 8916Mi) must report no runtimepod drift —
+	// comparing the release against a manufactured default nobody configured is
+	// exactly the bug, not the fix.
+	t.Run("real_run_runtime_pod_silent_config_reports_no_drift", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		responses := observeStubResponses()
+		responses["pods"] = `{"items":[{"metadata":{"name":"team-devops-abc123"},"spec":{"containers":[{"name":"erun-devops","resources":{"limits":{"cpu":"12","memory":"23552Mi"}}}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}],"containerStatuses":[{"name":"erun-devops","image":"registry.example/test/erun-devops:1.0.0","restartCount":0,"ready":true,"state":{"running":{"startedAt":"2024-01-01T00:00:00Z"}}}]}}]}`
+		fixture.StubKubectlGetJSON(t, stubs, responses)
+		statusStub := `{"name":"team-devops","namespace":"team-dev","version":3,"info":{"status":"deployed"},` +
+			`"config":{"imageOverrides":{"erun-devops":"registry.example/test/erun-devops:1.0.0"},` +
+			`"runtime":{"resources":{"limits":{"cpu":"12","memory":"23552Mi"}}}}}`
+		fixture.StubHelmObserve(t, stubs, statusStub, observeHelmListStubDefault())
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
+		result := erun.Run(t, []string{"observe", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/real_run_runtime_pod_silent_config_reports_no_drift", normalize.Apply(result.Combined))
+	})
+
+	// real_run_runtime_pod_configured_mismatch_reports_drift is the other
+	// direction of the same regression: once the env config actually records a
+	// runtimepod, a release that disagrees with it must still be flagged. CPU
+	// agrees and only memory diverges, so the golden isolates the memory-only
+	// finding instead of always pairing it with a CPU one.
+	t.Run("real_run_runtime_pod_configured_mismatch_reports_drift", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		appendEnvConfig(t, setup, "team", "dev", "runtimepod:\n  cpu: \"4\"\n  memory: 2048Mi\n")
+		stubs := setup.Cwd + "/stubs"
+		responses := observeStubResponses()
+		responses["pods"] = `{"items":[{"metadata":{"name":"team-devops-abc123"},"spec":{"containers":[{"name":"erun-devops","resources":{"limits":{"cpu":"4","memory":"4096Mi"}}}]},"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}],"containerStatuses":[{"name":"erun-devops","image":"registry.example/test/erun-devops:1.0.0","restartCount":0,"ready":true,"state":{"running":{"startedAt":"2024-01-01T00:00:00Z"}}}]}}]}`
+		fixture.StubKubectlGetJSON(t, stubs, responses)
+		statusStub := `{"name":"team-devops","namespace":"team-dev","version":3,"info":{"status":"deployed"},` +
+			`"config":{"imageOverrides":{"erun-devops":"registry.example/test/erun-devops:1.0.0"},` +
+			`"runtime":{"resources":{"limits":{"cpu":"4","memory":"4096Mi"}}}}}`
+		fixture.StubHelmObserve(t, stubs, statusStub, observeHelmListStubDefault())
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "helm")...)
+		result := erun.Run(t, []string{"observe", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "observe/real_run_runtime_pod_configured_mismatch_reports_drift", normalize.Apply(result.Combined))
 	})
 
 	// real_run_helm_release_not_found confirms an absent release is reported

--- a/erun-integration/testdata/observe/real_run_runtime_pod_configured_mismatch_reports_drift.txt
+++ b/erun-integration/testdata/observe/real_run_runtime_pod_configured_mismatch_reports_drift.txt
@@ -1,0 +1,114 @@
+{
+  "tenant": "team",
+  "environment": "dev",
+  "namespace": "team-dev",
+  "pods": [
+    {
+      "name": "team-devops-abc123",
+      "phase": "Running",
+      "ready": true,
+      "restartCount": 0,
+      "containers": [
+        {
+          "name": "erun-devops",
+          "image": "registry.example/test/erun-devops:<VERSION>",
+          "resourceLimits": {
+            "cpu": "4",
+            "memory": "4096Mi"
+          }
+        }
+      ]
+    }
+  ],
+  "resourceQuotas": [
+    {
+      "name": "erun-quota",
+      "hard": {
+        "limits.cpu": "4"
+      },
+      "used": {
+        "limits.cpu": "1"
+      }
+    }
+  ],
+  "limitRanges": [
+    {
+      "name": "erun-limits",
+      "limits": [
+        {
+          "type": "Container",
+          "default": {
+            "cpu": "1"
+          },
+          "defaultRequest": {
+            "cpu": "100m"
+          }
+        }
+      ]
+    }
+  ],
+  "ingresses": [
+    {
+      "name": "web",
+      "hosts": [
+        "dev.example.test"
+      ],
+      "tls": [
+        {
+          "hosts": [
+            "dev.example.test"
+          ],
+          "secretName": "web-tls"
+        }
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "wildcard",
+      "ready": false,
+      "reason": "Issuing",
+      "message": "waiting for order to complete",
+      "secretName": "wildcard-tls",
+      "dnsNames": [
+        "*.dev.example.test"
+      ],
+      "orders": [
+        {
+          "name": "wildcard-order-1",
+          "state": "pending",
+          "challenges": [
+            {
+              "name": "wildcard-challenge-1",
+              "type": "DNS-01",
+              "dnsName": "*.dev.example.test",
+              "state": "invalid",
+              "reason": "RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "helmRelease": {
+    "name": "team-devops",
+    "found": true,
+    "revision": 3,
+    "status": "deployed",
+    "chart": "erun-devops",
+    "chartVersion": "<VERSION>",
+    "appVersion": "<VERSION>",
+    "imageOverrides": {
+      "erun-devops": "registry.example/test/erun-devops:<VERSION>"
+    },
+    "runtimePod": {
+      "cpu": "4",
+      "memory": "4096Mi"
+    }
+  },
+  "drift": [
+    "env config runtimepod memory limit (2048Mi) does not match the release's runtime.resources.limits.memory (4096Mi)"
+  ]
+}
+audit: erun observe --output json
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason

--- a/erun-integration/testdata/observe/real_run_runtime_pod_silent_config_reports_no_drift.txt
+++ b/erun-integration/testdata/observe/real_run_runtime_pod_silent_config_reports_no_drift.txt
@@ -1,0 +1,111 @@
+{
+  "tenant": "team",
+  "environment": "dev",
+  "namespace": "team-dev",
+  "pods": [
+    {
+      "name": "team-devops-abc123",
+      "phase": "Running",
+      "ready": true,
+      "restartCount": 0,
+      "containers": [
+        {
+          "name": "erun-devops",
+          "image": "registry.example/test/erun-devops:<VERSION>",
+          "resourceLimits": {
+            "cpu": "12",
+            "memory": "23552Mi"
+          }
+        }
+      ]
+    }
+  ],
+  "resourceQuotas": [
+    {
+      "name": "erun-quota",
+      "hard": {
+        "limits.cpu": "4"
+      },
+      "used": {
+        "limits.cpu": "1"
+      }
+    }
+  ],
+  "limitRanges": [
+    {
+      "name": "erun-limits",
+      "limits": [
+        {
+          "type": "Container",
+          "default": {
+            "cpu": "1"
+          },
+          "defaultRequest": {
+            "cpu": "100m"
+          }
+        }
+      ]
+    }
+  ],
+  "ingresses": [
+    {
+      "name": "web",
+      "hosts": [
+        "dev.example.test"
+      ],
+      "tls": [
+        {
+          "hosts": [
+            "dev.example.test"
+          ],
+          "secretName": "web-tls"
+        }
+      ]
+    }
+  ],
+  "certificates": [
+    {
+      "name": "wildcard",
+      "ready": false,
+      "reason": "Issuing",
+      "message": "waiting for order to complete",
+      "secretName": "wildcard-tls",
+      "dnsNames": [
+        "*.dev.example.test"
+      ],
+      "orders": [
+        {
+          "name": "wildcard-order-1",
+          "state": "pending",
+          "challenges": [
+            {
+              "name": "wildcard-challenge-1",
+              "type": "DNS-01",
+              "dnsName": "*.dev.example.test",
+              "state": "invalid",
+              "reason": "RBAC denied: solvers.acme.cert-manager.io is forbidden: cannot create resource challenges"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "helmRelease": {
+    "name": "team-devops",
+    "found": true,
+    "revision": 3,
+    "status": "deployed",
+    "chart": "erun-devops",
+    "chartVersion": "<VERSION>",
+    "appVersion": "<VERSION>",
+    "imageOverrides": {
+      "erun-devops": "registry.example/test/erun-devops:<VERSION>"
+    },
+    "runtimePod": {
+      "cpu": "12",
+      "memory": "23552Mi"
+    }
+  }
+}
+audit: erun observe --output json
+observe: when a certificate is not Ready, its CertificateRequest -> Order -> Challenge chain is read for the failure reason


### PR DESCRIPTION
## The mechanism

The drift check normalised the environment's configured runtime pod before comparing:

```go
recorded := NormalizeRuntimePodResources(req.RuntimePod)
if recorded.Memory != live.Memory { ... }
```

`NormalizeRuntimePodResources` substitutes a package default for any unset field. So on an environment that never recorded a runtime-pod memory it compared **the default (8916Mi)** against the live release — and reported drift against a value nobody configured.

That is why `erun/ux` reported drift while every other source agreed at 8192Mi: `erun list` renders `runtime-pod: cpu=4 memory=8192Mi`, `erun deploy --dry-run` passes `runtime.resources.limits.memory=8192Mi`, the live release holds 8192Mi, and all three recorded deploys in its trace log passed 8192Mi.

## The fix

Compare a field only when the config actually recorded one:

```go
recorded := req.RuntimePod
if memory := strings.TrimSpace(recorded.Memory); memory != "" && memory != live.Memory { ... }
```

An unset config field asserts nothing about the environment's shape, so there is nothing to diff. Deploy is different and correctly so — it *must* resolve a concrete value to hand to helm, which is why it normalises. Drift does not.

This is the same reasoning the neighbouring `recordedVersion` and `runtimeImage` checks were already applying; the runtime-pod comparison was the one that didn't, which is the sibling audit the issue asked for.

## Why it mattered

A drift detector that fires when nothing has drifted trains the reader to skip the section, and this one is load-bearing: the orchestrator contract requires reading the live release and diffing it against the plan before any env-shaping deploy. It also dead-ended concretely — acting on the warning meant redeploying, the deploy would pass 8192Mi, nothing would change, and the warning would remain.

## Tests

Both directions, because the false-negative one matters as much:

- `..._runtime_pod_configured_mismatch_reports_drift.txt` — a genuinely different configured value still reports drift.
- `..._runtime_pod_silent_config_reports_no_drift.txt` — a config that records nothing reports none.

Verified: `make check-gate` green, coverage 76.3%.

**Not yet verified live**: the earlier live reproduction ran `observe` from the ux pod, which is currently occupied. The golden files cover both directions, but the live re-check against `erun/ux` is still outstanding and I will run it before relying on this.

Closes #1540