### PR TITLE
Emit every orchestrator hook as a portable node invocation

### DIFF
--- a/erun-integration/issue_reference_test.go
+++ b/erun-integration/issue_reference_test.go
@@ -344,7 +344,7 @@ var issueReferenceBaseline = map[string]int{
 	"erun-ui/host_open_path.go":                           1,
 	"erun-ui/host_open_path_test.go":                      1,
 	"erun-ui/mcp_errors.go":                               1,
-	"erun-ui/orchestrator.go":                             4,
+	"erun-ui/orchestrator.go":                             3,
 	"erun-ui/orchestrator_guidance_test.go":               1,
 	"erun-ui/orchestrator_mcp.go":                         2,
 	"erun-ui/orchestrator_mcp_test.go":                    2,

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -645,10 +645,8 @@ func fileSHA256(path string) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-// orchestratorContractFallback is echoed when the shared CLAUDE.md is somehow
-// missing, so a session still boots knowing it is under the contract. It is
-// ASCII-only and apostrophe-free so the single-quoted echo is safe in both Git
-// Bash (Windows) and sh (macOS/Linux).
+// orchestratorContractFallback is printed when the shared CLAUDE.md is somehow
+// missing, so a session still boots knowing it is under the contract.
 const orchestratorContractFallback = "You are a host-side erun orchestrator. Read and follow the CLAUDE.md in this directory and the erun-orchestrate skill before doing anything, even a trivial-looking question."
 
 // orchestratorSkillHookCommand is the SessionStart hook command written into the
@@ -656,29 +654,36 @@ const orchestratorContractFallback = "You are a host-side erun orchestrator. Rea
 // into the session by printing the shared CLAUDE.md to plain stdout (added to the
 // session context), so an orchestrator always has its contract in context instead
 // of being asked to load a skill it can skip. Plain stdout — not JSON — sidesteps
-// the 10,000-char additionalContext cap; cat reads the file directly, so the
-// contract body is never shell-quoted and only the forward-slashed path is
-// double-quoted (safe in Git Bash and sh). The apostrophe-free echo is the
-// fallback if the file is ever missing.
+// the 10,000-char additionalContext cap.
+//
+// Runs through node rather than cat/echo chained with a POSIX shell: this is a
+// SessionStart hook, and Windows' own hook shell (PowerShell) parses
+// `[ -n ... ]` test syntax as something else entirely rather than executing
+// it. Node reads each file directly and writes its bytes straight to stdout,
+// so neither file's body ever passes through the shell at all -- only the
+// two forward-slashed paths are baked into the script, and node resolves
+// identically regardless of the host's own hook shell.
 func orchestratorSkillHookCommand(dir string) string {
 	claudeMd := filepath.ToSlash(filepath.Join(dir, "CLAUDE.md"))
 	// The per-orchestrator layer, injected AFTER the shared contract so the
 	// ordering is the precedence rule: a role file can add to the common
-	// contract or override a line of it, and a reader can see which won (#1175).
+	// contract or override a line of it, and a reader can see which won.
 	//
-	// $ERUN_ORCHESTRATOR_ID is set at launch and is already proven visible to
-	// SessionStart hook commands on both host OSes -- the activity hook in this
-	// same block interpolates it into a path one line down. A transient
-	// (Investigate) session has an empty id by design, so the guard skips it and
-	// it gets the shared contract only.
+	// ERUN_ORCHESTRATOR_ID is set at launch and resolved at run time, since
+	// this settings file is shared by every orchestrator. A transient
+	// (Investigate) session has an empty id by design, so the guard skips it
+	// and it gets the shared contract only.
 	//
-	// Absent file is a silent no-op: most orchestrators will not have one, and a
-	// missing file must neither fail the hook nor write to stderr. Same quoting
-	// discipline as above -- forward-slashed, double-quoted path, and no file
-	// body ever passes through the shell -- so sh and Git Bash both work.
-	roleMd := filepath.ToSlash(filepath.Join(dir, "CLAUDE.$ERUN_ORCHESTRATOR_ID.md"))
-	return `cat "` + claudeMd + `" 2>/dev/null || echo '` + orchestratorContractFallback + `'` + "\n" +
-		`[ -n "$ERUN_ORCHESTRATOR_ID" ] && cat "` + roleMd + `" 2>/dev/null || true`
+	// Absent file is a silent no-op: most orchestrators will not have one, and
+	// a missing file must neither fail the hook nor write to stderr.
+	roleDir := filepath.ToSlash(dir)
+	script := `try{const fs=require("fs");` +
+		`try{process.stdout.write(fs.readFileSync("` + claudeMd + `","utf8"));}` +
+		`catch(e){process.stdout.write("` + orchestratorContractFallback + `\n");}` +
+		`const id=process.env.ERUN_ORCHESTRATOR_ID;` +
+		`if(id){try{process.stdout.write(fs.readFileSync("` + roleDir + `/CLAUDE."+id+".md","utf8"));}catch(e){}}` +
+		`}catch(e){}`
+	return `node -e '` + script + `'`
 }
 
 // orchestratorRoleFileSeed is written once into CLAUDE.<id>.md and never
@@ -799,8 +804,9 @@ func ensureOrchestratorSessionStartHook(dir string) error {
 const orchestratorNoAskGuardMarker = "noask_guard=1"
 
 // orchestratorNoAskStopGuardReason is fed back to the session when the guard
-// fires. ASCII-only and apostrophe-free so the single-quoted printf is safe in
-// both Git Bash (Windows) and sh (macOS/Linux).
+// fires. ASCII-only and apostrophe-free, since it is embedded as a plain JS
+// string inside a script wrapped in a single-quoted shell argument -- a
+// literal single quote in the text would close that argument early.
 const orchestratorNoAskStopGuardReason = "Your closing message hands the operator a decision. " +
 	"The orchestrator contract resolves ambiguity itself and carries the task to a verified end, " +
 	"so a question is a defect, not caution. Do what you offered, or state it as a decision already taken, " +
@@ -812,11 +818,18 @@ const orchestratorNoAskStopGuardReason = "Your closing message hands the operato
 // as long. Reading the turn's own last words is what puts the guarantee at the
 // layer the behaviour surfaces on.
 //
-// Every failure path exits 0. A guard that wedged a session on a transcript it
-// could not parse would cost more than the stalls it prevents, and an already
-// nudged turn (stop_hook_active) is let go so a session is corrected once rather
-// than looped. Like the activity reports it is bare shell, so it keeps working
-// when erun is not on PATH.
+// Every failure path falls through to node's default exit code, 0. A guard
+// that wedged a session on a transcript it could not parse would cost more
+// than the stalls it prevents, and an already nudged turn (stop_hook_active)
+// is let go so a session is corrected once rather than looped.
+//
+// Runs through node rather than a POSIX shell reading its own stdin with sed
+// and grep: this fires on every Stop event of every orchestrator, and
+// Windows' own hook shell (PowerShell) parses `[ -f ... ]` test syntax as
+// something else entirely rather than executing it. Node needs no helper
+// binary on PATH -- the AI harness that launched the session is itself an
+// npm package -- and resolves identically regardless of the host's own hook
+// shell.
 //
 // It reads the turn's last ASSISTANT entry, never the raw tail of the
 // transcript. A firing is itself recorded in the transcript, and the record
@@ -826,13 +839,21 @@ const orchestratorNoAskStopGuardReason = "Your closing message hands the operato
 // me to…") refuse the reply that answered it. Only what the turn said can
 // decide whether the turn handed back a decision.
 func orchestratorNoAskStopGuardCommand() string {
-	return orchestratorNoAskGuardMarker + `; input=$(cat); ` +
-		`printf '%s' "$input" | grep -q '"stop_hook_active"[[:space:]]*:[[:space:]]*true' && exit 0; ` +
-		`transcript=$(printf '%s' "$input" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed 's/\\\\/\//g'); ` +
-		`[ -f "$transcript" ] || exit 0; ` +
-		`said=$(tail -n 40 "$transcript" | grep -E '"type"[[:space:]]*:[[:space:]]*"assistant"' | tail -n 1); ` +
-		`printf '%s' "$said" | grep -qiE 'say the word|let me know if|let me know whether|shall i |do you want me to|would you like me to|next action is yours|if you.d like me to|your call' || exit 0; ` +
-		`printf '%s' '` + orchestratorNoAskStopGuardReason + `' >&2; exit 2`
+	script := `/*` + orchestratorNoAskGuardMarker + `*/` +
+		`let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
+		`const j=JSON.parse(d);` +
+		`if(j.stop_hook_active===true)return;` +
+		`const fs=require("fs");` +
+		`const lines=fs.readFileSync(j.transcript_path,"utf8").split("\n");` +
+		`const tail=lines.slice(-40);` +
+		`let said="";` +
+		`for(const line of tail){if(/"type"\s*:\s*"assistant"/.test(line))said=line;}` +
+		`const trigger=/say the word|let me know if|let me know whether|shall i |do you want me to|would you like me to|next action is yours|if you.d like me to|your call/i;` +
+		`if(!trigger.test(said))return;` +
+		`process.stderr.write("` + orchestratorNoAskStopGuardReason + `");` +
+		`process.exit(2);` +
+		`}catch(e){}});`
+	return `node -e '` + script + `'`
 }
 
 // orchestratorNoAskStopGuardBlock is the guard bound to the Stop event.

--- a/erun-ui/orchestrator_activity.go
+++ b/erun-ui/orchestrator_activity.go
@@ -111,15 +111,21 @@ func orchestratorActivityDir() string {
 // A session without that variable (transient/Investigate) writes nothing rather
 // than a file named for nobody.
 //
-// It is a bare shell redirect rather than a helper binary on purpose: this runs
-// at every turn boundary of every orchestrator, and a hook that needed erun on
-// PATH would stop reporting exactly when the environment is misconfigured.
+// It runs through node rather than a POSIX shell on purpose: this runs at every
+// turn boundary of every orchestrator, and Windows' own hook shell (PowerShell)
+// parses `[ -n ... ]`-style test syntax as something else entirely instead of
+// executing it. Node needs no helper binary on PATH -- the orchestrator session
+// could not have started without it, since the AI harness that launched it is
+// itself an npm package -- and resolves identically regardless of the host's
+// own hook shell.
 func orchestratorActivityHookCommand(busy bool) string {
 	dir := filepath.ToSlash(orchestratorActivityDir())
 	state := strconv.FormatBool(busy)
-	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
-		`printf '{"busy":` + state + `,"atUnix":%s}' "$(date +%s)" > "` + dir + `/$ERUN_ORCHESTRATOR_ID.json"` +
-		` || true`
+	script := `try{const id=process.env.ERUN_ORCHESTRATOR_ID;if(id){const fs=require("fs");` +
+		`fs.mkdirSync("` + dir + `",{recursive:true});` +
+		`fs.writeFileSync("` + dir + `/"+id+".json",JSON.stringify({busy:` + state + `,atUnix:Math.floor(Date.now()/1000)}));` +
+		`}}catch(e){}`
+	return `node -e '` + script + `'`
 }
 
 // orchestratorActivityHookMarker identifies a hook this file wrote, so a rewrite
@@ -150,7 +156,7 @@ func isOrchestratorActivityHookBlock(block any) bool {
 		if !ok {
 			continue
 		}
-		if strings.Contains(command, marker) && strings.Contains(command, `"busy":`) {
+		if strings.Contains(command, marker) && strings.Contains(command, `busy:`) {
 			return true
 		}
 	}

--- a/erun-ui/orchestrator_activity_test.go
+++ b/erun-ui/orchestrator_activity_test.go
@@ -98,19 +98,22 @@ func TestOrchestratorActivityHooksResolveTheirOwnOrchestrator(t *testing.T) {
 	idle := hookCommandText(t, idleHook)
 
 	for _, command := range []string{busy, idle} {
-		if !strings.Contains(command, "$ERUN_ORCHESTRATOR_ID") {
+		if !strings.Contains(command, "process.env.ERUN_ORCHESTRATOR_ID") {
 			t.Fatalf("the hook must resolve its orchestrator at run time: %q", command)
 		}
 		// A transient session carries no id and must write nothing rather than a
 		// file named for nobody.
-		if !strings.Contains(command, `[ -n "$ERUN_ORCHESTRATOR_ID" ]`) {
+		if !strings.Contains(command, "if(id)") {
 			t.Fatalf("the hook must skip a session with no id: %q", command)
 		}
+		if !orchestratorHookCommandIsPortable(command) {
+			t.Fatalf("the hook must run through node, not a POSIX shell: %q", command)
+		}
 	}
-	if !strings.Contains(busy, `"busy":true`) {
+	if !strings.Contains(busy, `busy:true`) {
 		t.Fatalf("the turn-start hook must report working: %q", busy)
 	}
-	if !strings.Contains(idle, `"busy":false`) {
+	if !strings.Contains(idle, `busy:false`) {
 		t.Fatalf("the turn-end hook must report idle: %q", idle)
 	}
 }

--- a/erun-ui/orchestrator_hook_portability.go
+++ b/erun-ui/orchestrator_hook_portability.go
@@ -1,0 +1,24 @@
+package main
+
+import "strings"
+
+// orchestratorHookCommandIsPortable reports whether a hook command is exactly
+// one "node -e '<script>'" invocation with no stray single quote inside the
+// script that would close the argument early. Every orchestrator hook is
+// emitted in this shape rather than as a POSIX shell one-liner, because a
+// POSIX-only construct ("[ ... ]" test syntax, "$(...)" command substitution,
+// sh's "&&"/"||" chaining) parses as something else entirely the moment the
+// host's own hook shell is not sh -- on Windows the harness runs orchestrator
+// hooks through PowerShell, where a leading "[" opens a type literal instead
+// of executing. A single quoted "node -e" argument is inert to the invoking
+// shell regardless of which one it is, so this check does not vary by host
+// OS: the same command is what every orchestrator installs on every
+// platform, which is the fix.
+func orchestratorHookCommandIsPortable(command string) bool {
+	const prefix = `node -e '`
+	if !strings.HasPrefix(command, prefix) || !strings.HasSuffix(command, `'`) {
+		return false
+	}
+	script := command[len(prefix) : len(command)-1]
+	return !strings.Contains(script, `'`)
+}

--- a/erun-ui/orchestrator_hook_portability_test.go
+++ b/erun-ui/orchestrator_hook_portability_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+// orchestratorAllHookCommands returns every command an orchestrator hook can
+// install, so one check can assert the portability invariant across all of
+// them instead of one at a time per hook.
+func orchestratorAllHookCommands() []string {
+	return []string{
+		orchestratorSkillHookCommand("/tmp/orchestrators"),
+		orchestratorActivityHookCommand(true),
+		orchestratorActivityHookCommand(false),
+		orchestratorShellActivityStartHookCommand(),
+		orchestratorShellActivityClearHookCommand(),
+		orchestratorShellActivityResetHookCommand(),
+		orchestratorLiveConversationHookCommand(),
+		orchestratorNoAskStopGuardCommand(),
+	}
+}
+
+// TestOrchestratorHookCommandsArePortableAcrossHostShells is the regression
+// test for the failure a POSIX-only hook produces the moment the host's own
+// hook shell is not sh: Windows runs orchestrator hooks through PowerShell,
+// where a leading "[" opens a type literal instead of a test expression, and
+// every hook died at parse time before a single statement ran.
+//
+// The commands erun emits do not vary by host OS -- every one runs through
+// node instead of a shell built-in -- so the same assertion holds for a POSIX
+// host and for Windows identically. Table-testing it against both labels
+// explicitly, rather than only the POSIX host this suite actually runs on, is
+// what keeps a future edit from quietly reintroducing a POSIX-only branch
+// that would pass here and still break on the platform that never runs this
+// suite.
+func TestOrchestratorHookCommandsArePortableAcrossHostShells(t *testing.T) {
+	for _, goos := range []string{"windows", "linux", "darwin"} {
+		t.Run(goos, func(t *testing.T) {
+			for _, command := range orchestratorAllHookCommands() {
+				if !orchestratorHookCommandIsPortable(command) {
+					t.Fatalf("hook command is not a single portable node invocation and would fail to parse under %s's own hook shell:\n%s", goos, command)
+				}
+			}
+		})
+	}
+}
+
+// TestOrchestratorHookCommandIsPortableRejectsPOSIXOnlyShapes locks in what
+// the checker itself is supposed to catch, so a future edit to it cannot
+// quietly stop catching the shape that broke Windows in the first place.
+func TestOrchestratorHookCommandIsPortableRejectsPOSIXOnlyShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"a bare POSIX test guard", `[ -n "$ERUN_ORCHESTRATOR_ID" ] && echo hi`, false},
+		{"command substitution", `echo "$(date +%s)"`, false},
+		{"sh chaining around a node call", `node -e 'x' || true`, false},
+		{"a portable node invocation", `node -e 'console.log("hi")'`, true},
+		{"a single quote breaking out of the node argument", `node -e 'x'; rm -rf /'`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orchestratorHookCommandIsPortable(tc.command); got != tc.want {
+				t.Fatalf("orchestratorHookCommandIsPortable(%q) = %v, want %v", tc.command, got, tc.want)
+			}
+		})
+	}
+}

--- a/erun-ui/orchestrator_live_conversation.go
+++ b/erun-ui/orchestrator_live_conversation.go
@@ -336,18 +336,27 @@ func orchestratorAttachmentUnusableNotice(id, attached, reason string) string {
 // moves to a new id mid-run is exactly the case this exists for, so the record
 // has to be refreshed as the session goes rather than only at its start.
 //
-// Bare shell, like the activity hooks and the no-ask guard, so it keeps working
-// when erun is not on PATH. Every failure path is `|| true`: a hook that could
-// wedge a session costs more than a missed record.
+// Runs through node, like the other orchestrator hooks, rather than a POSIX
+// shell reading its own stdin with sed: this fires on every session and turn
+// boundary of every orchestrator, and Windows' own hook shell (PowerShell)
+// parses `[ -n ... ]` test syntax as something else entirely rather than
+// executing it. Node needs no helper binary on PATH -- the AI harness that
+// launched the session is itself an npm package -- and resolves identically
+// regardless of the host's own hook shell. Every failure path is swallowed:
+// a hook that could wedge a session costs more than a missed record.
 func orchestratorLiveConversationHookCommand() string {
 	dir := filepath.ToSlash(orchestratorLiveConversationDir())
-	return `input=$(cat); ` +
-		`sid=$(printf '%s' "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'); ` +
-		`[ -n "$ERUN_ORCHESTRATOR_ID" ] && [ -n "$` + orchestratorLaunchEnvVar + `" ] && [ -n "$sid" ] && ` +
-		`mkdir -p "` + dir + `" && ` +
-		`printf '{"conversationId":"%s","launchId":"%s","atUnix":%s}' "$sid" "$` + orchestratorLaunchEnvVar + `" "$(date +%s)" ` +
-		`> "` + dir + `/$ERUN_ORCHESTRATOR_ID.json"` +
-		` || true`
+	script := `let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
+		`const id=process.env.ERUN_ORCHESTRATOR_ID;` +
+		`const launch=process.env.` + orchestratorLaunchEnvVar + `;` +
+		`if(!id||!launch)return;` +
+		`const j=JSON.parse(d);` +
+		`const sid=j.session_id;` +
+		`if(!sid)return;` +
+		`const fs=require("fs");fs.mkdirSync("` + dir + `",{recursive:true});` +
+		`fs.writeFileSync("` + dir + `/"+id+".json",JSON.stringify({conversationId:sid,launchId:launch,atUnix:Math.floor(Date.now()/1000)}));` +
+		`}catch(e){}});`
+	return `node -e '` + script + `'`
 }
 
 // isOrchestratorLiveConversationHookBlock reports whether a settings hook block
@@ -373,7 +382,7 @@ func isOrchestratorLiveConversationHookBlock(block any) bool {
 		if !ok {
 			continue
 		}
-		if strings.Contains(command, `"conversationId":`) && strings.Contains(command, orchestratorLaunchEnvVar) {
+		if strings.Contains(command, `conversationId:`) && strings.Contains(command, orchestratorLaunchEnvVar) {
 			return true
 		}
 	}

--- a/erun-ui/orchestrator_noask_guard_test.go
+++ b/erun-ui/orchestrator_noask_guard_test.go
@@ -78,12 +78,15 @@ func guardHookInput(t *testing.T, transcript string, active bool) string {
 	return string(encoded)
 }
 
-// The guard is a shell one-liner, so asserting on its text would prove nothing
-// about what it does. This runs it.
+// The guard is a one-liner, so asserting on its text would prove nothing about
+// what it does. This runs it.
 func TestOrchestratorNoAskStopGuardDecidesOnTheTurnsLastWords(t *testing.T) {
 	shell, err := exec.LookPath("sh")
 	if err != nil {
 		t.Skip("no POSIX shell on this host")
+	}
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("no node on this host")
 	}
 	dir := t.TempDir()
 	gate := writeGuardTranscript(t, dir, "gate.jsonl", "Filed it. Say the word and I will open the PR.")

--- a/erun-ui/orchestrator_role_file_test.go
+++ b/erun-ui/orchestrator_role_file_test.go
@@ -89,7 +89,7 @@ func TestOrchestratorSkillHookInjectsTheRoleFileAfterTheSharedContract(t *testin
 	command := orchestratorSkillHookCommand("/tmp/orchestrators")
 
 	shared := strings.Index(command, "CLAUDE.md")
-	role := strings.Index(command, "CLAUDE.$ERUN_ORCHESTRATOR_ID.md")
+	role := strings.Index(command, `CLAUDE."+id+".md`)
 	if shared < 0 {
 		t.Fatalf("hook does not read the shared contract:\n%s", command)
 	}
@@ -99,12 +99,15 @@ func TestOrchestratorSkillHookInjectsTheRoleFileAfterTheSharedContract(t *testin
 	if role < shared {
 		t.Errorf("the role file is read BEFORE the shared contract, inverting precedence:\n%s", command)
 	}
-	if !strings.Contains(command, `[ -n "$ERUN_ORCHESTRATOR_ID" ]`) {
-		t.Errorf("no guard on the id, so a transient session would cat CLAUDE..md:\n%s", command)
+	if !strings.Contains(command, "if(id)") {
+		t.Errorf("no guard on the id, so a transient session would read CLAUDE..md:\n%s", command)
 	}
 	// A missing role file is the common case and must not fail the hook or write
 	// to stderr.
-	if !strings.Contains(command, "|| true") {
+	if !strings.Contains(command, `id+".md","utf8"));}catch(e){}`) {
 		t.Errorf("a missing role file must be a silent no-op:\n%s", command)
+	}
+	if !orchestratorHookCommandIsPortable(command) {
+		t.Errorf("the hook must run through node, not a POSIX shell: %q", command)
 	}
 }

--- a/erun-ui/orchestrator_shell_activity.go
+++ b/erun-ui/orchestrator_shell_activity.go
@@ -137,12 +137,15 @@ func shellActivityNamesAReplacedSession(reportSessionID, liveSessionID string) b
 	return reportSessionID != "" && liveSessionID != "" && reportSessionID != liveSessionID
 }
 
-// orchestratorShellActivityFileVar is both the environment variable the hook
-// commands resolve their report path through and the marker
-// isOrchestratorShellActivityHookBlock looks for, so a rewrite recognizes and
-// replaces its own previous blocks instead of stacking another copy beside
-// them.
-const orchestratorShellActivityFileVar = "ERUN_SHELL_ACTIVITY_FILE"
+// orchestratorShellActivityHookMarker identifies a hook this file wrote, so a
+// rewrite replaces its own previous block instead of stacking another copy
+// beside it. The directory every one of these hooks resolves its report path
+// under is baked into the command at generation time and unique to this
+// report, so it doubles as the marker -- the same approach
+// orchestratorActivityHookMarker uses.
+func orchestratorShellActivityHookMarker() string {
+	return filepath.ToSlash(orchestratorShellActivityDir())
+}
 
 // isOrchestratorShellActivityHookBlock reports whether a settings hook block
 // is one of ours — either the start or the clear block, which share the
@@ -156,6 +159,7 @@ func isOrchestratorShellActivityHookBlock(block any) bool {
 	if !ok {
 		return false
 	}
+	marker := orchestratorShellActivityHookMarker()
 	for _, hook := range hooks {
 		entry, ok := hook.(map[string]any)
 		if !ok {
@@ -165,7 +169,7 @@ func isOrchestratorShellActivityHookBlock(block any) bool {
 		if !ok {
 			continue
 		}
-		if strings.Contains(command, orchestratorShellActivityFileVar) {
+		if strings.Contains(command, marker) {
 			return true
 		}
 	}
@@ -181,17 +185,24 @@ func isOrchestratorShellActivityHookBlock(block any) bool {
 // still live. Any other Bash call — foreground, or one that never
 // backgrounds — leaves the previous report untouched: a foreground command
 // says nothing about whatever shell is already running.
+//
+// Runs entirely inside the node script, including the orchestrator-id guard
+// and the report directory's creation: a POSIX shell prefix ("[ -n ... ] &&
+// mkdir ... && VAR=... node -e ...") is exactly the syntax Windows' own hook
+// shell (PowerShell) does not parse the way a POSIX shell does, and
+// "VAR=value command" inline env assignment is not PowerShell syntax at all.
 func orchestratorShellActivityStartHookCommand() string {
 	dir := filepath.ToSlash(orchestratorShellActivityDir())
 	script := `let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
+		`const id=process.env.ERUN_ORCHESTRATOR_ID;if(!id)return;` +
 		`const j=JSON.parse(d);` +
-		`const id=j.tool_response&&j.tool_response.backgroundTaskId;` +
-		`if(!id)return;` +
-		`const out={running:true,command:(j.tool_input&&j.tool_input.command)||"",taskId:id,sessionId:j.session_id||"",atUnix:Math.floor(Date.now()/1000)};` +
-		`require("fs").writeFileSync(process.env.` + orchestratorShellActivityFileVar + `,JSON.stringify(out));` +
+		`const taskId=j.tool_response&&j.tool_response.backgroundTaskId;` +
+		`if(!taskId)return;` +
+		`const out={running:true,command:(j.tool_input&&j.tool_input.command)||"",taskId:taskId,sessionId:j.session_id||"",atUnix:Math.floor(Date.now()/1000)};` +
+		`const fs=require("fs");fs.mkdirSync("` + dir + `",{recursive:true});` +
+		`fs.writeFileSync("` + dir + `/"+id+".json",JSON.stringify(out));` +
 		`}catch(e){}});`
-	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
-		orchestratorShellActivityFileVar + `="` + dir + `/$ERUN_ORCHESTRATOR_ID.json" node -e '` + script + `' || true`
+	return `node -e '` + script + `'`
 }
 
 // orchestratorShellActivityClearHookCommand recognizes a TaskOutput or
@@ -202,18 +213,19 @@ func orchestratorShellActivityStartHookCommand() string {
 func orchestratorShellActivityClearHookCommand() string {
 	dir := filepath.ToSlash(orchestratorShellActivityDir())
 	script := `let d="";process.stdin.on("data",c=>{d+=c});process.stdin.on("end",()=>{try{` +
+		`const id=process.env.ERUN_ORCHESTRATOR_ID;if(!id)return;` +
 		`const j=JSON.parse(d);` +
 		`const task=(j.tool_response&&j.tool_response.task)||{};` +
-		`const id=task.task_id||(j.tool_input&&(j.tool_input.task_id||j.tool_input.shell_id))||"";` +
-		`if(!id||task.status==="running")return;` +
-		`const path=process.env.` + orchestratorShellActivityFileVar + `;` +
+		`const taskId=task.task_id||(j.tool_input&&(j.tool_input.task_id||j.tool_input.shell_id))||"";` +
+		`if(!taskId||task.status==="running")return;` +
+		`const fs=require("fs");fs.mkdirSync("` + dir + `",{recursive:true});` +
+		`const path="` + dir + `/"+id+".json";` +
 		`let prev={};` +
-		`try{prev=JSON.parse(require("fs").readFileSync(path,"utf8"));}catch(e){}` +
-		`if(prev.taskId!==id)return;` +
-		`require("fs").writeFileSync(path,JSON.stringify({running:false,atUnix:Math.floor(Date.now()/1000)}));` +
+		`try{prev=JSON.parse(fs.readFileSync(path,"utf8"));}catch(e){}` +
+		`if(prev.taskId!==taskId)return;` +
+		`fs.writeFileSync(path,JSON.stringify({running:false,atUnix:Math.floor(Date.now()/1000)}));` +
 		`}catch(e){}});`
-	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
-		orchestratorShellActivityFileVar + `="` + dir + `/$ERUN_ORCHESTRATOR_ID.json" node -e '` + script + `' || true`
+	return `node -e '` + script + `'`
 }
 
 // orchestratorShellActivityResetHookCommand clears an inherited "running"
@@ -221,14 +233,14 @@ func orchestratorShellActivityClearHookCommand() string {
 // (false) clears the busy report there: an orchestrator id is mutable and
 // reusable, so a report a previous run under this id left behind — including
 // one whose shell finished without either hook ever observing it — must not
-// survive into a session that has not started any shell of its own yet. A
-// bare printf, like the busy report's reset, since there is nothing to parse:
-// it always writes the same fixed shape.
+// survive into a session that has not started any shell of its own yet.
 func orchestratorShellActivityResetHookCommand() string {
 	dir := filepath.ToSlash(orchestratorShellActivityDir())
-	return `[ -n "$ERUN_ORCHESTRATOR_ID" ] && mkdir -p "` + dir + `" && ` +
-		`printf '{"running":false,"atUnix":%s}' "$(date +%s)" > "` + dir + `/$ERUN_ORCHESTRATOR_ID.json"` +
-		` || true`
+	script := `try{const id=process.env.ERUN_ORCHESTRATOR_ID;if(id){const fs=require("fs");` +
+		`fs.mkdirSync("` + dir + `",{recursive:true});` +
+		`fs.writeFileSync("` + dir + `/"+id+".json",JSON.stringify({running:false,atUnix:Math.floor(Date.now()/1000)}));` +
+		`}}catch(e){}`
+	return `node -e '` + script + `'`
 }
 
 // orchestratorShellActivityHookBlocks are the two PostToolUse-only hooks the

--- a/erun-ui/orchestrator_shell_activity_test.go
+++ b/erun-ui/orchestrator_shell_activity_test.go
@@ -174,14 +174,17 @@ func TestOrchestratorShellActivityHooksResolveTheirOwnOrchestrator(t *testing.T)
 	clear := shellHookBlockCommand(t, blocks[1], "TaskOutput|TaskStop")
 
 	for _, command := range []string{start, clear} {
-		if !strings.Contains(command, "$ERUN_ORCHESTRATOR_ID") {
+		if !strings.Contains(command, "process.env.ERUN_ORCHESTRATOR_ID") {
 			t.Fatalf("the hook must resolve its orchestrator at run time: %q", command)
 		}
-		if !strings.Contains(command, `[ -n "$ERUN_ORCHESTRATOR_ID" ]`) {
+		if !strings.Contains(command, "if(!id)return") {
 			t.Fatalf("the hook must skip a session with no id: %q", command)
 		}
 		if !strings.Contains(command, "node -e") {
 			t.Fatalf("the hook must parse structured JSON, not scan text: %q", command)
+		}
+		if !orchestratorHookCommandIsPortable(command) {
+			t.Fatalf("the hook must run through node, not a POSIX shell: %q", command)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Every orchestrator hook erun writes into the shared `orchestrators/.claude/settings.json` was a POSIX-sh one-liner (`[ -n ... ]` test syntax, `$(...)` command substitution, sh's `&&`/`||` chaining). Windows runs orchestrator hooks through PowerShell, which parses a leading `[` as a type literal instead of executing it, so every hook — busy/idle activity, background-shell activity, the live-conversation recorder, the no-ask Stop guard, and the SessionStart contract/role-file injector — died at parse time with `ParserError`, and the desktop's live/busy reporting and no-ask guard went silently missing on Windows (#1578).

**Resolution chosen: option 1 from the issue** — emit every hook as a single `node -e '<script>'` invocation, with all logic (env-var checks, mkdir, file reads/writes, JSON parsing) done in JS instead of shell builtins, rather than branching on `runtime.GOOS` to emit a second PowerShell-shaped hook (option 2). Two of the hooks already used this shape for their payload but wrapped it in an sh prefix — the scaffolding was the whole problem, per the issue. Node is a hard dependency of every orchestrator session already (the AI harness that launches it is itself an npm package), and a single-quoted `node -e` argument is inert to whichever shell invokes it, so the same command works identically under sh and PowerShell with **no GOOS branch needed at all** — the emitted hook command does not vary by host OS.

## What changed

- `orchestrator_activity.go`, `orchestrator_shell_activity.go`, `orchestrator_live_conversation.go`, `orchestrator.go` (no-ask Stop guard + SessionStart skill/role-file injector): every hook command builder now returns `node -e '<script>'` with no POSIX-only syntax anywhere in the command.
- Marker/detection functions (`isOrchestratorXHookBlock`) that used to grep for exact sh-quoted substrings (`"busy":`, `"conversationId":`, an env-var-name marker) now match the equivalent node-script text (directory paths, unquoted object-literal keys, `process.env.X` references) — internal implementation detail, not an external contract.
- Removed the now-unused `ERUN_SHELL_ACTIVITY_FILE` env-var indirection; the report path is computed directly inside each script from the baked-in directory and the runtime `ERUN_ORCHESTRATOR_ID`.

## How the Windows path was made testable from Linux

This pod is Linux, so the fix had to be validated as a decision, not a platform. `orchestrator_hook_portability.go` adds `orchestratorHookCommandIsPortable`, a pure function asserting a hook command is exactly one `node -e '...'` invocation with no stray single quote breaking out of the argument (which is what actually determines whether the command is inert to *any* invoking shell — a plain "no `&&`/`||` substring" check would false-positive on legitimate JS logical operators already inside the scripts). `orchestrator_hook_portability_test.go` table-tests it across `windows`, `linux`, and `darwin` labels against every hook command the module emits — since the resolution does not vary by GOOS, the same assertion holds for all three, which is the fix (a POSIX-only regression would fail identically regardless of which label the subtest is under). A second test locks in what the checker itself must keep catching (bare `[ ... ]` guards, `$(...)`, sh chaining, a quote that breaks out of the argument).

The existing exec-based tests (`orchestrator_noask_guard_test.go`'s `TestOrchestratorNoAskStopGuardDecidesOnTheTurnsLastWords`, `orchestrator_live_conversation_test.go`'s recorder round-trip tests, `orchestrator_test.go`'s `TestOrchestratorSessionStartHookReinjectsRoleFileOnClearAndCompact`) already ran the real hook commands through `sh -c` and asserted on real behavior (exit codes, file writes, re-injected stdout) — these continue to pass unchanged in shape, now exercising `node -e` instead of raw sh, which is itself evidence the rewrite preserves behavior on the platform this suite can run.

## Test plan

- [x] `go test ./...` in `erun-ui` — all orchestrator hook tests pass, including the real-exec ones
- [x] `golangci-lint run ./...` in `erun-ui` — 0 issues
- [x] `make check` — green (golangci-lint all modules, `go test erun-ui`, frontend gates, chart tests, `make integration-test` including the issue-reference baseline, coverage 76.1% >= 75.8%)

Closes #1578

🤖 Generated with [Claude Code](https://claude.com/claude-code)