### PR TITLE
Key agent-gate.sh's job replay on tree state, not just job id

### DIFF
--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -29,8 +29,18 @@
 # start unconditionally would discard the outcome the caller came back to
 # collect and start a fresh run in its place, so before starting anything
 # this checks whether the job already finished and, if so, reports that
-# outcome instead. Set AGENT_GATE_RERUN=1 to skip the check and force a new
-# run once the underlying work has genuinely changed.
+# outcome instead.
+#
+# That replay is only safe when the tree being gated hasn't moved since the
+# recorded run. A job id that is stable across invocations (`check`,
+# `ui-playwright`, `integration-test`) would otherwise replay a finished
+# outcome over code changed after that run -- greening work nobody tested.
+# So the id actually used against the job store folds in a hash of the tree
+# state (HEAD, working-tree status, and diff content) alongside the caller's
+# id: an unchanged tree keeps hitting the same id and replays as before: a
+# changed tree resolves to a new id, finds no finished record under it, and
+# runs fresh. AGENT_GATE_RERUN=1 still skips the check and forces a new run
+# regardless of tree state.
 
 set -eu
 
@@ -52,13 +62,43 @@ fi
 : "${ERUN_TENANT:?agent-gate.sh: ERUN_TENANT is not set (expected inside an agent pod)}"
 : "${ERUN_ENVIRONMENT:?agent-gate.sh: ERUN_ENVIRONMENT is not set (expected inside an agent pod)}"
 
+# hash_stdin prints the sha256 of stdin. Prefers sha256sum (the Linux runtime
+# image); falls back to shasum so this runs on a macOS dev host too.
+hash_stdin() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum | cut -d' ' -f1
+	else
+		shasum -a 256 | cut -d' ' -f1
+	fi
+}
+
+# tree_state_key prints a key that changes whenever the working tree does:
+# the commit, the status of every tracked/untracked path, and the actual
+# diff content against HEAD (status alone can't tell two different edits to
+# the same path apart, since both show as the same "M <path>" line). Falls
+# back to a fixed marker outside a git worktree, which keeps replay keyed on
+# job id alone there -- the same as before this existed.
+tree_state_key() {
+	if ! command -v git >/dev/null 2>&1 || ! git rev-parse --git-dir >/dev/null 2>&1; then
+		printf 'no-git'
+		return
+	fi
+	{
+		git rev-parse HEAD
+		git status --porcelain
+		git diff HEAD
+	} 2>/dev/null | hash_stdin | cut -c1-16
+}
+
+resolved_job_id="${job_id}-$(tree_state_key)"
+
 await_timeout="${ERUN_AGENT_GATE_AWAIT_TIMEOUT:-8m}"
 
 if [ "${AGENT_GATE_RERUN:-}" != "1" ]; then
 	status_status=0
 	status_line=$(erun exec job status \
 		--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
-		--id "$job_id" 2>/dev/null) || status_status=$?
+		--id "$resolved_job_id" 2>/dev/null) || status_status=$?
 
 	if [ "$status_status" -eq 0 ]; then
 		case "$status_line" in
@@ -72,10 +112,10 @@ if [ "${AGENT_GATE_RERUN:-}" != "1" ]; then
 			replay_status=0
 			erun exec job await \
 				--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
-				--id "$job_id" --timeout 1s >&2 || replay_status=$?
+				--id "$resolved_job_id" --timeout 1s >&2 || replay_status=$?
 			erun exec job output \
 				--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
-				--id "$job_id" --max-bytes 16777216
+				--id "$resolved_job_id" --max-bytes 16777216
 			exit "$replay_status"
 			;;
 		esac
@@ -85,7 +125,7 @@ fi
 start_status=0
 start_output=$(erun exec job start \
 	--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
-	--id "$job_id" --name "$job_name" \
+	--id "$resolved_job_id" --name "$job_name" \
 	--env AGENT_GATE_DETACHED=1 \
 	-- "$@" 2>&1) || start_status=$?
 
@@ -107,7 +147,7 @@ fi
 await_status=0
 erun exec job await \
 	--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
-	--id "$job_id" --timeout "$await_timeout" >&2 || await_status=$?
+	--id "$resolved_job_id" --timeout "$await_timeout" >&2 || await_status=$?
 
 if [ "$await_status" -eq 124 ]; then
 	printf 'agent-gate: %s is still running after %s; run this command again to keep waiting\n' "$job_name" "$await_timeout" >&2
@@ -116,6 +156,6 @@ fi
 
 erun exec job output \
 	--tenant "$ERUN_TENANT" --environment "$ERUN_ENVIRONMENT" \
-	--id "$job_id" --max-bytes 16777216
+	--id "$resolved_job_id" --max-bytes 16777216
 
 exit "$await_status"

--- a/scripts/agent-gate_test.sh
+++ b/scripts/agent-gate_test.sh
@@ -66,6 +66,81 @@ EOF
 	chmod +x "${bin_dir}/erun"
 }
 
+# stub_erun_stateful writes a fake `erun` that behaves like a minimal real job
+# store, keyed by the exact --id value it receives: `exec job start` actually
+# runs the trailing command synchronously and records its output/exit code
+# under that id; `exec job status`/`await`/`output` answer from whatever is
+# recorded under the id they're asked about, and report "no such job" (status
+# 1) for an id nothing was ever recorded under. Unlike stub_erun above (which
+# answers every call the same way regardless of id, for testing argv shape),
+# this is what lets a test prove the *replay-vs-rerun* decision actually
+# tracks the id agent-gate.sh computes, not just that some erun call happened.
+stub_erun_stateful() {
+	bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/erun" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$STUB_ARGV_FILE"
+mkdir -p "$STUB_STORE_DIR"
+
+job_id=""
+prev=""
+for a in "$@"; do
+	if [ "$prev" = "--id" ]; then
+		job_id="$a"
+	fi
+	prev="$a"
+done
+
+verb="$1 $2 $3"
+
+if [ "$verb" = "exec job status" ]; then
+	if [ -f "${STUB_STORE_DIR}/${job_id}.status" ]; then
+		cat "${STUB_STORE_DIR}/${job_id}.status"
+		exit 0
+	fi
+	exit 1
+fi
+
+if [ "$verb" = "exec job start" ]; then
+	# Drop everything up to and including the literal "--" separator, leaving
+	# only the real command's own argv (untouched, so quoting survives).
+	while [ $# -gt 0 ]; do
+		cur="$1"
+		shift
+		if [ "$cur" = "--" ]; then
+			break
+		fi
+	done
+	set +e
+	out=$("$@" 2>&1)
+	code=$?
+	set -e
+	printf '%s' "$out" >"${STUB_STORE_DIR}/${job_id}.output"
+	printf '%s' "$code" >"${STUB_STORE_DIR}/${job_id}.exitcode"
+	printf 'exited %s: stateful job' "$code" >"${STUB_STORE_DIR}/${job_id}.status"
+	exit 0
+fi
+
+if [ "$verb" = "exec job await" ]; then
+	if [ -f "${STUB_STORE_DIR}/${job_id}.exitcode" ]; then
+		exit "$(cat "${STUB_STORE_DIR}/${job_id}.exitcode")"
+	fi
+	exit 0
+fi
+
+if [ "$verb" = "exec job output" ]; then
+	if [ -f "${STUB_STORE_DIR}/${job_id}.output" ]; then
+		cat "${STUB_STORE_DIR}/${job_id}.output"
+	fi
+	exit 0
+fi
+
+exit 0
+EOF
+	chmod +x "${bin_dir}/erun"
+}
+
 # run_gate invokes agent-gate.sh with a clean environment plus whatever the
 # caller exported, capturing stdout+stderr and the exit code without letting
 # `set -e` end the test on a nonzero (expected in several cases).
@@ -293,6 +368,119 @@ stub_erun "${case_dir}/bin"
 	if grep -q 'exec job status' "$STUB_ARGV_FILE"; then
 		fail "forced rerun: must not even probe status when a fresh run was explicitly requested"
 	fi
+)
+
+# --- the id used against the job store stays identical across two
+# invocations of an unchanged tree, but changes the moment a tracked file is
+# edited in between. This is what makes replay safe: same id -> same
+# finished record found -> replay; different id -> no record found -> fresh
+# run. Runs against a real scratch git repo (not the actual checkout) so the
+# tree state is fully controlled.
+case_dir="${work_root}/tree-state-id"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+
+repo_dir="${case_dir}/repo"
+mkdir -p "$repo_dir"
+(
+	cd "$repo_dir"
+	git init -q
+	git config user.email test@example.com
+	git config user.name test
+	echo v1 >tracked.txt
+	git add tracked.txt
+	git commit -q -m initial
+)
+(
+	cd "$repo_dir"
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT=out
+
+	run_gate check "make check" -- make check-gate >/dev/null
+	first_id=$(grep -o -- '--id [^ ]*' "$STUB_ARGV_FILE" | head -1)
+
+	: >"$STUB_ARGV_FILE"
+	run_gate check "make check" -- make check-gate >/dev/null
+	second_id=$(grep -o -- '--id [^ ]*' "$STUB_ARGV_FILE" | head -1)
+	[ "$first_id" = "$second_id" ] || fail "tree state id: unchanged tree must resolve to the same id, got $first_id then $second_id"
+
+	echo v2 >tracked.txt
+	: >"$STUB_ARGV_FILE"
+	run_gate check "make check" -- make check-gate >/dev/null
+	third_id=$(grep -o -- '--id [^ ]*' "$STUB_ARGV_FILE" | head -1)
+	[ "$third_id" != "$first_id" ] || fail "tree state id: editing a tracked file must resolve to a different id, stayed $first_id"
+)
+
+# --- the id change actually changes replay behavior end to end: a job store
+# that only knows the tree's ORIGINAL id must be treated as no record found
+# once the tree changes, so the wrapper runs the real command again instead
+# of replaying the stale result. Uses stub_erun_stateful so the command
+# genuinely does or doesn't execute, rather than asserting on argv alone.
+case_dir="${work_root}/tree-state-replay"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun_stateful "${case_dir}/bin"
+
+repo_dir="${case_dir}/repo"
+mkdir -p "$repo_dir"
+(
+	cd "$repo_dir"
+	git init -q
+	git config user.email test@example.com
+	git config user.name test
+	echo v1 >tracked.txt
+	git add tracked.txt
+	git commit -q -m initial
+)
+
+counter_file="${case_dir}/counter"
+: >"$counter_file"
+(
+	cd "$repo_dir"
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export STUB_STORE_DIR="${case_dir}/store"
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+
+	run_gate check "make check" -- sh -c "echo run >>'${counter_file}'; cat tracked.txt"
+	[ "$STATUS" -eq 0 ] || fail "tree state replay: first run expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*v1*) ;;
+	*) fail "tree state replay: first run expected to read v1, got: $OUT" ;;
+	esac
+	runs=$(wc -l <"$counter_file" | tr -d ' ')
+	[ "$runs" -eq 1 ] || fail "tree state replay: first run must actually execute the command, ran $runs times"
+
+	# Same tree, same command: must replay the recorded outcome rather than
+	# executing the command again.
+	run_gate check "make check" -- sh -c "echo run >>'${counter_file}'; cat tracked.txt"
+	[ "$STATUS" -eq 0 ] || fail "tree state replay: replay expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*v1*) ;;
+	*) fail "tree state replay: replay expected the recorded v1 output, got: $OUT" ;;
+	esac
+	runs=$(wc -l <"$counter_file" | tr -d ' ')
+	[ "$runs" -eq 1 ] || fail "tree state replay: unchanged tree must replay, not re-execute, ran $runs times"
+
+	# Edit the tracked file: the same job name must now resolve to a fresh id,
+	# find no record under it, and actually re-run and pick up v2.
+	echo v2 >tracked.txt
+	run_gate check "make check" -- sh -c "echo run >>'${counter_file}'; cat tracked.txt"
+	[ "$STATUS" -eq 0 ] || fail "tree state replay: rerun after edit expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*v2*) ;;
+	*) fail "tree state replay: changed tree must re-run and read v2, got: $OUT" ;;
+	esac
+	runs=$(wc -l <"$counter_file" | tr -d ' ')
+	[ "$runs" -eq 2 ] || fail "tree state replay: changed tree must actually re-execute the command instead of replaying the stale v1 result, ran $runs times"
 )
 
 # --- an unrelated start failure must be fatal: never silently await a job


### PR DESCRIPTION
## Summary
- `scripts/agent-gate.sh` replayed a finished job's recorded outcome keyed only on the caller's job id (`check`/`ui-playwright`/`integration-test`), which is stable across invocations. A lane that ran a gate, changed the code, and re-ran the gate got the pre-fix outcome replayed with nothing actually executing — greening unverified code.
- The id now used against the job store folds in a hash of the tree state (`git rev-parse HEAD` + `git status --porcelain` + `git diff HEAD`, so two different edits that happen to leave the same status letters still produce different keys). An unchanged tree resolves to the same id and still replays (keeping the prior fix for #1543/#1544 intact); a changed tree resolves to a new id, finds no finished record under it, and runs fresh. Falls back to a fixed marker outside a git worktree.
- `AGENT_GATE_RERUN=1` still forces a fresh run regardless of tree state.

## How the replay key works
`resolved_job_id = "<caller-id>-<sha256(HEAD + status --porcelain + diff HEAD)[:16]>"`, used for every `erun exec job status/start/await/output --id` call. Job start/await/output plumbing and argument shape are otherwise unchanged.

## Verification
- `sh scripts/agent-gate_test.sh` — all cases pass, including two new ones: `tree-state-id` (same id across an unchanged tree, different id after editing a tracked file) and `tree-state-replay` (using a stateful stub job store: unchanged tree replays without re-executing the command; editing a tracked file forces a real re-execution that picks up the new content).
- Real-world proof against the live `erun exec job` engine in this agent pod (not just the test harness):
  - Run 1 (fresh git repo, `f.txt` = `v1`): started job `realtest-5e9903d4a2480b33`, output `v1`, counter file at 1 line.
  - Run 2 (unchanged tree): `agent-gate: real test already finished; reporting its recorded outcome...`, same id `realtest-5e9903d4a2480b33`, output replayed `v1`, counter file **stayed at 1** — no re-execution.
  - Edited `f.txt` to `v2`, run 3: resolved a **new** id `realtest-d0562a181c8d6a48`, started a fresh job, output `v2`, counter file **advanced to 2** — genuinely re-executed and picked up the edit.
- `AGENT_GATE_RERUN=1 make check` is fully green: 0 lint issues, all suites pass, coverage 76.3% (≥75.8% threshold).

## Test plan
- [x] `sh scripts/agent-gate_test.sh`
- [x] `AGENT_GATE_RERUN=1 make check`
- [x] Manual touch-a-file-between-runs verification against the real job engine (see above)

Closes #1558