### PR TITLE
Report a finished gate's outcome instead of discarding it on re-invocation

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -20,6 +20,17 @@
 # when AGENT_GATE_DETACHED=1 marks this as the job's own re-exec'd body)
 # the command just runs in place via exec, so behaviour and exit status are
 # unchanged from calling it directly.
+#
+# `erun exec job start` replaces a finished record under the same id rather
+# than refusing to reuse it, so that an orchestrator can re-run named work
+# without inventing ids -- but re-invoking this wrapper after the job it
+# started has already finished is exactly the case the doc comment above
+# tells a caller to do ("run this command again to keep waiting"). Calling
+# start unconditionally would discard the outcome the caller came back to
+# collect and start a fresh run in its place, so before starting anything
+# this checks whether the job already finished and, if so, reports that
+# outcome instead. Set AGENT_GATE_RERUN=1 to skip the check and force a new
+# run once the underlying work has genuinely changed.
 
 set -eu
 
@@ -42,6 +53,34 @@ fi
 : "${ERUN_ENVIRONMENT:?agent-gate.sh: ERUN_ENVIRONMENT is not set (expected inside an agent pod)}"
 
 await_timeout="${ERUN_AGENT_GATE_AWAIT_TIMEOUT:-8m}"
+
+if [ "${AGENT_GATE_RERUN:-}" != "1" ]; then
+	status_status=0
+	status_line=$(erun exec job status \
+		--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
+		--id "$job_id" 2>/dev/null) || status_status=$?
+
+	if [ "$status_status" -eq 0 ]; then
+		case "$status_line" in
+		running:*)
+			# Still running: the start/await/output flow below already attaches to
+			# it correctly (start reports "already running" and falls through), so
+			# no special-casing is needed here.
+			;;
+		*)
+			printf 'agent-gate: %s already finished; reporting its recorded outcome instead of starting a new run (set AGENT_GATE_RERUN=1 to force a fresh run)\n' "$job_name" >&2
+			replay_status=0
+			erun exec job await \
+				--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
+				--id "$job_id" --timeout 1s >&2 || replay_status=$?
+			erun exec job output \
+				--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
+				--id "$job_id" --max-bytes 16777216
+			exit "$replay_status"
+			;;
+		esac
+	fi
+fi
 
 start_status=0
 start_output=$(erun exec job start \

--- a/scripts/agent-gate_test.sh
+++ b/scripts/agent-gate_test.sh
@@ -4,7 +4,9 @@
 # the recursion guard is set) it must exec the real command untouched; inside
 # one it must detach through `erun exec job start`/`await`/`output` with the
 # right arguments and propagate the job's real exit status and output. It also
-# covers erun-ui/playwright/run.sh's wiring into that same wrapper.
+# covers erun-ui/playwright/run.sh's wiring into that same wrapper, and the
+# job-status probe that decides whether to replay a finished job's outcome or
+# start a fresh run.
 #
 # Run directly (not wired into `make check`, same reasoning as
 # erun-devops/docker/erun-devops/entrypoint_test.sh): a stub `erun` on PATH
@@ -25,8 +27,11 @@ fail() {
 }
 
 # stub_erun writes a fake `erun` on PATH that records every invocation's argv
-# (one line per call) and answers `exec job start`/`await`/`output` per the
-# STUB_* env vars a test case sets, without ever touching a real job store.
+# (one line per call) and answers `exec job start`/`await`/`output`/`status`
+# per the STUB_* env vars a test case sets, without ever touching a real job
+# store. `exec job status` defaults to "no job" (status 1) so every existing
+# case that never sets STUB_STATUS_* keeps behaving as if no prior record
+# existed, matching what a first invocation actually sees.
 stub_erun() {
 	bin_dir="$1"
 	mkdir -p "$bin_dir"
@@ -46,6 +51,12 @@ case "$1 $2 $3" in
 "exec job output")
 	printf '%s' "${STUB_JOB_OUTPUT:-}"
 	exit "${STUB_OUTPUT_STATUS:-0}"
+	;;
+"exec job status")
+	if [ "${STUB_STATUS_STATUS:-1}" -eq 0 ]; then
+		printf '%s\n' "${STUB_STATUS_LINE:-}"
+	fi
+	exit "${STUB_STATUS_STATUS:-1}"
 	;;
 *)
 	exit 0
@@ -162,6 +173,126 @@ stub_erun "${case_dir}/bin"
 	*) fail "already running: expected the running job's output once it finished, got: $OUT" ;;
 	esac
 	grep -q 'exec job await' "$STUB_ARGV_FILE" || fail "already running: must still await the in-flight job"
+)
+
+# --- the job-status probe reports "running": the start/await/output flow
+# below must still run untouched (start falls through on "already running"
+# exactly as the case above), never treating a running job as finished.
+case_dir="${work_root}/status-running"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=remote-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_STATUS_STATUS=0
+	export STUB_STATUS_LINE='running: make check, pid 123'
+	export STUB_START_STATUS=1
+	export STUB_START_STDERR='job "check" is already running (pid 123); pass a different id or cancel it first'
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='resumed output'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 0 ] || fail "status running: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"resumed output"*) ;;
+	*) fail "status running: expected the running job's output once it finished, got: $OUT" ;;
+	esac
+	grep -q 'exec job start' "$STUB_ARGV_FILE" || fail "status running: must still start/attach through the normal flow"
+	if grep -q -- '--timeout 1s' "$STUB_ARGV_FILE"; then
+		fail "status running: must not take the finished-replay path for a job still running"
+	fi
+)
+
+# --- a finished job's outcome is replayed rather than starting a new run.
+# `exec job start` must never be called, since that is what discards the
+# finished record.
+case_dir="${work_root}/status-finished-pass"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_STATUS_STATUS=0
+	export STUB_STATUS_LINE='exited 0: make check'
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='earlier passing output'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 0 ] || fail "status finished pass: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"earlier passing output"*) ;;
+	*) fail "status finished pass: expected the finished job's captured output, got: $OUT" ;;
+	esac
+	case "$OUT" in
+	*"already finished"*) ;;
+	*) fail "status finished pass: expected the replay notice, got: $OUT" ;;
+	esac
+	if grep -q 'exec job start' "$STUB_ARGV_FILE"; then
+		fail "status finished pass: must never start a new run over a finished record"
+	fi
+	grep -q -- '--timeout 1s' "$STUB_ARGV_FILE" || fail "status finished pass: must await the finished job to learn its real exit status"
+)
+
+# --- a FAILING finished job replays as failing, not as a fresh pass. This is
+# the regression that matters most: replaying a stale pass over a
+# since-broken tree would be worse than the original bug.
+case_dir="${work_root}/status-finished-fail"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_STATUS_STATUS=0
+	export STUB_STATUS_LINE='exited 7: make check'
+	export STUB_AWAIT_STATUS=1
+	export STUB_JOB_OUTPUT='earlier failing output'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 1 ] || fail "status finished fail: expected the replayed failure to exit nonzero, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"earlier failing output"*) ;;
+	*) fail "status finished fail: expected the finished job's captured output, got: $OUT" ;;
+	esac
+	if grep -q 'exec job start' "$STUB_ARGV_FILE"; then
+		fail "status finished fail: must never start a new run over a finished record"
+	fi
+)
+
+# --- AGENT_GATE_RERUN=1 skips the finished-job replay and starts a genuinely
+# new run, so a caller who changed the tree can still force a fresh result.
+case_dir="${work_root}/status-forced-rerun"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent AGENT_GATE_RERUN=1
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_STATUS_STATUS=0
+	export STUB_STATUS_LINE='exited 0: make check'
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='fresh output'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 0 ] || fail "forced rerun: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"fresh output"*) ;;
+	*) fail "forced rerun: expected the fresh run's captured output, got: $OUT" ;;
+	esac
+	grep -q 'exec job start' "$STUB_ARGV_FILE" || fail "forced rerun: must start a new run when AGENT_GATE_RERUN=1"
+	if grep -q 'exec job status' "$STUB_ARGV_FILE"; then
+		fail "forced rerun: must not even probe status when a fresh run was explicitly requested"
+	fi
 )
 
 # --- an unrelated start failure must be fatal: never silently await a job


### PR DESCRIPTION
## Summary
- `scripts/agent-gate.sh` re-invoked `erun exec job start` unconditionally on every call, and `start` replaces a *finished* job record under the same id (by design, so an id can be reused) — so an agent following the documented "still running, run it again" flow could never observe a result it had already earned, because the act of asking again destroyed it.
- Before starting anything, the wrapper now probes `erun exec job status --id <id>`. If a finished record already exists, it replays that job's real captured output and exit status instead of starting a new run. A job still running is untouched — the existing start/await/output flow already attaches to it correctly.
- `AGENT_GATE_RERUN=1` skips the probe entirely and forces a genuinely new run, for a caller who changed the tree and wants a fresh result under the same id.

## How replay is distinguished from a deliberate re-run
- Default (no env var set): the wrapper reads the job's status line before deciding whether to start. `running:*` → fall through to the normal flow unchanged. Any other prefix (`exited`/`unknown`/`abandoned`) → finished → replay its outcome via `job await --timeout 1s` (returns instantly since the job is already finished, and reuses the same exit-code mapping `job await` already uses) plus `job output`, and exit with that status. `erun exec job start` is never called in this path, so the finished record is never discarded.
- `AGENT_GATE_RERUN=1` bypasses the status probe entirely and goes straight to the original start/await/output flow, which is what actually starts a fresh run (and is what replaces the finished record, exactly as it did before this fix).

## Test plan
- [x] Reproduced the bug live against the real job store (this session runs inside an erun agent pod): ran a short job through the unpatched wrapper, let it finish, re-invoked the identical command, and observed the `job: replacing the finished job record ...` trace line plus a genuinely different timestamp in the second run's output.
- [x] Verified the fix the same way: identical re-invocation after the fix now replays the exact same output (byte-identical) instead of re-executing.
- [x] Verified a failing finished job replays as failing (exit nonzero), not as a fresh pass.
- [x] Verified `AGENT_GATE_RERUN=1` still forces a genuinely fresh run over a finished record.
- [x] Extended `scripts/agent-gate_test.sh` with stub-`erun`-driven cases: status says running (normal flow untouched), finished job replays a pass, finished job replays a failure, and `AGENT_GATE_RERUN=1` forces a fresh run without even probing status. `sh scripts/agent-gate_test.sh` passes.
- [x] `node scripts/check-issue-references.mjs erun-kit/src erun-ui/frontend/src erun-console/src` unaffected (that gate only scans TS sources; confirmed no issue references were introduced in the shell diff).

Closes #1543