### PR TITLE
Rearm orchestrator pacing on any fresh report, not just a busy one

### DIFF
--- a/erun-ui/orchestrator_pacing.go
+++ b/erun-ui/orchestrator_pacing.go
@@ -367,7 +367,13 @@ func (a *App) reconcileOrchestratorPacingOne(row orchestratorPacingRow, now time
 	if ok && report.at.After(lastActiveAt) {
 		lastActiveAt = report.at
 	}
-	if ok && report.activity.Busy && report.at.Unix() > row.lastNudgeAtUnix {
+	// A report written after the last nudge is the turn boundary itself,
+	// whether that turn ended busy or idle: the session did something in
+	// response to being asked. Requiring Busy here missed exactly the
+	// compliant case — a short reply that returns to idle before the next
+	// tick samples it — so a session answering every nudge still climbed
+	// toward the cap.
+	if ok && report.at.Unix() > row.lastNudgeAtUnix {
 		a.rearmOrchestratorPacing(row.id)
 		row.nudgeCount = 0
 		row.capped = false
@@ -418,9 +424,10 @@ func (a *App) logOrchestratorPacingTransition(row orchestratorPacingRow, reason 
 }
 
 // rearmOrchestratorPacing clears the nudge count and the cap, so the next
-// staleness period starts counting from zero. Called both for a fresh busy
-// report (this reconciler) and for real operator input into the pane
-// (SendSessionInput) — the two rearm paths the cap bound names.
+// staleness period starts counting from zero. Called both for a fresh
+// activity report written after the last nudge (this reconciler) and for
+// real operator input into the pane (SendSessionInput) — the two rearm
+// paths the cap bound names.
 func (a *App) rearmOrchestratorPacing(id string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/erun-ui/orchestrator_pacing_test.go
+++ b/erun-ui/orchestrator_pacing_test.go
@@ -266,6 +266,112 @@ func TestOrchestratorPacingCapsAfterRepeatedSilenceAndRearmsOnFreshBusy(t *testi
 	}
 }
 
+// TestOrchestratorPacingRearmsOnIdleReplyAcrossManyStaleCycles pins the bug: a
+// session that answers every pacing nudge with a short reply — one that ends
+// back at idle before the next reconciler tick samples it — must never accrue
+// toward the cap. Driving reconcileOrchestratorPacingOne directly with a
+// synthetic, always-advancing clock lets the test push the session through
+// many more stale-then-reply cycles than orchestratorPacingMaxNudges without
+// waiting on the real 10-minute staleness window between them.
+func TestOrchestratorPacingRearmsOnIdleReplyAcrossManyStaleCycles(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+
+	session := newCallRecordingSession()
+	key := orchestratorSessionKey("agent")
+	app.sessions[key] = &managedTerminal{session: session, key: key, serial: 5, kind: sessionKindOrchestrator}
+	base := time.Unix(1_700_000_000, 0)
+	app.orchestrators["agent"] = &orchestratorSession{id: "agent", serial: 5, name: "agent", startedAt: base}
+
+	cycles := orchestratorPacingMaxNudges + 2
+	tick := base
+	for i := 0; i < cycles; i++ {
+		// Advance well past the staleness window so this cycle's first tick
+		// is due a nudge, exactly as an orchestrator that replies and then
+		// falls quiet again for the next stretch would look.
+		tick = tick.Add(orchestratorPacingStaleAfter + time.Minute)
+
+		rows := app.orchestratorPacingRows()
+		if len(rows) != 1 {
+			t.Fatalf("expected one pacing row, got %d", len(rows))
+		}
+		decision, _ := app.reconcileOrchestratorPacingOne(rows[0], tick, false)
+		if decision != orchestratorPacingNudge {
+			t.Fatalf("cycle %d: expected a nudge, got decision=%v", i, decision)
+		}
+
+		app.mu.Lock()
+		lastNudgeAtUnix := app.orchestrators["agent"].pacingLastNudgeAtUnix
+		app.mu.Unlock()
+
+		// The session answers in one line and returns to idle well before
+		// the next tick — the compliant case the bug missed.
+		replyAt := time.Unix(lastNudgeAtUnix, 0).Add(time.Second)
+		writeOrchestratorActivity(t, "agent", orchestratorActivity{Busy: false, AtUnix: replyAt.Unix()})
+
+		// The next tick, shortly after the reply, must observe the fresh
+		// report and rearm rather than letting the count carry forward.
+		tick = replyAt.Add(10 * time.Second)
+		rows = app.orchestratorPacingRows()
+		app.reconcileOrchestratorPacingOne(rows[0], tick, false)
+
+		app.mu.Lock()
+		count := app.orchestrators["agent"].pacingNudgeCount
+		capped := app.orchestrators["agent"].pacingCapped
+		app.mu.Unlock()
+		if capped {
+			t.Fatalf("cycle %d: a session that answered its nudge must not be capped", i)
+		}
+		if count != 0 {
+			t.Fatalf("cycle %d: expected the reply to rearm the nudge count, got count=%d", i, count)
+		}
+	}
+
+	if notices := emits.events(appNotificationEvent); len(notices) != 0 {
+		t.Fatalf("expected no capped notification for a session that answered every nudge, got %d", len(notices))
+	}
+}
+
+// TestOrchestratorPacingStillCapsWithoutAFreshReply is the control for
+// TestOrchestratorPacingRearmsOnIdleReplyAcrossManyStaleCycles: a session that
+// never writes an activity report newer than its last nudge still caps, so
+// the rearm fix does not turn the cap into a no-op for a genuinely silent
+// session.
+func TestOrchestratorPacingStillCapsWithoutAFreshReply(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+
+	session := newCallRecordingSession()
+	key := orchestratorSessionKey("agent")
+	app.sessions[key] = &managedTerminal{session: session, key: key, serial: 5, kind: sessionKindOrchestrator}
+	longAgo := time.Now().Add(-24 * time.Hour)
+	app.orchestrators["agent"] = &orchestratorSession{id: "agent", serial: 5, name: "agent", startedAt: longAgo}
+
+	for i := 0; i < orchestratorPacingMaxNudges+1; i++ {
+		app.reconcileOrchestratorPacing()
+	}
+
+	app.mu.Lock()
+	capped := app.orchestrators["agent"].pacingCapped
+	app.mu.Unlock()
+	if !capped {
+		t.Fatal("expected a session that never replies to still cap")
+	}
+	if notices := emits.events(appNotificationEvent); len(notices) != 1 {
+		t.Fatalf("expected exactly one capped notification, got %d", len(notices))
+	}
+}
+
 // TestSendOrchestratorPacingNudgeSkipsWhilePaneBeingTypedInto pins the third
 // place #1330's hazard applies: the pacing nudge writes its text, then a bare
 // carriage return 150ms later, the same shape as the AI repaint resize that


### PR DESCRIPTION
## Summary

- A session that answered every pacing nudge with a short, compliant reply still got capped: `reconcileOrchestratorPacingOne` only reset the nudge count/cap when the latest activity report said `Busy: true` at sample time, but a quick reply returns to idle before the next 15s reconciler tick, so the rearm condition never fired and the count kept climbing every stale period even though the session responded every time.
- Fix: rearm on any activity report timestamped after the last nudge, whether the turn it reports ended busy or idle. A turn boundary — evidenced by a fresh report — is the signal, not the transient state a completed turn has already left. This matches the file's own stated intent (`orchestrator_pacing.go`'s header comment), which the old condition didn't actually deliver.
- A session that never writes a fresh report still caps unchanged (covered by a new control test).

## UX Impact Review Checklist (erun-ui/AGENTS.md)

1. **Affected paths.** Desktop's 15s orchestrator-pacing reconciler tick (`reconcileOrchestratorPacing` → `reconcileOrchestratorPacingOne`) — no dialog, button, or other direct user action; it runs on a timer and decides whether to write a pacing-nudge marker into an orchestrator's pane or raise the "stopped answering" cap notification.
2. **User-visible sequence.** Unchanged: a stale orchestrator still gets a nudge marker in its pane, and a genuinely silent one still gets capped with the existing marker/notification text. The only change is *when* the cap fires — it no longer fires against a session that has been replying to every nudge.
3. **State-without-affordance.** No new state introduced; existing `pacingNudgeCount`/`pacingCapped` fields are reset more correctly.
4. **Visibility of system status.** Unaffected — same markers, same notification text.
5. **Success/failure feedback.** Unaffected.
6. **Consistency with comparable flows.** Same emission paths (`emitOrchestratorPacingMarker`, `emitOrchestratorPacingCappedMarker`, `emitAppNotification`) as before; no new surface.
7. **Nielsen heuristics.** #1 (visibility of system status) is the one this bug violated — a compliant session was shown as capped/broken with no way to have prevented it. Fixed by correcting the accounting so the status now reflects reality.
8. **Playwright coverage.** Not added. This bookkeeping is explicitly documented as unreachable by the headless harness in `erun-ui/playwright/tests/orchestrator-pacing-nudge.spec.ts`'s own comment (needs a real orchestrator PTY and real elapsed staleness), and is covered by the Go suite instead — the same precedent that spec already establishes for `TestOrchestratorPacingCapsAfterRepeatedSilenceAndRearmsOnFreshBusy`. This PR adds `TestOrchestratorPacingRearmsOnIdleReplyAcrossManyStaleCycles` (drives `reconcileOrchestratorPacingOne` directly with a synthetic clock to prove many stale-then-reply cycles never accrue toward the cap — fails on the pre-fix code, passes post-fix) and `TestOrchestratorPacingStillCapsWithoutAFreshReply` (control: a silent session still caps).

## Test plan

- [x] `go build ./...` and `go test ./...` in `erun-ui` — all green.
- [x] New test fails against the pre-fix code (`report.activity.Busy` required) and passes post-fix, confirmed by temporarily reverting the condition.
- [x] `make check` (fresh run via `AGENT_GATE_RERUN=1`) — lint clean across all modules, `erun-ui` tests pass, integration suite green, coverage 76.3% ≥ 75.8%.

Closes #1529