### PR TITLE
Implement the API error-code envelope; label pagination and rate limiting as not-yet-available

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/builds.go
+++ b/erun-backend/erun-backend-api/internal/repository/builds.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 
+	"github.com/jackc/pgerrcode"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/uptrace/bun"
 )
@@ -22,16 +23,37 @@ func NewBuildRepository(txs *TxManager) *BuildRepository {
 func (r *BuildRepository) Create(ctx context.Context, build model.Build) (model.Build, error) {
 	created := build
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
-		if err := tx.NewInsert().
+		err := tx.NewInsert().
 			Model(&created).
 			Column("review_id", "kind", "successful", "commit_id", "version", "failure_detail").
 			Returning("*").
-			Scan(ctx); err != nil {
-			return err
-		}
-		return nil
+			Scan(ctx)
+		return classifyBuildError(err)
 	})
 	return created, err
+}
+
+// classifyBuildError maps the builds table's foreign key and CHECK
+// constraints onto the repository's sentinel errors so callers see a 4xx
+// instead of a bare 500 — a reviewId the caller's tenant cannot see fails the
+// same foreign key check whether the row genuinely doesn't exist or just
+// isn't this tenant's, matching the "doesn't exist or isn't visible" 404
+// documented in collaboration/builds.md.
+func classifyBuildError(err error) error {
+	code, ok := pgErrorCode(err)
+	if !ok {
+		return err
+	}
+	switch code {
+	case pgerrcode.ForeignKeyViolation:
+		return ErrNotFound
+	case pgerrcode.NotNullViolation, pgerrcode.CheckViolation:
+		return ErrInvalidInput
+	case pgerrcode.UniqueViolation:
+		return ErrConflict
+	default:
+		return err
+	}
 }
 
 func (r *BuildRepository) Get(ctx context.Context, buildID string) (model.Build, error) {

--- a/erun-backend/erun-backend-api/internal/repository/builds_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/builds_test.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestClassifyBuildErrorForeignKeyViolationIsNotFound: a reviewId the
+// caller's tenant cannot see fails the same foreign key check whether the row
+// genuinely doesn't exist or just isn't this tenant's, matching the "doesn't
+// exist or isn't visible" 404 documented in collaboration/builds.md.
+func TestClassifyBuildErrorForeignKeyViolationIsNotFound(t *testing.T) {
+	err := classifyBuildError(&pgconn.PgError{Code: pgerrcode.ForeignKeyViolation})
+
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestClassifyBuildErrorCheckViolationIsInvalidInput covers the remaining
+// CHECK constraints on builds (kind, commit_id, version, failure_detail).
+func TestClassifyBuildErrorCheckViolationIsInvalidInput(t *testing.T) {
+	err := classifyBuildError(&pgconn.PgError{Code: pgerrcode.CheckViolation})
+
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("err = %v, want ErrInvalidInput", err)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/comments.go
+++ b/erun-backend/erun-backend-api/internal/repository/comments.go
@@ -80,15 +80,26 @@ func (r *CommentRepository) Update(ctx context.Context, comment model.Comment) (
 	return updated, err
 }
 
-// classifyCommentError maps the comments table's CHECK constraints and the
-// erun_validate_comments trigger's RAISE EXCEPTIONs onto the repository's
-// sentinel errors so callers see a 4xx instead of a bare 500.
+// classifyCommentError maps the comments table's foreign keys and CHECK
+// constraints, and the erun_validate_comments trigger's RAISE EXCEPTIONs,
+// onto the repository's sentinel errors so callers see a 4xx instead of a
+// bare 500 — a reviewId/parentCommentId the caller's tenant cannot see fails
+// the same foreign key check whether the row genuinely doesn't exist or just
+// isn't this tenant's, matching the "doesn't exist or isn't visible" 404
+// documented in collaboration/comments.md.
 func classifyCommentError(err error) error {
 	code, ok := pgErrorCode(err)
 	if !ok {
 		return err
 	}
+	if code == pgerrcode.CheckViolation {
+		if name, ok := pgConstraintName(err); ok && name == "comments_body_check" {
+			return ErrCommentBodyInvalid
+		}
+	}
 	switch code {
+	case pgerrcode.ForeignKeyViolation:
+		return ErrNotFound
 	case pgerrcode.NotNullViolation, pgerrcode.CheckViolation:
 		return ErrInvalidInput
 	case pgerrcode.UniqueViolation:

--- a/erun-backend/erun-backend-api/internal/repository/comments_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/comments_test.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestClassifyCommentErrorDistinguishesTheBodyConstraint: comments.md
+// documents INVALID_BODY as the machine code for the body length/emptiness
+// constraint specifically, so it has to be distinguishable from the other
+// check_violation conditions the comments_validate trigger raises.
+func TestClassifyCommentErrorDistinguishesTheBodyConstraint(t *testing.T) {
+	err := classifyCommentError(&pgconn.PgError{Code: pgerrcode.CheckViolation, ConstraintName: "comments_body_check"})
+
+	if !errors.Is(err, ErrCommentBodyInvalid) {
+		t.Fatalf("err = %v, want ErrCommentBodyInvalid", err)
+	}
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("err = %v, want it to unwrap to ErrInvalidInput", err)
+	}
+}
+
+// TestClassifyCommentErrorForeignKeyViolationIsNotFound: a reviewId or
+// parentCommentId the caller's tenant cannot see fails the composite foreign
+// key the same way a genuinely nonexistent one would, matching the "doesn't
+// exist or isn't visible" 404 documented in collaboration/comments.md.
+func TestClassifyCommentErrorForeignKeyViolationIsNotFound(t *testing.T) {
+	err := classifyCommentError(&pgconn.PgError{Code: pgerrcode.ForeignKeyViolation})
+
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestClassifyCommentErrorOtherCheckViolationsStayGeneric: a trigger-raised
+// check_violation with no constraint name (e.g. "child comments must
+// reference the root comment...") must not be mistaken for the body
+// constraint.
+func TestClassifyCommentErrorOtherCheckViolationsStayGeneric(t *testing.T) {
+	err := classifyCommentError(&pgconn.PgError{Code: pgerrcode.CheckViolation, Message: "child comments must reference the root comment for the same review, commit, file, and line"})
+
+	if errors.Is(err, ErrCommentBodyInvalid) {
+		t.Fatalf("err = %v, want it not to be classified as the body constraint", err)
+	}
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("err = %v, want it to still unwrap to ErrInvalidInput", err)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/errors.go
+++ b/erun-backend/erun-backend-api/internal/repository/errors.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -18,6 +19,11 @@ var (
 	// own role management: revoking it would leave no user able to grant roles,
 	// and there would be no recovery lever left inside the product.
 	ErrLastGrantCapableRole = errors.New("revoking this role would leave the tenant with no user able to grant roles")
+	// ErrCommentBodyInvalid signals the comments.body CHECK constraint
+	// specifically (empty/whitespace-only or over 8 KiB), distinguished from
+	// other check_violations so a caller can be given the documented
+	// INVALID_BODY machine code instead of a generic one.
+	ErrCommentBodyInvalid = fmt.Errorf("comment body is empty or exceeds 8 KiB: %w", ErrInvalidInput)
 )
 
 func normalizeNoRows(err error) error {
@@ -52,4 +58,16 @@ func pgErrorCode(err error) (string, bool) {
 		return "", false
 	}
 	return pgErr.Code, true
+}
+
+// pgConstraintName returns the name of the table CHECK/UNIQUE/FK constraint
+// err violated, if any. Trigger RAISE EXCEPTIONs (used for cross-row
+// invariants Postgres constraints can't express) carry no constraint name —
+// this only identifies violations of a real named constraint on the table.
+func pgConstraintName(err error) (string, bool) {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.ConstraintName == "" {
+		return "", false
+	}
+	return pgErr.ConstraintName, true
 }

--- a/erun-backend/erun-backend-api/internal/routes/builds.go
+++ b/erun-backend/erun-backend-api/internal/routes/builds.go
@@ -2,10 +2,12 @@ package routes
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	apirepository "github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
 )
 
 type BuildRepository interface {
@@ -41,7 +43,7 @@ func (r BuildRoutes) listBuilds(w http.ResponseWriter, req *http.Request) {
 func (r BuildRoutes) createBuild(w http.ResponseWriter, req *http.Request) {
 	var build model.Build
 	if err := decodeJSON(req, &build); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	build.ReviewID = req.PathValue("review_id")
@@ -51,10 +53,27 @@ func (r BuildRoutes) createBuild(w http.ResponseWriter, req *http.Request) {
 	build.Kind = model.BuildKindRecorded
 	build, err := r.service.Create(req.Context(), build)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeBuildError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, build)
+}
+
+// writeBuildError gives builds.md's two documented business codes their
+// exact machine code; every other failure falls through to the generic
+// status-derived code.
+func writeBuildError(w http.ResponseWriter, err error) {
+	var invalidCommitID *service.InvalidCommitIDError
+	if errors.As(err, &invalidCommitID) {
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_COMMIT_ID", invalidCommitID.Error())
+		return
+	}
+	var invalidVersion *service.InvalidVersionError
+	if errors.As(err, &invalidVersion) {
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_VERSION", invalidVersion.Error())
+		return
+	}
+	writeRepositoryError(w, err)
 }
 
 func (r BuildRoutes) getBuild(w http.ResponseWriter, req *http.Request) {

--- a/erun-backend/erun-backend-api/internal/routes/builds_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/builds_test.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	apirepository "github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
 )
 
 type stubBuildService struct {
@@ -54,6 +56,46 @@ func TestCreateBuildForcesKindRecorded(t *testing.T) {
 	}
 	if service.created.Kind != model.BuildKindRecorded {
 		t.Fatalf("kind persisted = %q, want %q despite the client asserting GATE", service.created.Kind, model.BuildKindRecorded)
+	}
+}
+
+// TestCreateBuildInvalidCommitIDReportsItsCode: builds.md documents
+// INVALID_COMMIT_ID as 400 for a commitId that is not 40 lowercase hex chars.
+func TestCreateBuildInvalidCommitIDReportsItsCode(t *testing.T) {
+	service := &stubBuildService{err: &service.InvalidCommitIDError{CommitID: "bad"}}
+	routes := BuildRoutes{service: service}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/review-1/builds",
+		bytes.NewBufferString(`{"successful":true,"commitId":"bad","version":"1.0.0"}`))
+	req.SetPathValue("review_id", "review-1")
+	rec := httptest.NewRecorder()
+
+	routes.createBuild(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_COMMIT_ID"`) {
+		t.Fatalf("body = %q, want code INVALID_COMMIT_ID", rec.Body.String())
+	}
+}
+
+// TestCreateBuildInvalidVersionReportsItsCode: builds.md documents
+// INVALID_VERSION as 400 for a version failing the version grammar.
+func TestCreateBuildInvalidVersionReportsItsCode(t *testing.T) {
+	service := &stubBuildService{err: &service.InvalidVersionError{Version: "bad"}}
+	routes := BuildRoutes{service: service}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/review-1/builds",
+		bytes.NewBufferString(`{"successful":true,"commitId":"abcdef0123456789abcdef0123456789abcdef01","version":"bad"}`))
+	req.SetPathValue("review_id", "review-1")
+	rec := httptest.NewRecorder()
+
+	routes.createBuild(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_VERSION"`) {
+		t.Fatalf("body = %q, want code INVALID_VERSION", rec.Body.String())
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/routes/comments.go
+++ b/erun-backend/erun-backend-api/internal/routes/comments.go
@@ -2,10 +2,12 @@ package routes
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	apirepository "github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
 )
 
 type CommentRepository interface {
@@ -46,18 +48,18 @@ func (r CommentRoutes) listComments(w http.ResponseWriter, req *http.Request) {
 func (r CommentRoutes) createComment(w http.ResponseWriter, req *http.Request) {
 	var comment model.Comment
 	if err := decodeJSON(req, &comment); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	comment.ReviewID = req.PathValue("review_id")
 	comment, err := r.service.PrepareCreate(req.Context(), comment)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeCommentError(w, err)
 		return
 	}
 	comment, err = r.comments.Create(req.Context(), comment)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeCommentError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, comment)
@@ -66,13 +68,34 @@ func (r CommentRoutes) createComment(w http.ResponseWriter, req *http.Request) {
 func (r CommentRoutes) updateCommentStatus(w http.ResponseWriter, req *http.Request) {
 	var input updateCommentStatusRequest
 	if err := decodeJSON(req, &input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	comment, err := r.service.UpdateStatus(req.Context(), req.PathValue("comment_id"), input.Status)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeCommentError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, comment)
+}
+
+// writeCommentError gives comments.md's documented business codes their
+// exact machine code; every other failure falls through to the generic
+// status-derived code.
+func writeCommentError(w http.ResponseWriter, err error) {
+	var invalidCommitID *service.InvalidCommitIDError
+	if errors.As(err, &invalidCommitID) {
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_COMMIT_ID", invalidCommitID.Error())
+		return
+	}
+	var alreadyClosed *service.AlreadyClosedError
+	if errors.As(err, &alreadyClosed) {
+		writeErrorCode(w, http.StatusConflict, "ALREADY_CLOSED", alreadyClosed.Error())
+		return
+	}
+	if errors.Is(err, apirepository.ErrCommentBodyInvalid) {
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
+		return
+	}
+	writeRepositoryError(w, err)
 }

--- a/erun-backend/erun-backend-api/internal/routes/comments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/comments_test.go
@@ -1,0 +1,137 @@
+package routes
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	apirepository "github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
+)
+
+type stubCommentRepository struct {
+	err error
+}
+
+func (s *stubCommentRepository) Create(_ context.Context, comment model.Comment) (model.Comment, error) {
+	if s.err != nil {
+		return model.Comment{}, s.err
+	}
+	comment.CommentID = "comment-1"
+	return comment, nil
+}
+
+func (s *stubCommentRepository) List(context.Context, apirepository.CommentFilter) ([]model.Comment, error) {
+	return nil, s.err
+}
+
+type stubCommentService struct {
+	comment model.Comment
+	err     error
+}
+
+func (s *stubCommentService) PrepareCreate(_ context.Context, comment model.Comment) (model.Comment, error) {
+	if s.err != nil {
+		return model.Comment{}, s.err
+	}
+	return comment, nil
+}
+
+func (s *stubCommentService) UpdateStatus(context.Context, string, model.CommentStatus) (model.Comment, error) {
+	return s.comment, s.err
+}
+
+// TestCreateCommentInvalidCommitIDReportsItsCode: comments.md documents
+// INVALID_COMMIT_ID as 400 for a commitId that is not 40 lowercase hex chars.
+func TestCreateCommentInvalidCommitIDReportsItsCode(t *testing.T) {
+	routes := CommentRoutes{service: &stubCommentService{err: &service.InvalidCommitIDError{CommitID: "bad"}}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/review-1/comments", bytes.NewBufferString(`{"commitId":"bad"}`))
+	req.SetPathValue("review_id", "review-1")
+	rec := httptest.NewRecorder()
+
+	routes.createComment(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_COMMIT_ID"`) {
+		t.Fatalf("body = %q, want code INVALID_COMMIT_ID", rec.Body.String())
+	}
+}
+
+// TestCreateCommentMalformedJSONReportsInvalidBody: a decode failure gets the
+// same INVALID_BODY code documented for a missing/invalid field.
+func TestCreateCommentMalformedJSONReportsInvalidBody(t *testing.T) {
+	routes := CommentRoutes{service: &stubCommentService{}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/review-1/comments", bytes.NewBufferString(`{not json`))
+	req.SetPathValue("review_id", "review-1")
+	rec := httptest.NewRecorder()
+
+	routes.createComment(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_BODY"`) {
+		t.Fatalf("body = %q, want code INVALID_BODY", rec.Body.String())
+	}
+}
+
+// TestUpdateCommentStatusAlreadyClosedReportsItsCode: comments.md documents
+// ALREADY_CLOSED as 409 for closing an already-closed thread.
+func TestUpdateCommentStatusAlreadyClosedReportsItsCode(t *testing.T) {
+	routes := CommentRoutes{service: &stubCommentService{err: &service.AlreadyClosedError{CommentID: "comment-1"}}}
+	req := httptest.NewRequest(http.MethodPatch, "/v1/reviews/review-1/comments/comment-1/status", bytes.NewBufferString(`{"status":"CLOSED"}`))
+	req.SetPathValue("comment_id", "comment-1")
+	rec := httptest.NewRecorder()
+
+	routes.updateCommentStatus(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"ALREADY_CLOSED"`) {
+		t.Fatalf("body = %q, want code ALREADY_CLOSED", rec.Body.String())
+	}
+}
+
+// TestCreateCommentBodyConstraintReportsInvalidBody: the comments.body CHECK
+// constraint (empty or over 8 KiB) is documented as INVALID_BODY, distinct
+// from the generic code a malformed-JSON decode failure would also produce.
+func TestCreateCommentBodyConstraintReportsInvalidBody(t *testing.T) {
+	routes := CommentRoutes{service: &stubCommentService{err: apirepository.ErrCommentBodyInvalid}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/review-1/comments", bytes.NewBufferString(`{"commitId":"abcdef0123456789abcdef0123456789abcdef01","body":""}`))
+	req.SetPathValue("review_id", "review-1")
+	rec := httptest.NewRecorder()
+
+	routes.createComment(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_BODY"`) {
+		t.Fatalf("body = %q, want code INVALID_BODY", rec.Body.String())
+	}
+}
+
+// TestListCommentsGenericErrorCarriesAStatusDerivedCode covers the codepath
+// with no business-specific code: the envelope still always carries one.
+func TestListCommentsGenericErrorCarriesAStatusDerivedCode(t *testing.T) {
+	routes := CommentRoutes{comments: &stubCommentRepository{err: apirepository.ErrForbidden}}
+	req := httptest.NewRequest(http.MethodGet, "/v1/reviews/review-1/comments", nil)
+	req.SetPathValue("review_id", "review-1")
+	rec := httptest.NewRecorder()
+
+	routes.listComments(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"FORBIDDEN"`) {
+		t.Fatalf("body = %q, want code FORBIDDEN", rec.Body.String())
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/errors.go
+++ b/erun-backend/erun-backend-api/internal/routes/errors.go
@@ -3,12 +3,53 @@ package routes
 import (
 	"errors"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 )
 
+// errorEnvelope is the {code, message, details} JSON body every error
+// response now carries. code is always populated, even where no call site
+// names a more specific business code, so a client branching on it never sees
+// the field simply absent.
+type errorEnvelope struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Details any    `json:"details,omitempty"`
+}
+
+// nonAlphanumericRun matches any run of characters that don't belong in a
+// SCREAMING_SNAKE_CASE code, so http.StatusText's punctuation (e.g. "I'm a
+// teapot") collapses to a single separator instead of leaking through.
+var nonAlphanumericRun = regexp.MustCompile(`[^A-Za-z0-9]+`)
+
+// defaultErrorCode derives a machine code from the HTTP status alone. It is
+// the fallback every error gets when the call site has no more specific code
+// to report — e.g. NOT_FOUND for 404, INTERNAL_SERVER_ERROR for 500.
+func defaultErrorCode(status int) string {
+	text := http.StatusText(status)
+	if text == "" {
+		return "ERROR"
+	}
+	code := strings.Trim(nonAlphanumericRun.ReplaceAllString(text, "_"), "_")
+	return strings.ToUpper(code)
+}
+
 func writeError(w http.ResponseWriter, status int, message string) {
-	http.Error(w, message, status)
+	writeErrorCode(w, status, defaultErrorCode(status), message)
+}
+
+// writeErrorCode reports a specific machine-readable code instead of the
+// status-derived default, for the business conditions the docs name one for.
+func writeErrorCode(w http.ResponseWriter, status int, code, message string) {
+	writeErrorDetails(w, status, code, message, nil)
+}
+
+// writeErrorDetails is writeErrorCode plus a details object, for the few
+// codes whose docs promise one (e.g. INVALID_TRANSITION's validTargets).
+func writeErrorDetails(w http.ResponseWriter, status int, code, message string, details any) {
+	writeJSON(w, status, errorEnvelope{Code: code, Message: message, Details: details})
 }
 
 func writeRepositoryError(w http.ResponseWriter, err error) {

--- a/erun-backend/erun-backend-api/internal/routes/errors_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/errors_test.go
@@ -1,0 +1,77 @@
+package routes
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+// TestWriteErrorAlwaysCarriesACode is the property the whole envelope exists
+// for: a client branching on `code` must never see it absent, even when the
+// call site supplies only a status and a message.
+func TestWriteErrorAlwaysCarriesACode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeError(rec, http.StatusTeapot, "I am a teapot")
+
+	var body errorEnvelope
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response body is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	if body.Code == "" {
+		t.Fatalf("code is empty, want a status-derived default")
+	}
+	if body.Code != "I_M_A_TEAPOT" {
+		t.Fatalf("code = %q, want I_M_A_TEAPOT", body.Code)
+	}
+	if body.Message != "I am a teapot" {
+		t.Fatalf("message = %q, want the original message preserved", body.Message)
+	}
+}
+
+// TestWriteRepositoryErrorMapsEverySentinelToACode covers the generic path
+// every route without a business-specific code falls through to.
+func TestWriteRepositoryErrorMapsEverySentinelToACode(t *testing.T) {
+	cases := []struct {
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{repository.ErrNotFound, http.StatusNotFound, "NOT_FOUND"},
+		{repository.ErrForbidden, http.StatusForbidden, "FORBIDDEN"},
+		{repository.ErrInvalidInput, http.StatusBadRequest, "BAD_REQUEST"},
+		{repository.ErrMissingSecurityContext, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR"},
+		{repository.ErrConflict, http.StatusConflict, "CONFLICT"},
+		{errors.New("unrecognized"), http.StatusInternalServerError, "INTERNAL_SERVER_ERROR"},
+	}
+	for _, c := range cases {
+		rec := httptest.NewRecorder()
+		writeRepositoryError(rec, c.err)
+
+		if rec.Code != c.wantStatus {
+			t.Fatalf("err=%v: status = %d, want %d", c.err, rec.Code, c.wantStatus)
+		}
+		var body errorEnvelope
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("err=%v: response body is not JSON: %v (%s)", c.err, err, rec.Body.String())
+		}
+		if body.Code != c.wantCode {
+			t.Fatalf("err=%v: code = %q, want %q", c.err, body.Code, c.wantCode)
+		}
+	}
+}
+
+// TestWriteErrorDetailsOmitsDetailsWhenNil: details is documented as present
+// only "where useful" — a nil details must not render as a literal null.
+func TestWriteErrorDetailsOmitsDetailsWhenNil(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeErrorCode(rec, http.StatusBadRequest, "SOME_CODE", "message")
+
+	if strings.Contains(rec.Body.String(), `"details"`) {
+		t.Fatalf("body = %s, want no details field when none was given", rec.Body.String())
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/reviews.go
+++ b/erun-backend/erun-backend-api/internal/routes/reviews.go
@@ -121,7 +121,7 @@ func (r ReviewRoutes) listReviewers(w http.ResponseWriter, req *http.Request) {
 func (r ReviewRoutes) addReviewer(w http.ResponseWriter, req *http.Request) {
 	var input addReviewerRequest
 	if err := decodeJSON(req, &input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	reviewer, err := r.reviewers.Create(req.Context(), model.ReviewReviewer{
@@ -146,7 +146,7 @@ func (r ReviewRoutes) removeReviewer(w http.ResponseWriter, req *http.Request) {
 func (r ReviewRoutes) createReview(w http.ResponseWriter, req *http.Request) {
 	var review model.Review
 	if err := decodeJSON(req, &review); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	review = r.service.PrepareCreate(review)
@@ -170,7 +170,7 @@ func (r ReviewRoutes) listMergeQueue(w http.ResponseWriter, req *http.Request) {
 func (r ReviewRoutes) advanceMergeQueue(w http.ResponseWriter, req *http.Request) {
 	var input advanceMergeQueueRequest
 	if err := decodeJSON(req, &input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	review, err := r.service.AdvanceMergeQueue(req.Context(), input.TargetBranch)
@@ -185,7 +185,7 @@ func (r ReviewRoutes) advanceMergeQueue(w http.ResponseWriter, req *http.Request
 func (r ReviewRoutes) overrideAdvanceMergeQueue(w http.ResponseWriter, req *http.Request) {
 	var input overrideAdvanceMergeQueueRequest
 	if err := decodeJSON(req, &input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	review, err := r.service.OverrideAdvanceMergeQueue(req.Context(), input.TargetBranch, input.Reason)
@@ -205,7 +205,8 @@ func (r ReviewRoutes) dispatchMergeQueue(ctx context.Context, review model.Revie
 
 // writeAdvanceMergeQueueError reports an unresolved-thread block as a 409 with
 // the count and the review to route the operator to, rather than the bare
-// status text writeRepositoryError gives every other conflict.
+// status text writeRepositoryError gives every other conflict, and gives the
+// merge-queue-specific machine codes documented in collaboration/reviews.md.
 func writeAdvanceMergeQueueError(w http.ResponseWriter, err error) {
 	var blocked *service.UnresolvedThreadsError
 	if errors.As(err, &blocked) {
@@ -215,6 +216,15 @@ func writeAdvanceMergeQueueError(w http.ResponseWriter, err error) {
 			ReviewID:          blocked.ReviewID,
 			UnresolvedThreads: blocked.UnresolvedThreads,
 		})
+		return
+	}
+	if errors.Is(err, service.ErrInvalidTargetBranch) {
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_TARGET_BRANCH", err.Error())
+		return
+	}
+	var empty *service.EmptyMergeQueueError
+	if errors.As(err, &empty) {
+		writeErrorCode(w, http.StatusNotFound, "EMPTY_QUEUE", empty.Error())
 		return
 	}
 	writeRepositoryError(w, err)
@@ -232,13 +242,35 @@ func (r ReviewRoutes) getReview(w http.ResponseWriter, req *http.Request) {
 func (r ReviewRoutes) updateReviewStatus(w http.ResponseWriter, req *http.Request) {
 	var input updateReviewStatusRequest
 	if err := decodeJSON(req, &input); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
 	review, err := r.service.UpdateStatus(req.Context(), req.PathValue("review_id"), input.Status, input.BuildID)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeUpdateStatusError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, review)
+}
+
+// writeUpdateStatusError gives PATCH .../status's two documented business
+// codes their exact machine code and details shape; every other failure
+// (not found, missing security context, ...) falls through to the generic
+// status-derived code.
+func writeUpdateStatusError(w http.ResponseWriter, err error) {
+	var invalidTransition *service.InvalidTransitionError
+	if errors.As(err, &invalidTransition) {
+		writeErrorDetails(w, http.StatusBadRequest, "INVALID_TRANSITION", invalidTransition.Error(), map[string]any{
+			"from":         invalidTransition.From,
+			"to":           invalidTransition.To,
+			"validTargets": invalidTransition.ValidTargets,
+		})
+		return
+	}
+	var missingBuildID *service.MissingBuildIDError
+	if errors.As(err, &missingBuildID) {
+		writeErrorDetails(w, http.StatusBadRequest, "INVALID_BODY", missingBuildID.Error(), map[string]any{"field": "buildId"})
+		return
+	}
+	writeRepositoryError(w, err)
 }

--- a/erun-backend/erun-backend-api/internal/routes/reviews_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/reviews_test.go
@@ -311,3 +311,108 @@ func TestRemoveReviewerNotFoundReturns404(t *testing.T) {
 		t.Fatalf("status = %d, want 404", rec.Code)
 	}
 }
+
+// TestGenericRepositoryErrorCarriesAStatusDerivedCode is the base case the
+// envelope exists for: a caller branching on `code` must never see it absent,
+// even on a route with no business-specific code of its own.
+func TestGenericRepositoryErrorCarriesAStatusDerivedCode(t *testing.T) {
+	reviewers := &stubReviewReviewerRepository{err: apirepository.ErrNotFound}
+	routes := ReviewRoutes{reviewers: reviewers}
+	req := httptest.NewRequest(http.MethodDelete, "/v1/reviews/review-1/reviewers/user-1", nil)
+	req.SetPathValue("review_id", "review-1")
+	req.SetPathValue("user_id", "user-1")
+	rec := httptest.NewRecorder()
+
+	routes.removeReviewer(rec, req)
+
+	if !strings.Contains(rec.Body.String(), `"code":"NOT_FOUND"`) {
+		t.Fatalf("body = %q, want a NOT_FOUND code", rec.Body.String())
+	}
+}
+
+// TestAdvanceMergeQueueEmptyQueueReportsEmptyQueueCode: the queue-empty case
+// must be distinguishable from every other 404 this route can return, so a
+// caller can tell "nothing to promote" from "another review is merging".
+func TestAdvanceMergeQueueEmptyQueueReportsEmptyQueueCode(t *testing.T) {
+	routes := ReviewRoutes{service: &stubReviewService{err: &service.EmptyMergeQueueError{TargetBranch: "main"}}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/merge-queue/advance", bytes.NewBufferString(`{"targetBranch":"main"}`))
+	rec := httptest.NewRecorder()
+
+	routes.advanceMergeQueue(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"EMPTY_QUEUE"`) {
+		t.Fatalf("body = %q, want code EMPTY_QUEUE", rec.Body.String())
+	}
+}
+
+// TestAdvanceMergeQueueInvalidTargetBranchReportsItsCode: an empty
+// targetBranch must not be confused with OverrideAdvanceMergeQueue's own
+// ErrInvalidInput (a blank reason) — both are 400 but only one is this code.
+func TestAdvanceMergeQueueInvalidTargetBranchReportsItsCode(t *testing.T) {
+	routes := ReviewRoutes{service: &stubReviewService{err: service.ErrInvalidTargetBranch}}
+	req := httptest.NewRequest(http.MethodPost, "/v1/reviews/merge-queue/advance", bytes.NewBufferString(`{"targetBranch":""}`))
+	rec := httptest.NewRecorder()
+
+	routes.advanceMergeQueue(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_TARGET_BRANCH"`) {
+		t.Fatalf("body = %q, want code INVALID_TARGET_BRANCH", rec.Body.String())
+	}
+}
+
+// TestUpdateReviewStatusInvalidTransitionReportsCodeAndDetails: a caller
+// asserting MERGE/MERGED directly must get INVALID_TRANSITION with the
+// documented details shape (from/to/validTargets), not a bare status text.
+func TestUpdateReviewStatusInvalidTransitionReportsCodeAndDetails(t *testing.T) {
+	routes := ReviewRoutes{service: &stubReviewService{err: &service.InvalidTransitionError{
+		From:         model.ReviewStatusOpen,
+		To:           model.ReviewStatusMerged,
+		ValidTargets: []model.ReviewStatus{model.ReviewStatusFailed, model.ReviewStatusReady, model.ReviewStatusClosed},
+	}}}
+	rec := patchReviewStatus(t, routes, `{"status":"MERGED"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{`"code":"INVALID_TRANSITION"`, `"from":"OPEN"`, `"to":"MERGED"`, `"validTargets":["FAILED","READY","CLOSED"]`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body = %q, want it to contain %q", body, want)
+		}
+	}
+}
+
+// TestUpdateReviewStatusMissingBuildIDReportsInvalidBody: READY/FAILED
+// without a buildId is a missing required field, not a bare 400.
+func TestUpdateReviewStatusMissingBuildIDReportsInvalidBody(t *testing.T) {
+	routes := ReviewRoutes{service: &stubReviewService{err: &service.MissingBuildIDError{Status: model.ReviewStatusFailed}}}
+	rec := patchReviewStatus(t, routes, `{"status":"FAILED"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"code":"INVALID_BODY"`) || !strings.Contains(body, `"field":"buildId"`) {
+		t.Fatalf("body = %q, want code INVALID_BODY naming field buildId", body)
+	}
+}
+
+// TestUpdateReviewStatusMalformedJSONReportsInvalidBody: a decode failure is
+// the same INVALID_BODY code as a semantically missing field.
+func TestUpdateReviewStatusMalformedJSONReportsInvalidBody(t *testing.T) {
+	routes := ReviewRoutes{service: &stubReviewService{}}
+	rec := patchReviewStatus(t, routes, `{not json`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"INVALID_BODY"`) {
+		t.Fatalf("body = %q, want code INVALID_BODY", rec.Body.String())
+	}
+}

--- a/erun-backend/erun-backend-api/internal/service/builds.go
+++ b/erun-backend/erun-backend-api/internal/service/builds.go
@@ -2,9 +2,29 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 )
+
+// buildVersionPattern is the semver-or-agent-env-snapshot grammar documented
+// in collaboration/builds.md's Validation rules table (the same grammar as
+// agent-reference/release-policy#version-string-grammar).
+var buildVersionPattern = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$`)
+
+// InvalidVersionError refuses a RECORDED build whose version fails the
+// version grammar.
+type InvalidVersionError struct {
+	Version string
+}
+
+func (e *InvalidVersionError) Error() string {
+	return fmt.Sprintf("version %q does not match the required grammar", e.Version)
+}
+
+func (e *InvalidVersionError) Unwrap() error { return repository.ErrInvalidInput }
 
 type BuildRepository interface {
 	Create(ctx context.Context, build model.Build) (model.Build, error)
@@ -37,8 +57,14 @@ func NewBuildService(builds BuildRepository, reviews BuildReviewService, merge M
 }
 
 func (s *BuildService) Create(ctx context.Context, build model.Build) (model.Build, error) {
+	if !commitIDPattern.MatchString(build.CommitID) {
+		return model.Build{}, &InvalidCommitIDError{CommitID: build.CommitID}
+	}
 	if build.Kind == "" {
 		build.Kind = model.BuildKindRecorded
+	}
+	if build.Kind == model.BuildKindRecorded && !buildVersionPattern.MatchString(build.Version) {
+		return model.Build{}, &InvalidVersionError{Version: build.Version}
 	}
 	created, err := s.builds.Create(ctx, build)
 	if err != nil {

--- a/erun-backend/erun-backend-api/internal/service/builds_test.go
+++ b/erun-backend/erun-backend-api/internal/service/builds_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+)
+
+type fakeBuildRepo struct {
+	created model.Build
+}
+
+func (f *fakeBuildRepo) Create(_ context.Context, build model.Build) (model.Build, error) {
+	build.BuildID = "build-1"
+	f.created = build
+	return build, nil
+}
+
+type fakeBuildReviewService struct{}
+
+func (fakeBuildReviewService) MarkBuildResult(context.Context, string, string, bool) (model.Review, bool, error) {
+	return model.Review{}, false, nil
+}
+
+const validCommitID = "abcdef0123456789abcdef0123456789abcdef01"
+
+// TestBuildCreateRefusesAMalformedCommitID: builds.md documents the same
+// 40-lowercase-hex-character grammar as comments.md, as INVALID_COMMIT_ID.
+func TestBuildCreateRefusesAMalformedCommitID(t *testing.T) {
+	svc := NewBuildService(&fakeBuildRepo{}, nil, nil)
+	_, err := svc.Create(context.Background(), model.Build{CommitID: "short", Version: "1.0.0", Successful: true})
+
+	var invalidCommitID *InvalidCommitIDError
+	if !errors.As(err, &invalidCommitID) {
+		t.Fatalf("Create error = %v, want *InvalidCommitIDError", err)
+	}
+	if !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("Create error = %v, want it to unwrap to ErrInvalidInput", err)
+	}
+}
+
+// TestBuildCreateRefusesAMalformedVersion: builds.md documents
+// INVALID_VERSION for a version failing the semver/snapshot grammar.
+func TestBuildCreateRefusesAMalformedVersion(t *testing.T) {
+	svc := NewBuildService(&fakeBuildRepo{}, nil, nil)
+	_, err := svc.Create(context.Background(), model.Build{CommitID: validCommitID, Version: "not-a-version", Successful: true})
+
+	var invalidVersion *InvalidVersionError
+	if !errors.As(err, &invalidVersion) {
+		t.Fatalf("Create error = %v, want *InvalidVersionError", err)
+	}
+	if !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("Create error = %v, want it to unwrap to ErrInvalidInput", err)
+	}
+}
+
+// TestBuildCreateAcceptsASnapshotVersion: the agent-env snapshot tag shape
+// (<semver>-snapshot-<UTC-timestamp>) is a documented valid version, not just
+// a plain semver.
+func TestBuildCreateAcceptsASnapshotVersion(t *testing.T) {
+	svc := NewBuildService(&fakeBuildRepo{}, fakeBuildReviewService{}, nil)
+	_, err := svc.Create(context.Background(), model.Build{
+		CommitID: validCommitID, Version: "1.2.3-snapshot-20260824091244", Successful: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/service/comments.go
+++ b/erun-backend/erun-backend-api/internal/service/comments.go
@@ -2,11 +2,40 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
+
+// commitIDPattern is the 40-lowercase-hex-character grammar documented in
+// collaboration/comments.md's Validation rules table.
+var commitIDPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// InvalidCommitIDError refuses a comment whose commitId is not 40 lowercase
+// hex characters.
+type InvalidCommitIDError struct {
+	CommitID string
+}
+
+func (e *InvalidCommitIDError) Error() string {
+	return fmt.Sprintf("commitId %q is not 40 lowercase hex characters", e.CommitID)
+}
+
+func (e *InvalidCommitIDError) Unwrap() error { return repository.ErrInvalidInput }
+
+// AlreadyClosedError refuses closing a comment thread that is already closed.
+type AlreadyClosedError struct {
+	CommentID string
+}
+
+func (e *AlreadyClosedError) Error() string {
+	return fmt.Sprintf("comment %s is already closed", e.CommentID)
+}
+
+func (e *AlreadyClosedError) Unwrap() error { return repository.ErrConflict }
 
 type CommentRepository interface {
 	Create(ctx context.Context, comment model.Comment) (model.Comment, error)
@@ -27,6 +56,9 @@ func (s *CommentService) PrepareCreate(ctx context.Context, comment model.Commen
 	if err != nil {
 		return model.Comment{}, repository.ErrMissingSecurityContext
 	}
+	if !commitIDPattern.MatchString(comment.CommitID) {
+		return model.Comment{}, &InvalidCommitIDError{CommitID: comment.CommitID}
+	}
 	if comment.Status == "" {
 		comment.Status = model.CommentStatusOpen
 	}
@@ -38,6 +70,9 @@ func (s *CommentService) UpdateStatus(ctx context.Context, commentID string, sta
 	comment, err := s.comments.Get(ctx, commentID)
 	if err != nil {
 		return model.Comment{}, err
+	}
+	if comment.Status == model.CommentStatusClosed && status == model.CommentStatusClosed {
+		return model.Comment{}, &AlreadyClosedError{CommentID: commentID}
 	}
 	comment.Status = status
 	return s.comments.Update(ctx, comment)

--- a/erun-backend/erun-backend-api/internal/service/comments_test.go
+++ b/erun-backend/erun-backend-api/internal/service/comments_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+)
+
+type fakeCommentRepo struct {
+	comments map[string]model.Comment
+}
+
+func (f *fakeCommentRepo) Create(_ context.Context, comment model.Comment) (model.Comment, error) {
+	return comment, nil
+}
+
+func (f *fakeCommentRepo) Get(_ context.Context, commentID string) (model.Comment, error) {
+	c, ok := f.comments[commentID]
+	if !ok {
+		return model.Comment{}, repository.ErrNotFound
+	}
+	return c, nil
+}
+
+func (f *fakeCommentRepo) Update(_ context.Context, comment model.Comment) (model.Comment, error) {
+	f.comments[comment.CommentID] = comment
+	return comment, nil
+}
+
+func withTestSecurity(ctx context.Context) context.Context {
+	return security.WithContext(ctx, security.Context{TenantID: "tenant-1", ErunUserID: "user-1"})
+}
+
+// TestPrepareCreateRefusesAMalformedCommitID: the 40-lowercase-hex-character
+// grammar collaboration/comments.md documents as INVALID_COMMIT_ID.
+func TestPrepareCreateRefusesAMalformedCommitID(t *testing.T) {
+	svc := NewCommentService(&fakeCommentRepo{})
+	_, err := svc.PrepareCreate(withTestSecurity(context.Background()), model.Comment{CommitID: "not-a-commit"})
+
+	var invalidCommitID *InvalidCommitIDError
+	if !errors.As(err, &invalidCommitID) {
+		t.Fatalf("PrepareCreate error = %v, want *InvalidCommitIDError", err)
+	}
+	if !errors.Is(err, repository.ErrInvalidInput) {
+		t.Fatalf("PrepareCreate error = %v, want it to unwrap to ErrInvalidInput", err)
+	}
+}
+
+// TestPrepareCreateAcceptsAWellFormedCommitID is the companion positive case:
+// the validation must not reject the exact grammar it documents.
+func TestPrepareCreateAcceptsAWellFormedCommitID(t *testing.T) {
+	svc := NewCommentService(&fakeCommentRepo{})
+	comment, err := svc.PrepareCreate(withTestSecurity(context.Background()), model.Comment{
+		CommitID: "abcdef0123456789abcdef0123456789abcdef01",
+	})
+	if err != nil {
+		t.Fatalf("PrepareCreate: %v", err)
+	}
+	if comment.CreatorUserID != "user-1" {
+		t.Fatalf("CreatorUserID = %q, want it set from the security context", comment.CreatorUserID)
+	}
+}
+
+// TestUpdateStatusRefusesClosingAnAlreadyClosedThread: comments.md documents
+// ALREADY_CLOSED as a 409, distinct from every other UpdateStatus failure.
+func TestUpdateStatusRefusesClosingAnAlreadyClosedThread(t *testing.T) {
+	repo := &fakeCommentRepo{comments: map[string]model.Comment{
+		"c1": {CommentID: "c1", Status: model.CommentStatusClosed},
+	}}
+	svc := NewCommentService(repo)
+
+	_, err := svc.UpdateStatus(context.Background(), "c1", model.CommentStatusClosed)
+
+	var alreadyClosed *AlreadyClosedError
+	if !errors.As(err, &alreadyClosed) {
+		t.Fatalf("UpdateStatus error = %v, want *AlreadyClosedError", err)
+	}
+	if !errors.Is(err, repository.ErrConflict) {
+		t.Fatalf("UpdateStatus error = %v, want it to unwrap to ErrConflict", err)
+	}
+}
+
+// TestUpdateStatusAllowsReopeningAClosedThread: only closing an
+// already-closed thread is refused — reopening it is a normal transition.
+func TestUpdateStatusAllowsReopeningAClosedThread(t *testing.T) {
+	repo := &fakeCommentRepo{comments: map[string]model.Comment{
+		"c1": {CommentID: "c1", Status: model.CommentStatusClosed},
+	}}
+	svc := NewCommentService(repo)
+
+	updated, err := svc.UpdateStatus(context.Background(), "c1", model.CommentStatusOpen)
+	if err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	if updated.Status != model.CommentStatusOpen {
+		t.Fatalf("status = %s, want OPEN", updated.Status)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/service/reviews.go
+++ b/erun-backend/erun-backend-api/internal/service/reviews.go
@@ -60,6 +60,70 @@ func (e *UnresolvedThreadsError) Error() string {
 	return fmt.Sprintf("review %s has %d unresolved comment thread(s); resolve them before advancing the merge queue", e.ReviewID, e.UnresolvedThreads)
 }
 
+// ErrInvalidTargetBranch refuses an empty targetBranch on merge-queue
+// advance — distinguished from OverrideAdvanceMergeQueue's blank-reason
+// refusal (also ErrInvalidInput) so a caller can be told which field it was.
+var ErrInvalidTargetBranch = fmt.Errorf("targetBranch is required: %w", repository.ErrInvalidInput)
+
+// EmptyMergeQueueError distinguishes "nothing waiting to promote" from the
+// review-already-merging case headOfMergeQueue also refuses with the bare
+// ErrNotFound sentinel — both keep the same 404, but only this one is the
+// EMPTY_QUEUE machine code documented in collaboration/reviews.md.
+type EmptyMergeQueueError struct {
+	TargetBranch string
+}
+
+func (e *EmptyMergeQueueError) Error() string {
+	return fmt.Sprintf("no review waiting to merge for target branch %s", e.TargetBranch)
+}
+
+func (e *EmptyMergeQueueError) Unwrap() error { return repository.ErrNotFound }
+
+// InvalidTransitionError refuses a caller's PATCH .../status asserting MERGE
+// or MERGED directly — the merge queue's own gate is the only path to either.
+type InvalidTransitionError struct {
+	From         model.ReviewStatus
+	To           model.ReviewStatus
+	ValidTargets []model.ReviewStatus
+}
+
+func (e *InvalidTransitionError) Error() string {
+	return fmt.Sprintf("cannot transition review from %s directly to %s", e.From, e.To)
+}
+
+func (e *InvalidTransitionError) Unwrap() error { return repository.ErrInvalidInput }
+
+// MissingBuildIDError refuses a FAILED/READY status update with no buildId:
+// both statuses record which build produced them.
+type MissingBuildIDError struct {
+	Status model.ReviewStatus
+}
+
+func (e *MissingBuildIDError) Error() string {
+	return fmt.Sprintf("buildId is required when setting status to %s", e.Status)
+}
+
+func (e *MissingBuildIDError) Unwrap() error { return repository.ErrInvalidInput }
+
+// validTargetsFor lists the statuses a caller's PATCH .../status may set from
+// the review's current status, mirroring the Status lifecycle documented in
+// collaboration/reviews.md. MERGE and MERGED never appear: only the merge
+// queue's own gate result reaches either.
+func validTargetsFor(status model.ReviewStatus) []model.ReviewStatus {
+	switch status {
+	case model.ReviewStatusOpen:
+		return []model.ReviewStatus{model.ReviewStatusFailed, model.ReviewStatusReady, model.ReviewStatusClosed}
+	case model.ReviewStatusFailed:
+		return []model.ReviewStatus{model.ReviewStatusReady, model.ReviewStatusClosed}
+	case model.ReviewStatusReady:
+		return []model.ReviewStatus{model.ReviewStatusClosed}
+	case model.ReviewStatusMerge:
+		return []model.ReviewStatus{model.ReviewStatusReady}
+	default:
+		return nil
+	}
+}
+
 type ReviewService struct {
 	reviews  ReviewRepository
 	builds   ReviewBuildRepository
@@ -127,14 +191,18 @@ func (s *ReviewService) OverrideAdvanceMergeQueue(ctx context.Context, targetBra
 // another review is already merging on that branch.
 func (s *ReviewService) headOfMergeQueue(ctx context.Context, targetBranch string) (model.Review, error) {
 	if targetBranch == "" {
-		return model.Review{}, repository.ErrInvalidInput
+		return model.Review{}, ErrInvalidTargetBranch
 	}
 	if _, err := s.reviews.FindActiveMergeReview(ctx, targetBranch); err == nil {
 		return model.Review{}, repository.ErrNotFound
 	} else if !errors.Is(err, repository.ErrNotFound) {
 		return model.Review{}, err
 	}
-	return s.reviews.FindNextMergeQueueReview(ctx, targetBranch)
+	review, err := s.reviews.FindNextMergeQueueReview(ctx, targetBranch)
+	if errors.Is(err, repository.ErrNotFound) {
+		return model.Review{}, &EmptyMergeQueueError{TargetBranch: targetBranch}
+	}
+	return review, err
 }
 
 // promoteToMerge moves review from the queue to MERGE. Both AdvanceMergeQueue
@@ -198,16 +266,17 @@ func (s *ReviewService) auditOverrideAdvance(ctx context.Context, review model.R
 }
 
 func (s *ReviewService) UpdateStatus(ctx context.Context, reviewID string, status model.ReviewStatus, buildID string) (model.Review, error) {
+	review, err := s.reviews.Get(ctx, reviewID)
+	if err != nil {
+		return model.Review{}, err
+	}
+
 	// MERGE is reached only by AdvanceMergeQueue promoting the queue head, and
 	// MERGED only by the merge queue's own gate build succeeding — a caller's
 	// PATCH asserting either is an assertion nothing verified, which is exactly
 	// what a merge queue exists to refuse.
 	if status == model.ReviewStatusMerge || status == model.ReviewStatusMerged {
-		return model.Review{}, repository.ErrInvalidInput
-	}
-	review, err := s.reviews.Get(ctx, reviewID)
-	if err != nil {
-		return model.Review{}, err
+		return model.Review{}, &InvalidTransitionError{From: review.Status, To: status, ValidTargets: validTargetsFor(review.Status)}
 	}
 
 	// READY without a build is the missed-merge-window path, not a build result.
@@ -217,7 +286,7 @@ func (s *ReviewService) UpdateStatus(ctx context.Context, reviewID string, statu
 
 	if reviewLastBuildColumn(status) != "" {
 		if buildID == "" {
-			return model.Review{}, repository.ErrInvalidInput
+			return model.Review{}, &MissingBuildIDError{Status: status}
 		}
 		return s.updateBuildStatus(ctx, review, status, buildID)
 	}

--- a/erun-backend/erun-backend-api/internal/service/reviews_test.go
+++ b/erun-backend/erun-backend-api/internal/service/reviews_test.go
@@ -141,8 +141,16 @@ func TestUpdateStatusRefusesMergeAndMerged(t *testing.T) {
 	svc, _ := newTestReviewService(reviews, &fakeReviewBuilds{})
 
 	for _, status := range []model.ReviewStatus{model.ReviewStatusMerge, model.ReviewStatusMerged} {
-		if _, err := svc.UpdateStatus(context.Background(), "review-1", status, "build-1"); err != repository.ErrInvalidInput {
-			t.Fatalf("UpdateStatus(%s) error = %v, want ErrInvalidInput", status, err)
+		_, err := svc.UpdateStatus(context.Background(), "review-1", status, "build-1")
+		var invalidTransition *InvalidTransitionError
+		if !errors.As(err, &invalidTransition) {
+			t.Fatalf("UpdateStatus(%s) error = %v, want *InvalidTransitionError", status, err)
+		}
+		if !errors.Is(err, repository.ErrInvalidInput) {
+			t.Fatalf("UpdateStatus(%s) error = %v, want it to unwrap to ErrInvalidInput", status, err)
+		}
+		if invalidTransition.From != model.ReviewStatusReady || invalidTransition.To != status {
+			t.Fatalf("InvalidTransitionError = %+v, want from READY to %s", invalidTransition, status)
 		}
 		if got := reviews.reviews["review-1"].Status; got != model.ReviewStatusReady {
 			t.Fatalf("UpdateStatus(%s) changed the review to %s despite being refused", status, got)

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -88,7 +88,7 @@ When no trust anchor is configured the edge stays loopback-only (legacy, unauthe
 ### Endpoints
 
 :::note Shipped vs planned
-The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), and `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name). New tenants and their issuer mapping can be registered through the operations-only `POST /v1/tenants` below; for an existing tenant, additional issuers and their org-scoping mode are still provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a tenant-self-service endpoint. `POST /v1/users` enrolls additional users beyond the first-user bootstrap. A tenant-self-service **trust-management** API (a tenant adding/removing its own issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the structured machine-readable error `code` field — today the API returns bare HTTP status codes with a plain-text body (see [Errors](#errors) below).
+The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), and `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name). New tenants and their issuer mapping can be registered through the operations-only `POST /v1/tenants` below; for an existing tenant, additional issuers and their org-scoping mode are still provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a tenant-self-service endpoint. `POST /v1/users` enrolls additional users beyond the first-user bootstrap. A tenant-self-service **trust-management** API (a tenant adding/removing its own issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the structured machine-readable error `code` field for authentication/authorization failures specifically — today those return bare HTTP status codes with a plain-text body (see [Errors](#errors) below). Business-logic errors past the auth layer do carry a `code` today — see [Reviews · Errors](/collaboration/reviews#errors).
 :::
 
 | Method | Path | Description | Required scope |
@@ -319,7 +319,7 @@ The executor is **opt-in and off by default** — it requires the backend to run
 
 Registration deploys an environment **once**. To deploy it again — retrying a failure, or moving it to another published version — use [`POST /v1/environments/{id}/deploy`](#deploy-endpoint).
 
-**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -353,7 +353,7 @@ A body-less request (no body at all, or `{}`) deploys the environment's own `run
 
 **Resource quota, re-checked.** Before claiming, the endpoint re-runs the same two checks [`POST /v1/environments`](#post-v1environments) does at create — the tenant's `maxCpuMillicores`/`maxMemoryMb`/`maxStorageGb` caps against the runtime pod's minimum, and the aggregate `maxTotalCpuMillicores`/`maxTotalMemoryMb`/`maxTotalStorageGb` budget projection (using the environment's own existing runtime count, not +1, since a redeploy adds nothing new) — and rejects with `409` if either is now insufficient (see [Quotas](/concepts/hosted-platform#quotas)). This catches an operator lowering the tenant's quota (`PUT /v1/tenants/{tenant_id}/quota`) after the environment was already created: without the re-check, the next deploy would only discover the shortfall as a five-minute rollout timeout.
 
-**Error behaviour.** Bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -423,7 +423,7 @@ The endpoint takes **no body**. On success it returns HTTP `200`:
 
 **Usable once the env is deployed.** A minted token only authenticates against a **deployed** env whose edge already carries the backend's public key. A dedicated `409`-until-deployed guard is `(Planned.)` — the backend tracks a per-env provisioning `status` (see [`POST /v1/environments`](#post-v1environments)) but the mint endpoint does not yet gate on it reaching `running`; until it does, the endpoint mints whenever the signer is configured and the environment exists.
 
-**Error behaviour.** Bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -446,7 +446,7 @@ Mints a per-env **DNS-01 broker token** — the long-lived, backend-signed crede
 
 The operator lands this token as the Secret the per-tenant Issuer's webhook solver references (see the `erun-enable-hosting-edge` skill). Enabled by the same `ERUN_API_MCP_SIGNING_KEY_PATH` as the mcp-token endpoint; unset → `501`.
 
-**Error behaviour.** Bare HTTP status, plain-text body:
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -487,7 +487,7 @@ Mints the short-lived, scope-limited access token erun's hosted container regist
 
 Same signing key as the [mcp-token](#mcp-token-endpoint) and [dns01-token](#dns01-token-endpoint) endpoints, again with a **distinct audience**: the minted token's `aud` is the registry's own `service` value from the challenge (`registry.erunpaas.com`), never `erun-api` or an `erun-mcp:<tenant>/<env>` value, so it cannot be replayed against the platform API or an env's MCP edge. `iss` is the fixed `erun-registry-token-service` value. Enabled by the same `ERUN_API_MCP_SIGNING_KEY_PATH` as the other two; unset, or no tenant resolver configured (no database), leaves the route **unregistered** (`404`), matching the [DNS-01 broker](#dns01-broker)'s absent-when-unconfigured behaviour rather than the mcp-token endpoint's `501`.
 
-**Error behaviour.** Bare HTTP status, plain-text body:
+**Error behaviour.** This endpoint lives in its own `internal/registrytoken` package, outside `internal/routes` — bare HTTP status with a plain-text body, not the `{code, message}` envelope [Reviews · Errors](/collaboration/reviews#errors) documents for the rest of this API:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -553,7 +553,7 @@ Registers a **cloud context** (a managed cluster) for the caller's tenant and re
 
 **Prerequisites.** Live provisioning requires (1) a registered cloud-provider alias holding the tenant's encrypted BYO-cloud credentials (`PUT /v1/cloud-provider-aliases/{alias}`, below), and (2) the platform configured with a DBOS system database (`DBOS_SYSTEM_DATABASE_URL`) and a secrets key (`ERUN_SECRETS_KEY`). When provisioning is **not** configured, `POST /v1/contexts` registers the row and returns `201` with the plan only (no live bootstrap) — the pre-#676 behaviour.
 
-**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -673,7 +673,7 @@ Provide **either** a `context` block (provision a new cluster — its bootstrap 
 
 **This endpoint itself only resolves and returns the plan — it never executes it or writes to the database.** But the discrete endpoints it composes are executing paths in their own right: [`POST /v1/environments`](#post-v1environments) (with `preview: false`, the default) really registers the row and, for a pinned `runtime` environment, really starts the deploy — which, per [Automatic exposure](/concepts/hosted-platform#automatic-exposure), also chains the expose line above when the platform is configured for it; [`POST /v1/environments/{id}/deploy`](#deploy-endpoint), [`.../stop`](#stop-endpoint), and [`DELETE`](#delete-endpoint) really run their Jobs (`deploy` and `DELETE` asynchronously, behind a durable workflow); [`POST /v1/contexts`](#post-v1contexts) (with `preview: false`) really bootstraps a cluster.
 
-**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -714,7 +714,7 @@ The three identity rows — the `tenants` row, the `issuers` registry row (the g
 }
 ```
 
-**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -772,7 +772,7 @@ This endpoint requires the caller to already know the enrollee's `issuer`/`subje
 ]
 ```
 
-**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -831,7 +831,7 @@ Each permission needs **exactly one** of the exact pair or the pattern pair (mat
 
 **The lockout guard.** `DELETE /v1/users/{user_id}/roles/{role_id}` refuses when the revoke would leave the tenant with **no user holding a role that can grant roles** (a permission matching `POST /v1/users/{user_id}/roles` itself) — the one failure this feature makes impossible rather than merely recoverable, since there would be no lever left inside the product to undo it. The check runs against every user in the tenant, not just the one being revoked, so revoking a role from one admin while another admin still holds a grant-capable role succeeds normally.
 
-**Error behaviour.** Bare HTTP status, plain-text body, same as `/v1/users`:
+**Error behaviour.** Same generic JSON `{code, message}` envelope as `/v1/users`:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -966,7 +966,7 @@ Sets a tenant's full quota row — the environment-count cap the [`POST /v1/envi
 
 **What the resource caps mean.** `maxCpuMillicores`/`maxMemoryMb`/`maxStorageGb` are a **per-environment namespace ceiling**, not an aggregate tenant budget: every `runtime` environment this tenant provisions gets its own Kubernetes `ResourceQuota` + `LimitRange` capped at these same values (see [Quotas](/concepts/hosted-platform#quotas)), so a tenant with ten environments can use up to this cap in *each* of the ten namespaces, not this cap split across all ten. `maxTotalCpuMillicores`/`maxTotalMemoryMb`/`maxTotalStorageGb` are the separate **aggregate tenant-wide budget**: since every environment gets the identical per-environment cap, admission projects `(existing runtime environment count + 1) × the per-environment cap` against this budget and refuses a create that would exceed it (a redeploy uses the count as-is, since it does not add one). Absent a `tenant_quotas` row, a tenant gets the default cap: `maxEnvironments: 10`, `maxCpuMillicores: 8000`, `maxMemoryMb: 17832`, `maxStorageGb: 72` — sized to fit the `erun-devops` chart's own default runtime pod summed across **both** its containers (`erun-devops` cpu limit `4` + memory limit `8916Mi`, plus the `erun-dind` sidecar at the same limits) plus its three default PVCs (`2Gi + 50Gi + 20Gi = 72Gi`) — and `maxTotalCpuMillicores: 80000`, `maxTotalMemoryMb: 178320`, `maxTotalStorageGb: 720` (`maxEnvironments` × the per-environment defaults, so the default budget accommodates the default environment-count cap at the default per-environment size). Setting either resource cap below this floor is accepted here (an operator may deliberately want a tenant that cannot provision runtime environments yet), but the next [`POST /v1/environments`](#post-v1environments) or [`POST .../deploy`](#deploy-endpoint) for that tenant then refuses with `409` rather than letting the create/deploy proceed toward a pod Kubernetes will never admit.
 
-**Error behaviour.** Today the API returns a bare HTTP status with a plain-text body (no JSON envelope):
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)) — `code` is the status-derived default (e.g. `NOT_FOUND`, `CONFLICT`); none of the [Reviews-specific machine codes](/collaboration/reviews#machine-error-codes) apply here:
 
 | Status | Condition | Recovery |
 |---|---|---|
@@ -1065,9 +1065,9 @@ A future structured error envelope will return a machine-readable `code` (and, w
 | `422` | `DISCOVERY_FETCH_FAILED` | Self-service add with an issuer whose `<issuerUrl>/.well-known/openid-configuration` can't be fetched. | Verify the issuer is online and the URL is correct. |
 | `422` | `JWKS_INVALID` | Discovery document loads but `jwks_uri` returns no usable keys. | Verify the issuer's JWKS is published correctly. |
 
-## Rate limits
+## Rate limits `(Planned.)` {#rate-limits}
 
-The erun API enforces per-token and per-tenant limits to keep multi-agent traffic predictable.
+**Not implemented yet.** There is no request-rate limiter anywhere in `erun-backend-api` today — no per-token bucket, no per-tenant aggregate, and no `429` response on any path. A caller can call as fast as it wants; the only ceiling is ordinary HTTP concurrency and the database beneath it. The design below is the target shape, kept here so a client that wants to be a good citizen ahead of time can already structure its retry logic around `Retry-After`/`RateLimit-*` — but nothing enforces it, and no client should treat a `429` as a documented possibility today.
 
 | Bucket | Limit | Notes |
 |---|---|---|
@@ -1076,7 +1076,7 @@ The erun API enforces per-token and per-tenant limits to keep multi-agent traffi
 | Per-token, merge-queue advance | 10 req/min | `POST /v1/reviews/merge-queue/advance`. Tightened because each call mutates shared state. |
 | Per-tenant aggregate | 1500 req/min | Sum of all tokens belonging to the tenant. |
 
-Hitting a limit returns `429 Too Many Requests` with:
+Once implemented, hitting a limit would return `429 Too Many Requests` with:
 
 ```
 Retry-After: <seconds>
@@ -1085,11 +1085,9 @@ RateLimit-Remaining: 0
 RateLimit-Reset: <unix epoch>
 ```
 
-Clients should respect `Retry-After`. Persistent over-spend at the tenant aggregate level triggers an audit-trail event and an administrator notification — agents that hammer the API are visible.
+## Pagination `(Planned.)` {#pagination}
 
-## Pagination
-
-List endpoints (`GET /v1/reviews`, `GET /v1/reviews/{id}/comments`, `GET /v1/reviews/{id}/builds`) return at most **100 items per response**. When more exist, the response includes:
+**Not implemented yet.** List endpoints (`GET /v1/reviews`, `GET /v1/reviews/{id}/comments`, `GET /v1/reviews/{id}/builds`, and every other `GET` list route in [Endpoints](#endpoints)) return the **entire result set in one response** today — no page size cap, no `items`/`nextPageToken` envelope, and no `pageToken` query parameter accepted anywhere. A caller that sends `?pageToken=...` has it silently ignored (list routes read only the filter query params each one documents). The shape below is the target design:
 
 ```jsonc
 {
@@ -1098,7 +1096,7 @@ List endpoints (`GET /v1/reviews`, `GET /v1/reviews/{id}/comments`, `GET /v1/rev
 }
 ```
 
-Pass the token back as `?pageToken=<token>` on the next call. When `nextPageToken` is absent, you've reached the end of the list. Tokens are opaque and stable; passing a stale token returns `400 Bad Request` with code `EXPIRED_PAGE_TOKEN`.
+Once implemented, the token would be passed back as `?pageToken=<token>` on the next call, with a stale token refused as `400 Bad Request` (code `EXPIRED_PAGE_TOKEN`). Until then, a tenant with a very large number of reviews/comments/builds gets them all back in one call — there is no signal that more exist because there never is more than what came back.
 
 ## See also
 

--- a/erun-docs/docs/agent-reference/overview.md
+++ b/erun-docs/docs/agent-reference/overview.md
@@ -41,7 +41,7 @@ Per the Operator/Agent split, an Agent is responsible for the following classes 
 - Following the [build-path resolution algorithm](/reference/configuration-build-paths) when explaining why a build resolved to a particular image tag.
 - Loading the [right skill](/concepts/skills) before writing a service, migration, or ingress — and writing conformant code by hand from the skill's guidance.
 - Recording [structured audit events](/agent-reference/audit-log#event-shape) so the Operator can replay the session.
-- Respecting the [rate limits](/agent-reference/api-protocol#rate-limits) — backing off when hit, not hammering the API.
+- Not hammering the API — rate limiting is [planned but not yet enforced](/agent-reference/api-protocol#rate-limits), so nothing stops a runaway loop except the Agent itself.
 
 ## What stays in the Operator's hands
 

--- a/erun-docs/docs/collaboration/agent-patterns.md
+++ b/erun-docs/docs/collaboration/agent-patterns.md
@@ -93,7 +93,7 @@ The Agent's natural fit for peer review is a tight loop:
 # 6. Merge queue advances (POST /v1/reviews/merge-queue/advance)
 ```
 
-Avoid spamming — rate-limit your own comments to one per discussion thread until the other side replies. The API itself rate-limits you anyway (see [Rate limits](/agent-reference/api-protocol#rate-limits)).
+Avoid spamming — rate-limit your own comments to one per discussion thread until the other side replies. The API does not enforce this for you today (rate limiting is [planned, not shipped](/agent-reference/api-protocol#rate-limits)), so a well-behaved Agent is the only thing keeping the thread readable.
 
 For the concrete, non-abstract version of this loop — which environment runs each side, why they're separate environments, and the two reusable agents that implement it — see [Review loop topology](/collaboration/review-loop-topology).
 

--- a/erun-docs/docs/collaboration/builds.md
+++ b/erun-docs/docs/collaboration/builds.md
@@ -176,17 +176,19 @@ A release whose control plane stops reporting for 4 hours is failed with a reaso
 
 ## Errors
 
-Standard HTTP semantics (see [Reviews · Errors](/collaboration/reviews#errors)). Build-specific cases:
+Same envelope and status-code conventions as [Reviews · Errors](/collaboration/reviews#errors). Build-specific cases:
 
 | Status | `code` | When |
 |---|---|---|
+| `400` | `INVALID_BODY` | Malformed JSON. |
 | `400` | `INVALID_COMMIT_ID` | `commitId` is not 40 lowercase hex chars. |
-| `400` | `INVALID_VERSION` | `version` fails the version grammar. |
-| `404` | — | The review id doesn't exist or isn't visible. |
-| `422` | `UNKNOWN_COMMIT` | `commitId` doesn't exist on the review's `sourceBranch`. |
+| `400` | `INVALID_VERSION` | `version` fails the version grammar (a `RECORDED` build only — `GATE` builds never reach this route). |
+| `404` | — (generic) | The review id doesn't exist or isn't visible to the caller's tenant. |
+
+`422 Unprocessable Entity` and the `UNKNOWN_COMMIT` code from an earlier draft of this table do not appear above: nothing in this API returns `422`, and `UNKNOWN_COMMIT`'s original description — confirming `commitId` exists on the review's `sourceBranch` — is a check the API cannot perform (it has no git access to the repository). `PATCH /reviews/{id}/status` referencing a `buildId` that doesn't belong to the review, or whose `successful` flag disagrees with the target status, is a plain `404` — see [Reviews · Errors](/collaboration/reviews#errors).
 
 Builds are append-only — there is no `PATCH /builds/{id}` and no DELETE. Re-running a build records a new build resource; the review's `lastReadyBuildId` / `lastFailedBuildId` are updated by the subsequent `PATCH /reviews/{id}/status` call.
 
 ## Pagination + rate limits
 
-`GET /builds` paginates at 100 items per response; see [API protocol · Pagination](/agent-reference/api-protocol#pagination). Builds share the write rate-limit bucket (60 req/min/token); see [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits).
+Neither is implemented yet. `GET /builds` returns every build on the review in one response — see [API protocol · Pagination](/agent-reference/api-protocol#pagination) — and no request is refused for rate; see [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits) for the target design.

--- a/erun-docs/docs/collaboration/comments.md
+++ b/erun-docs/docs/collaboration/comments.md
@@ -96,23 +96,24 @@ PATCH /v1/reviews/rev_abc/comments/cmt_01H.../status
 | `body` | UTF-8, byte length ≤ 8 KiB (8192 bytes). Empty or whitespace-only rejected. Immutable after creation — there is no edit endpoint. |
 | `commitId` | Exactly 40 lowercase hex characters: `^[0-9a-f]{40}$`. |
 | `filePath` | Non-empty string. Part of the comment's address alongside `commitId` and `line`; immutable after creation. |
-| `line` | Positive integer; must point at a line that exists in the file at `commitId` (validated lazily — out-of-range lines return `422 LINE_OUT_OF_RANGE`). Immutable after creation. |
-| `parentCommentId` | If set, must reference an existing root comment in the same review with the same `commitId`, `filePath`, and `line`. |
+| `line` | Positive integer. **Not checked against the file's actual length** — the API has no git access to confirm a line exists at `commitId`, so an out-of-range `line` is accepted as-is. `(Planned.)` A future revision may validate this against the commit if the API gains a way to read it. Immutable after creation. |
+| `parentCommentId` | If set, must reference an existing root comment in the same review with the same `commitId`, `filePath`, and `line` — enforced by a database trigger, refused as a generic `400` (see Errors below). |
 | `status` | Enum: `OPEN` or `CLOSED`. Only settable on a thread's root comment; a reply's status is not independently settable. |
 
 ## Errors
 
-Same status-code conventions as the [reviews API](/collaboration/reviews#errors). Comment-specific cases:
+Same envelope and status-code conventions as the [reviews API](/collaboration/reviews#errors). Comment-specific cases:
 
 | Status | `code` | When |
 |---|---|---|
-| `400` | `INVALID_BODY` | `body` missing or exceeds 8 KiB. |
+| `400` | `INVALID_BODY` | Malformed JSON, or `body` empty/whitespace-only/over 8 KiB. |
 | `400` | `INVALID_COMMIT_ID` | `commitId` is not 40 lowercase hex chars. |
-| `404` | — | The review or parent comment doesn't exist or isn't visible. |
+| `400` | — (generic) | `parentCommentId` points to a comment in a different review, commit, or file, or otherwise fails the database's thread-shape trigger. There is no distinct machine code for this today — it reads the same as any other malformed body. |
+| `404` | — (generic) | The review or parent comment doesn't exist or isn't visible to the caller's tenant. |
 | `409` | `ALREADY_CLOSED` | Closing a thread that's already closed. |
-| `422` | `MISMATCHED_PARENT` | `parentCommentId` points to a comment in a different review, commit, or file. |
-| `422` | `LINE_OUT_OF_RANGE` | `line` is beyond the file's length at `commitId`. |
+
+`422 Unprocessable Entity` does not appear above, and neither do `MISMATCHED_PARENT` or `LINE_OUT_OF_RANGE` from earlier drafts of this table: nothing in this API returns `422`, and the two removed codes described checks not implemented — see [Reviews · Machine error codes](/collaboration/reviews#machine-error-codes) for why this API drops rather than fakes codes for conditions it can't actually distinguish or detect.
 
 ## Pagination + rate limits
 
-`GET /comments` paginates at 100 items per response; see [API protocol · Pagination](/agent-reference/api-protocol#pagination). Comments share the write rate-limit bucket (60 req/min/token); see [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits).
+Neither is implemented yet. `GET /comments` returns every comment on the review in one response — see [API protocol · Pagination](/agent-reference/api-protocol#pagination) — and no request is refused for rate; see [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits) for the target design.

--- a/erun-docs/docs/collaboration/merge-queue.md
+++ b/erun-docs/docs/collaboration/merge-queue.md
@@ -24,7 +24,7 @@ The gate's build is recorded as a [`GATE`-kind build](/collaboration/builds#merg
 
 ## The unresolved-thread check {#the-unresolved-thread-check}
 
-Before promoting the head review, the queue checks its comment threads. If any thread is still `OPEN` (its root comment unresolved), advancing refuses with `409 Conflict` and a structured body — the one place on this API that returns JSON rather than a plain-text error, naming the count and the review so a caller can act on it instead of parsing a sentence:
+Before promoting the head review, the queue checks its comment threads. If any thread is still `OPEN` (its root comment unresolved), advancing refuses with `409 Conflict` and a structured body — the one place on this API that uses its own bespoke shape instead of the standard `{code, message, details}` envelope, naming the count and the review so a caller can act on it instead of parsing a sentence:
 
 ```jsonc
 {
@@ -97,11 +97,11 @@ Omitting `buildId` on a `READY` transition is what marks this as the missed-merg
 
 | Refusal | HTTP status | Body | How to unblock |
 |---|---|---|---|
-| No `READY` review waiting for that target branch (queue empty) | `404 Not Found` | plain text | Wait for a review to reach `READY` — its build succeeded — then advance again. |
-| Another review is already `MERGE` for that target branch | `404 Not Found` | plain text | Wait for it to reach `MERGED`/`FAILED`, or see [When the gate wedges](#when-the-gate-wedges) if it looks stuck. |
+| No `READY` review waiting for that target branch (queue empty) | `404 Not Found` | `{code: "EMPTY_QUEUE", message}` (no `details`) | Wait for a review to reach `READY` — its build succeeded — then advance again. |
+| Another review is already `MERGE` for that target branch | `404 Not Found` | `{code: "NOT_FOUND", message}` (no `details`) | Wait for it to reach `MERGED`/`FAILED`, or see [When the gate wedges](#when-the-gate-wedges) if it looks stuck. |
 | The head review has an unresolved comment thread | `409 Conflict` | structured — `{error, message, reviewId, unresolvedThreads}`, shown [above](#the-unresolved-thread-check) | Resolve the thread (its root author only), or [`override-advance`](#overriding-the-gate). |
 
-The first two rows are both cases where nothing was waiting to be promoted, so they currently share one plain `404 Not Found` — indistinguishable from each other or from any other missing-resource 404. [Reviews · Machine error codes](/collaboration/reviews#machine-error-codes) names `EMPTY_QUEUE` as the intended code for the first case, defined against the `READY` reviews actually waiting in the line (a review already `MERGE` has left it) — that code isn't wired into the response yet, and the second row has no code proposed for it either.
+The first two rows both 404, but are distinguishable now: [Reviews · Machine error codes](/collaboration/reviews#machine-error-codes) names `EMPTY_QUEUE` for the first case (nothing `READY` waiting), while the second — another review already merging — falls through to the generic `NOT_FOUND` code every 404 gets by default, since that case has no business-specific code of its own.
 
 ## See also
 

--- a/erun-docs/docs/collaboration/reviews.md
+++ b/erun-docs/docs/collaboration/reviews.md
@@ -117,38 +117,39 @@ See [Merge queue § Overriding the gate](/collaboration/merge-queue#overriding-t
 
 ## Errors
 
-Endpoints return a plain-text error body by default (the HTTP status text). The one structured exception today is the merge queue's unresolved-thread refusal — see [Merge queue § The unresolved-thread check](/collaboration/merge-queue#the-unresolved-thread-check) for its JSON shape. *Machine error codes* below is this API's target `code`/`details` contract for the rest of these cases — it is not yet wired into any response, the one exception above aside.
+Every endpoint returns a JSON body `{code, message, details}` — `code` is always present, even where no business-specific value applies (a route with no documented code below gets a generic status-derived one, such as `NOT_FOUND` or `BAD_REQUEST`). The one exception is the merge queue's unresolved-thread refusal, which keeps its own bespoke `{error, message, reviewId, unresolvedThreads}` shape instead — see [Merge queue § The unresolved-thread check](/collaboration/merge-queue#the-unresolved-thread-check).
 
 ```jsonc
 {
   "code": "INVALID_TRANSITION",
-  "message": "Cannot transition review from OPEN directly to MERGED",
+  "message": "cannot transition review from OPEN directly to MERGED",
   "details": { "from": "OPEN", "to": "MERGED", "validTargets": ["FAILED", "READY", "CLOSED"] }
 }
 ```
 
 | Status | When | Example |
 |---|---|---|
-| `400 Bad Request` | Malformed JSON, missing required fields, type mismatches; a caller asserting `MERGE` or `MERGED` directly; `override-advance` with a blank or missing `reason`. | `POST /v1/reviews` without `sourceBranch`; `PATCH .../status` with `{"status": "MERGED"}` — that status is written only by the merge queue's own gate result; `override-advance` with `reason` omitted. |
+| `400 Bad Request` | Malformed JSON, missing required fields, type mismatches; a caller asserting `MERGE` or `MERGED` directly; `override-advance` with a blank or missing `reason`; an empty `targetBranch` on merge-queue advance. | `POST /v1/reviews` without `sourceBranch`; `PATCH .../status` with `{"status": "MERGED"}` — that status is written only by the merge queue's own gate result; `override-advance` with `reason` omitted. |
 | `401 Unauthorized` | No `Authorization` header, or token validation failed. | Bearer token expired. |
 | `403 Forbidden` | Token valid; caller not allowed in this tenant. | Agent of tenant A calling on tenant B. |
-| `404 Not Found` | The review or build id doesn't exist or isn't visible to the caller; `merge-queue/advance` against a target branch with nothing waiting to promote — see [Merge queue § Failure table](/collaboration/merge-queue#failure-table). | `GET /v1/reviews/rev_unknown`; `POST /v1/reviews/merge-queue/advance` on an empty queue, or while another review is already `MERGE` for that target branch. |
-| `409 Conflict` | Invalid state transition; a second live review for a branch pair already proposed by a live review; a reviewer already assigned to the review; the queue head has unresolved comment threads. | `POST /v1/reviews` proposing `feature-a` onto `main` while another live review already does; `advance` against a head review with an open thread — see [Merge queue](/collaboration/merge-queue#the-unresolved-thread-check) for that response's structured body. |
-| `422 Unprocessable Entity` | Structurally valid but semantically invalid. | `PATCH status` to `READY` without a successful build. |
-| `429 Too Many Requests` | Rate limit exceeded. | Burst of `POST /comments`. |
+| `404 Not Found` | The review or build id doesn't exist or isn't visible to the caller; a `buildId` on `PATCH .../status` that doesn't belong to the review or whose `successful` flag doesn't match the target status; `merge-queue/advance` against a target branch with nothing waiting to promote, or while another review is already `MERGE` for that target branch — see [Merge queue § Failure table](/collaboration/merge-queue#failure-table). | `GET /v1/reviews/rev_unknown`; `POST /v1/reviews/merge-queue/advance` on an empty queue. |
+| `409 Conflict` | A second live review for a branch pair already proposed by a live review; a reviewer already assigned to the review; the queue head has unresolved comment threads. | `POST /v1/reviews` proposing `feature-a` onto `main` while another live review already does; `advance` against a head review with an open thread — see [Merge queue](/collaboration/merge-queue#the-unresolved-thread-check) for that response's structured body. |
+| `429 Too Many Requests` `(Planned.)` | Not implemented — no request ever gets this today. Kept here as the target shape; see [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits). | n/a |
 | `500 Internal Server Error` | Server error. Retry. | Database unavailable. |
+
+`422 Unprocessable Entity` does not appear above because nothing in this API returns it — earlier drafts of this page and the machine-code table below described a `422` for a semantically-invalid-but-structurally-valid request, but no route ever produced one; every condition that reads that way in practice is either a `400` (malformed input) or a `404` (a referenced id/state that isn't there).
 
 ### Machine error codes
 
+The codes below are the ones this API's review/merge-queue routes can actually distinguish and emit. Two codes sketched in earlier drafts of this table described checks the API does not perform — `UNKNOWN_COMMIT` as "does this commit exist on the source branch" (the API has no git access to check that; a build/review mismatch on `PATCH /status` is a plain `404` instead, above) and `EXPIRED_PAGE_TOKEN` (depends on pagination, which is [not implemented](/agent-reference/api-protocol#pagination)) — both are dropped rather than left describing behavior that doesn't exist.
+
 | `code` | When | HTTP status |
 |---|---|---|
-| `INVALID_TRANSITION` | `PATCH /status` with a transition not allowed by the [Status lifecycle](#status-lifecycle). `details.validTargets` lists the allowed next statuses. | `409` |
-| `EMPTY_QUEUE` | `POST /merge-queue/advance` against a target branch whose queue has no `READY` reviews waiting — a review already `MERGE` has left that waiting line, so its presence is the separate "another review already merging" case, not this one. | `404` |
-| `UNKNOWN_COMMIT` | `PATCH /status` (or `POST /builds`) referencing a `buildId` whose `commitId` doesn't exist on the review's `sourceBranch`. | `422` |
-| `INVALID_BODY` | Request body missing required field or fails type validation. `details.field` names the offender. | `400` |
-| `INVALID_TARGET_BRANCH` | `targetBranch` is not a valid branch name. | `400` |
-| `EXPIRED_PAGE_TOKEN` | `pageToken` is stale or malformed. | `400` |
+| `INVALID_TRANSITION` | `PATCH /status` asserting `MERGE` or `MERGED` directly. `details.from`/`details.to`/`details.validTargets` name the review's current status, the rejected target, and the statuses actually reachable from `from` per the [Status lifecycle](#status-lifecycle). | `400` |
+| `EMPTY_QUEUE` | `POST /merge-queue/advance` against a target branch whose queue has no `READY` reviews waiting — a review already `MERGE` has left that waiting line, so its presence is the separate "another review already merging" case, not this one (that case is a plain `404` with no code above). | `404` |
+| `INVALID_BODY` | Request body missing required field or fails type validation (malformed JSON), or `PATCH /status` to `READY`/`FAILED` with no `buildId` (`details.field` names it: `buildId`). | `400` |
+| `INVALID_TARGET_BRANCH` | `targetBranch` is empty on `merge-queue/advance` or `override-advance`. | `400` |
 
 ### Pagination + rate limits
 
-List endpoints page at 100 items max; see [API protocol · Pagination](/agent-reference/api-protocol#pagination). Rate-limit buckets per token: read 600 req/min, write 60 req/min, merge-queue-advance 10 req/min. Full table: [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits).
+Neither is implemented yet. List endpoints return every matching row in one response — see [API protocol · Pagination](/agent-reference/api-protocol#pagination) — and no request is ever refused for rate; see [API protocol · Rate limits](/agent-reference/api-protocol#rate-limits) for the target design.


### PR DESCRIPTION
## Summary

Closes #1557. Per item, doc vs code:

**1. Machine error codes — implemented the envelope.** `writeError`/`writeRepositoryError` now emit `{code, message, details}` JSON on every response instead of `http.Error`'s plain text. `code` is always present: a generic status-derived default (`NOT_FOUND`, `BAD_REQUEST`, ...) for every route with no documented business code, and the exact documented value for the conditions the reviews/comments/builds routes can genuinely distinguish today — `INVALID_TRANSITION` (with `details.from/to/validTargets`), `EMPTY_QUEUE`, `INVALID_TARGET_BRANCH`, `INVALID_BODY`, `ALREADY_CLOSED`, `INVALID_COMMIT_ID`, `INVALID_VERSION`.

I did **not** implement the codes whose underlying check doesn't exist and can't cheaply be added: `UNKNOWN_COMMIT` (needs git access to confirm a commit exists on a branch — this API has none) and `LINE_OUT_OF_RANGE` (needs file content at a commit — same gap). Rather than half-wire those, I removed them from the docs and stated plainly why. `MISMATCHED_PARENT`'s underlying check *is* real (a DB trigger), but it's one of several trigger-raised `check_violation`s that all currently collapse to a generic 400 — I didn't split it out via message-parsing, since that's a fragile DB/Go string coupling for one row in a table; docs now say so.

While auditing the actual behavior I found two real bugs (not just doc drift) and fixed both: an unclassified Postgres foreign-key violation on comment/build create was returning a bare `500` instead of the documented `404` (added `classifyBuildError`, extended `classifyCommentError`), and the `comments.body` length/emptiness CHECK constraint had no distinguishable code at all (now `INVALID_BODY`, matched by Postgres constraint name — not message text — so it isn't fragile).

**2. Pagination and rate limiting — labelled, not implemented.** Neither exists anywhere in `erun-backend-api` (confirmed: no rate limiter, no `pageToken` handling anywhere). Implementing either is a materially larger change than this issue should carry (a real limiter needs a bucket store and policy; real pagination needs cursor-stable ordering across every list route). `agent-reference/api-protocol.md`'s Rate limits and Pagination sections are now headed `(Planned.)`, state plainly what a caller gets today (unbounded lists, no enforcement), and keep the target design for reference. Fixed two other pages that asserted rate limiting as real (`agent-patterns.md`, `agent-reference/overview.md`).

**3. Status-code audit of comments.md / builds.md (and, since I found the same defect class there, reviews.md).** Findings:
- Every `422 Unprocessable Entity` in all three pages was fictional — no code path in this module ever returns 422. Removed.
- `reviews.md`'s own machine-code table had `INVALID_TRANSITION → 409`, but the actual sentinel (`ErrInvalidInput`) maps to `400`, and the general Errors table already said 400 for the same condition — the table contradicted itself. Now consistently 400.
- `comments.md`/`builds.md` documented `404 — review/parent doesn't exist` as if implemented; it wasn't (unclassified FK violation → 500, fixed above).
- `builds.md`'s `UNKNOWN_COMMIT/422` and `comments.md`'s `LINE_OUT_OF_RANGE/422`/`MISMATCHED_PARENT/422` described checks that don't exist; removed per item 1's reasoning.
- The one case #1556 already fixed (`EMPTY_QUEUE` vs "another review merging", both 404) is now also machine-distinguishable: `headOfMergeQueue` returns a typed `EmptyMergeQueueError` only for the true empty-queue path, so a caller no longer has to guess which 404 it got.

## Tests

Added unit tests asserting the actual `code` (and `details` where documented) on every wired error path — `errors_test.go` (envelope + generic status-derived codes), `reviews_test.go`/`reviews_test.go` (service), `comments_test.go` (route + service + repository classification), `builds_test.go` (route + service + repository classification). No test asserts "the type compiles" without also asserting the wire-visible `code`/status.

## Verification

- `go build ./...`, `go test ./...`, `golangci-lint run ./...` — all green in `erun-backend-api`.
- `cd erun-docs && yarn build` — clean, no broken links/anchors (explicit `{#rate-limits}`/`{#pagination}` anchors added since the heading text changed).
- `make check` (full repo gate, including `erun-integration`'s coverage-gated suite) — green: `ok coverage 76.3% (>= 75.8%)`.
- **Not verified live**: no live cluster/Postgres run of `erun-backend-api` was stood up to hit these routes over real HTTP — verification is unit/integration-test-level only (real `httptest` requests through the actual route/service/repository code, and one repository test that constructs a real `*pgconn.PgError` for the classification paths). Flagging this explicitly per the End-to-End Verification Gate rather than implying more than was done.

## Test plan

- [x] `go test ./...` in `erun-backend-api`
- [x] `golangci-lint run ./...` in `erun-backend-api`
- [x] `cd erun-docs && yarn build`
- [x] `make check` (repo root)