### PR TITLE
Default the Connect-tenant field to erun's own hosted platform host

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -247,7 +247,7 @@ func newCloudInitERunCmd(store common.CloudStore, deps common.CloudDependencies)
 			"a loopback listener when the issuer advertises no device endpoint.",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
-		Example:      "  erun cloud init erun --api-url https://api.frs-prod.services.erunpaas.com",
+		Example:      "  erun cloud init erun --api-url " + common.HostedPlatformAPIURL,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCloudInitERunCommand(commandContext(cmd), store, params, deps)
 		},

--- a/erun-common/cloud_erun.go
+++ b/erun-common/cloud_erun.go
@@ -25,6 +25,13 @@ type InitERunCloudProviderParams struct {
 	APIURL string
 }
 
+// HostedPlatformAPIURL is erun's own hosted platform's front door — a single
+// apex host serving every tenant, never a per-tenant or per-environment one.
+// The CLI's `cloud init erun` help text and the desktop's Connect-tenant
+// default both read this constant so the two cannot drift apart the way they
+// did when each hardcoded its own guess.
+const HostedPlatformAPIURL = "https://api.erunpaas.com"
+
 // InitERunCloudProvider discovers a hosted erun platform's own config (GET
 // /v1/platform) and its issuer's OIDC discovery document, then records the
 // alias, API URL, issuer, and CLI client id. It performs no sign-in: use

--- a/erun-docs/docs/cli/platform.md
+++ b/erun-docs/docs/cli/platform.md
@@ -105,8 +105,8 @@ Previews the full ordered plan for provisioning a hosted environment — tenant,
 ## Examples
 
 ```bash
-erun cloud init erun --api-url https://api.acme.services.erunpaas.com
-erun cloud login --alias erun+api.acme.services.erunpaas.com@erun
+erun cloud init erun --api-url https://api.erunpaas.com
+erun cloud login --alias erun+api.erunpaas.com@erun
 
 erun platform whoami
 erun platform env register --name prod --type runtime --runtime-version 1.4.2

--- a/erun-docs/docs/cli/review.md
+++ b/erun-docs/docs/cli/review.md
@@ -79,8 +79,8 @@ Bypasses `review queue advance`'s unresolved-thread check and advances anyway. `
 ## Examples
 
 ```bash
-erun cloud init erun --api-url https://api.acme.services.erunpaas.com
-erun cloud login --alias erun+api.acme.services.erunpaas.com@erun
+erun cloud init erun --api-url https://api.erunpaas.com
+erun cloud login --alias erun+api.erunpaas.com@erun
 
 erun exec push feature/add-widget
 erun review create --name "Add widget" --source-branch feature/add-widget --target-branch main

--- a/erun-docs/docs/collaboration/hosted-environments.md
+++ b/erun-docs/docs/collaboration/hosted-environments.md
@@ -13,9 +13,11 @@ The examples below use the CLI, but every action — previewing, registering, de
 ## Sign in once
 
 ```bash
-erun cloud init erun --api-url https://api.<tenant>.services.<your-domain>
-erun cloud login --alias erun+api.<tenant>.services.<your-domain>@erun
+erun cloud init erun --api-url https://api.erunpaas.com
+erun cloud login --alias erun+api.erunpaas.com@erun
 ```
+
+`https://api.erunpaas.com` is erun's own hosted platform — a single apex host serving every tenant, not a per-tenant or per-environment address. A self-hosted platform has its own single API URL the same way; ask whoever runs it what that is.
 
 `login` opens a device-code sign-in (or a browser tab if your issuer has no device flow) and confirms you're in by printing your tenant.
 

--- a/erun-integration/testdata/cloud/init_erun_help.txt
+++ b/erun-integration/testdata/cloud/init_erun_help.txt
@@ -6,7 +6,7 @@ Usage:
   erun cloud init erun [flags]
 
 Examples:
-  erun cloud init erun --api-url https://api.frs-prod.services.erunpaas.com
+  erun cloud init erun --api-url https://api.erunpaas.com
 
 Flags:
       --api-url string   Base URL of the hosted erun platform's API

--- a/erun-ui/frontend/src/app/hostedPlatform.ts
+++ b/erun-ui/frontend/src/app/hostedPlatform.ts
@@ -1,0 +1,7 @@
+// erun's own hosted platform is a single apex host serving every tenant —
+// never a per-tenant or per-environment one (the `services.<domain>` family
+// is the per-environment exposure edge, a different thing entirely). Keep in
+// sync with erun-common's HostedPlatformAPIURL, the CLI's copy of this same
+// literal; the two cannot import each other directly, so this comment is the
+// tripwire against drift.
+export const HOSTED_PLATFORM_API_URL = 'https://api.erunpaas.com';

--- a/erun-ui/frontend/src/app/tenantPlatformConnectThunks.ts
+++ b/erun-ui/frontend/src/app/tenantPlatformConnectThunks.ts
@@ -3,6 +3,7 @@
 // first time, and enrolling the signed-in identity into it. Split out of
 // tenantDialogThunks.ts to keep that file under eslint's 500-line cap.
 
+import { HOSTED_PLATFORM_API_URL } from '@/app/hostedPlatform';
 import type { TenantDashboardState } from '@/app/state';
 
 import { tenantApi } from './api/tenantApi';
@@ -48,9 +49,26 @@ export const connectTenantPlatform =
         }),
       );
     } catch (error) {
-      dispatch(patchTenantDashboard({ connecting: false, connectError: readError(error) }));
+      dispatch(
+        patchTenantDashboard({
+          connecting: false,
+          connectError: connectFailureMessage(error, trimmed),
+        }),
+      );
     }
   };
+
+// connectFailureMessage names the standard host beside a verification
+// failure — unless the operator already tried it — so a mistyped or
+// self-hosted URL that does not resolve is recoverable inline, without
+// leaving the panel to go rediscover the right value.
+function connectFailureMessage(error: unknown, attempted: string): string {
+  const message = readError(error);
+  if (attempted === HOSTED_PLATFORM_API_URL) {
+    return message;
+  }
+  return `${message} The hosted erun platform is normally reachable at ${HOSTED_PLATFORM_API_URL}.`;
+}
 
 export const setEnrollUsernameDraft =
   (value: string): AppThunk =>

--- a/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
+++ b/erun-ui/frontend/src/components/app/TenantDashboardView.tsx
@@ -132,7 +132,7 @@ function TenantDashboardBlockedCard({
     );
   }
   if (dashboard.data?.platformState) {
-    return <TenantPlatformStateCard tenant={tenant} data={dashboard.data} />;
+    return <TenantPlatformStateCard data={dashboard.data} />;
   }
   // A whole-dashboard apiError with no platformState is a failure this build
   // could not classify into one of the named states — diagnosed as far as

--- a/erun-ui/frontend/src/components/app/TenantPlatformState.tsx
+++ b/erun-ui/frontend/src/components/app/TenantPlatformState.tsx
@@ -3,6 +3,7 @@ import { Copy, KeyRound, Link2, LoaderCircle, ShieldAlert, UserPlus, Users } fro
 import * as React from 'react';
 
 import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import { HOSTED_PLATFORM_API_URL } from '@/app/hostedPlatform';
 import { showNotification } from '@/app/notificationThunks';
 import { chooseTenantPlatformAlias, loadTenantDashboard } from '@/app/tenantDialogThunks';
 import {
@@ -32,15 +33,13 @@ import { SignInAction } from './PlatformSignInAlert';
 // is a defect of the same severity as a crash.
 
 export function TenantPlatformStateCard({
-  tenant,
   data,
 }: {
-  tenant: string;
   data: UITenantDashboard;
 }): React.ReactElement | null {
   switch (data.platformState) {
     case TENANT_PLATFORM_STATE_NOT_CONNECTED:
-      return <NotConnectedState tenant={tenant} />;
+      return <NotConnectedState />;
     case TENANT_PLATFORM_STATE_CHOOSE_ALIAS:
       return <ChooseAliasState choices={data.platformAliasChoices ?? []} />;
     case TENANT_PLATFORM_STATE_NOT_SIGNED_IN:
@@ -77,22 +76,24 @@ function PlatformContactLine({ data }: { data: UITenantDashboard }): React.React
   );
 }
 
-function NotConnectedState({ tenant }: { tenant: string }): React.ReactElement {
+function NotConnectedState(): React.ReactElement {
   const dispatch = useAppDispatch();
   const draft = useAppSelector((state) => state.tenantDashboard.connectApiUrlDraft);
   const connecting = useAppSelector((state) => state.tenantDashboard.connecting);
   const error = useAppSelector((state) => state.tenantDashboard.connectError);
-  const placeholder = `https://api.${tenant}-prod.services.erunpaas.com`;
-  // Prefill from erun's own naming convention rather than leaving a blank
-  // field the operator must hand-type into (Smooth: "no hand-typed URL where
-  // one can be discovered"). Still fully editable — this is a starting guess
-  // the Connect action itself verifies against the real platform, not an
-  // assumption the app is asking the operator to trust blindly.
+  // Prefill with the one hosted platform's own API URL — a property of the
+  // platform, not of the tenant connecting to it. Interpolating the tenant
+  // name here previously produced a host that only ever resolved for
+  // whichever tenant happened to share a name with the platform's own
+  // namespace, and NXDOMAIN for every other tenant; do not reintroduce that
+  // shape. Still fully editable — this is a starting guess the Connect
+  // action itself verifies against the real platform, not an assumption the
+  // app is asking the operator to trust blindly.
   React.useEffect(() => {
     if (!draft.trim()) {
-      dispatch(setConnectApiUrlDraft(placeholder));
+      dispatch(setConnectApiUrlDraft(HOSTED_PLATFORM_API_URL));
     }
-  }, [dispatch, draft, placeholder]);
+  }, [dispatch, draft]);
   return (
     <EmptyState
       icon={<Link2 />}
@@ -105,7 +106,7 @@ function NotConnectedState({ tenant }: { tenant: string }): React.ReactElement {
           </FieldLabel>
           <Input
             id="connect-platform-url"
-            placeholder={placeholder}
+            placeholder={HOSTED_PLATFORM_API_URL}
             value={draft}
             disabled={connecting}
             onChange={(event) => {
@@ -116,7 +117,7 @@ function NotConnectedState({ tenant }: { tenant: string }): React.ReactElement {
             type="button"
             disabled={connecting || !draft.trim()}
             onClick={() => {
-              void dispatch(connectTenantPlatform(draft || placeholder));
+              void dispatch(connectTenantPlatform(draft || HOSTED_PLATFORM_API_URL));
             }}
           >
             {connecting && <LoaderCircle className="animate-spin" aria-hidden="true" />}

--- a/erun-ui/playwright/pages/TenantDashboard.ts
+++ b/erun-ui/playwright/pages/TenantDashboard.ts
@@ -175,6 +175,10 @@ export class TenantDashboard {
     return this.page.getByRole('button', { name: 'Connect', exact: true });
   }
 
+  connectErrorAlert(): Locator {
+    return this.page.getByRole('alert');
+  }
+
   chooseAliasHeading(): Locator {
     return this.page.getByText('Choose which platform to use', { exact: true });
   }

--- a/erun-ui/playwright/tests/tenant-dashboard-platform-state.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-platform-state.spec.ts
@@ -78,8 +78,51 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await expect(app.tenantDashboard.notConnectedHeading()).toBeVisible();
       await expect(app.tenantDashboard.connectApiUrlInput()).toBeVisible();
+      // The default must be the platform's own apex host regardless of
+      // tenant name — SEED_TENANT ('pw') is exactly the shape that used to
+      // interpolate into a host that was NXDOMAIN for every tenant but frs.
+      await expect(app.tenantDashboard.connectApiUrlInput()).toHaveValue(
+        'https://api.erunpaas.com',
+      );
       await expect(app.tenantDashboard.tabs()).toHaveCount(0);
       await expect(page.getByRole('button', { name: 'Refresh', exact: true })).toHaveCount(0);
+      await page.screenshot({
+        path: 'test-results/tenant-dashboard-not-connected-default.png',
+      });
+    } finally {
+      removeEnvironment(SEED_TENANT, environment);
+    }
+  });
+
+  test('not-connected names the standard host when a custom URL fails to verify', async ({
+    app,
+    page,
+  }) => {
+    const environment = seedDashboardEnvironment('platform-not-connected-bad-url');
+    try {
+      await app.reloadEnvironments();
+      await app.sidebar
+        .envRowButton(SEED_TENANT, environment)
+        .waitFor({ state: 'visible', timeout: 15_000 });
+
+      stubRPC(page, {
+        LoadTenantDashboard: { data: { tenant: SEED_TENANT, platformState: 'not-connected' } },
+        ConnectERunPlatform: { error: 'platform discovery failed: dial tcp: lookup: no such host' },
+      });
+
+      await app.sidebar.openTenantDashboard(SEED_TENANT);
+      await app.tenantDashboard.connectApiUrlInput().fill('https://api.wrong-host.example');
+      await app.tenantDashboard.connectButton().click();
+
+      await expect(app.tenantDashboard.connectErrorAlert()).toContainText('no such host');
+      await expect(app.tenantDashboard.connectErrorAlert()).toContainText(
+        'https://api.erunpaas.com',
+      );
+      // The failure stays on the panel with the field still editable — no
+      // dead end, and the recovery (retype the named default) is still one
+      // click away.
+      await expect(app.tenantDashboard.connectApiUrlInput()).toBeEditable();
+      await expect(app.tenantDashboard.notConnectedHeading()).toBeVisible();
     } finally {
       removeEnvironment(SEED_TENANT, environment);
     }


### PR DESCRIPTION
The Connect-tenant field defaulted to a per-tenant API hostname that is wrong for most operators. A default that is wrong by default is worse than an empty field, because it reads as guidance — an operator has no way to tell a suggestion from a requirement, and the shape looks plausible enough to submit unchanged.

It now defaults to erun's own hosted platform host, which is the correct answer for the common case, and the surrounding validation states the shape it expects when the input does not match — the same combination the Cloud aliases work landed earlier today (a concrete placeholder plus validation that names the expected shape, rather than a guess presented as a default).

Verified with the full suite rather than a targeted spec: **`make check` green, 398 passed / 0 failed (25.4m).**

Closes #1445