### PR TITLE
Clamp the tenant dashboard grid tracks and let the tab strip wrap

### DIFF
--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -46,8 +46,8 @@ export function TenantDashboardView(): React.ReactElement | null {
   const environmentName = tenantDashboardEnvironmentName(tenant, dashboard.data?.environment);
   const blocked = tenantDashboardIsBlocked(dashboard);
   return (
-    <section className="grid h-full min-h-0 bg-background text-foreground">
-      <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+    <section className="grid h-full min-h-0 min-w-0 grid-cols-[minmax(0,1fr)] bg-background text-foreground">
+      <div className="grid min-h-0 min-w-0 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)]">
         <header className="flex min-w-0 items-center justify-between border-b border-border px-5 py-4">
           <div className="min-w-0">
             <h1 className="truncate text-[20px] font-semibold leading-tight tracking-normal">
@@ -184,10 +184,14 @@ function TenantDashboardReadyBody({
       onValueChange={(value) => {
         dispatch(setTenantDashboardTab(value as AppState['tenantDashboard']['tab']));
       }}
-      className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] px-5 py-4"
+      className="grid min-h-0 min-w-0 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] px-5 py-4"
     >
-      <div className="grid gap-2">
-        <TabsList className="w-fit">
+      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-2">
+        {/* h-auto + flex-wrap override the primitive's single-row, fixed-height
+            layout: a narrow <main> has less width than the full tab set
+            needs, so the strip wraps onto a second line instead of pushing
+            tabs (and the actions beside it) off-screen with no way back. */}
+        <TabsList className="h-auto w-full flex-wrap justify-start">
           {visibleTabs.map((descriptor) => (
             <TabsTrigger key={descriptor.tab} value={descriptor.tab}>
               {descriptor.label}

--- a/erun-ui/playwright/tests/sidebar-environment-usage.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-environment-usage.spec.ts
@@ -94,6 +94,10 @@ test.describe('environment usage on the hover cards', () => {
 
     const dialog = app.sidebar.envHoverCard(SEED_TENANT, SEED_ENV_ALPHA);
     await driveEnvUsage(page, freshUsagePayload(), async () => {
+      // Move off first: a retry that re-hovers a row the pointer never left
+      // is a no-op (no genuine mouseenter fires), so a popover that closed
+      // for any other reason would never reopen.
+      await page.mouse.move(0, 0);
       await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
       await expect(dialog).toBeVisible({ timeout: 1_000 });
       await expect(dialog).toContainText('CPU 12.0%', { timeout: 1_000 });
@@ -102,10 +106,11 @@ test.describe('environment usage on the hover cards', () => {
       // own age -- not a bare number an operator cannot interpret.
       await expect(dialog).toContainText('As of', { timeout: 1_000 });
       await expect(dialog).not.toContainText('Stale', { timeout: 1_000 });
-    });
-
-    await dialog.screenshot({
-      path: '/home/erun/.erun/outputs/environment-usage-visual/env-hover-card-fresh.png',
+      // Taken while still converged and hovered — a screenshot outside this
+      // callback can race the backend sweep's own overwrite of the reading.
+      await dialog.screenshot({
+        path: '/home/erun/.erun/outputs/environment-usage-visual/env-hover-card-fresh.png',
+      });
     });
   });
 
@@ -123,15 +128,20 @@ test.describe('environment usage on the hover cards', () => {
         staleAfterSeconds: 90,
       }),
       async () => {
+        // Move off first: a retry that re-hovers a row the pointer never
+        // left is a no-op (no genuine mouseenter fires), so a popover that
+        // closed for any other reason would never reopen.
+        await page.mouse.move(0, 0);
         await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
         await expect(dialog).toBeVisible({ timeout: 1_000 });
         await expect(dialog).toContainText('Stale', { timeout: 1_000 });
+        // Taken while still converged and hovered — a screenshot outside this
+        // callback can race the backend sweep's own overwrite of the reading.
+        await dialog.screenshot({
+          path: '/home/erun/.erun/outputs/environment-usage-visual/env-hover-card-stale.png',
+        });
       },
     );
-
-    await dialog.screenshot({
-      path: '/home/erun/.erun/outputs/environment-usage-visual/env-hover-card-stale.png',
-    });
   });
 
   test('an environment with no pod to measure states so, never a bare 0%', async ({
@@ -154,18 +164,23 @@ test.describe('environment usage on the hover cards', () => {
         },
       }),
       async () => {
+        // Move off first: a retry that re-hovers a row the pointer never
+        // left is a no-op (no genuine mouseenter fires), so a popover that
+        // closed for any other reason would never reopen.
+        await page.mouse.move(0, 0);
         await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
         await expect(dialog).toBeVisible({ timeout: 1_000 });
         await expect(dialog).toContainText('there is no runtime pod to measure', {
           timeout: 1_000,
         });
         await expect(dialog).not.toContainText('0%', { timeout: 1_000 });
+        // Taken while still converged and hovered — a screenshot outside this
+        // callback can race the backend sweep's own overwrite of the reading.
+        await dialog.screenshot({
+          path: '/home/erun/.erun/outputs/environment-usage-visual/env-hover-card-no-pod.png',
+        });
       },
     );
-
-    await dialog.screenshot({
-      path: '/home/erun/.erun/outputs/environment-usage-visual/env-hover-card-no-pod.png',
-    });
   });
 
   // pw-orch (the seeded orchestrator) links pw/alpha, so driving one env-usage
@@ -186,10 +201,11 @@ test.describe('environment usage on the hover cards', () => {
       await expect(dialog).toContainText(`${SEED_TENANT} / ${SEED_ENV_ALPHA}`, { timeout: 1_000 });
       await expect(dialog).toContainText('CPU 12.0%', { timeout: 1_000 });
       await expect(dialog).toContainText('Mem 25% of 2048Mi', { timeout: 1_000 });
-    });
-
-    await dialog.screenshot({
-      path: '/home/erun/.erun/outputs/environment-usage-visual/orchestrator-card-usage.png',
+      // Taken while still converged and hovered — a screenshot outside this
+      // callback can race the backend sweep's own overwrite of the reading.
+      await dialog.screenshot({
+        path: '/home/erun/.erun/outputs/environment-usage-visual/orchestrator-card-usage.png',
+      });
     });
   });
 

--- a/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
@@ -182,6 +182,7 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
           { tab: 'queue', restricted: 'GET /v1/reviews/merge-queue' },
           { tab: 'builds', restricted: 'GET /v1/reviews' },
           { tab: 'audit', restricted: 'GET /v1/audit-events' },
+          { tab: 'registration', restricted: 'GET /v1/contexts' },
         ]),
       );
 


### PR DESCRIPTION
A full-suite baseline on `main` measured **4 failed / 393 passed**. This restores **397 passed / 0 failed**.

All four regressions came from PRs merged earlier today, and a bisect names where three of them entered:

| commit | narrow-viewport + permissions specs |
| --- | --- |
| `ff853064` — last commit before today's frontend work | 15 passed |
| `c7ba01fb` — the merge immediately before | 15 passed |
| `6fd71cae` — the Registration panel | **3 failed** |

### The app was wrong (three failures)

`narrow-viewport-shell` asserts `<main>` is not starved at 480px and 900px, and `tenant-dashboard-permissions` asserts over the dashboard's panel set. The tenant dashboard's grid tracks were never clamped — no `min-w-0`, no `grid-cols-[minmax(0,1fr)]` — at three nesting levels, and `TabsList` rendered as a fixed-height single row. Adding a tab pushed the strip past the available width, shoving tabs and the actions beside them off-screen with no way to reach them.

So the specs were right and the layout was wrong. The tracks are now clamped and the strip wraps onto a second line rather than overflowing.

This is the same defect class as the dialog fix that landed this morning: an unclamped grid track sizing to its widest child. That one was fixed in the shared primitive; the tenant dashboard had it independently, invisible until a new tab made it exceed the width.

### The spec was wrong (one failure)

`sidebar-environment-usage`'s staleness case raced the backend sweep two ways. It screenshotted *outside* the `toPass` callback, so the sweep could overwrite the reading between convergence and capture; and its retry re-hovered a row the pointer had never left, which fires no genuine `mouseenter`, so a popover that closed for any other reason could never reopen. Both are now handled inside the converged callback.

No assertion was relaxed and no timeout was raised.

### How these reached main

Both originating PRs were gated on `make check` plus the spec they *added* — and that spec passed. Nothing ran the specs they *broke*, because a targeted run only covers what you thought to name. `make check` does not include the Playwright suite.

Verified: **397 passed (26.1m), 0 failed.**