### PR TITLE
Skip a baseline entry whose file is absent from the tree being walked

### DIFF
--- a/erun-integration/bare_required_input_test.go
+++ b/erun-integration/bare_required_input_test.go
@@ -199,6 +199,14 @@ func TestNoBareRequiredInputError(t *testing.T) {
 // KnownUnsurfacedRoutes. A fix that lowers a file's count without lowering
 // its baseline entry here would otherwise let the debt silently look larger
 // than it is forever.
+//
+// A baselined file absent from root is skipped rather than compared, the
+// same reasoning as issueReferenceBaseline's own baseline-is-current check:
+// a narrowed tree (a container build context COPYing a subset of the repo)
+// can legitimately omit a file a full checkout has, and a walker cannot tell
+// "cleaned up" from "not here" by hit count alone. The full-checkout run
+// still enforces the shrink-only contract for every file, since only there
+// do all baselined files exist to compare.
 func TestBareRequiredInputBaselineIsCurrent(t *testing.T) {
 	root := repoRoot(t)
 	counts := map[string]int{}
@@ -206,6 +214,12 @@ func TestBareRequiredInputBaselineIsCurrent(t *testing.T) {
 		counts[hit.file]++
 	}
 	for file, baseline := range bareRequiredInputBaseline {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(file))); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("stat %s: %v", file, err)
+		}
 		if actual := counts[file]; actual < baseline {
 			t.Errorf("%s: bareRequiredInputBaseline claims %d hit(s) but only %d remain -- lower the baseline entry (see https://github.com/sophium/erun/issues/1506)", file, baseline, actual)
 		}

--- a/erun-integration/issue_reference_test.go
+++ b/erun-integration/issue_reference_test.go
@@ -390,6 +390,18 @@ func TestNoIssueReferenceInCode(t *testing.T) {
 // above. A cleanup that removes a reference without lowering its baseline
 // entry here would otherwise let the debt silently look larger than it is
 // forever.
+//
+// A baselined file that is absent from root entirely is skipped rather than
+// compared: this walker only ever runs against whatever tree it was pointed
+// at, and a narrowed tree (a container build context that COPYs a subset of
+// the repo, for instance) legitimately does not contain every file a full
+// checkout does. Zero hits from a file that is not there and zero hits from
+// a file that was genuinely cleaned up are indistinguishable by count alone,
+// so treating an absent file as "cleaned up" silently defeats the shrink-only
+// contract for exactly the files a narrowed tree omits. Skipping instead
+// means a genuinely stale entry still fails here on any tree that does
+// contain the file -- including a full checkout -- so the contract holds
+// everywhere the file exists to check.
 func TestIssueReferenceBaselineIsCurrent(t *testing.T) {
 	root := repoRoot(t)
 	counts := map[string]int{}
@@ -397,6 +409,12 @@ func TestIssueReferenceBaselineIsCurrent(t *testing.T) {
 		counts[hit.file]++
 	}
 	for file, baseline := range issueReferenceBaseline {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(file))); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			t.Fatalf("stat %s: %v", file, err)
+		}
 		if actual := counts[file]; actual < baseline {
 			t.Errorf("%s: issueReferenceBaseline claims %d hit(s) but only %d remain -- lower the baseline entry", file, baseline, actual)
 		}


### PR DESCRIPTION
Release 1.0.207 failed on this. `erun release` builds the `erun-devops` image, whose test stage runs `make check`, and:

```
--- FAIL: TestIssueReferenceBaselineIsCurrent
    erun-devops/dns01-webhook/solver.go: issueReferenceBaseline claims 1 hit(s) but only 0 remain -- lower the baseline entry
    erun-devops/dns01-webhook/solver_test.go: issueReferenceBaseline claims 1 hit(s) but only 0 remain -- lower the baseline entry
```

The same test passes on a full checkout of the same commit.

## Why

`erun-devops/docker/erun-devops/Dockerfile` COPYs a deliberate subset of the repo and does not include `erun-devops/dns01-webhook` — correctly, since that is a separate component with its own image. Inside that context the files simply do not exist, the walker finds zero occurrences, and the shrink-only check reads zero as "cleaned up, lower the entry."

**A count-based baseline cannot distinguish "no longer contains the pattern" from "not here."** Both are zero and they mean opposite things.

## The fix

A baselined file absent from the tree being walked is skipped rather than compared. That keeps the shrink-only contract intact everywhere the file exists to check: a genuinely stale entry still fails on any tree containing the file, including every full checkout and therefore every PR gate. It only stops a narrowed tree from reporting an omission as a cleanup.

`erun-integration/bare_required_input_test.go` uses the same baseline pattern and had the same assumption; it is fixed here too.

`desktop_surface_test.go` was audited and needs no change — its baseline (`KnownUnsurfacedRoutes`) is keyed on route names rather than file paths, so an absent file cannot skew it.

## How this was missed

`make check-gate` on a full worktree passes, which is what every PR gate runs. The image-build context is the only place the difference appears, and nothing runs `make check` there except a release. The gate was green everywhere it was tested and red in the one place that ships — so any gate that walks the filesystem needs checking in the image-build context too, not only in a worktree.

Verified: `make check-gate` green.

Closes #1549