### PR TITLE
Report the tracked-conversation resume notice only when it changes

### DIFF
--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -308,6 +308,7 @@ func (a *App) resolveReopenSessionID(entry orchestratorOpenEntry) (string, strin
 		return uuid.NewString(), ""
 	}
 	choice := a.resolveOrchestratorConversation(entry)
+	a.markConversationChoiceReported(entry.OrchestratorID, choice)
 	return choice.ConversationID, choice.Notice
 }
 

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1689,6 +1689,7 @@ func (a *App) conversationToLaunch(id, named string) string {
 	}
 	choice := a.resolveOrchestratorConversation(orchestratorEntryOrEmpty(
 		readOpenOrchestrators(a.deps.orchestratorOpenPath), id))
+	a.markConversationChoiceReported(id, choice)
 	if choice.Notice != "" {
 		a.emitAppNotification(orchestratorConversationNoticeKind(choice.Source), choice.Notice)
 	}

--- a/erun-ui/orchestrator_live_conversation.go
+++ b/erun-ui/orchestrator_live_conversation.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,10 +209,36 @@ func (a *App) resolveOrchestratorConversation(entry orchestratorOpenEntry) orche
 			Notice:         orchestratorTrackedConversationUnconfirmedNotice(id, record.ConversationID, derived, reason),
 		}
 	}
+	// The tracked conversation is confirmed and stands: report it only while it
+	// is new information. Once this exact tracked id has already been told to
+	// the operator, resolving to it again on every later launch has nothing new
+	// to say -- repeating a healthy steady state on every launch is what trains
+	// the operator to stop reading this notice family at all. A tracked id that
+	// changes from what was last reported is new information again and is
+	// reported.
+	notice := ""
+	if strings.TrimSpace(entry.LastReportedConversationID) != record.ConversationID {
+		notice = orchestratorResumedTrackedConversationNotice(id, record.ConversationID, derived)
+	}
 	return orchestratorConversationChoice{
 		ConversationID: record.ConversationID,
 		Source:         orchestratorConversationTracked,
-		Notice:         orchestratorResumedTrackedConversationNotice(id, record.ConversationID, derived),
+		Notice:         notice,
+	}
+}
+
+// markConversationChoiceReported persists that the operator has now been told
+// about a tracked-conversation resolution, so a later launch that resolves to
+// the SAME tracked conversation finds nothing new to say. Only the "info"
+// resolution is ever recorded here -- see orchestratorConversationNoticeKind --
+// because the three warning resolutions must keep reporting on every
+// occurrence. A no-op when there was nothing to report.
+func (a *App) markConversationChoiceReported(id string, choice orchestratorConversationChoice) {
+	if choice.Notice == "" || choice.Source != orchestratorConversationTracked {
+		return
+	}
+	if err := markOrchestratorConversationReported(a.deps.orchestratorOpenPath, id, choice.ConversationID); err != nil {
+		log.Printf("erun-app: mark orchestrator %s conversation reported: %v", id, err)
 	}
 }
 

--- a/erun-ui/orchestrator_live_conversation_test.go
+++ b/erun-ui/orchestrator_live_conversation_test.go
@@ -232,6 +232,118 @@ func TestATrackedConversationFromAnotherLaunchIsNotSilentlyAuthoritative(t *test
 	}
 }
 
+// The habituation failure this whole notice family exists to avoid: a launch
+// that resumes the SAME tracked conversation it already told the operator about
+// has nothing new to say, and must say nothing. A notice that fires on every
+// launch forever trains the operator to stop reading it -- including the three
+// warning notices that share its surface and still need to be believed every
+// time they fire.
+func TestRestoreReportsARepeatedTrackedConversationOnlyOnce(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	stageOrchestratorConversation(t, orchestratorSessionID(id))
+	stageOrchestratorConversation(t, live)
+	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
+		ConversationID: live,
+		LaunchID:       recordedLaunchID(t, openPath, id),
+	})
+
+	first := app.ResolveOrchestratorToReopen()
+	if first.ConversationID != live {
+		t.Fatalf("expected the first launch to resume the live conversation %q, got %q", live, first.ConversationID)
+	}
+	if first.Notice == "" {
+		t.Fatal("expected the first divergence between tracked and derived to be reported")
+	}
+
+	second := app.ResolveOrchestratorToReopen()
+	if second.ConversationID != live {
+		t.Fatalf("expected the second launch to resume the same live conversation %q, got %q", live, second.ConversationID)
+	}
+	if second.Notice != "" {
+		t.Fatalf("expected a launch that resumes the conversation already reported to say nothing, got %q", second.Notice)
+	}
+
+	// The record still resolves the same tracked conversation; only the notice
+	// about it is quiet the second time.
+	third := app.ResolveOrchestratorToReopen()
+	if third.Notice != "" {
+		t.Fatalf("expected a third repeat launch to stay silent too, got %q", third.Notice)
+	}
+}
+
+// A tracked conversation that changes AFTER already being reported is new
+// information again and must be reported, even though the orchestrator has
+// already been told about a previous divergence.
+func TestRestoreReportsAChangeToADifferentTrackedConversation(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	const firstLive = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	const secondLive = "22222222-3333-4444-8555-666666666666"
+	stageOrchestratorConversation(t, orchestratorSessionID(id))
+	stageOrchestratorConversation(t, firstLive)
+	stageOrchestratorConversation(t, secondLive)
+	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
+		ConversationID: firstLive,
+		LaunchID:       recordedLaunchID(t, openPath, id),
+	})
+
+	if target := app.ResolveOrchestratorToReopen(); target.Notice == "" || target.ConversationID != firstLive {
+		t.Fatalf("expected the first divergence reported and resumed, got conversation %q notice %q", target.ConversationID, target.Notice)
+	}
+	if target := app.ResolveOrchestratorToReopen(); target.Notice != "" {
+		t.Fatalf("expected the repeat of the same tracked conversation to say nothing, got %q", target.Notice)
+	}
+
+	// A new launch under the SAME entry's launch id, whose session now reports a
+	// different conversation than the one already reported.
+	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
+		ConversationID: secondLive,
+		LaunchID:       recordedLaunchID(t, openPath, id),
+	})
+	target := app.ResolveOrchestratorToReopen()
+	if target.ConversationID != secondLive {
+		t.Fatalf("expected the changed tracked conversation %q resumed, got %q", secondLive, target.ConversationID)
+	}
+	if target.Notice == "" {
+		t.Fatal("expected a change to a different tracked conversation to be reported")
+	}
+	if target := app.ResolveOrchestratorToReopen(); target.Notice != "" {
+		t.Fatalf("expected the repeat of the newly reported conversation to say nothing, got %q", target.Notice)
+	}
+}
+
+// A warning resolution is not a steady state to acclimatise to; it is
+// something that just went wrong, and it must say so on every occurrence, not
+// only the first. A record from an earlier, replaced launch stays wrong on
+// every later launch too.
+func TestAnUnconfirmedTrackedConversationIsReportedOnEveryLaunch(t *testing.T) {
+	app, _, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	id := createAndStartOrchestrator(t, app)
+	const stranded = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	stageOrchestratorConversation(t, orchestratorSessionID(id))
+	stageOrchestratorConversation(t, stranded)
+	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
+		ConversationID: stranded,
+		LaunchID:       "a-launch-that-is-not-this-one",
+	})
+
+	first := app.ResolveOrchestratorToReopen()
+	second := app.ResolveOrchestratorToReopen()
+	for _, target := range []relaunchTarget{first, second} {
+		if !strings.Contains(target.Notice, stranded) {
+			t.Fatalf("expected every launch to report the unconfirmed conversation, got %q", target.Notice)
+		}
+	}
+}
+
 // The same refusal for a record whose conversation is gone: resuming nothing is
 // safer than resuming the wrong thing, and either way the operator hears it.
 func TestATrackedConversationWithNoTranscriptFallsBackAndSaysSo(t *testing.T) {

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -69,6 +69,16 @@ type orchestratorOpenEntry struct {
 	// release wrote, which restore treats as unknown rather than a guaranteed
 	// match.
 	Environments []string `json:"environments,omitempty"`
+	// LastReportedConversationID is the tracked conversation id this
+	// orchestrator's operator was last told about (see
+	// orchestratorResumedTrackedConversationNotice). Resolving to the SAME
+	// tracked conversation again has nothing new to say and stays silent;
+	// resolving to a different one is new information and is reported, which is
+	// what stops the notice from repeating forever once a divergence has already
+	// been explained. It only tracks the "info" resolution -- a warning
+	// (unconfirmed record, refused attachment) reports on every occurrence by
+	// design and never updates this.
+	LastReportedConversationID string `json:"lastReportedConversationId,omitempty"`
 }
 
 type orchestratorOpenState struct {
@@ -112,7 +122,9 @@ func recordOpenOrchestrator(path, orchestratorID, launchID string, scope []strin
 		return nil
 	}
 	entries := readOpenOrchestrators(path)
-	attached := strings.TrimSpace(orchestratorEntryOrEmpty(entries, orchestratorID).AttachedConversationID)
+	existing := orchestratorEntryOrEmpty(entries, orchestratorID)
+	attached := strings.TrimSpace(existing.AttachedConversationID)
+	lastReported := strings.TrimSpace(existing.LastReportedConversationID)
 	out := make([]orchestratorOpenEntry, 0, len(entries)+1)
 	for _, entry := range entries {
 		if entry.OrchestratorID == orchestratorID {
@@ -121,10 +133,11 @@ func recordOpenOrchestrator(path, orchestratorID, launchID string, scope []strin
 		out = append(out, entry)
 	}
 	out = append(out, orchestratorOpenEntry{
-		OrchestratorID:         orchestratorID,
-		LaunchID:               strings.TrimSpace(launchID),
-		AttachedConversationID: attached,
-		Environments:           scope,
+		OrchestratorID:             orchestratorID,
+		LaunchID:                   strings.TrimSpace(launchID),
+		AttachedConversationID:     attached,
+		Environments:               scope,
+		LastReportedConversationID: lastReported,
 	})
 	return writeOpenOrchestrators(path, out)
 }
@@ -152,6 +165,39 @@ func setAttachedOrchestratorConversation(path, orchestratorID, conversationID st
 		entries = append(entries, orchestratorOpenEntry{
 			OrchestratorID:         orchestratorID,
 			AttachedConversationID: strings.TrimSpace(conversationID),
+		})
+	}
+	return writeOpenOrchestrators(path, entries)
+}
+
+// markOrchestratorConversationReported records the tracked conversation id an
+// orchestrator's operator was just told about, so a later launch that resolves
+// the SAME tracked conversation again finds nothing new to say. Called only for
+// the "info" resolution (see orchestratorConversationNoticeKind); a warning
+// resolution reports every occurrence and never calls this. Creates the entry
+// when none exists yet, mirroring setAttachedOrchestratorConversation.
+func markOrchestratorConversationReported(path, orchestratorID, conversationID string) error {
+	orchestratorID = strings.TrimSpace(orchestratorID)
+	if path == "" || orchestratorID == "" {
+		return nil
+	}
+	conversationID = strings.TrimSpace(conversationID)
+	entries := readOpenOrchestrators(path)
+	found := false
+	for i, entry := range entries {
+		if entry.OrchestratorID != orchestratorID {
+			continue
+		}
+		if entry.LastReportedConversationID == conversationID {
+			return nil
+		}
+		entries[i].LastReportedConversationID = conversationID
+		found = true
+	}
+	if !found {
+		entries = append(entries, orchestratorOpenEntry{
+			OrchestratorID:             orchestratorID,
+			LastReportedConversationID: conversationID,
 		})
 	}
 	return writeOpenOrchestrators(path, entries)
@@ -231,10 +277,11 @@ func dedupOrchestratorEntries(entries []orchestratorOpenEntry) []orchestratorOpe
 		}
 		seen[id] = struct{}{}
 		out = append(out, orchestratorOpenEntry{
-			OrchestratorID:         id,
-			LaunchID:               strings.TrimSpace(entry.LaunchID),
-			AttachedConversationID: strings.TrimSpace(entry.AttachedConversationID),
-			Environments:           entry.Environments,
+			OrchestratorID:             id,
+			LaunchID:                   strings.TrimSpace(entry.LaunchID),
+			AttachedConversationID:     strings.TrimSpace(entry.AttachedConversationID),
+			Environments:               entry.Environments,
+			LastReportedConversationID: strings.TrimSpace(entry.LastReportedConversationID),
 		})
 	}
 	if len(out) == 0 {


### PR DESCRIPTION
## Summary

Closes #1577.

An orchestrator whose live conversation ever diverged from its derived anchor reported the "resumed the tracked conversation" notice on **every single launch, forever** — training the operator to ignore the notice family, including the three `warning` resolutions that share its surface and actually need attention every time they fire.

**Fix: report the change, not the steady state.** `orchestratorOpenEntry` gains a durable `LastReportedConversationID` field — the tracked conversation id this orchestrator's operator was last told about. `resolveOrchestratorConversation` now reports the "info" tracked notice only when the resolved tracked conversation differs from that stored id; resolving to the same tracked conversation again has nothing new to say and stays silent. A launch call site (`conversationToLaunch` for an ordinary start, `resolveReopenSessionID` for restore/AlsoReopen) persists the id once it reports it, via `markOrchestratorConversationReported`. `recordOpenOrchestrator` carries the field forward on every relaunch the same way it already carries `AttachedConversationID`, so the marker survives across launches.

**The three `warning` resolutions are untouched** — an unconfirmed record and a refused attachment still report on every occurrence, by design, since those are never a steady state to acclimatise to.

`ListOrchestratorConversations` (the Manage dialog's read-only listing) stays a pure read: it calls the same `resolveOrchestratorConversation`, so it reflects the same "already told you" comparison naturally, with no dialog-specific special-casing needed. This matches the acceptance criterion that the Manage dialog still lists every resumable conversation with its status.

## Where the notice now fires

- The first launch on which the tracked conversation is observed to differ from the derived anchor.
- Any later launch where the tracked conversation differs from the one last reported for this orchestrator (a genuine change, e.g. the session moved to a different conversation again).
- Never on a launch that resolves to the exact tracked conversation already reported — that is the healthy steady state the mechanism is designed to reach, and repeating it is what caused the habituation this issue describes.

## Tests

Added to `erun-ui/orchestrator_live_conversation_test.go`:
- `TestRestoreReportsARepeatedTrackedConversationOnlyOnce` — the **silent case**: two, then three, consecutive `ResolveOrchestratorToReopen()` calls against the same tracked/derived divergence report the notice once and stay silent after.
- `TestRestoreReportsAChangeToADifferentTrackedConversation` — a tracked conversation that changes to a *different* one after already being reported is new information and is reported again, then goes silent on repeat.
- `TestAnUnconfirmedTrackedConversationIsReportedOnEveryLaunch` — a `warning`-tier unconfirmed record keeps reporting on every occurrence, unchanged.

I verified both silent-case tests fail against the unfixed code: temporarily reverted just the non-test source files (`app_restart.go`, `orchestrator.go`, `orchestrator_live_conversation.go`, `orchestrator_open_state.go`) on top of the new test file and reran — both failed with the repeated notice text on the second launch, confirming the tests exercise the actual defect, then restored the fix and confirmed green.

## UX Impact Review Checklist (erun-ui/AGENTS.md)

1. **Affected paths.** `ResolveOrchestratorToReopen` (desktop boot restore, and the restart hand-off's AlsoReopen set) and the ordinary "start an orchestrator" click (`conversationToLaunch` inside `spawnOrchestratorSession`).
2. **User-visible sequence.** On boot, `restoreOpenOrchestrators` dispatches `setOrchestratorsError(notice)` beside the orchestrator list only when there is something new to say; previously it dispatched on every boot regardless. On an ordinary start, `emitAppNotification` fires the same way, only when new. The Manage dialog's Conversation section (`ListOrchestratorConversations`) is unaffected in shape; its editorial notice text now also naturally quiets once the same divergence has been explained, since it reads the same resolution.
3. **State-without-affordance.** N/A — no new state field is rendered; this changes when an existing notice string is populated.
4. **Visibility of system status.** Unchanged: the notice, when it fires, still surfaces exactly where it did (restore's inline `role="status"`/error line beside the orchestrator list, and the titlebar `AppNotification` for an ordinary start).
5. **Success/failure feedback.** N/A, not a success/failure action.
6. **Consistency with comparable flows.** The three warning resolutions (unconfirmed record, refused attachment) are deliberately left firing on every occurrence — consistent with `erun-ui/AGENTS.md`'s existing decision that "a resolution that is not the plain answer is reported, never silent," which this PR does not weaken for warnings.
7. **Nielsen heuristics.** #1 (visibility of system status) is the one this PR is about: a notice that no longer carries new information is noise that degrades visibility of the notices that do. No other heuristic is implicated by this change.
8. **Playwright coverage.** No new/modified Playwright spec. This change is Go-only: it changes *when* `resolveOrchestratorConversation` populates its `Notice` string, never the wire shape of `relaunchTarget`/`orchestratorConversations`, never how the frontend displays whatever notice string arrives (already covered by the existing `orchestratorRestore.test.ts` and `OrchestratorDialog.Conversations.helpers.test.ts` frontend unit tests, both unmodified and still passing). Reproducing the divergence itself requires a real orchestrator session's hooks reporting a live conversation under a specific launch nonce — the same "real Codex/Claude session" case `erun-ui/AGENTS.md` § "End-to-end UI tests" names as unreachable by the headless harness; the closest observable invariant is covered by the Go tests above. The full Playwright suite (409 tests) was still run for regression confidence and is green.

## Validation

- `make check` — green (golangci-lint across all modules: 0 issues; `go test ./...` for erun-ui; erun-kit/erun-console typecheck+lint+format+build; chart tests; `make integration-test` with coverage 76.1% ≥ 75.8% threshold).
- `./playwright/run.sh` — 409 passed.