### PR TITLE
Name the operation and recovery for bare tenant/environment errors

### DIFF
--- a/erun-cli/cmd/activity.go
+++ b/erun-cli/cmd/activity.go
@@ -207,8 +207,8 @@ func newActivityCancelStopPendingCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			tenant = strings.TrimSpace(tenant)
 			environment = strings.TrimSpace(environment)
-			if tenant == "" || environment == "" {
-				return fmt.Errorf("tenant and environment are required")
+			if err := validateActivityTarget(tenant, environment); err != nil {
+				return err
 			}
 			return common.ClearEnvironmentStopPending(tenant, environment)
 		},
@@ -247,8 +247,8 @@ func newActivityRecordStopCmd() *cobra.Command {
 func runActivityRecordStop(cmd *cobra.Command, tenant, environment, reason, cloudContextName, source string, stateStdin bool) error {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := validateActivityTarget(tenant, environment); err != nil {
+		return err
 	}
 	source = normalizeStopHistorySource(source)
 	pending, havePending, err := loadPendingForRecord(commandContext(cmd).Stdin, stateStdin, tenant, environment)
@@ -357,8 +357,8 @@ func addActivityTargetFlags(cmd *cobra.Command, tenant, environment *string) {
 func resolveActivityStatus(store common.OpenStore, tenant, environment string) (common.EnvironmentIdleStatus, error) {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return common.EnvironmentIdleStatus{}, fmt.Errorf("tenant and environment are required")
+	if err := validateActivityTarget(tenant, environment); err != nil {
+		return common.EnvironmentIdleStatus{}, err
 	}
 	return common.ResolveStoredEnvironmentIdleStatus(store, tenant, environment, time.Now())
 }

--- a/erun-cli/cmd/activity_lease.go
+++ b/erun-cli/cmd/activity_lease.go
@@ -391,9 +391,28 @@ func retainRuntimeUsage(tenant, environment, cgroupRoot string) error {
 	return common.SaveRuntimeUsageHistory(tenant, environment, common.AppendRuntimeUsageSample(history, sample, time.Now()))
 }
 
-func validateActivityTarget(tenant, environment string) error {
-	if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
-		return fmt.Errorf("tenant and environment are required")
+// missingTenantOrEnvironmentFlags names which of the shared --tenant/--environment
+// flags a caller left empty, for validateActivityTarget/validateJobTarget to build
+// an operation-specific refusal instead of a bare "tenant and environment are
+// required" dead end.
+func missingTenantOrEnvironmentFlags(tenant, environment string) []string {
+	var missing []string
+	if strings.TrimSpace(tenant) == "" {
+		missing = append(missing, "tenant")
 	}
-	return nil
+	if strings.TrimSpace(environment) == "" {
+		missing = append(missing, "environment")
+	}
+	return missing
+}
+
+func validateActivityTarget(tenant, environment string) error {
+	missing := missingTenantOrEnvironmentFlags(tenant, environment)
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s not set: erun activity commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly",
+		strings.Join(missing, " and "),
+	)
 }

--- a/erun-cli/cmd/activity_proxy.go
+++ b/erun-cli/cmd/activity_proxy.go
@@ -52,8 +52,8 @@ func runActivitySSHProxy(params activitySSHProxyParams) error {
 	params.Environment = strings.TrimSpace(params.Environment)
 	params.ListenAddress = strings.TrimSpace(params.ListenAddress)
 	params.TargetAddress = strings.TrimSpace(params.TargetAddress)
-	if params.Tenant == "" || params.Environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := validateActivityTarget(params.Tenant, params.Environment); err != nil {
+		return err
 	}
 	if params.ListenAddress == "" || params.TargetAddress == "" {
 		return fmt.Errorf("listen and target addresses are required")

--- a/erun-cli/cmd/delete.go
+++ b/erun-cli/cmd/delete.go
@@ -36,7 +36,7 @@ func runDeleteCommand(ctx common.Context, store common.DeleteStore, promptRunner
 	environment = strings.TrimSpace(environment)
 	expected := common.DeleteEnvironmentConfirmation(tenant, environment)
 	if expected == "" {
-		return fmt.Errorf("tenant and environment are required")
+		return fmt.Errorf("tenant and environment must not be empty: run `erun delete TENANT ENVIRONMENT` with both positional arguments set")
 	}
 
 	if !ctx.DryRun && !yes {

--- a/erun-cli/cmd/job.go
+++ b/erun-cli/cmd/job.go
@@ -814,8 +814,12 @@ func addJobTargetFlags(cmd *cobra.Command, tenant, environment *string) {
 }
 
 func validateJobTarget(tenant, environment string) error {
-	if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
-		return fmt.Errorf("tenant and environment are required")
+	missing := missingTenantOrEnvironmentFlags(tenant, environment)
+	if len(missing) == 0 {
+		return nil
 	}
-	return nil
+	return fmt.Errorf(
+		"%s not set: erun job commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly",
+		strings.Join(missing, " and "),
+	)
 }

--- a/erun-common/activity.go
+++ b/erun-common/activity.go
@@ -250,8 +250,8 @@ func ResolveStoredEnvironmentIdleStatus(store EnvironmentIdleStore, tenant, envi
 	if store == nil {
 		return EnvironmentIdleStatus{}, fmt.Errorf("store is required")
 	}
-	if tenant == "" || environment == "" {
-		return EnvironmentIdleStatus{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve environment idle status", tenant, environment); err != nil {
+		return EnvironmentIdleStatus{}, err
 	}
 	config, _, err := store.LoadEnvConfig(tenant, environment)
 	if err != nil {
@@ -367,8 +367,8 @@ func RecordEnvironmentActivity(params EnvironmentActivityParams) error {
 	tenant := strings.TrimSpace(params.Tenant)
 	environment := strings.TrimSpace(params.Environment)
 	kind := strings.TrimSpace(params.Kind)
-	if tenant == "" || environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("record environment activity", tenant, environment); err != nil {
+		return err
 	}
 	if !validEnvironmentActivityKind(kind) {
 		return fmt.Errorf("unsupported activity kind %q", kind)
@@ -472,8 +472,8 @@ func LoadEnvironmentActivity(tenant, environment string) (map[string]Environment
 func EnvironmentActivityDir(tenant, environment string) (string, error) {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return "", fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve environment activity directory", tenant, environment); err != nil {
+		return "", err
 	}
 	dir, err := xdg.CacheFile(filepath.Join("erun", "activity", tenant, environment))
 	if err != nil {

--- a/erun-common/delete.go
+++ b/erun-common/delete.go
@@ -57,8 +57,8 @@ func RunDeleteEnvironment(ctx Context, params DeleteEnvironmentParams, store Del
 
 	tenant := strings.TrimSpace(params.Tenant)
 	environment := strings.TrimSpace(params.Environment)
-	if tenant == "" || environment == "" {
-		return DeleteEnvironmentResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("delete environment", tenant, environment); err != nil {
+		return DeleteEnvironmentResult{}, err
 	}
 
 	envConfig, configPath, err := store.LoadEnvConfig(tenant, environment)

--- a/erun-common/env_trace.go
+++ b/erun-common/env_trace.go
@@ -22,8 +22,8 @@ func EnvTraceLogPath(tenant, environment string) (string, error) {
 	}
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return "", fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve env trace log path", tenant, environment); err != nil {
+		return "", err
 	}
 	return filepath.Join(home, ".erun", tenant, environment, "trace.log"), nil
 }

--- a/erun-common/environment_target_required.go
+++ b/erun-common/environment_target_required.go
@@ -1,0 +1,32 @@
+package eruncommon
+
+import (
+	"fmt"
+	"strings"
+)
+
+// errMissingTenantOrEnvironment names which of tenant/environment an
+// erun-common call was given empty, the operation that needed them, and the
+// fix -- the same shape as erun-mcp's errMissingLocalTarget, adapted for a
+// library function instead of a bound server: erun-common never resolves a
+// tenant/environment target from ambient state (this package is called
+// directly as a plain library by all three transports), so a blank value
+// here means the caller -- a CLI flag, an MCP tool argument, or a desktop
+// binding -- did not resolve one before calling in. Returns nil when both
+// are set, so callers can use it as their whole guard clause.
+func errMissingTenantOrEnvironment(operation, tenant, environment string) error {
+	var missing []string
+	if strings.TrimSpace(tenant) == "" {
+		missing = append(missing, "tenant")
+	}
+	if strings.TrimSpace(environment) == "" {
+		missing = append(missing, "environment")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s: %s not set -- erun-common does not resolve a tenant/environment target from ambient state, so the caller must pass both explicitly",
+		operation, strings.Join(missing, " and "),
+	)
+}

--- a/erun-common/idle_stop_pending.go
+++ b/erun-common/idle_stop_pending.go
@@ -101,8 +101,8 @@ type MaybeArmOrFireIdleStopResult struct {
 func MaybeArmOrFireIdleStop(params MaybeArmOrFireIdleStopParams) (MaybeArmOrFireIdleStopResult, error) {
 	tenant := strings.TrimSpace(params.Tenant)
 	environment := strings.TrimSpace(params.Environment)
-	if tenant == "" || environment == "" {
-		return MaybeArmOrFireIdleStopResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve idle-stop arm/wait/fire decision", tenant, environment); err != nil {
+		return MaybeArmOrFireIdleStopResult{}, err
 	}
 	now := params.Now
 	if now.IsZero() {
@@ -205,8 +205,8 @@ func cloneIdleMarkersForPending(markers []EnvironmentIdleMarker) []EnvironmentId
 func LoadEnvironmentStopPending(tenant, environment string) (EnvironmentStopPending, bool, error) {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return EnvironmentStopPending{}, false, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load environment stop-pending state", tenant, environment); err != nil {
+		return EnvironmentStopPending{}, false, err
 	}
 	path, err := EnvironmentStopPendingPath(tenant, environment)
 	if err != nil {
@@ -284,8 +284,8 @@ func EnvironmentStopHistoryPath(tenant, environment string) (string, error) {
 func AppendStopHistoryEntry(tenant, environment string, entry EnvironmentStopHistoryEntry) error {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("append stop-history entry", tenant, environment); err != nil {
+		return err
 	}
 	path, err := EnvironmentStopHistoryPath(tenant, environment)
 	if err != nil {
@@ -315,8 +315,8 @@ func AppendStopHistoryEntry(tenant, environment string, entry EnvironmentStopHis
 func LoadEnvironmentStopHistory(tenant, environment string) ([]EnvironmentStopHistoryEntry, error) {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return nil, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load stop-history", tenant, environment); err != nil {
+		return nil, err
 	}
 	path, err := EnvironmentStopHistoryPath(tenant, environment)
 	if err != nil {

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -136,8 +136,8 @@ func resolveEnvironmentJobDir(dir string) (string, error) {
 // addressed by, shared by starting and attaching. The id defaults to the name,
 // matching the lease store, so re-running the same named work keeps one handle.
 func normalizeEnvironmentJobIdentity(tenant, environment, name, id string) (string, error) {
-	if strings.TrimSpace(tenant) == "" || strings.TrimSpace(environment) == "" {
-		return "", fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve environment job identity", tenant, environment); err != nil {
+		return "", err
 	}
 	if strings.TrimSpace(name) == "" {
 		return "", fmt.Errorf("job name is required")

--- a/erun-common/unexpose.go
+++ b/erun-common/unexpose.go
@@ -87,8 +87,8 @@ func RunUnexposeService(ctx Context, params UnexposeParams, store ExposeStore, d
 func resolveUnexposeServicePlan(params UnexposeParams, store ExposeStore) (UnexposeResult, error) {
 	tenant := strings.TrimSpace(params.Tenant)
 	environment := strings.TrimSpace(params.Environment)
-	if tenant == "" || environment == "" {
-		return UnexposeResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve unexpose service plan", tenant, environment); err != nil {
+		return UnexposeResult{}, err
 	}
 	if err := ValidateTenantName(tenant); err != nil {
 		return UnexposeResult{}, err

--- a/erun-integration/bare_required_input_test.go
+++ b/erun-integration/bare_required_input_test.go
@@ -61,46 +61,18 @@ var bareRequiredInputPattern = regexp.MustCompile(`^(?:tenant|environment)(?: an
 // for the "tenant and environment are required" hits that widening the
 // pattern above newly caught: 65 pre-existing call sites across erun-cli,
 // erun-common, and erun-ui, none of them reachable from the exec_agent bug
-// this gate change was made for. Rewriting all of them to name their own
-// operation and recovery is a distinct, large effort of its own (tracked in
-// a separate GitHub issue), not something to rush inline with a one-tool
-// schema fix. This baseline may only shrink: fixing a site
-// and forgetting to remove its entry here fails TestBareRequiredInputBaselineIsCurrent
-// below, the same way a stale KnownUnsurfacedRoutes entry fails its own gate.
-// The key is the file path relative to the repo root; the value is the exact
-// count of matching literals still in that file.
-var bareRequiredInputBaseline = map[string]int{
-	"erun-cli/cmd/activity.go":         3,
-	"erun-cli/cmd/activity_lease.go":   1,
-	"erun-cli/cmd/activity_proxy.go":   1,
-	"erun-cli/cmd/delete.go":           1,
-	"erun-cli/cmd/job.go":              1,
-	"erun-common/activity.go":          3,
-	"erun-common/delete.go":            1,
-	"erun-common/env_trace.go":         1,
-	"erun-common/idle_stop_pending.go": 4,
-	"erun-common/job_supervisor.go":    1,
-	"erun-common/unexpose.go":          1,
-	"erun-ui/contribute_mode.go":       2,
-	"erun-ui/contribute_sessions.go":   2,
-	"erun-ui/deploy_components.go":     1,
-	"erun-ui/environment_config.go":    4,
-	"erun-ui/environment_health.go":    1,
-	"erun-ui/environment_jobs.go":      1,
-	"erun-ui/environment_stop.go":      1,
-	"erun-ui/env_trace_handlers.go":    1,
-	"erun-ui/exec_write_push.go":       2,
-	"erun-ui/exposure_app.go":          3,
-	"erun-ui/host_open_path.go":        1,
-	"erun-ui/host_workspace.go":        4,
-	"erun-ui/idle_status.go":           3,
-	"erun-ui/outputs.go":               2,
-	"erun-ui/pin_version.go":           3,
-	"erun-ui/runtime_activity.go":      2,
-	"erun-ui/runtime_sizing.go":        2,
-	"erun-ui/runtime_usage.go":         1,
-	"erun-ui/terminal_sessions.go":     11,
-}
+// this gate change was made for. All 65 have since been rewritten to name
+// their own operation and recovery (see erun-common's errMissingTenantOrEnvironment
+// and erun-ui's errMissingTenantOrEnvironment), so the baseline is empty: it
+// stays declared, rather than deleted, so a reintroduced bare literal in one
+// of these files gets zero tolerance like any other file, and so a future
+// widening of this baseline documents the same shrink-only contract. This
+// baseline may only shrink: fixing a site and forgetting to remove its entry
+// here fails TestBareRequiredInputBaselineIsCurrent below, the same way a
+// stale KnownUnsurfacedRoutes entry fails its own gate. The key is the file
+// path relative to the repo root; the value is the exact count of matching
+// literals still in that file.
+var bareRequiredInputBaseline = map[string]int{}
 
 // skipDirForBareRequiredInputScan excludes directories that hold no
 // hand-written production Go source: version control, installed JS

--- a/erun-integration/testdata/activity/cancel_stop_pending_requires_target.txt
+++ b/erun-integration/testdata/activity/cancel_stop_pending_requires_target.txt
@@ -1,2 +1,2 @@
 audit: erun activity cancel-stop-pending
-tenant and environment are required
+tenant and environment not set: erun activity commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly

--- a/erun-integration/testdata/activity/sample_requires_target.txt
+++ b/erun-integration/testdata/activity/sample_requires_target.txt
@@ -1,2 +1,2 @@
 audit: erun activity sample
-tenant and environment are required
+tenant and environment not set: erun activity commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly

--- a/erun-integration/testdata/activity/ssh_proxy_requires_tenant_and_environment.txt
+++ b/erun-integration/testdata/activity/ssh_proxy_requires_tenant_and_environment.txt
@@ -1,2 +1,2 @@
 audit: erun activity ssh-proxy --listen <LOOPBACK>:0 --target <LOOPBACK>:1
-tenant and environment are required
+tenant and environment not set: erun activity commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly

--- a/erun-integration/testdata/activity/stop_ready_requires_target.txt
+++ b/erun-integration/testdata/activity/stop_ready_requires_target.txt
@@ -1,2 +1,2 @@
 audit: erun activity stop-ready
-tenant and environment are required
+tenant and environment not set: erun activity commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly

--- a/erun-integration/testdata/job/start_requires_target_and_name.txt
+++ b/erun-integration/testdata/job/start_requires_target_and_name.txt
@@ -1,4 +1,4 @@
 audit: erun job start --name suite work
-tenant and environment are required
+tenant and environment not set: erun job commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly
 audit: erun job start --environment dev --tenant team work
 job name is required

--- a/erun-ui/contribute_mode.go
+++ b/erun-ui/contribute_mode.go
@@ -65,8 +65,8 @@ func (a *App) GetContributeMode(selection uiSelection) bool {
 // after this returns; this method does not touch them.
 func (a *App) SetContributeMode(selection uiSelection, on bool) (uiContributeState, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiContributeState{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("set contribute mode", selection.Tenant, selection.Environment); err != nil {
+		return uiContributeState{}, err
 	}
 	if on {
 		if !a.IsContributeEligible(selection) {
@@ -124,8 +124,8 @@ func (a *App) runEnsureErunClone(selection uiSelection) error {
 }
 
 func (a *App) resolveContributeAppPort(selection uiSelection) (int, error) {
-	if selection.Tenant == "" || selection.Environment == "" {
-		return 0, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve contribute app port", selection.Tenant, selection.Environment); err != nil {
+		return 0, err
 	}
 	if !a.GetContributeMode(selection) {
 		return 0, fmt.Errorf("contribute mode is not enabled for %s/%s", selection.Tenant, selection.Environment)

--- a/erun-ui/contribute_sessions.go
+++ b/erun-ui/contribute_sessions.go
@@ -18,8 +18,8 @@ const (
 // operator's local erun clone where `erun` runs the locally-built CLI.
 func (a *App) StartContributeSession(selection uiSelection, slot, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("start contribute ERun session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
 	}
 	return a.enqueueGatedSession(selection, "contribute-erun", func(ctx context.Context) (startSessionResult, *managedTerminal, error) {
 		return a.runContributeSession(ctx, selection, slot, cols, rows, false)
@@ -30,8 +30,8 @@ func (a *App) StartContributeSession(selection uiSelection, slot, cols, rows int
 // ERun tab, but boots the env's AI assistant inside the clone.
 func (a *App) StartContributeAISession(selection uiSelection, slot, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("start contribute AI session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
 	}
 	return a.enqueueGatedSession(selection, "contribute-ai", func(ctx context.Context) (startSessionResult, *managedTerminal, error) {
 		return a.runContributeSession(ctx, selection, slot, cols, rows, true)

--- a/erun-ui/deploy_components.go
+++ b/erun-ui/deploy_components.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -22,8 +21,8 @@ func (a *App) LoadDeployComponents(selection uiSelection) (uiDeployComponents, e
 	selection = normalizeSelection(selection)
 	tenant := strings.TrimSpace(selection.Tenant)
 	environment := strings.TrimSpace(selection.Environment)
-	if tenant == "" || environment == "" {
-		return uiDeployComponents{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load deploy components", tenant, environment); err != nil {
+		return uiDeployComponents{}, err
 	}
 	components, err := eruncommon.ResolveDeployableComponents(
 		a.deps.store,

--- a/erun-ui/env_trace_handlers.go
+++ b/erun-ui/env_trace_handlers.go
@@ -33,8 +33,8 @@ type uiEnvTrace struct {
 // the env or hold it awake.
 func (a *App) LoadEnvTrace(selection uiSelection) (uiEnvTrace, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiEnvTrace{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load environment trace", selection.Tenant, selection.Environment); err != nil {
+		return uiEnvTrace{}, err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,

--- a/erun-ui/environment_config.go
+++ b/erun-ui/environment_config.go
@@ -15,8 +15,8 @@ import (
 
 func (a *App) LoadEnvironmentConfig(selection uiSelection) (uiEnvironmentConfig, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiEnvironmentConfig{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load environment config", selection.Tenant, selection.Environment); err != nil {
+		return uiEnvironmentConfig{}, err
 	}
 
 	config, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
@@ -32,8 +32,8 @@ func (a *App) LoadEnvironmentConfig(selection uiSelection) (uiEnvironmentConfig,
 
 func (a *App) SaveEnvironmentConfig(selection uiSelection, config uiEnvironmentConfig) (uiEnvironmentConfig, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiEnvironmentConfig{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("save environment config", selection.Tenant, selection.Environment); err != nil {
+		return uiEnvironmentConfig{}, err
 	}
 
 	existing, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
@@ -113,8 +113,8 @@ func (a *App) saveEnvironmentProjectRegistries(tenant string, config eruncommon.
 // the desktop honors it; CLI users always run the preflight start.
 func (a *App) SetEnvironmentAutoStart(selection uiSelection, mode string) (uiEnvironmentConfig, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiEnvironmentConfig{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("set environment auto-start", selection.Tenant, selection.Environment); err != nil {
+		return uiEnvironmentConfig{}, err
 	}
 	value, err := parseAutoStartMode(mode)
 	if err != nil {
@@ -151,8 +151,8 @@ func parseAutoStartMode(mode string) (*bool, error) {
 
 func (a *App) ChooseWorkspaceSyncLocalFolder(selection uiSelection, current string) (string, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return "", fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("choose workspace-sync local folder", selection.Tenant, selection.Environment); err != nil {
+		return "", err
 	}
 	if a.ctx == nil {
 		return "", fmt.Errorf("application context is not ready")

--- a/erun-ui/environment_health.go
+++ b/erun-ui/environment_health.go
@@ -18,8 +18,8 @@ import (
 // cannot report the "not deployed" case this covers.
 func (a *App) CheckEnvironmentHealth(selection uiSelection) (uiEnvironmentHealth, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiEnvironmentHealth{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("check environment health", selection.Tenant, selection.Environment); err != nil {
+		return uiEnvironmentHealth{}, err
 	}
 	config, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
 	if err != nil {

--- a/erun-ui/environment_jobs.go
+++ b/erun-ui/environment_jobs.go
@@ -34,8 +34,8 @@ import (
 func (a *App) LoadEnvironmentJobs(tenant, environment string) ([]uiEnvironmentJob, error) {
 	tenant = strings.TrimSpace(tenant)
 	environment = strings.TrimSpace(environment)
-	if tenant == "" || environment == "" {
-		return nil, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load environment jobs", tenant, environment); err != nil {
+		return nil, err
 	}
 	result, useMCP, err := a.jobsReachability(tenant, environment)
 	if err != nil {

--- a/erun-ui/environment_jobs_test.go
+++ b/erun-ui/environment_jobs_test.go
@@ -178,7 +178,7 @@ func TestJobToUIKeepsAbsentOutcomesAbsent(t *testing.T) {
 func TestJobReadsRequireTheirIdentifiers(t *testing.T) {
 	app := &App{}
 	if _, err := app.LoadEnvironmentJobs(" ", "build"); err == nil ||
-		!strings.Contains(err.Error(), "tenant and environment are required") {
+		!strings.Contains(err.Error(), "tenant not set") {
 		t.Fatalf("blank tenant: %v", err)
 	}
 	if _, err := app.ReadEnvironmentJobOutput(uiJobOutputInput{Tenant: "t", Environment: "e"}); err == nil ||

--- a/erun-ui/environment_stop.go
+++ b/erun-ui/environment_stop.go
@@ -19,8 +19,8 @@ import (
 // deploy reconciles it instead of quietly restarting the pod.
 func (a *App) StopEnvironment(selection uiSelection) (uiEnvironmentStopResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiEnvironmentStopResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("stop environment", selection.Tenant, selection.Environment); err != nil {
+		return uiEnvironmentStopResult{}, err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,

--- a/erun-ui/exec_write_push.go
+++ b/erun-ui/exec_write_push.go
@@ -48,8 +48,8 @@ func withDefaultExecWriteDeps(deps erunUIDeps) erunUIDeps {
 // from the call itself so ExecCommit's own branching stays under the
 // module's cyclomatic-complexity cap.
 func validateExecCommitInput(selection uiSelection, input uiExecCommitInput) (branch, message string, err error) {
-	if selection.Tenant == "" || selection.Environment == "" {
-		return "", "", fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("commit environment working tree", selection.Tenant, selection.Environment); err != nil {
+		return "", "", err
 	}
 	branch = strings.TrimSpace(input.Branch)
 	if branch == "" {
@@ -105,8 +105,8 @@ func (a *App) ExecCommit(selection uiSelection, input uiExecCommitInput) (erunco
 func (a *App) ExecPush(selection uiSelection, input uiExecPushInput) (eruncommon.PushWorkingTreeBranchResult, error) {
 	selection = normalizeSelection(selection)
 	branch := strings.TrimSpace(input.Branch)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return eruncommon.PushWorkingTreeBranchResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("push environment branch", selection.Tenant, selection.Environment); err != nil {
+		return eruncommon.PushWorkingTreeBranchResult{}, err
 	}
 	if branch == "" {
 		return eruncommon.PushWorkingTreeBranchResult{}, fmt.Errorf("branch is required")

--- a/erun-ui/exposure_app.go
+++ b/erun-ui/exposure_app.go
@@ -23,8 +23,8 @@ import (
 // reports Restricted instead of a bare empty list.
 func (a *App) ListEnvironmentExposures(selection uiSelection) (uiExposureList, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiExposureList{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("list environment exposures", selection.Tenant, selection.Environment); err != nil {
+		return uiExposureList{}, err
 	}
 	req, configured, notConfiguredReason, err := a.resolveExposureRequest(selection)
 	if err != nil {
@@ -49,8 +49,8 @@ func (a *App) ListEnvironmentExposures(selection uiSelection) (uiExposureList, e
 // commits on submit, matching every other Manage dialog save action).
 func (a *App) ExposeEnvironmentService(selection uiSelection, input uiExposeServiceInput) (uiExposedService, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiExposedService{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("expose environment service", selection.Tenant, selection.Environment); err != nil {
+		return uiExposedService{}, err
 	}
 	service := strings.TrimSpace(input.Service)
 	targetIP := strings.TrimSpace(input.TargetIP)
@@ -83,8 +83,8 @@ func (a *App) ExposeEnvironmentService(selection uiSelection, input uiExposeServ
 // eruncommon.RunUnexposeService).
 func (a *App) UnexposeEnvironment(selection uiSelection) (uiUnexposeResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiUnexposeResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("unexpose environment", selection.Tenant, selection.Environment); err != nil {
+		return uiUnexposeResult{}, err
 	}
 	projectRoot := a.exposeProjectRoot()
 	if !eruncommon.ProjectHasExposablePlatform(projectRoot) {

--- a/erun-ui/host_open_path.go
+++ b/erun-ui/host_open_path.go
@@ -122,8 +122,8 @@ type podPathResolution struct {
 func (a *App) ResolveEnvironmentHostPath(selection uiSelection, podPath string) (podPathResolution, error) {
 	selection = normalizeSelection(selection)
 	podPath = strings.TrimSpace(podPath)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return podPathResolution{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve environment host path", selection.Tenant, selection.Environment); err != nil {
+		return podPathResolution{}, err
 	}
 	if podPath == "" {
 		return podPathResolution{}, fmt.Errorf("path is required")

--- a/erun-ui/host_workspace.go
+++ b/erun-ui/host_workspace.go
@@ -53,8 +53,8 @@ func (a *App) resolveHostWorkspace(selection uiSelection) (eruncommon.OpenResult
 // mirror directly.
 func (a *App) LoadHostDiff(selection uiSelection, options uiDiffOptions) (eruncommon.DiffResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return eruncommon.DiffResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load host diff", selection.Tenant, selection.Environment); err != nil {
+		return eruncommon.DiffResult{}, err
 	}
 	_, path, err := a.resolveHostWorkspace(selection)
 	if err != nil {
@@ -75,8 +75,8 @@ func (a *App) LoadHostDiff(selection uiSelection, options uiDiffOptions) (erunco
 func (a *App) OpenHostIDE(selection uiSelection, ide string) error {
 	selection = normalizeSelection(selection)
 	ide = strings.TrimSpace(ide)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("open host IDE", selection.Tenant, selection.Environment); err != nil {
+		return err
 	}
 	if ide != "vscode" && ide != "intellij" {
 		return fmt.Errorf("unsupported IDE %q", ide)
@@ -117,8 +117,8 @@ type hostArtifact struct {
 // $ERUN_OUTPUTS_DIR into the host workspace (e.g. a cross-built Windows .exe).
 func (a *App) ListHostArtifacts(selection uiSelection) ([]hostArtifact, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return nil, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("list host artifacts", selection.Tenant, selection.Environment); err != nil {
+		return nil, err
 	}
 	_, path, err := a.resolveHostWorkspace(selection)
 	if err != nil {
@@ -150,8 +150,8 @@ func (a *App) ListHostArtifacts(selection uiSelection) ([]hostArtifact, error) {
 func (a *App) RunHostArtifact(selection uiSelection, relPath string) error {
 	selection = normalizeSelection(selection)
 	relPath = strings.TrimSpace(relPath)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("run host artifact", selection.Tenant, selection.Environment); err != nil {
+		return err
 	}
 	if !eruncommon.SafeWorkspaceSyncPath(relPath) {
 		return fmt.Errorf("invalid artifact path %q", relPath)

--- a/erun-ui/idle_status.go
+++ b/erun-ui/idle_status.go
@@ -11,8 +11,8 @@ import (
 
 func (a *App) LoadIdleStatus(selection uiSelection) (uiIdleStatus, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiIdleStatus{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load idle status", selection.Tenant, selection.Environment); err != nil {
+		return uiIdleStatus{}, err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
@@ -254,8 +254,8 @@ func (a *App) maybeStopIdleCloudEnvironment(result eruncommon.OpenResult, _ erun
 // client observe it too.
 func (a *App) CancelPendingIdleStop(selection uiSelection) error {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("cancel pending idle stop", selection.Tenant, selection.Environment); err != nil {
+		return err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
@@ -312,8 +312,8 @@ func (a *App) recordManualStopForCloudContext(ctx context.Context, cloudContextN
 // canonical history the in-pod monitor records rather than any local copy.
 func (a *App) LoadStopHistory(selection uiSelection) ([]uiLastStopEvent, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return nil, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load stop history", selection.Tenant, selection.Environment); err != nil {
+		return nil, err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,

--- a/erun-ui/outputs.go
+++ b/erun-ui/outputs.go
@@ -31,8 +31,8 @@ func downloadAgentOutputViaRuntime(result eruncommon.OpenResult, params eruncomm
 // ListAgentOutputs lists the files an agent produced in the selected env's runtime pod, newest-first.
 func (a *App) ListAgentOutputs(selection uiSelection) (eruncommon.RuntimeOutputsListResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return eruncommon.RuntimeOutputsListResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("list agent outputs", selection.Tenant, selection.Environment); err != nil {
+		return eruncommon.RuntimeOutputsListResult{}, err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
@@ -50,8 +50,8 @@ func (a *App) ListAgentOutputs(selection uiSelection) (eruncommon.RuntimeOutputs
 // as a <name>.tar.gz archive.
 func (a *App) DownloadAgentOutput(selection uiSelection, name string) (string, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return "", fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("download agent output", selection.Tenant, selection.Environment); err != nil {
+		return "", err
 	}
 	if strings.TrimSpace(name) == "" {
 		return "", fmt.Errorf("output name is required")

--- a/erun-ui/pin_version.go
+++ b/erun-ui/pin_version.go
@@ -59,8 +59,8 @@ func (a *App) RevertPinVersion(selection uiSelection) (uiPinPlan, error) {
 
 func (a *App) runPinCommand(selection uiSelection, target string, preview, revert bool) (uiPinPlan, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiPinPlan{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("run pin command", selection.Tenant, selection.Environment); err != nil {
+		return uiPinPlan{}, err
 	}
 	ctx := a.ctx
 	if ctx == nil {
@@ -169,8 +169,8 @@ func pinSiteLabel(site eruncommon.PinSite) string {
 // picker offers real published versions rather than a free-text box.
 func (a *App) ListPinnableVersions(selection uiSelection) ([]string, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return nil, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("list pinnable versions", selection.Tenant, selection.Environment); err != nil {
+		return nil, err
 	}
 	ctx := a.ctx
 	if ctx == nil {
@@ -212,8 +212,8 @@ type uiPinRepoCheckoutStatus struct {
 // that does, since every environment of a tenant shares one repo.
 func (a *App) PinRepoCheckoutStatus(selection uiSelection) (uiPinRepoCheckoutStatus, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiPinRepoCheckoutStatus{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resolve pin repo checkout status", selection.Tenant, selection.Environment); err != nil {
+		return uiPinRepoCheckoutStatus{}, err
 	}
 	target, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
 	if err != nil {

--- a/erun-ui/runtime_activity.go
+++ b/erun-ui/runtime_activity.go
@@ -61,8 +61,8 @@ const (
 // error that turns the Runtime tab into a failure surface.
 func (a *App) LoadRuntimeActivity(selection uiSelection) (uiRuntimeActivity, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiRuntimeActivity{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load runtime activity", selection.Tenant, selection.Environment); err != nil {
+		return uiRuntimeActivity{}, err
 	}
 	report, err := a.probeRuntimeActivity(selection)
 	if err != nil {
@@ -80,8 +80,8 @@ func (a *App) LoadRuntimeActivity(selection uiSelection) (uiRuntimeActivity, err
 // what is there before anything is stopped.
 func (a *App) ReclaimRuntimeResources(input uiRuntimeReclaimInput) (uiRuntimeReclaimResult, error) {
 	selection := normalizeSelection(uiSelection{Tenant: input.Tenant, Environment: input.Environment})
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiRuntimeReclaimResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("reclaim runtime resources", selection.Tenant, selection.Environment); err != nil {
+		return uiRuntimeReclaimResult{}, err
 	}
 	action := strings.TrimSpace(input.Action)
 	script, err := runtimeReclaimScript(action)

--- a/erun-ui/runtime_sizing.go
+++ b/erun-ui/runtime_sizing.go
@@ -78,8 +78,8 @@ type uiRuntimeSizingRecommendation struct {
 // and never writes anything.
 func (a *App) LoadRuntimeSizing(selection uiSelection) (uiRuntimeSizingRecommendation, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiRuntimeSizingRecommendation{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load runtime sizing", selection.Tenant, selection.Environment); err != nil {
+		return uiRuntimeSizingRecommendation{}, err
 	}
 	ctx, cancel := context.WithTimeout(a.backgroundContext(), runtimeSizingTimeout)
 	defer cancel()
@@ -102,8 +102,8 @@ func (a *App) LoadRuntimeSizing(selection uiSelection) (uiRuntimeSizingRecommend
 // that does.
 func (a *App) ResizeRuntimeToRecommendation(selection uiSelection, overrideLease bool) (uiRuntimeSizingRecommendation, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiRuntimeSizingRecommendation{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("resize runtime to recommendation", selection.Tenant, selection.Environment); err != nil {
+		return uiRuntimeSizingRecommendation{}, err
 	}
 	ctx, cancel := context.WithTimeout(a.backgroundContext(), runtimeReclaimTimeout)
 	defer cancel()

--- a/erun-ui/runtime_usage.go
+++ b/erun-ui/runtime_usage.go
@@ -33,8 +33,8 @@ const runtimeUsageTimeout = 10 * time.Second
 // that turns the Runtime tab into a failure surface.
 func (a *App) LoadRuntimeUsage(selection uiSelection) (uiRuntimeUsage, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return uiRuntimeUsage{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load runtime usage", selection.Tenant, selection.Environment); err != nil {
+		return uiRuntimeUsage{}, err
 	}
 	usage, err := a.deps.loadRuntimeUsage(a.backgroundContext(), selection)
 	if err != nil {

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -358,6 +358,29 @@ func preferCurrentKubernetesContext(contexts []string, current string) []string 
 	return result
 }
 
+// errMissingTenantOrEnvironment names which of tenant/environment a Wails
+// binding needed but was called with empty, the operation, and the fix.
+// Every binding here acts on the environment the frontend currently has
+// selected, so a blank value means it was invoked with no selection --
+// select an environment in the sidebar before retrying. Returns nil when
+// both are set, so callers can use it as their whole guard clause.
+func errMissingTenantOrEnvironment(operation, tenant, environment string) error {
+	var missing []string
+	if strings.TrimSpace(tenant) == "" {
+		missing = append(missing, "tenant")
+	}
+	if strings.TrimSpace(environment) == "" {
+		missing = append(missing, "environment")
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s: %s not set -- select an environment in the sidebar before retrying this action",
+		operation, strings.Join(missing, " and "),
+	)
+}
+
 func normalizeSelection(selection uiSelection) uiSelection {
 	return uiSelection{
 		Tenant:            strings.TrimSpace(selection.Tenant),

--- a/erun-ui/terminal_sessions.go
+++ b/erun-ui/terminal_sessions.go
@@ -21,8 +21,8 @@ import (
 // session is created or fails.
 func (a *App) StartSession(selection uiSelection, slot, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("start ERun session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
 	}
 	return a.enqueueGatedSession(selection, "open", func(ctx context.Context) (startSessionResult, *managedTerminal, error) {
 		return a.runOpenSession(ctx, selection, slot, cols, rows)
@@ -131,8 +131,8 @@ func (a *App) runOpenSession(ctx context.Context, selection uiSelection, slot, c
 
 func (a *App) StartLocalSession(selection uiSelection, slot, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("start local session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
 	}
 	cols, rows = clampTerminalSize(cols, rows)
 
@@ -215,8 +215,8 @@ func (a *App) StartLocalSession(selection uiSelection, slot, cols, rows int) (st
 // deliberate choice instead of a silent one.
 func (a *App) StartAISession(selection uiSelection, slot, cols, rows int, confirmed bool) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("start AI session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
 	}
 	return a.enqueueGatedSession(selection, "ai", func(ctx context.Context) (startSessionResult, *managedTerminal, error) {
 		return a.runAISession(ctx, selection, slot, cols, rows, confirmed)
@@ -353,8 +353,11 @@ func (a *App) StartDeploySession(selection uiSelection, cols, rows int) (startSe
 // satisfies.
 func (a *App) StartCreateVersionSession(selection uiSelection, cols, rows int) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if a.ctx == nil || strings.TrimSpace(selection.Tenant) == "" || strings.TrimSpace(selection.Environment) == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("start create-version session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
+	}
+	if a.ctx == nil {
+		return startSessionResult{}, fmt.Errorf("start create-version session: application context is not ready")
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
@@ -416,8 +419,8 @@ func (a *App) StartDoctorSession(selection uiSelection, cols, rows int) (startSe
 
 func (a *App) runErunCommandInLocal(selection uiSelection, cols, rows int, args []string) (startSessionResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return startSessionResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("run erun command in local session", selection.Tenant, selection.Environment); err != nil {
+		return startSessionResult{}, err
 	}
 
 	local, err := a.ensureLocalSession(selection, 0, cols, rows)
@@ -547,8 +550,8 @@ func shellQuoteSafeRune(r rune) bool {
 func (a *App) OpenIDE(selection uiSelection, ide string) error {
 	selection = normalizeSelection(selection)
 	ide = strings.TrimSpace(ide)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("open IDE", selection.Tenant, selection.Environment); err != nil {
+		return err
 	}
 	if ide != "vscode" && ide != "intellij" {
 		return fmt.Errorf("unsupported IDE %q", ide)
@@ -695,8 +698,8 @@ func (a *App) StartCloudInitCloudflareSession(cols, rows int) (startSessionResul
 
 func (a *App) DeleteEnvironment(selection uiSelection, confirmation string) (deleteEnvironmentResult, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return deleteEnvironmentResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("delete environment", selection.Tenant, selection.Environment); err != nil {
+		return deleteEnvironmentResult{}, err
 	}
 	expected := eruncommon.DeleteEnvironmentConfirmation(selection.Tenant, selection.Environment)
 	if strings.TrimSpace(confirmation) != expected {
@@ -840,8 +843,8 @@ func (a *App) LoadDiff(selection uiSelection, options uiDiffOptions) (eruncommon
 	selection = normalizeSelection(selection)
 	options.Scope = strings.TrimSpace(options.Scope)
 	options.SelectedCommit = strings.TrimSpace(options.SelectedCommit)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return eruncommon.DiffResult{}, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("load diff", selection.Tenant, selection.Environment); err != nil {
+		return eruncommon.DiffResult{}, err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
@@ -904,8 +907,8 @@ func (a *App) ensureMCPAvailable(ctx context.Context, result eruncommon.OpenResu
 // to the frontend so a long-running deploy does not look frozen.
 func (a *App) ReconnectMCP(selection uiSelection) error {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("reconnect MCP", selection.Tenant, selection.Environment); err != nil {
+		return err
 	}
 	result, err := eruncommon.ResolveOpen(a.deps.store, eruncommon.OpenParams{
 		Tenant:      selection.Tenant,
@@ -1028,8 +1031,8 @@ func (a *App) CloseSession(sessionID int) error {
 // lock would deadlock.
 func (a *App) CloseEnvironmentSessions(selection uiSelection) ([]int, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return nil, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("close environment sessions", selection.Tenant, selection.Environment); err != nil {
+		return nil, err
 	}
 	targets := a.collectAndMarkClosedForSelection(selection)
 	// Close is a real teardown: stop the env's workspace-sync worker so a
@@ -1111,8 +1114,8 @@ func closeManagedTerminals(targets []*managedTerminal) ([]int, error) {
 // cannot affect it.
 func (a *App) EndAISessions(selection uiSelection) (bool, error) {
 	selection = normalizeSelection(selection)
-	if selection.Tenant == "" || selection.Environment == "" {
-		return false, fmt.Errorf("tenant and environment are required")
+	if err := errMissingTenantOrEnvironment("end AI sessions", selection.Tenant, selection.Environment); err != nil {
+		return false, err
 	}
 	if envConfig, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment); err == nil {
 		launch := eruncommon.AISessionLaunchCommand(envConfig.AITool, envConfig.Claude, selection.Tenant, selection.Environment)


### PR DESCRIPTION
## Summary

- Rewrites all 65 pre-existing `tenant and environment are required` call sites the shrink-only baseline in `erun-integration/bare_required_input_test.go` carried (`erun-cli`: 7, `erun-common`: 11, `erun-ui`: 47) to name what's missing, why, and what to do — the same shape `errMissingLocalTarget` already established for `erun-mcp`.
- `erun-cli` consolidates its 7 sites onto two existing shared validators (`validateActivityTarget`, `validateJobTarget`), backed by a new `missingTenantOrEnvironmentFlags` helper, and rewords them to say these commands take `--tenant`/`--environment` explicitly and never read the ambient config.
- `erun-common` (transport-neutral) and `erun-ui` (desktop Wails bindings) each get one shared `errMissingTenantOrEnvironment(operation, tenant, environment)` helper reused across their call sites — named per operation (`"resolve environment idle status"`, `"start ERun session"`, etc.) — instead of 58 separately hand-worded messages. `erun-common`'s recovery is "the caller must pass both explicitly since erun-common never resolves ambient state"; `erun-ui`'s is "select an environment in the sidebar before retrying this action" (these are Wails bindings whose tenant/environment always comes from the frontend's current sidebar selection).
- Lowers `bareRequiredInputBaseline` to an empty map now that no bare hits remain anywhere in the baselined files (kept declared, not deleted, so a reintroduced hit still gets caught, and to preserve the shrink-only-baseline pattern documentation).
- Regenerates the 5 integration goldens whose `--dry-run` output captured the old bare message text (`activity/{cancel_stop_pending,sample,ssh_proxy,stop_ready}_requires_target*.txt`, `job/start_requires_target_and_name.txt`).
- Fixes one erun-ui unit test (`environment_jobs_test.go`) that asserted the old literal.

## Left alone (deliberately out of scope)

- `erun-common/port_forward_state.go` ("kind, tenant and environment are required") and `erun-common/remote_init_marker.go` ("save remote init marker: tenant and environment are required") already name an operation/subject prefix, so they don't match the gate's bare-literal shape and weren't in the original 65-site baseline. Left as-is.

## Verification

- `go build ./...` and `go test ./...` clean in `erun-cli`, `erun-common`, `erun-mcp`, `erun-ui`.
- `make integration-test`: green, coverage 76.3% (>= 75.8% threshold).
- `make check`: green (lint clean across all Go modules, frontend gates, chart tests, integration suite).
- Triggered three of the fixed paths against a real compiled `erun` binary:
  - `erun activity stop-ready` →
    ```
    audit: erun activity stop-ready
    tenant and environment not set: erun activity commands run outside any resolved environment and never read the ambient config -- pass --tenant and --environment explicitly
    ```
  - `erun delete "" "" -y` →
    ```
    audit: erun delete --yes
    tenant and environment must not be empty: run `erun delete TENANT ENVIRONMENT` with both positional arguments set
    ```
  - `erun unexpose "" "" --dry-run` (erun-common's `resolveUnexposeServicePlan`) →
    ```
    audit: erun unexpose --dry-run
    resolve unexpose service plan: tenant and environment not set -- erun-common does not resolve a tenant/environment target from ambient state, so the caller must pass both explicitly
    ```

## UX Impact Review Checklist (root AGENTS.md)

1. **Affected paths.** Internal validation errors in CLI commands (mostly `Hidden` lifecycle commands: `activity *`, `job *`), erun-common library guard clauses, and erun-ui Wails bindings backing Manage-dialog/Runtime-tab/Ports-tab/Diagnostics actions.
2. **User-visible sequence.** No new UI surface, dialog, or control — this is copy-only on an existing error path. A desktop action invoked with no environment selected (already an edge case the UI does not normally allow) now returns a clearer message string to the same error-surfacing code that already existed.
3. **State-without-affordance.** N/A — no new state mutation.
4/5. **Visibility of system status / success-failure feedback.** Unchanged: whatever surfaced the old bare string (CLI stderr, an MCP tool error, a desktop `InlineAlert`) now surfaces the improved string through the same path.
6. **Consistency.** Matches `erun-mcp`'s `errMissingLocalTarget` shape, which the same audit trail (#1506's parent issue) established as the reference pattern.
7. **Heuristic pass.** Nielsen #9 (help users recognize, diagnose, recover from errors) is the one this whole change is for — every message now names the fix.
8. **Playwright coverage.** Not added: this is a wording-only change to an existing error path (no new control, dialog, or interaction), and none of the desktop tests asserted the old string.

Closes #1506