### PR TITLE
Size resize --apply-recommendation from live cgroup limits, not config defaults

### DIFF
--- a/erun-common/runtime_resize.go
+++ b/erun-common/runtime_resize.go
@@ -74,6 +74,35 @@ func validateRuntimeResizeInput(input RuntimeResizeInput, explicitCPU, explicitM
 	return nil
 }
 
+// liveRuntimePodResources prefers the live cgroup limits a recommendation's
+// verdicts already read over the configured value, for the same reason
+// RecommendRuntimeSizing itself reasons from cgroups rather than config (see
+// its comment): the in-pod config carries no runtimepod at all when it is
+// silent, so treating the configured value as "current" scores a resize
+// against NormalizeRuntimePodResources' package defaults instead of the size
+// the container is actually running under — the resource a verdict says to
+// hold would then be silently reset to that default. A resource with no
+// verdict reading (no history yet) falls back to the configured value, the
+// only source available for it.
+func liveRuntimePodResources(configured RuntimePodResources, recommendation *RuntimeSizingRecommendation) RuntimePodResources {
+	if recommendation == nil {
+		return configured
+	}
+	live := configured
+	for _, verdict := range recommendation.Verdicts {
+		if verdict.Current == "" {
+			continue
+		}
+		switch verdict.Resource {
+		case "cpu":
+			live.CPU = verdict.Current
+		case "memory":
+			live.Memory = verdict.Current
+		}
+	}
+	return live
+}
+
 // resolveRuntimeResizeTarget applies either the standing recommendation or the
 // explicit values on top of the current sizing, leaving whatever the input does
 // not name unchanged.
@@ -119,7 +148,7 @@ func runtimeResizeActions(current, target RuntimePodResources) []RuntimeResizeAc
 }
 
 func ResolveRuntimeResizePlan(tenant, environment string, current RuntimePodResources, ceiling NamespaceResourceQuota, input RuntimeResizeInput, recommendation *RuntimeSizingRecommendation) (RuntimeResizePlan, error) {
-	current = NormalizeRuntimePodResources(current)
+	current = NormalizeRuntimePodResources(liveRuntimePodResources(current, recommendation))
 	explicitCPU := strings.TrimSpace(input.CPU)
 	explicitMemory := strings.TrimSpace(input.Memory)
 

--- a/erun-integration/resize_test.go
+++ b/erun-integration/resize_test.go
@@ -161,6 +161,42 @@ func TestResize(t *testing.T) {
 		golden.Equal(t, "resize/dry_run_apply_recommendation_traces_the_evidence", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_apply_recommendation_holds_cpu_at_live_limit", func(t *testing.T) {
+		// Regression for the bug where the apply plan was built from the
+		// configured runtimepod (silent in-pod, so it normalizes to the
+		// package defaults cpu=4/8916Mi) instead of the live cgroup limits
+		// the verdict itself is scored against. Fixture mirrors a real
+		// environment running at 12 CPUs / 23552Mi with a silent config: the
+		// verdict says "cpu hold from 12" and "memory lower ... from
+		// 23552Mi", so the resolved plan must carry cpu=12 through unchanged
+		// and read memory's "from" as 23552Mi, never fall back to cpu=4 or
+		// memory 8916Mi.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		seedUsageHistory(t, setup, "team", "dev", usageHistorySpec{
+			windowHours: 48, samples: 240,
+			peakMemoryBytes: 7751073792, limitBytes: 24696061952,
+			quotaMilli: 12000, periods: 900598, throttled: 13, peakCPUMilli: 4567,
+		})
+		result := erun.Run(t, []string{"resize", "--tenant", "team", "--environment", "dev", "--apply-recommendation", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "cpu hold from 12") {
+			t.Fatalf("expected the verdict to hold cpu at the live 12, got:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "memory 23552Mi -> 11264Mi") {
+			t.Fatalf("expected the plan to read memory's live 23552Mi as its from value, got:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "cpu=12") {
+			t.Fatalf("expected the resolved command to carry cpu=12 (the live value) through unchanged, got:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "cpu=4") || strings.Contains(result.Combined, "8916Mi") {
+			t.Fatalf("expected the plan to never fall back to the package defaults cpu=4/8916Mi, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "resize/dry_run_apply_recommendation_holds_cpu_at_live_limit", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_apply_recommendation_no_op_still_traces_why", func(t *testing.T) {
 		// The exact case the recommendation's evidence has to answer: a
 		// no-op that reports "already sized" must not go silent about why --

--- a/erun-integration/testdata/resize/dry_run_apply_recommendation_holds_cpu_at_live_limit.txt
+++ b/erun-integration/testdata/resize/dry_run_apply_recommendation_holds_cpu_at_live_limit.txt
@@ -1,0 +1,8 @@
+audit: erun resize --apply-recommendation --dry-run --environment dev --tenant team
+resize: team/dev sizing: memory lower to 11264Mi from 23552Mi (peak 7392Mi of 23552Mi (31%), no oom kills, keeping 1.5x headroom, low confidence)
+resize: team/dev sizing: cpu hold from 12 (0.00% of scheduling periods throttled (13 of 900598), tolerable but not unused)
+resize: team/dev sizing-evidence: 48h12m observed, 240 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
+resize: team/dev memory 23552Mi -> 11264Mi
+resize: team/dev this moves the runtime container's throttle/OOM ceiling and its namespace quota draw; it does not change what the scheduler reserves (a fixed request independent of runtimepod) and it does not resize the erun-dind sidecar or any PVC
+resize team dev cpu=12 memory=11264Mi
+resize: team/dev will roll the runtime pod once to apply the new limits

--- a/erun-integration/testdata/resize/dry_run_apply_recommendation_no_op_still_traces_why.txt
+++ b/erun-integration/testdata/resize/dry_run_apply_recommendation_no_op_still_traces_why.txt
@@ -2,4 +2,4 @@ audit: erun resize --apply-recommendation --dry-run --environment dev --tenant t
 resize: team/dev sizing: memory insufficient-evidence from 23552Mi (peak 12153Mi of 23552Mi (52%), but only 1h12m observed of the 24h0m a shrink needs)
 resize: team/dev sizing: cpu insufficient-evidence from 12 (0.00% of scheduling periods throttled (0 of 376556), but only 1h12m observed of the 24h0m a shrink needs)
 resize: team/dev sizing-evidence: 1h12m observed, 120 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
-resize: team/dev is already sized at cpu=4 memory=8916Mi; no change
+resize: team/dev is already sized at cpu=12 memory=23552Mi; no change

--- a/erun-integration/testdata/resize/dry_run_apply_recommendation_traces_the_evidence.txt
+++ b/erun-integration/testdata/resize/dry_run_apply_recommendation_traces_the_evidence.txt
@@ -2,8 +2,8 @@ audit: erun resize --apply-recommendation --dry-run --environment dev --tenant t
 resize: team/dev sizing: memory lower to 18432Mi from 23552Mi (peak 12153Mi of 23552Mi (52%), no oom kills, keeping 1.5x headroom, low confidence)
 resize: team/dev sizing: cpu lower to 10 from 12 (busiest interval 4.567 of 12, 0.00% of scheduling periods throttled (0 of 376556), keeping 2x headroom, low confidence)
 resize: team/dev sizing-evidence: 31h12m observed, 240 samples, 0 restarts, knob=runtimepod, from cgroup memory.peak, cgroup memory.events oom_kill, cgroup cpu.stat usage_usec/nr_throttled (not loadavg)
-resize: team/dev cpu 4 -> 10
-resize: team/dev memory 8916Mi -> 18432Mi
+resize: team/dev cpu 12 -> 10
+resize: team/dev memory 23552Mi -> 18432Mi
 resize: team/dev this moves the runtime container's throttle/OOM ceiling and its namespace quota draw; it does not change what the scheduler reserves (a fixed request independent of runtimepod) and it does not resize the erun-dind sidecar or any PVC
 resize team dev cpu=10 memory=18432Mi
 resize: team/dev will roll the runtime pod once to apply the new limits


### PR DESCRIPTION
`erun resize` built its plan from the *configured* runtimepod. The in-pod config carries no runtimepod (the chart injects the container's limits), so `NormalizeRuntimePodResources` filled in package defaults — `cpu=4`, `memory=8916Mi` — and the plan was computed against those instead of the size the container actually runs under.

On erun/build (really 12 cores / 23552Mi) that produced a plan that would **cut the environment to a third of its CPU**, while the verdict on the line above said to hold:

```
resize: erun/build sizing: cpu hold from 12 (...)
resize: erun/build memory 8916Mi -> 11264Mi     <- wrong "from"
resize erun build cpu=4 memory=11264Mi          <- would cut cpu 12 -> 4
```

The desktop's "Resize to this" button scrapes that output, so this was a one-click destructive action behind a correct-looking recommendation, and it rolls the runtime pod as it applies.

## Fix

`liveRuntimePodResources` overlays the recommendation verdicts' `Current` values — which are read from the live cgroup limits — onto the configured resources *before* normalization, so normalization can no longer substitute a default for a value that is actually known.

This mirrors what `RecommendRuntimeSizing` already does for the **scoring** path, and for the reason its own comment gives: *"on a 12-core, 23552Mi environment whose config is silent, that reads as a 8916Mi limit and turns a 2x over-provision into a recommendation to grow."* The scoring path was fixed; the apply path still read the normalized config. Now both reason from the same source.

## Scope was wider than the issue described

The golden updates show two paths that were also affected, not just `--apply-recommendation`:

```diff
-resize: team/dev is already sized at cpu=4 memory=8916Mi; no change
+resize: team/dev is already sized at cpu=12 memory=23552Mi; no change
-resize: team/dev cpu 4 -> 10
+resize: team/dev cpu 12 -> 10
```

An explicit `resize --cpu 10` was misreporting what it was changing *from*, and the no-op check compared against defaults — so it could report "already sized" for a size the environment was not running at.

## Tests

New `dry_run_apply_recommendation_holds_cpu_at_live_limit`: given a silent config, live limits of 12 cores / 23552Mi, and a memory-only recommendation, the emitted plan keeps `cpu=12`. This is the invariant that matters — a test asserting only the memory number would have passed while the CPU bug shipped.

## Verification

- `make check` green, integration coverage **76.1%** (>= 75.8%).
- Playwright not run: `erun-ui/frontend` is untouched (the change is `erun-common` + integration tests + goldens), so there is no user-visible React surface to exercise. The desktop panel reads this command's output, and the goldens lock that output.

Closes #1574