### PR TITLE
Reject ssh-keyscan diagnostics before they land in known_hosts

### DIFF
--- a/erun-cli/internal/sshknownhosts/sshknownhosts.go
+++ b/erun-cli/internal/sshknownhosts/sshknownhosts.go
@@ -62,26 +62,62 @@ func UpsertKnownHost(path, alias, host string, port int) error {
 
 func scanHostKeys(host string, port int) ([]string, error) {
 	cmd := eruncommon.Command("ssh-keyscan", "-p", fmt.Sprintf("%d", port), host)
-	output := new(bytes.Buffer)
-	cmd.Stdout = output
-	cmd.Stderr = output
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	err := cmd.Run()
+	return parseHostKeyScanOutput(stdout.String(), stderr.String(), err)
+}
 
+// parseHostKeyScanOutput extracts host key lines from an ssh-keyscan run. Only
+// stdout is a candidate for keys: ssh-keyscan writes diagnostics (KEX/negotiation
+// failures) to stderr, and a diagnostic has no "#" prefix, so it would otherwise
+// pass the blank/comment filter and be mistaken for a key. Each candidate line is
+// further required to name a known host key type, since a scan can also emit
+// non-key stdout noise.
+func parseHostKeyScanOutput(stdout, stderr string, cmdErr error) ([]string, error) {
 	lines := make([]string, 0, 3)
-	for _, line := range strings.Split(strings.ReplaceAll(output.String(), "\r\n", "\n"), "\n") {
+	for _, line := range strings.Split(strings.ReplaceAll(stdout, "\r\n", "\n"), "\n") {
 		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
+		if line == "" || strings.HasPrefix(line, "#") || !isHostKeyLine(line) {
 			continue
 		}
 		lines = append(lines, line)
 	}
 	if len(lines) == 0 {
-		if err != nil {
-			return nil, fmt.Errorf("scan ssh host key: %w: %s", err, strings.TrimSpace(output.String()))
+		detail := strings.TrimSpace(stderr)
+		if detail == "" {
+			detail = strings.TrimSpace(stdout)
+		}
+		if cmdErr != nil {
+			return nil, fmt.Errorf("scan ssh host key: %w: %s", cmdErr, detail)
+		}
+		if detail != "" {
+			return nil, fmt.Errorf("scan ssh host key: no host keys returned: %s", detail)
 		}
 		return nil, fmt.Errorf("scan ssh host key: no host keys returned")
 	}
 	return lines, nil
+}
+
+// isHostKeyLine reports whether line looks like a "host keytype base64key"
+// known_hosts entry rather than diagnostic text such as an unsupported-KEX
+// message, which has no key-type token to match against.
+func isHostKeyLine(line string) bool {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return false
+	}
+	return isKnownHostKeyType(fields[1])
+}
+
+func isKnownHostKeyType(keyType string) bool {
+	switch keyType {
+	case "ssh-rsa", "ssh-dss", "ssh-ed25519":
+		return true
+	}
+	return strings.HasPrefix(keyType, "ecdsa-sha2-") || strings.HasPrefix(keyType, "sk-")
 }
 
 func upsertKnownHostsContent(existing, alias, hostToken string, scannedLines []string) string {

--- a/erun-cli/internal/sshknownhosts/sshknownhosts_test.go
+++ b/erun-cli/internal/sshknownhosts/sshknownhosts_test.go
@@ -1,0 +1,106 @@
+package sshknownhosts
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const realEd25519Line = "[127.0.0.1]:17122 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIQVXbogPCLGY4kU3ZTIZgOX6uK5wKJn1nzTQ1E0uYm+1"
+
+func TestParseHostKeyScanOutput_ReturnsOnlyTheRealKey(t *testing.T) {
+	stdout := strings.Join([]string{
+		"# 127.0.0.1:17122 SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.18",
+		realEd25519Line,
+	}, "\n")
+	stderr := "unsupported KEX method sntrup761x25519-sha512@openssh.com"
+
+	lines, err := parseHostKeyScanOutput(stdout, stderr, nil)
+	if err != nil {
+		t.Fatalf("parseHostKeyScanOutput returned error: %v", err)
+	}
+	if len(lines) != 1 || lines[0] != realEd25519Line {
+		t.Fatalf("expected only the real key line, got %v", lines)
+	}
+}
+
+func TestParseHostKeyScanOutput_DiagnosticOnlyFailsRatherThanReturningLines(t *testing.T) {
+	// A merged-stream regression would put this diagnostic on stdout; guard against
+	// that by asserting the failure case even when it lands where a key would.
+	stdout := "erun-validationagent-review unsupported KEX method sntrup761x25519-sha512@openssh.com"
+
+	lines, err := parseHostKeyScanOutput(stdout, "", errors.New("exit status 1"))
+	if err == nil {
+		t.Fatalf("expected an error, got lines %v", lines)
+	}
+	if lines != nil {
+		t.Fatalf("expected no lines on failure, got %v", lines)
+	}
+}
+
+func TestParseHostKeyScanOutput_DiagnosticOnStderrOnlyFails(t *testing.T) {
+	lines, err := parseHostKeyScanOutput("", "unsupported KEX method sntrup761x25519-sha512@openssh.com", errors.New("exit status 1"))
+	if err == nil {
+		t.Fatalf("expected an error, got lines %v", lines)
+	}
+	if lines != nil {
+		t.Fatalf("expected no lines on failure, got %v", lines)
+	}
+	if !strings.Contains(err.Error(), "unsupported KEX method") {
+		t.Fatalf("expected error to carry the diagnostic detail, got %q", err.Error())
+	}
+}
+
+func TestParseHostKeyScanOutput_EmptyOutputFails(t *testing.T) {
+	lines, err := parseHostKeyScanOutput("", "", nil)
+	if err == nil {
+		t.Fatalf("expected an error, got lines %v", lines)
+	}
+	if lines != nil {
+		t.Fatalf("expected no lines on failure, got %v", lines)
+	}
+}
+
+func TestIsHostKeyLine(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"real ed25519 key", realEd25519Line, true},
+		{"real ecdsa key", "host ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTY=", true},
+		{"diagnostic with alias token", "erun-validationagent-review unsupported KEX method sntrup761x25519-sha512@openssh.com", false},
+		{"diagnostic with host token", "[127.0.0.1]:17122 unsupported KEX method sntrup761x25519-sha512@openssh.com", false},
+		{"too few fields", "host ssh-ed25519", false},
+		{"blank", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHostKeyLine(tc.line); got != tc.want {
+				t.Fatalf("isHostKeyLine(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUpsertKnownHostsContent_RepairsAPreviouslyCorruptedEntry(t *testing.T) {
+	alias := "erun-validationagent-review"
+	hostToken := "[127.0.0.1]:17122"
+	existing := strings.Join([]string{
+		alias + " unsupported KEX method sntrup761x25519-sha512@openssh.com",
+		hostToken + " unsupported KEX method sntrup761x25519-sha512@openssh.com",
+		"other-alias ssh-ed25519 AAAAunrelated",
+	}, "\n") + "\n"
+
+	updated := upsertKnownHostsContent(existing, alias, hostToken, []string{realEd25519Line})
+
+	if strings.Contains(updated, "unsupported KEX method") {
+		t.Fatalf("expected the corrupted lines to be repaired, got:\n%s", updated)
+	}
+	if !strings.Contains(updated, "other-alias ssh-ed25519 AAAAunrelated") {
+		t.Fatalf("expected the unrelated entry to survive, got:\n%s", updated)
+	}
+	if !strings.Contains(updated, alias+" ssh-ed25519") || !strings.Contains(updated, hostToken+" ssh-ed25519") {
+		t.Fatalf("expected the alias and host token to be re-recorded with the real key, got:\n%s", updated)
+	}
+}


### PR DESCRIPTION
## Summary
- `scanHostKeys` merged ssh-keyscan's stdout and stderr into one buffer and accepted any non-blank, non-`#` line as a host key. ssh-keyscan writes negotiation diagnostics (e.g. `unsupported KEX method sntrup761x25519-sha512@openssh.com`) to stderr with no `#` prefix, so a diagnostic passed the filter and got written into `known_hosts` under both the alias and `[host]:port` tokens — breaking host key verification for every SSH client on the machine, not just erun's.
- Fix: keep stdout and stderr in separate buffers so diagnostics never reach the candidate-line pool, and additionally require each candidate line to name a known SSH host key type (`ssh-ed25519`, `ecdsa-sha2-*`, `ssh-rsa`, `ssh-dss`, `sk-*`) before accepting it. A scan that yields no valid key now returns an error (carrying the diagnostic detail) instead of reporting success.
- Already-corrupted `known_hosts`: repaired, not left. `upsertKnownHostsContent` already replaces any existing line whose first field matches the current alias or `[host]:port` token before appending the freshly scanned key, regardless of what that old line contained — so a machine with a corrupted entry heals automatically the next time that same alias/token is rescanned successfully (e.g. the next `erun sshd init` / `erun open --vscode` for that env). A corrupted entry under a token that never gets rescanned again would not be touched by this fix; that's outside what a single upsert can know to clean up.

## Test plan
- [x] `TestParseHostKeyScanOutput_ReturnsOnlyTheRealKey` — mixed banner + stderr diagnostic + one real key: only the real key line survives.
- [x] `TestParseHostKeyScanOutput_DiagnosticOnlyFailsRatherThanReturningLines` — the negative case: a keyscan whose "output" is only the diagnostic returns an error, not lines.
- [x] `TestParseHostKeyScanOutput_DiagnosticOnStderrOnlyFails` / `TestParseHostKeyScanOutput_EmptyOutputFails` — stderr-only and empty-output scans also fail cleanly.
- [x] `TestIsHostKeyLine` — table test distinguishing real key types from diagnostic lines that happen to start with the alias/host token.
- [x] `TestUpsertKnownHostsContent_RepairsAPreviouslyCorruptedEntry` — asserts a pre-existing corrupted line for the alias/host token is dropped (not treated as a valid key) on the next successful upsert, while an unrelated entry for a different alias survives untouched.
- [x] `make check` green (unit tests, lint, integration suite w/ coverage 76.1% ≥ 75.8% threshold, chart tests).

Closes #1579

🤖 Generated with [Claude Code](https://claude.com/claude-code)