### PR TITLE
Give the merge queue its own docs page

### DIFF
--- a/erun-docs/docs/cli/review.md
+++ b/erun-docs/docs/cli/review.md
@@ -4,7 +4,7 @@ title: erun review
 
 # `erun review`
 
-Review code on a hosted erun platform from a terminal or an Agent — the client for the [collaboration API](/collaboration/reviews) — using the **erun-type cloud alias** [`erun cloud init erun`](/cli/cloud) and `erun cloud login` set up. List reviews, open one, comment on a line (or reply to an existing comment), resolve or reopen a comment thread, close a review, and inspect or advance a target branch's merge queue.
+Review code on a hosted erun platform from a terminal or an Agent — the client for the [collaboration API](/collaboration/reviews) — using the **erun-type cloud alias** [`erun cloud init erun`](/cli/cloud) and `erun cloud login` set up. List reviews, open one, comment on a line (or reply to an existing comment), resolve or reopen a comment thread, close a review, and inspect or advance a target branch's [merge queue](/collaboration/merge-queue).
 
 Starting a review needs the source branch to already exist on the remote — push it first with [`erun exec push`](/cli/exec#exec-push).
 
@@ -62,17 +62,17 @@ Comments on a line of a review, or replies to an existing comment with `--reply-
 
 ### `review resolve` / `review unresolve` {#review-resolve--review-unresolve}
 
-Resolve a comment thread by closing its root comment, or reopen one by marking its root comment `OPEN` again. A thread's status lives entirely on its root comment — `COMMENT_ID` must be the thread's root (the first comment posted at a file/line, not one made with `--reply-to`); addressing a reply fails, naming the root comment to retry against.
+Resolve a comment thread by closing its root comment, or reopen one by marking its root comment `OPEN` again. A thread's status lives entirely on its root comment — `COMMENT_ID` must be the thread's root (the first comment posted at a file/line, not one made with `--reply-to`); addressing a reply fails, naming the root comment to retry against. Only that thread's own root-comment author can resolve or reopen it — running this against someone else's thread is refused; ask that author, or see [Merge queue § Overriding the gate](/collaboration/merge-queue#overriding-the-gate) if it's blocking a merge and the author is unavailable.
 
 ### `review close`
 
 Closes a review without merging it.
 
-### `review queue list` / `review queue advance`
+### `review queue list` / `review queue advance` {#review-queue-list--review-queue-advance}
 
-Lists or advances a target branch's merge queue. `list` returns the queue in order; `advance` promotes the queue's head to `MERGE` and starts its merge-gate build — a real build of the prospective merge, gating whether it actually lands. It fails if the queue is empty, its head is not `READY`, or the head still has unresolved comment threads. On that last refusal, the command names how many threads and on which review; resolve them with [`review resolve`](#review-resolve--review-unresolve) or use `review queue override-advance`.
+Lists or advances a target branch's merge queue. `list` returns the queue in order; `advance` promotes the queue's head to `MERGE` and starts its merge-gate build — a real build of the prospective merge, gating whether it actually lands. It fails if the queue is empty or its head is not `READY` (both surface as `404 Not Found`), or if the head still has unresolved comment threads (`409 Conflict`). On that last refusal, the command names how many threads and on which review; resolve them with [`review resolve`](#review-resolve--review-unresolve) or use `review queue override-advance`. See [Merge queue](/collaboration/merge-queue) for the full mechanics — why the queue exists, what the gate does, and how to recover a wedged gate build (no CLI flag for that yet; see [Merge queue § When the gate wedges](/collaboration/merge-queue#when-the-gate-wedges)).
 
-### `review queue override-advance`
+### `review queue override-advance` {#review-queue-override-advance}
 
 Bypasses `review queue advance`'s unresolved-thread check and advances anyway. `--reason` is required and is recorded in the platform's [audit trail](/collaboration/operator-in-the-loop) alongside your identity — this is a deliberate, accountable escape hatch for a genuine exception, not a routine way to advance the queue. A tenant can grant this separately from ordinary `advance`, so it may be unavailable even to operators who can otherwise advance the queue.
 
@@ -112,6 +112,6 @@ erun review queue override-advance --target-branch main --reason "hotfix, review
 | `create` with a `--source-branch` that already has a live (non-`MERGED`/`CLOSED`) review proposing it onto the same `--target-branch`. | `409 Conflict` — see [branch uniqueness](/collaboration/reviews#author-reviewers-and-discovery). |
 | `show`/`comment`/`close` on an unknown review id. | `404 Not Found`. |
 | `resolve`/`unresolve` addressed to a reply rather than its thread's root comment. | Aborts before the status change, naming the root comment id to retry against. |
-| `queue advance` on an empty queue, or whose head is not `READY`. | `409 Conflict`. |
+| `queue advance` on an empty queue, or whose head is not `READY`. | `404 Not Found`. |
 | `queue advance` whose head still has unresolved comment threads. | `409 Conflict`, naming the count and the review. Resolve them or use `queue override-advance`. |
 | `queue override-advance` with `--reason` omitted or blank. | Aborts before any network call. |

--- a/erun-docs/docs/collaboration/builds.md
+++ b/erun-docs/docs/collaboration/builds.md
@@ -72,7 +72,7 @@ ERun also ships its own trigger for two cases it owns end to end: gating a revie
 
 ## Merge queue
 
-A `GATE` build is never `POST`ed — it is written by the merge queue itself once a review reaches `MERGE` (see [Reviews · Merge queue](/collaboration/reviews#merge-queue) for the promotion and dispatch workflow). Where a `RECORDED` build is against whatever commit its reporter names, a `GATE` build is always against the specific commit the merge queue built: the prospective squash merge of the review's `sourceBranch` onto its target branch as that target stood *at gate time* — not the source branch tip, and not a stale target.
+A `GATE` build is never `POST`ed — it is written by the merge queue itself once a review reaches `MERGE` (see [Merge queue § The gate](/collaboration/merge-queue#the-gate) for the promotion and dispatch workflow). Where a `RECORDED` build is against whatever commit its reporter names, a `GATE` build is always against the specific commit the merge queue built: the prospective squash merge of the review's `sourceBranch` onto its target branch as that target stood *at gate time* — not the source branch tip, and not a stale target.
 
 ```jsonc
 {

--- a/erun-docs/docs/collaboration/merge-queue.md
+++ b/erun-docs/docs/collaboration/merge-queue.md
@@ -1,0 +1,114 @@
+---
+title: Merge queue
+---
+
+# Merge queue
+
+The merge queue is the only path to `MERGED` — it is what makes two independently-green reviews that break the target branch together impossible, and it carries the one audited escape hatch in the product. It also has a lot of surface: a shape, a gate, a comment-thread check, three clients that can advance it, and a wedge-recovery path. This page is the single account of all of it; [Reviews](/collaboration/reviews) stays the wire-level endpoint reference, [`erun review`](/cli/review) the CLI reference, and the [desktop reviews tab](/desktop/reviews) the app reference — each links here for the mechanics rather than repeating them.
+
+For the standing builder/reviewer roles that drive a review through this queue, see [Review loop topology](/collaboration/review-loop-topology).
+
+## Why it exists
+
+Two reviews can each be green on their own and still break the target branch when both land — the second one was only ever tested against a target branch snapshot that the first hadn't touched yet. The merge queue closes that gap by serialising `READY` reviews per target branch: the second review promoted onto a branch is always gated against whatever the first one just landed, never against a stale snapshot.
+
+## Shape of the queue
+
+The queue is **shared per target branch**, not global. Every `READY` review for a given `targetBranch` waits in a single FIFO — `GET /v1/reviews/merge-queue?targetBranch=main` lists it in order. A review that has been promoted (status `MERGE`) has already left that waiting line; only one review per target branch may be `MERGE` at a time, so the review currently being gated and the reviews still waiting are always disjoint sets.
+
+## The gate {#the-gate}
+
+Promoting the head of the queue does real work, not a status flip. The merge queue fetches the review's target and source branches, builds the prospective squash merge of the source onto the *current* target, runs a real build (`erun build`) against that merge, and pushes only if it passes. `MERGED` means that gate actually ran and actually passed — it is never a status a caller can assert directly (`PATCH .../status` refuses both `MERGE` and `MERGED`).
+
+The gate's build is recorded as a [`GATE`-kind build](/collaboration/builds#merge-queue): it publishes nothing, so it carries no `version`, and a failed one carries `failureDetail` in the gate's own words. A successful gate's build becomes the review's `lastMergedBuildId`.
+
+## The unresolved-thread check {#the-unresolved-thread-check}
+
+Before promoting the head review, the queue checks its comment threads. If any thread is still `OPEN` (its root comment unresolved), advancing refuses with `409 Conflict` and a structured body — the one place on this API that returns JSON rather than a plain-text error, naming the count and the review so a caller can act on it instead of parsing a sentence:
+
+```jsonc
+{
+  "error": "unresolved_threads",
+  "message": "review rev_01H... has 3 unresolved comment thread(s); resolve them before advancing the merge queue",
+  "reviewId": "rev_01H...",
+  "unresolvedThreads": 3
+}
+```
+
+Clearing it takes one of two things: resolve the threads, or use [`override-advance`](#overriding-the-gate). Resolving a thread is itself restricted — **only that thread's own root-comment author can close it** (see [Comments § Open / closed](/collaboration/comments#comment-status)). The builder that opened the review cannot resolve a reviewer's thread no matter how completely it addressed the point; if the reviewer never comes back, the review is stuck behind that thread short of an override. This is deliberate, not an oversight — see [Review loop topology § The reviewer must come back](/collaboration/review-loop-topology#the-reviewer-must-come-back) for why the loop is designed around it.
+
+## Advancing it {#advancing-it}
+
+All three clients do the same thing: promote the queue's current head to `MERGE` and dispatch its gate build. The response in every case is the *promoted* review, not the merged one — poll for the terminal `MERGED` or `FAILED` outcome.
+
+### From the API
+
+```
+POST /v1/reviews/merge-queue/advance
+Content-Type: application/json
+
+{ "targetBranch": "main" }
+```
+
+See [Reviews § Endpoints](/collaboration/reviews#endpoints) for the full request/response shape.
+
+### From the CLI
+
+```bash
+erun review queue advance --target-branch main
+```
+
+See [`erun review queue advance`](/cli/review#review-queue-list--review-queue-advance).
+
+### From the desktop
+
+Tenant dashboard → a review's detail → **Merge queue** tab → **Advance queue**, behind a confirm step. The action is replaced by the missing-access affordance when your account can't use it. See [Desktop reviews § Merge queue and comment threads](/desktop/reviews#merge-queue-and-comment-threads).
+
+## Overriding the gate {#overriding-the-gate}
+
+`override-advance` promotes the head exactly as `advance` does, but skips the unresolved-thread check:
+
+```
+POST /v1/reviews/merge-queue/override-advance
+Content-Type: application/json
+
+{ "targetBranch": "main", "reason": "hotfix, reviewers unavailable" }
+```
+
+`reason` is required — blank or missing is refused with `400 Bad Request` before anything is promoted — and is recorded in the [audit trail](/agent-reference/audit-log) alongside the caller's identity, as an `API`-type event whose `apiPath` is `/v1/reviews/merge-queue/override-advance`. This is the one legitimate escape from the thread gate: deliberate (a distinct call, not a flag on `advance`), accountable (reason + caller both durably recorded), and separately authorized — a tenant can grant `advance` without granting `override-advance`, since they're different API paths.
+
+- **CLI:** `erun review queue override-advance --target-branch main --reason "hotfix, reviewers unavailable"` — see [`erun review queue override-advance`](/cli/review#review-queue-override-advance).
+- **Desktop:** same **Advance queue** action, available only to an account with the separate override permission; it bypasses the thread-count refusal by asking for a reason inline.
+
+## When the gate wedges {#when-the-gate-wedges}
+
+If a `MERGE` review's gate never reaches a terminal state — an operator-diagnosed stuck run — requeuing it needs a direct API call today:
+
+```
+PATCH /v1/reviews/{reviewId}/status
+Content-Type: application/json
+
+{ "status": "READY" }
+```
+
+Omitting `buildId` on a `READY` transition is what marks this as the missed-merge-window path rather than a build result: the review moves back to `READY` and rejoins its target branch's queue **at the tail**, not the head — it does not get promoted again immediately. There is no CLI flag or desktop button for this yet; until one exists, an operator (or an Agent with API access) makes this call directly.
+
+## Failure table {#failure-table}
+
+| Refusal | HTTP status | Body | How to unblock |
+|---|---|---|---|
+| No `READY` review waiting for that target branch (queue empty) | `404 Not Found` | plain text | Wait for a review to reach `READY` — its build succeeded — then advance again. |
+| Another review is already `MERGE` for that target branch | `404 Not Found` | plain text | Wait for it to reach `MERGED`/`FAILED`, or see [When the gate wedges](#when-the-gate-wedges) if it looks stuck. |
+| The head review has an unresolved comment thread | `409 Conflict` | structured — `{error, message, reviewId, unresolvedThreads}`, shown [above](#the-unresolved-thread-check) | Resolve the thread (its root author only), or [`override-advance`](#overriding-the-gate). |
+
+The first two rows are both cases where nothing was waiting to be promoted, so they currently share one plain `404 Not Found` — indistinguishable from each other or from any other missing-resource 404. [Reviews · Machine error codes](/collaboration/reviews#machine-error-codes) names `EMPTY_QUEUE` as the intended code for the first case, defined against the `READY` reviews actually waiting in the line (a review already `MERGE` has left it) — that code isn't wired into the response yet, and the second row has no code proposed for it either.
+
+## See also
+
+- [Reviews](/collaboration/reviews) — the review resource, its status lifecycle, and the merge-queue endpoints' wire contract.
+- [Comments](/collaboration/comments) — thread status and the root-author-only close rule the unresolved-thread check depends on.
+- [Builds](/collaboration/builds) — the `GATE` build kind the gate writes.
+- [`erun review`](/cli/review) — the CLI client.
+- [Desktop reviews](/desktop/reviews) — the desktop client.
+- [Review loop topology](/collaboration/review-loop-topology) — the builder/reviewer roles that drive a review through this queue.
+- [Workflow](/collaboration/workflow) — where `MERGE`/`MERGED` sit in the larger `PR`/`QA`/`DONE` mapping.

--- a/erun-docs/docs/collaboration/overview.md
+++ b/erun-docs/docs/collaboration/overview.md
@@ -19,7 +19,7 @@ Every actor — Agent or Operator — talks to the same API and signs in the sam
 | [Reviews](/collaboration/reviews) | A unit of work-to-be-merged. Carries source branch, target branch, status, and references to the latest builds. |
 | [Comments](/collaboration/comments) | Threaded, per-commit-and-line comments on a review. Agents and humans use the same shape. |
 | [Builds](/collaboration/builds) | Per-review build results: commit, version, success/failure. Drives review status transitions. |
-| Merge queue | A shared queue of `READY` reviews targeting the same branch. `POST /v1/reviews/merge-queue/advance` promotes the next one. |
+| [Merge queue](/collaboration/merge-queue) | A shared queue of `READY` reviews targeting the same branch. `POST /v1/reviews/merge-queue/advance` promotes the next one. |
 | Whoami | `GET /v1/whoami` returns the resolved identity for the calling token. |
 | [Identity administration](/collaboration/identity-administration) | Enroll, list, deactivate, and reactivate identities in the platform's own IdP, and read/update its login and password policy. Restricted to an `OPERATIONS` tenant. |
 

--- a/erun-docs/docs/collaboration/review-loop-topology.md
+++ b/erun-docs/docs/collaboration/review-loop-topology.md
@@ -18,7 +18,7 @@ One review moves between two environments as it goes from a proposed change to a
 | `READY`, threads open | **builder** | Reads the threads, judges each proposal on merit, merges the ones it accepts, pushes, rebuilds. It is not obliged to take a proposal, and says why when it declines, in that thread. |
 | `READY`, threads open | **reviewer** | Returns to its own threads, reads the builder's replies, and resolves the ones the builder addressed. |
 | `READY`, all resolved | **builder** | Advances the merge queue (`erun review queue advance`). |
-| `MERGE` → `MERGED` | platform | The merge queue's gate builds the prospective merge and pushes only on green — see [Reviews § Merge queue](/collaboration/reviews#merge-queue). |
+| `MERGE` → `MERGED` | platform | The merge queue's gate builds the prospective merge and pushes only on green — see [Merge queue § The gate](/collaboration/merge-queue#the-gate). |
 
 ## Why two environments, not two agents in one
 
@@ -35,7 +35,7 @@ Both are ordinary agent environments. Neither is a dedicated build environment: 
 
 **Only a thread's root comment author can close it.** `PATCH /v1/reviews/{id}/comments/{commentId}/status` acts on the thread as a whole through its root, and only the root's own author may call it — see [Comments](/collaboration/comments#comment-status). This means the builder cannot resolve a reviewer's thread no matter how completely it addressed the point; the reviewer agent watching for "the author replied to my thread" and resolving it is not a nicety, it is the only thing that unblocks the merge short of an audited override.
 
-`erun review queue advance` refuses to promote a review with any thread still `OPEN` (its root comment unresolved), naming the unresolved count in its `409` response. The one deliberate escape is `erun review queue override-advance`: a distinct, separately-authorized call that records its `reason` in the audit trail alongside the caller's identity — see [Reviews § Overriding the gate](/collaboration/reviews#overriding-the-gate). It exists for exactly the case a reviewer never comes back; it is not a substitute for a reviewer agent that does.
+`erun review queue advance` refuses to promote a review with any thread still `OPEN` (its root comment unresolved), naming the unresolved count in its `409` response. The one deliberate escape is `erun review queue override-advance`: a distinct, separately-authorized call that records its `reason` in the audit trail alongside the caller's identity — see [Merge queue § Overriding the gate](/collaboration/merge-queue#overriding-the-gate). It exists for exactly the case a reviewer never comes back; it is not a substitute for a reviewer agent that does.
 
 A reviewer agent that opens threads and never returns to resolve them blocks the merge permanently short of that override. Opening threads sparingly is part of the same discipline — every open thread blocks a merge.
 
@@ -47,6 +47,7 @@ A reviewer agent that opens threads and never returns to resolve them blocks the
 
 - [Agent patterns](/collaboration/agent-patterns) — the underlying MCP/API call sequence this topology composes.
 - [Workflow](/collaboration/workflow) — where the Build Agent / Review Agent pattern sits in the larger Operator-Agent maturity model.
+- [Merge queue](/collaboration/merge-queue) — the queue this topology's `advance`/`override-advance` step drives, including recovering a wedged gate.
 - [Reviews](/collaboration/reviews), [Comments](/collaboration/comments) — the API resources this topology operates over.
 - [Environment types](/concepts/environment-types) — why `runtime` and `host` sit outside the builder/reviewer choice.
 - [Reusable-agent spec](/agent-reference/agents-spec) — the `erun-builder` / `erun-reviewer` catalogue entries.

--- a/erun-docs/docs/collaboration/reviews.md
+++ b/erun-docs/docs/collaboration/reviews.md
@@ -109,48 +109,15 @@ The status transitions are enforced server-side: an Agent cannot directly mark a
 
 ## Merge queue
 
-The merge queue is **shared per target branch**. Every `READY` review for a given `targetBranch` waits in a single FIFO — `GET /v1/reviews/merge-queue?targetBranch=main` lists that waiting line. The review currently being gated (status `MERGE`) has already left the waiting line; only one review per target branch may be `MERGE` at a time. `POST /v1/reviews/merge-queue/advance` promotes the head of the waiting line:
+`GET /v1/reviews/merge-queue` and `POST /v1/reviews/merge-queue/advance` (and its `override-advance` counterpart) above are the wire contract for the merge queue. For why it exists, the queue's shape, what the gate does, the unresolved-thread check's structured body, advancing and overriding it from every client, and recovering a wedged gate — see **[Merge queue](/collaboration/merge-queue)**.
 
-```
-POST /v1/reviews/merge-queue/advance
-Content-Type: application/json
+### Overriding the gate {#overriding-the-gate}
 
-{ "targetBranch": "main" }
-```
-
-Before promoting, the server checks the head review's comment threads: if any thread is still `OPEN` (its root comment unresolved), `advance` refuses with `409 Conflict` and a structured body naming the count and the review, rather than the plain-text body every other error on this API returns —
-
-```jsonc
-{
-  "error": "unresolved_threads",
-  "message": "review rev_01H... has 3 unresolved comment thread(s); resolve them before advancing the merge queue",
-  "reviewId": "rev_01H...",
-  "unresolvedThreads": 3
-}
-```
-
-— so a caller can act on the refusal (open the review, resolve the threads, or use [`override-advance`](#overriding-the-gate)) instead of parsing a sentence. Once every thread is resolved (or there are none), `advance` picks the head of the waiting line for that target branch, transitions it to `MERGE`, and dispatches the merge queue's gate for it: fetch the review's target and source branches, build the prospective merge of the source onto the *current* target, run a real build against that prospective merge, and push it only if the build passes. The response to `advance` is the promoted (now `MERGE`) review, not the merged one — poll `GET /v1/reviews/{reviewId}` for the terminal `MERGED` or `FAILED` outcome. If the waiting line is empty, or another review is already `MERGE` for that target branch, the API returns an error.
-
-This is what catches two reviews that are each green on their own but broken together: the second review promoted onto a target branch is always gated against whatever the first one just landed, not against a stale snapshot, so their combination is tested before the target branch ever sees it.
-
-If a `MERGE` review's gate never reaches a terminal state (an operator-diagnosed stuck run), `PATCH /v1/reviews/{reviewId}/status` with `{"status": "READY"}` and no `buildId` requeues it: it moves back to `READY` and rejoins the waiting line at the tail rather than being promoted again immediately.
-
-### Overriding the gate
-
-`POST /v1/reviews/merge-queue/override-advance` promotes the head of the waiting line exactly as `advance` does, but skips the unresolved-thread check:
-
-```
-POST /v1/reviews/merge-queue/override-advance
-Content-Type: application/json
-
-{ "targetBranch": "main", "reason": "hotfix, reviewers unavailable" }
-```
-
-`reason` is required — a blank or missing one is refused with `400 Bad Request` before anything is promoted — and is recorded in the [audit trail](/agent-reference/audit-log) alongside the caller's identity, as an `API`-type event whose `apiPath` is `/v1/reviews/merge-queue/override-advance`. This is the one legitimate escape from the thread gate: it is deliberate (a distinct call, not a flag on `advance`), accountable (the reason and the caller are both durably recorded), and separately authorized — a tenant's `role_permissions` can grant `advance` without granting `override-advance`, since they are different API paths. A caller with no permission for this path gets the same `403 Forbidden` any unauthorized route returns.
+See [Merge queue § Overriding the gate](/collaboration/merge-queue#overriding-the-gate).
 
 ## Errors
 
-All endpoints return JSON error bodies:
+Endpoints return a plain-text error body by default (the HTTP status text). The one structured exception today is the merge queue's unresolved-thread refusal — see [Merge queue § The unresolved-thread check](/collaboration/merge-queue#the-unresolved-thread-check) for its JSON shape. *Machine error codes* below is this API's target `code`/`details` contract for the rest of these cases — it is not yet wired into any response, the one exception above aside.
 
 ```jsonc
 {
@@ -165,8 +132,8 @@ All endpoints return JSON error bodies:
 | `400 Bad Request` | Malformed JSON, missing required fields, type mismatches; a caller asserting `MERGE` or `MERGED` directly; `override-advance` with a blank or missing `reason`. | `POST /v1/reviews` without `sourceBranch`; `PATCH .../status` with `{"status": "MERGED"}` — that status is written only by the merge queue's own gate result; `override-advance` with `reason` omitted. |
 | `401 Unauthorized` | No `Authorization` header, or token validation failed. | Bearer token expired. |
 | `403 Forbidden` | Token valid; caller not allowed in this tenant. | Agent of tenant A calling on tenant B. |
-| `404 Not Found` | The review or build id doesn't exist or isn't visible to the caller. | `GET /v1/reviews/rev_unknown`. |
-| `409 Conflict` | Invalid state transition or queue-state mismatch; a second live review for a branch pair already proposed by a live review; a reviewer already assigned to the review; the queue head has unresolved comment threads. | `POST /v1/reviews/merge-queue/advance` while another review is already `MERGE` for that target branch; `POST /v1/reviews` proposing `feature-a` onto `main` while another live review already does; `advance` against a head review with an open thread — see [Merge queue](#merge-queue) for that response's structured body. |
+| `404 Not Found` | The review or build id doesn't exist or isn't visible to the caller; `merge-queue/advance` against a target branch with nothing waiting to promote — see [Merge queue § Failure table](/collaboration/merge-queue#failure-table). | `GET /v1/reviews/rev_unknown`; `POST /v1/reviews/merge-queue/advance` on an empty queue, or while another review is already `MERGE` for that target branch. |
+| `409 Conflict` | Invalid state transition; a second live review for a branch pair already proposed by a live review; a reviewer already assigned to the review; the queue head has unresolved comment threads. | `POST /v1/reviews` proposing `feature-a` onto `main` while another live review already does; `advance` against a head review with an open thread — see [Merge queue](/collaboration/merge-queue#the-unresolved-thread-check) for that response's structured body. |
 | `422 Unprocessable Entity` | Structurally valid but semantically invalid. | `PATCH status` to `READY` without a successful build. |
 | `429 Too Many Requests` | Rate limit exceeded. | Burst of `POST /comments`. |
 | `500 Internal Server Error` | Server error. Retry. | Database unavailable. |
@@ -176,7 +143,7 @@ All endpoints return JSON error bodies:
 | `code` | When | HTTP status |
 |---|---|---|
 | `INVALID_TRANSITION` | `PATCH /status` with a transition not allowed by the [Status lifecycle](#status-lifecycle). `details.validTargets` lists the allowed next statuses. | `409` |
-| `EMPTY_QUEUE` | `POST /merge-queue/advance` against a target branch whose queue has no `MERGE`-status reviews. | `409` |
+| `EMPTY_QUEUE` | `POST /merge-queue/advance` against a target branch whose queue has no `READY` reviews waiting — a review already `MERGE` has left that waiting line, so its presence is the separate "another review already merging" case, not this one. | `404` |
 | `UNKNOWN_COMMIT` | `PATCH /status` (or `POST /builds`) referencing a `buildId` whose `commitId` doesn't exist on the review's `sourceBranch`. | `422` |
 | `INVALID_BODY` | Request body missing required field or fails type validation. `details.field` names the offender. | `400` |
 | `INVALID_TARGET_BRANCH` | `targetBranch` is not a valid branch name. | `400` |

--- a/erun-docs/docs/collaboration/workflow.md
+++ b/erun-docs/docs/collaboration/workflow.md
@@ -73,7 +73,7 @@ ERun isn't tied to a specific workflow tool or a fixed set of states. It slots u
 | **DONE** | Merged via the queue. |
 | **REJECTED** | Abandoned at any stage. |
 
-`PR / QA / DONE` map cleanly to the ERun review lifecycle (`OPEN → READY → MERGE → MERGED`). `TRIAGE / TODO / IN PROGRESS` sit above ERun as project-management states the team owns. Rename any of them; ERun's behaviour doesn't change underneath.
+`PR / QA / DONE` map cleanly to the ERun review lifecycle (`OPEN → READY → MERGE → MERGED`). `TRIAGE / TODO / IN PROGRESS` sit above ERun as project-management states the team owns. Rename any of them; ERun's behaviour doesn't change underneath. `READY` becomes `MERGE` and then `MERGED` through the [merge queue](/collaboration/merge-queue), never by a caller asserting either status directly.
 
 ## What flows through — Stories, Epics, Tasks
 
@@ -161,5 +161,6 @@ The state machine the team uses is orthogonal to this: an Agent at Supervised ma
 ## See also
 
 - [Agent collaboration overview](/collaboration/overview) — the erun API that backs reviews, comments, builds, and the merge queue.
+- [Merge queue](/collaboration/merge-queue) — how a `READY` review becomes `MERGED`, from every client, plus recovering a wedged gate.
 - [Operator in the loop](/collaboration/operator-in-the-loop) — what the Operator's control surfaces look like over a Level-3 fleet.
 - [Reviews](/collaboration/reviews), [Comments](/collaboration/comments), [Builds](/collaboration/builds) — the API resources the workflow operates over.

--- a/erun-docs/docs/concepts/glossary.md
+++ b/erun-docs/docs/concepts/glossary.md
@@ -71,7 +71,7 @@ Three interfaces, one engine. See the anatomy diagram on the [introduction](/int
 
 **Review** — a unit of work-to-be-merged. Source branch, target branch, status, and references to its latest builds. See [Reviews](/collaboration/reviews).
 
-**Merge queue** — shared per target branch. FIFO; `POST /v1/reviews/merge-queue/advance` promotes the head to `MERGED`.
+**Merge queue** — shared per target branch. FIFO; `POST /v1/reviews/merge-queue/advance` promotes the head to `MERGE`, which the gate then lands as `MERGED` or `FAILED`. See [Merge queue](/collaboration/merge-queue).
 
 ## Non-canonical terms
 

--- a/erun-docs/docs/desktop/reviews.md
+++ b/erun-docs/docs/desktop/reviews.md
@@ -12,7 +12,7 @@ The tenant dashboard's **Reviews** tab lists every review for the signed-in tena
 
 ### Merge queue and comment threads
 
-A review's own detail adds **Close review**, and the **Merge queue** tab an **Advance queue** action — each behind a confirm step, and each replaced by the access you are missing when your account may not use it. If the queue head still has unresolved comment threads, advancing is refused and names the count and the review, with **View discussion** to open it directly; an account with the separate override permission can instead bypass the check by stating a reason, which is recorded against your identity. To start a *new* comment thread rather than reply to one, hover a line in the review panel's diff and use the comment affordance that appears; the thread is anchored to that file and line. See [`erun review`](/cli/review) for the same actions from the CLI.
+A review's own detail adds **Close review**, and the **Merge queue** tab an **Advance queue** action — each behind a confirm step, and each replaced by the access you are missing when your account may not use it. If the queue head still has unresolved comment threads, advancing is refused and names the count and the review, with **View discussion** to open it directly; an account with the separate override permission can instead bypass the check by stating a reason, which is recorded against your identity. Only a thread's own root-comment author can resolve or reopen it — this dashboard included — so if that refusal names a thread you didn't open, ask its author or use the override rather than trying to close it yourself. To start a *new* comment thread rather than reply to one, hover a line in the review panel's diff and use the comment affordance that appears; the thread is anchored to that file and line. See [`erun review`](/cli/review) for the same actions from the CLI, and [Merge queue](/collaboration/merge-queue) for the full mechanics — including recovering a merge whose gate build gets stuck, which has no button here yet.
 
 ### Keyboard shortcuts in the review surface
 
@@ -28,6 +28,7 @@ The tenant dashboard's **Registration** tab is where a tenant/environment you cr
 
 ## Where next
 
+- [Merge queue](/collaboration/merge-queue) — why the queue exists, what the gate does, and recovering a wedged gate.
 - [Activities and recovery](/desktop/activities-and-recovery) — the operations queue, failed-deploy recovery, and closing the window while work runs.
 - [`erun review`](/cli/review) — the same review actions from the CLI.
 - [Managing hosted environments](/collaboration/hosted-environments) — the Registration tab's actions from the CLI.

--- a/erun-docs/docs/pipeline.md
+++ b/erun-docs/docs/pipeline.md
@@ -84,7 +84,7 @@ The pipeline is the same whether a person or a machine runs it.
 - **CLI** — `erun build` / `release` / `push` / `deploy`, scriptable and headless. See the [CLI overview](/cli/overview).
 - **Desktop app** — the same commands behind buttons. See the [desktop app](/desktop/overview).
 - **MCP** — an Agent calls the `build` / `push` / `deploy` / `release` [tools](/mcp/overview), which run the identical logic and return structured results instead of stdout.
-- **CI** — before a review can be accepted, ERun's own [merge queue](/collaboration/reviews#merge-queue) builds the prospective merge of its source onto its *current* target and gates it with a real `erun build`, pushing only on green — the step that catches two reviews that are each green alone but broken together, before the target branch moves. Once a review actually merges this way, it triggers `erun release` through the [release queue](/collaboration/builds#release-queue), which runs it in an agent env with warm caches, one release at a time per tenant; a later `erun deploy --version` rolls the published version out.
+- **CI** — before a review can be accepted, ERun's own [merge queue](/collaboration/merge-queue) builds the prospective merge of its source onto its *current* target and gates it with a real `erun build`, pushing only on green — the step that catches two reviews that are each green alone but broken together, before the target branch moves. Once a review actually merges this way, it triggers `erun release` through the [release queue](/collaboration/builds#release-queue), which runs it in an agent env with warm caches, one release at a time per tenant; a later `erun deploy --version` rolls the published version out.
 
 ## Promotion: agent env to runtime env
 

--- a/erun-docs/sidebars.ts
+++ b/erun-docs/sidebars.ts
@@ -149,6 +149,11 @@ const sidebars: SidebarsConfig = {
           label: 'Review loop topology',
         },
         {
+          type: 'doc',
+          id: 'collaboration/merge-queue',
+          label: 'Merge queue',
+        },
+        {
           type: 'category',
           label: 'erun API',
           link: { type: 'generated-index' },


### PR DESCRIPTION
## Summary

The merge queue's docs were scattered across three client-specific pages (`collaboration/reviews`, `cli/review`, `desktop/overview`), none of which was about it, and none of which was findable by searching "merge queue." Adds `collaboration/merge-queue` as the single page: why the queue exists, its FIFO shape, what the gate does, the unresolved-thread check (with its structured body), advancing/overriding from the API, CLI, and desktop, recovering a wedged gate, and a failure table. Linked from `collaboration/workflow`, `collaboration/reviews`, `cli/review`, `desktop/reviews`, and `collaboration/review-loop-topology` (the adjacent page from #1552).

## The four factual errors named in #1513

1. **`EMPTY_QUEUE` inverted** — redefined against the `READY` reviews actually waiting (a review already `MERGE` has left the line), not "no `MERGE`-status reviews."
2. **Error-body self-contradiction** — `collaboration/reviews`' Errors section claimed "All endpoints return JSON error bodies" while its own Merge queue section said the opposite for everything except `unresolved_threads`. Resolved in the direction the code actually behaves (see below): plain-text is the default, `unresolved_threads` is the one implemented exception, and the JSON `code`/`details` envelope is now marked as this API's target contract, not yet wired in.
3. **`unresolved_threads`'s divergent envelope** — documented as a deliberate exception on the new page rather than unified, since unifying it is a backend change outside this PR's scope.
4. **Thread-close author restriction** — verified it **is** enforced (`erun_validate_comments` trigger in `erun-backend-db/schema/triggers/comments.sql`, not application code — I checked the actual trigger, not just the docs), so no behavior correction was needed; added the fact to `cli/review.md` (`review resolve`/`review unresolve`) and `desktop/reviews.md`, where it was previously only stated on `collaboration/comments`.

## A fifth thing found while verifying, fixed rather than left

Writing the failure table meant checking what `POST /v1/reviews/merge-queue/advance` actually returns for "empty queue" and "another review already MERGE." Both trace to `repository.ErrNotFound` in `internal/service/reviews.go`'s `headOfMergeQueue`, which `writeRepositoryError` maps to a **plain `404 Not Found`** — not the `409 Conflict` the existing docs claimed for those two cases. More broadly, `writeRepositoryError`/`writeError` never set a JSON `code` field for *any* error path — the entire `{code, message, details}` envelope and the "Machine error codes" table in `collaboration/reviews` describe a contract that isn't wired into the backend anywhere except the one bespoke `unresolved_threads` body. I corrected the specific rows this issue's own content touches (the 404 vs 409 example in the general Errors table, and the `EMPTY_QUEUE` row) and added one clarifying sentence marking the codes table as target-not-yet-implemented, rather than rewriting `comments.md`/`builds.md`'s own error tables or `agent-reference/api-protocol.md`'s pagination/rate-limit sections, which share the same gap but are outside `collaboration/reviews`' self-contradiction this issue named. Flagging this here for visibility since it's a real, separate finding: pagination and rate limiting also have no implementation in `erun-backend-api` at all today (no matches for a rate limiter or a `pageToken` field anywhere in the module) — that's a materially bigger spec-vs-implementation gap than #1513 asked me to fix, and touches every resource page, not just the merge queue.

## Nothing dropped

Every paragraph that lived in `collaboration/reviews`' "Merge queue" and "Overriding the gate" sections moved to the new page verbatim-in-substance (mechanics, JSON examples, the requeue trick) rather than being cut; those sections in `reviews.md` are now short pointers, and their headings (`## Merge queue`, `### Overriding the gate {#overriding-the-gate}`) are unchanged so any external bookmark to `/collaboration/reviews#merge-queue` still lands in the right place.

## Inbound links

Searched with `grep -rn "merge queue\|merge-queue\|override-advance"` across docs prose, `sidebars.ts`, `erun-skills/`, `AGENTS.md` files, and code comments (repo-wide, not just `erun-docs/`). Found and repointed the 4 anchored references to the old `/collaboration/reviews#merge-queue` / `#overriding-the-gate` locations: `collaboration/review-loop-topology.md` (×2), `collaboration/builds.md`, `pipeline.md`. Added new links from `collaboration/workflow.md`, `collaboration/overview.md`, `concepts/glossary.md` (also fixed: its entry said `advance` promotes the head to `MERGED`, but it promotes to `MERGE` — the gate is what lands `MERGED`), `cli/review.md`, and `desktop/reviews.md`. `erun-skills/agents/erun-builder.md` and `erun-reviewer.md` mention the merge queue generically with no anchor — no broken link there, left as-is. No hits in `AGENTS.md` files needing changes (their "merge queue" mentions are engineering guidance about the backend, not docs cross-references).

## Test plan

- [x] `cd erun-docs && yarn build` — clean, zero broken-link/anchor warnings (`onBrokenLinks: 'throw'`)
- [x] `cd erun-docs && yarn typecheck` — clean
- [x] `git diff --stat origin/main...HEAD` lists only the intended 11 files, no `yarn.lock`

Closes #1513