### PR TITLE
Repeat the seeded-row reload instead of waiting once

### DIFF
--- a/erun-ui/playwright/tests/diagnostics-erun-trace-clear.spec.ts
+++ b/erun-ui/playwright/tests/diagnostics-erun-trace-clear.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_TENANT,
   removeEnvironment,
@@ -78,9 +78,7 @@ test.describe('diagnostics erun-trace clear', () => {
     const envB = uniqueEnvironmentName('per-env-reset-b');
     seedEnvironment(SEED_TENANT, envB);
     try {
-      await app.sidebar
-        .envRowButton(SEED_TENANT, envB)
-        .waitFor({ state: 'visible', timeout: 10_000 });
+      await waitForSeededRow(app, SEED_TENANT, envB);
 
       await page.route('**/__erun_invoke', async (route, request) => {
         const body = JSON.parse(request.postData() ?? '{}') as {

--- a/erun-ui/playwright/tests/env-row-wait-baseline.spec.ts
+++ b/erun-ui/playwright/tests/env-row-wait-baseline.spec.ts
@@ -1,0 +1,193 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+import ts from 'typescript';
+
+// env-row-wait-baseline.spec.ts is a repo-state structural gate for issue
+// #1565: a seeded-row wait shaped like
+//
+//   await app.reloadEnvironments();
+//   await app.sidebar
+//     .envRowButton(tenant, environment)
+//     .waitFor({ state: 'visible', timeout: 15_000 });
+//
+// reads the sidebar exactly once and then waits — if that single reload lands
+// before the row is seeded, or is overwritten by the backend sweep, the
+// following timeout cannot recover it because there is no second read. This
+// is not a "too short" timeout, it is an *unrepeated* one.
+// `waitForSeededRow` (fixtures/erunApp.ts) is the fix: it puts the reload
+// inside the retry, so every attempt re-reads. This gate targets the shape
+// the bug takes in source — a bare `envRowButton(...).waitFor({ ...,
+// timeout })` call — via the TypeScript AST rather than an enumerated list of
+// phrasings, the same reasoning erun-integration's issue_reference_test.go
+// and bare_required_input_test.go give for matching shape over literals: a
+// grep tuned to today's exact call layout is one reflow away from missing
+// the next instance.
+//
+// A file's count may only shrink from here, never grow: `waitForSeededRow`'s
+// own implementation legitimately contains this exact shape (it is the retry
+// body the whole fix is built from), so the baseline is not zero everywhere
+// — it is "no more than what already exists", enforced per file the same way
+// erun-integration's bareRequiredInputBaseline/issueReferenceBaseline and
+// erun-backend-api's KnownUnsurfacedRoutes are.
+
+const PLAYWRIGHT_ROOT = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(PLAYWRIGHT_ROOT, '..', '..');
+const SCAN_DIRS = ['tests', 'fixtures', 'pages'];
+
+// envRowWaitBaseline is a shrink-only baseline (the same pattern as
+// erun-integration's bareRequiredInputBaseline/issueReferenceBaseline): the
+// key is the file path relative to the repo root, the value is the exact
+// count of matching call sites still in that file. `fixtures/erunApp.ts`
+// carries the one legitimate hit — `waitForSeededRow`'s own retry body.
+// Every other file must stay at zero: any new hit there is a fresh instance
+// of the unrepeated-reload bug this gate exists to catch.
+const envRowWaitBaseline: Record<string, number> = {
+  'erun-ui/playwright/fixtures/erunApp.ts': 1,
+};
+
+interface EnvRowWaitHit {
+  file: string; // path relative to the repo root, forward-slash separated
+  line: number;
+}
+
+// isEnvRowButtonCall matches `<expr>.envRowButton(...)`, regardless of the
+// receiver expression, so `app.sidebar.envRowButton(...)` and any future
+// wrapper around it are both caught.
+function isEnvRowButtonCall(node: ts.Node): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'envRowButton'
+  );
+}
+
+// objectLiteralHasTimeoutProperty matches shape, not phrasing: any property
+// named `timeout` (declared or shorthand), regardless of the timeout value
+// or the other properties alongside it (e.g. `state: 'visible'`).
+function objectLiteralHasTimeoutProperty(objectLiteral: ts.ObjectLiteralExpression): boolean {
+  return objectLiteral.properties.some(
+    (property) =>
+      property.name && ts.isIdentifier(property.name) && property.name.text === 'timeout',
+  );
+}
+
+// isBareEnvRowButtonWaitFor matches `<expr>.envRowButton(...).waitFor({ ...,
+// timeout: N })` — a seeded-row wait with no retry around it. `waitForSeededRow`
+// puts the identical call inside an `expect(async () => { ... }).toPass(...)`
+// retry; this matcher intentionally does not look at the surrounding
+// statements, since the baseline (not a zero-tolerance rule) is what carries
+// that one legitimate exception.
+function isBareEnvRowButtonWaitFor(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+  if (!ts.isPropertyAccessExpression(node.expression) || node.expression.name.text !== 'waitFor') {
+    return false;
+  }
+  if (!isEnvRowButtonCall(node.expression.expression)) {
+    return false;
+  }
+  const [firstArg] = node.arguments;
+  return (
+    !!firstArg &&
+    ts.isObjectLiteralExpression(firstArg) &&
+    objectLiteralHasTimeoutProperty(firstArg)
+  );
+}
+
+function findEnvRowWaitHitsInFile(absPath: string, relPath: string): EnvRowWaitHit[] {
+  const sourceText = fs.readFileSync(absPath, 'utf8');
+  const sourceFile = ts.createSourceFile(absPath, sourceText, ts.ScriptTarget.Latest, true);
+  const hits: EnvRowWaitHit[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (isBareEnvRowButtonWaitFor(node)) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      hits.push({ file: relPath, line: line + 1 });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return hits;
+}
+
+function walkTypeScriptFiles(dir: string, out: string[]): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkTypeScriptFiles(entryPath, out);
+    } else if (entry.name.endsWith('.ts')) {
+      out.push(entryPath);
+    }
+  }
+}
+
+function findAllEnvRowWaitHits(): EnvRowWaitHit[] {
+  const files: string[] = [];
+  for (const dir of SCAN_DIRS) {
+    const absDir = path.join(PLAYWRIGHT_ROOT, dir);
+    if (fs.existsSync(absDir)) {
+      walkTypeScriptFiles(absDir, files);
+    }
+  }
+  const hits: EnvRowWaitHit[] = [];
+  for (const absPath of files) {
+    const relPath = path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+    hits.push(...findEnvRowWaitHitsInFile(absPath, relPath));
+  }
+  return hits;
+}
+
+// findOverages reports one entry per hit beyond what envRowWaitBaseline
+// allows for its file -- a file with no entry gets zero tolerance.
+function findOverages(): string[] {
+  const counts = new Map<string, number>();
+  const overages: string[] = [];
+  for (const hit of findAllEnvRowWaitHits()) {
+    const count = (counts.get(hit.file) ?? 0) + 1;
+    counts.set(hit.file, count);
+    const baseline = envRowWaitBaseline[hit.file] ?? 0;
+    const isOverage = count > baseline;
+    const message = isOverage
+      ? `${hit.file}:${hit.line}: bare envRowButton(...).waitFor({ ..., timeout }) reintroduced ` +
+        `-- migrate to waitForSeededRow (see fixtures/erunApp.ts) instead of a single unrepeated reload+wait`
+      : null;
+    if (message) {
+      overages.push(message);
+    }
+  }
+  return overages;
+}
+
+// findStaleBaselineEntries reports a baseline entry that claims more hits
+// than a file still has -- the shrink-only enforcement half of the gate. A
+// baselined file absent from this checkout (a narrowed build context) is
+// skipped rather than compared, the same reasoning erun-integration's own
+// baseline-is-current checks use.
+function findStaleBaselineEntries(): string[] {
+  const counts = new Map<string, number>();
+  for (const hit of findAllEnvRowWaitHits()) {
+    counts.set(hit.file, (counts.get(hit.file) ?? 0) + 1);
+  }
+  return Object.entries(envRowWaitBaseline)
+    .filter(([file]) => fs.existsSync(path.join(REPO_ROOT, file)))
+    .filter(([file, baseline]) => (counts.get(file) ?? 0) < baseline)
+    .map(
+      ([file, baseline]) =>
+        `${file}: envRowWaitBaseline claims ${baseline} hit(s) but only ${counts.get(file) ?? 0} remain -- lower the baseline entry`,
+    );
+}
+
+// This gate scans source, not rendered UI, so it needs neither the app
+// fixture nor the headless backend.
+test.describe('env row wait baseline (#1565)', () => {
+  test('no file exceeds its envRowWaitBaseline entry', () => {
+    expect(findOverages()).toEqual([]);
+  });
+
+  test('envRowWaitBaseline is current', () => {
+    expect(findStaleBaselineEntries()).toEqual([]);
+  });
+});

--- a/erun-ui/playwright/tests/env-row-wait-baseline.spec.ts
+++ b/erun-ui/playwright/tests/env-row-wait-baseline.spec.ts
@@ -4,8 +4,8 @@ import * as path from 'node:path';
 import { expect, test } from '@playwright/test';
 import ts from 'typescript';
 
-// env-row-wait-baseline.spec.ts is a repo-state structural gate for issue
-// #1565: a seeded-row wait shaped like
+// env-row-wait-baseline.spec.ts is a repo-state structural gate: a
+// seeded-row wait shaped like
 //
 //   await app.reloadEnvironments();
 //   await app.sidebar
@@ -182,7 +182,7 @@ function findStaleBaselineEntries(): string[] {
 
 // This gate scans source, not rendered UI, so it needs neither the app
 // fixture nor the headless backend.
-test.describe('env row wait baseline (#1565)', () => {
+test.describe('env row wait baseline', () => {
   test('no file exceeds its envRowWaitBaseline entry', () => {
     expect(findOverages()).toEqual([]);
   });

--- a/erun-ui/playwright/tests/local-port-reachability-isolation.spec.ts
+++ b/erun-ui/playwright/tests/local-port-reachability-isolation.spec.ts
@@ -1,6 +1,6 @@
 import * as http from 'node:http';
 
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_TENANT,
   removeEnvironment,
@@ -59,10 +59,7 @@ test.describe('local port isolation from a real, unrelated listener', () => {
 
     try {
       seedEnvironment(SEED_TENANT, environment, `localportrangestart: ${PINNED_RANGE_START}\n`);
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await app.sidebar.openEnvironment(SEED_TENANT, environment);
 
@@ -118,10 +115,7 @@ test.describe('local port isolation from a real, unrelated listener', () => {
         `localportrangestart: ${PINNED_RANGE_START_WITH_LEASE}\n`,
       );
       writeHeldLease(SEED_TENANT, environment, OCCUPANT_LEASE);
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await app.sidebar.openEnvironment(SEED_TENANT, environment);
 

--- a/erun-ui/playwright/tests/manage-cloud-alias-local-agent.spec.ts
+++ b/erun-ui/playwright/tests/manage-cloud-alias-local-agent.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_CLOUD_ALIAS,
   SEED_TENANT,
@@ -28,10 +28,7 @@ test.describe('manage dialog AWS alias on a local-agent env', () => {
     // an unrelated listener on the developer's machine.
     seedEnvironment(SEED_TENANT, environment, 'localportrangestart: 46500\n');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await app.sidebar.openManageDialogViaKeyboard(SEED_TENANT, environment);
       await app.manageDialog.waitForOpen();

--- a/erun-ui/playwright/tests/narrow-viewport-shell.spec.ts
+++ b/erun-ui/playwright/tests/narrow-viewport-shell.spec.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page, Route, Request } from '@playwright/test';
 
 import { boundingBoxOf } from '../fixtures/boundingBox.js';
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import type { AppShell } from '../pages/index.js';
 import {
   SEED_TENANT,
@@ -108,10 +108,7 @@ async function openReviewsTab(app: AppShell, page: Page, environment: string): P
     await route.continue();
   });
 
-  await app.reloadEnvironments();
-  await app.sidebar
-    .envRowButton(SEED_TENANT, environment)
-    .waitFor({ state: 'visible', timeout: 15_000 });
+  await waitForSeededRow(app, SEED_TENANT, environment);
 
   // A narrow enough boot needs the sidebar reopened before any sidebar-housed
   // navigation, exactly like an operator would have to reopen it themselves

--- a/erun-ui/playwright/tests/tenant-dashboard-audit-log.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-audit-log.spec.ts
@@ -1,6 +1,6 @@
 import type { Route, Request } from '@playwright/test';
 
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_TENANT,
   removeEnvironment,
@@ -43,10 +43,7 @@ test.describe('tenant dashboard — audit log tab (#1205)', () => {
   }) => {
     const environment = seedDashboardEnvironment('audit-log-populated');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await stubLoadTenantDashboard(page, {
         tenant: SEED_TENANT,
@@ -100,10 +97,7 @@ test.describe('tenant dashboard — audit log tab (#1205)', () => {
   }) => {
     const environment = seedDashboardEnvironment('audit-log-empty');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await stubLoadTenantDashboard(page, {
         tenant: SEED_TENANT,

--- a/erun-ui/playwright/tests/tenant-dashboard-merge-queue-gate.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-merge-queue-gate.spec.ts
@@ -1,6 +1,6 @@
 import type { Request, Route } from '@playwright/test';
 
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   removeEnvironment,
   SEED_TENANT,
@@ -79,10 +79,7 @@ function dashboardResponse(
 }
 
 async function openMergeQueueTab(app: AppShell, environment: string): Promise<void> {
-  await app.reloadEnvironments();
-  await app.sidebar
-    .envRowButton(SEED_TENANT, environment)
-    .waitFor({ state: 'visible', timeout: 15_000 });
+  await waitForSeededRow(app, SEED_TENANT, environment);
   await app.sidebar.openTenantDashboard(SEED_TENANT);
   await app.tenantDashboard.waitForOpen();
   await app.tenantDashboard.selectTab('Merge queue');

--- a/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-permissions.spec.ts
@@ -1,6 +1,6 @@
 import type { Route, Request } from '@playwright/test';
 
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_TENANT,
   removeEnvironment,
@@ -56,10 +56,7 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
   }) => {
     const environment = seedDashboardEnvironment('permissions-hidden-tabs');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await stubLoadTenantDashboard(
         page,
@@ -110,10 +107,7 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
   }) => {
     const environment = seedDashboardEnvironment('permissions-partial-failure');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await stubLoadTenantDashboard(
         page,
@@ -169,10 +163,7 @@ test.describe('tenant dashboard — permission-derived surfaces (#1210)', () => 
   }) => {
     const environment = seedDashboardEnvironment('permissions-none');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await stubLoadTenantDashboard(
         page,
@@ -272,10 +263,7 @@ test.describe('tenant dashboard — a stale identity blocks the whole dashboard 
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
 
       await expect(app.tenantDashboard.notSignedInHeading()).toBeVisible();
@@ -332,10 +320,7 @@ test.describe('tenant dashboard — a stale identity blocks the whole dashboard 
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
 
       await expect(app.tenantDashboard.notSignedInHeading()).toBeVisible();
@@ -381,10 +366,7 @@ test.describe('tenant dashboard — a stale identity blocks the whole dashboard 
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
 
       await expect(app.tenantDashboard.noPermissionHeading()).toBeVisible();

--- a/erun-ui/playwright/tests/tenant-dashboard-platform-state.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-platform-state.spec.ts
@@ -1,6 +1,6 @@
 import type { Request, Route } from '@playwright/test';
 
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_TENANT,
   removeEnvironment,
@@ -66,10 +66,7 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
   test('not-connected renders a Connect action, no tab strip', async ({ app, page }) => {
     const environment = seedDashboardEnvironment('platform-not-connected');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       stubRPC(page, {
         LoadTenantDashboard: { data: { tenant: SEED_TENANT, platformState: 'not-connected' } },
@@ -100,10 +97,7 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
   }) => {
     const environment = seedDashboardEnvironment('platform-not-connected-bad-url');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       stubRPC(page, {
         LoadTenantDashboard: { data: { tenant: SEED_TENANT, platformState: 'not-connected' } },
@@ -131,10 +125,7 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
   test('choose-alias lists every configured alias as its own choice', async ({ app, page }) => {
     const environment = seedDashboardEnvironment('platform-choose-alias');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       stubRPC(page, {
         LoadTenantDashboard: {
@@ -161,10 +152,7 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
   }) => {
     const environment = seedDashboardEnvironment('platform-not-signed-in');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       const stub = stubRPC(page, {
         LoadTenantDashboard: {
@@ -216,10 +204,7 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
   }) => {
     const environment = seedDashboardEnvironment('platform-not-enrolled');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       stubRPC(page, {
         LoadTenantDashboard: {
@@ -250,10 +235,7 @@ test.describe('tenant dashboard — platform-readiness states (#1393)', () => {
   test('no-permission is a plain notice with no dead-end action', async ({ app, page }) => {
     const environment = seedDashboardEnvironment('platform-no-permission');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       stubRPC(page, {
         LoadTenantDashboard: {

--- a/erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-refresh.spec.ts
@@ -1,6 +1,6 @@
 import type { Route, Request } from '@playwright/test';
 
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   SEED_TENANT,
   removeEnvironment,
@@ -58,10 +58,7 @@ test.describe('tenant dashboard — refresh (#1213)', () => {
   }) => {
     const environment = seedDashboardEnvironment('refresh-refetches');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       const stub = stubLoadTenantDashboard(page, {
         data: {
@@ -104,10 +101,7 @@ test.describe('tenant dashboard — refresh (#1213)', () => {
   test('a failing refresh reports the failure, not a success toast', async ({ app, page }) => {
     const environment = seedDashboardEnvironment('refresh-reports-failure');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       const stub = stubLoadTenantDashboard(page, {
         data: {

--- a/erun-ui/playwright/tests/tenant-dashboard-registration.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-registration.spec.ts
@@ -1,6 +1,6 @@
 import type { Request, Route } from '@playwright/test';
 
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   removeEnvironment,
   seedEnvironment,
@@ -79,10 +79,7 @@ test.describe('tenant dashboard — Registration tab', () => {
   test('shows the two registries and what is already registered', async ({ app, page }) => {
     const environment = seedDashboardEnvironment('registration-visible');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await routeInvoke(page, {
         LoadTenantDashboard: () =>
@@ -131,10 +128,7 @@ test.describe('tenant dashboard — Registration tab', () => {
   }) => {
     const environment = seedDashboardEnvironment('registration-restricted');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await routeInvoke(page, {
         LoadTenantDashboard: () => ({
@@ -167,10 +161,7 @@ test.describe('tenant dashboard — Registration tab', () => {
   }) => {
     const environment = seedDashboardEnvironment('registration-full-path');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       let dashboardLoads = 0;
       let previewCalled = false;
@@ -236,10 +227,7 @@ test.describe('tenant dashboard — Registration tab', () => {
   }) => {
     const environment = seedDashboardEnvironment('registration-quota-conflict');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       await routeInvoke(page, {
         LoadTenantDashboard: () =>
@@ -273,10 +261,7 @@ test.describe('tenant dashboard — Registration tab', () => {
   test('deleting an environment requires typing its name to confirm', async ({ app, page }) => {
     const environment = seedDashboardEnvironment('registration-delete-confirm');
     try {
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
 
       let deleteCalled = false;
       await routeInvoke(page, {

--- a/erun-ui/playwright/tests/tenant-dashboard-review-write.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-review-write.spec.ts
@@ -1,6 +1,6 @@
 import type { Page, Request, Route } from '@playwright/test';
 
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   removeEnvironment,
   SEED_TENANT,
@@ -73,10 +73,7 @@ async function openDashboardReviewsTab(
   environment: string,
   tab: 'Reviews' | 'Merge queue' = 'Reviews',
 ): Promise<void> {
-  await app.reloadEnvironments();
-  await app.sidebar
-    .envRowButton(SEED_TENANT, environment)
-    .waitFor({ state: 'visible', timeout: 15_000 });
+  await waitForSeededRow(app, SEED_TENANT, environment);
   await app.sidebar.openTenantDashboard(SEED_TENANT);
   await app.tenantDashboard.waitForOpen();
   await app.tenantDashboard.selectTab(tab);

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews-long-values.spec.ts
@@ -1,7 +1,7 @@
 import type { Request, Route } from '@playwright/test';
 
 import { boundingBoxOf } from '../fixtures/boundingBox.js';
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   removeEnvironment,
   SEED_TENANT,
@@ -84,10 +84,7 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -154,10 +151,7 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -231,10 +225,7 @@ test.describe('tenant dashboard reviews — long values render bounded, not over
       // the shell actually supports and asserts real reachability there.
       await page.setViewportSize({ width: 1000, height: 900 });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');

--- a/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
+++ b/erun-ui/playwright/tests/tenant-dashboard-reviews.spec.ts
@@ -1,7 +1,7 @@
 import type { Page, Route, Request } from '@playwright/test';
 
 import { boundingBoxOf } from '../fixtures/boundingBox.js';
-import { test, expect } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import type { AppShell } from '../pages/index.js';
 import {
   SEED_TENANT,
@@ -138,10 +138,7 @@ async function openReviewsTabWithOneReview(
     await route.continue();
   });
 
-  await app.reloadEnvironments();
-  await app.sidebar
-    .envRowButton(SEED_TENANT, environment)
-    .waitFor({ state: 'visible', timeout: 15_000 });
+  await waitForSeededRow(app, SEED_TENANT, environment);
   await app.sidebar.openTenantDashboard(SEED_TENANT);
   await app.tenantDashboard.waitForOpen();
   await app.tenantDashboard.selectTab('Reviews');
@@ -194,10 +191,7 @@ test.describe('tenant dashboard — reviews tab and detail dialog (#1199)', () =
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -286,10 +280,7 @@ test.describe('tenant dashboard — reviews discovery (#1378)', () => {
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -339,10 +330,7 @@ test.describe('tenant dashboard — reviews discovery (#1378)', () => {
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -412,10 +400,7 @@ test.describe('tenant dashboard — resolving a comment thread (#1378)', () => {
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -481,10 +466,7 @@ test.describe('tenant dashboard — resolving a comment thread (#1378)', () => {
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');
@@ -558,10 +540,7 @@ test.describe('tenant dashboard — resolving a comment thread (#1378)', () => {
         await route.continue();
       });
 
-      await app.reloadEnvironments();
-      await app.sidebar
-        .envRowButton(SEED_TENANT, environment)
-        .waitFor({ state: 'visible', timeout: 15_000 });
+      await waitForSeededRow(app, SEED_TENANT, environment);
       await app.sidebar.openTenantDashboard(SEED_TENANT);
       await app.tenantDashboard.waitForOpen();
       await app.tenantDashboard.selectTab('Reviews');


### PR DESCRIPTION
38 Playwright specs waited for a seeded environment row like this:

```ts
await app.reloadEnvironments();
await app.sidebar
  .envRowButton(SEED_TENANT, environment)
  .waitFor({ state: 'visible', timeout: 15_000 });
```

The reload happens once, **outside** the wait. If that single re-read lands before the row is seeded, or is overwritten by the backend activity sweep, the following 15s cannot recover it — there is no second read. The defect is an *unrepeated* wait, not a short one, which is why raising the timeout would not have fixed it.

Observed: `manage-cloud-alias-local-agent.spec.ts` timed out at 15s in a full-suite run and passed in **6.5s** on its own.

## Changes

- All 38 sites migrated to `waitForSeededRow` (`fixtures/erunApp.ts`), which puts the reload **inside** an `expect().toPass()` retry so every attempt re-reads. Redundant standalone `reloadEnvironments()` calls that existed only to feed those waits are removed.
- New `env-row-wait-baseline.spec.ts`: a shrink-only structural gate matching the shape via the **TypeScript AST**, not enumerated phrasings — the same reasoning `issue_reference_test.go` and `bare_required_input_test.go` give, and the lesson of #1502, where a grep tuned to one call layout missed the real instance. It enforces both directions: no file may exceed its entry, and an entry claiming more hits than remain must be lowered. The baseline is a single allowed hit in `fixtures/erunApp.ts` — `waitForSeededRow`'s own retry body, the one legitimate occurrence.
- The 16 `aiTab`/`localTab`/`erunTab` fixed-timeout waits are deliberately left alone: different shape, and nothing has shown them flaking.

## Verification

- Full Playwright suite: **402 passed, 0 failed** (25.3m).
- The gate was proven by a negative control — a deliberate violation was added and confirmed to fail it, then reverted.

Closes #1565