### PR TITLE
Report a leased environment as busy even when this desktop has not opened it

### DIFF
--- a/erun-ui/environment_activity.go
+++ b/erun-ui/environment_activity.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -58,6 +59,14 @@ type environmentActivityState struct {
 	// other field here renders such an environment exactly like an idle one, or
 	// like one nobody ever opened.
 	outage bool
+	// checkFailed is outage's counterpart for the other channel this poller
+	// reads: an environment with no local forward is not left unasked just
+	// because this desktop never opened it, but the fallback check (over
+	// kubectl exec, see observeEnvironmentActivityViaPod) can itself fail to
+	// answer. That must not collapse into the same "nobody opened it" reading
+	// a never-checked environment gets — a real attempt that came back empty is
+	// its own condition, not silence.
+	checkFailed bool
 	// detail names what is keeping the environment busy, in the operator's
 	// language, so the row can say "held by gradle-build" rather than "busy".
 	detail string
@@ -108,23 +117,24 @@ func (a *App) configuredSelections() []uiSelection {
 	return out
 }
 
-// observeEnvironmentActivity is deliberately cheap for the common case. An
-// environment nobody opened costs one small file read and nothing else — no
-// config resolution, no dial, no HTTP — because most environments in a
-// configured store are not running at any given moment, and this sweep runs
-// forever beside the desktop's own work.
+// observeEnvironmentActivity is deliberately cheap for the common case of an
+// environment this desktop has open: one loopback dial, and an HTTP call only
+// for the ones that answer. An environment with no local forward is not the
+// common case's "leave it alone" anymore (see observeEnvironmentActivityViaPod)
+// — the activity lease this poller looks for is environment-side state, not
+// desktop-side, so a CLI- or agent-driven environment must be askable too.
 func (a *App) observeEnvironmentActivity(selection uiSelection) environmentActivity {
 	observation := environmentActivity{selection: selection}
 	// Reachability is "a forward was established for this environment and its
 	// edge answers" — not "some process holds that port". The state file is what
 	// distinguishes the two, and `erun open` writes it whoever ran it, which is
-	// what makes a CLI-opened environment visible here at all. It is also the
-	// only record that this environment was ever open, so its absence is the
-	// line the sweep does not cross: an environment nobody opened is left alone.
+	// what makes a CLI-opened environment visible here at all. Its absence only
+	// means this desktop has no local forward; it does not mean nobody is using
+	// the environment, so the fallback below still asks.
 	forward, established, err := eruncommon.LoadPortForwardState("mcp", selection.Tenant, selection.Environment)
 	if err != nil || !established {
 		a.forgetForwardRepair(selection)
-		return observation
+		return a.observeEnvironmentActivityViaPod(selection, observation)
 	}
 	if a.deps.canConnectLocalPort == nil {
 		// Nothing was observed, so there is nothing to diagnose. An unanswerable
@@ -169,6 +179,60 @@ func (a *App) observeEnvironmentActivity(selection uiSelection) environmentActiv
 		return observation
 	}
 	a.forgetForwardRepair(selection)
+	observation.state.observed = true
+	observation.state.busy, observation.state.detail = environmentBusyFromIdleStatus(status)
+	return observation
+}
+
+// environmentActivityPodProbeTimeout bounds the kubectl-exec fallback below.
+// It is looser than environmentActivityTimeout's loopback-dial budget because
+// a pod exec is a real round trip to the cluster's API server, not a dial to
+// this machine, but it still has to stay short enough that one wedged cluster
+// cannot stall the rest of the sweep for long.
+const environmentActivityPodProbeTimeout = 8 * time.Second
+
+// observeEnvironmentActivityViaPod is the fallback for an environment this
+// desktop has no local MCP forward for. An operator driving the environment
+// from a CLI, or an agent holding it from another machine entirely, is the
+// ordinary case erun is built for, not an error — so "no local forward" must
+// not read as "nobody is using this". The environment's own activity lease is
+// readable straight from its runtime pod, the same way runtime_activity.go
+// already reads pod state the MCP edge cannot: over kubectl exec, without
+// ever establishing a forward of its own. `erun idle --json` run inside the
+// pod answers from the pod's own local store (see erun-cli's
+// environmentTargetsItself), so this is one exec, not a repeat of the network
+// hop the desktop cannot make.
+func (a *App) observeEnvironmentActivityViaPod(selection uiSelection, observation environmentActivity) environmentActivity {
+	if a.deps.store == nil {
+		return observation
+	}
+	envConfig, _, err := a.deps.store.LoadEnvConfig(selection.Tenant, selection.Environment)
+	if err != nil || strings.TrimSpace(envConfig.KubernetesContext) == "" {
+		// This environment has never named a cluster it could be running in, so
+		// there is nothing to ask — "not open here" already says everything
+		// there is to say about it.
+		return observation
+	}
+	parent := a.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, environmentActivityPodProbeTimeout)
+	defer cancel()
+	script := fmt.Sprintf("erun idle %s %s --json", shellQuote(selection.Tenant), shellQuote(selection.Environment))
+	output, err := a.execInRuntimePod(ctx, selection, script)
+	if err != nil {
+		// A real attempt that did not come back is not the same silence as
+		// never asking — see checkFailed's own comment.
+		observation.state.checkFailed = true
+		return observation
+	}
+	var status eruncommon.EnvironmentIdleStatus
+	if err := json.Unmarshal([]byte(output), &status); err != nil {
+		observation.state.checkFailed = true
+		return observation
+	}
+	observation.state.reachable = true
 	observation.state.observed = true
 	observation.state.busy, observation.state.detail = environmentBusyFromIdleStatus(status)
 	return observation
@@ -241,11 +305,12 @@ func (a *App) seedEnvironmentActivitySnapshots(state *uiState) {
 				continue
 			}
 			env.Activity = &uiEnvironmentActivitySnapshot{
-				Reachable: observed.reachable,
-				Observed:  observed.observed,
-				Outage:    observed.outage,
-				Busy:      observed.busy,
-				Detail:    observed.detail,
+				Reachable:   observed.reachable,
+				Observed:    observed.observed,
+				Outage:      observed.outage,
+				CheckFailed: observed.checkFailed,
+				Busy:        observed.busy,
+				Detail:      observed.detail,
 			}
 		}
 	}
@@ -275,6 +340,7 @@ func (a *App) emitEnvActivity(observation environmentActivity) {
 		Reachable:   observation.state.reachable,
 		Observed:    observation.state.observed,
 		Outage:      observation.state.outage,
+		CheckFailed: observation.state.checkFailed,
 		Busy:        observation.state.busy,
 		Detail:      observation.state.detail,
 	})

--- a/erun-ui/environment_activity_observed_test.go
+++ b/erun-ui/environment_activity_observed_test.go
@@ -131,8 +131,8 @@ func TestEnvActivityStateComparesTheVerdict(t *testing.T) {
 	}
 }
 
-// erun#1572: an environment not open in this desktop is not the same as an
-// environment nobody is using. The activity lease this poller looks for is
+// An environment not open in this desktop is not the same as an environment
+// nobody is using. The activity lease this poller looks for is
 // environment-side state, held by whatever is driving the environment — a CLI
 // orchestrator, an agent over MCP from another machine — not by whoever
 // happened to open a local forward to it. These tests lock in the fallback

--- a/erun-ui/environment_activity_observed_test.go
+++ b/erun-ui/environment_activity_observed_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/adrg/xdg"
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -127,5 +128,117 @@ func TestEnvActivityStateComparesTheVerdict(t *testing.T) {
 	silent := environmentActivityState{reachable: true}
 	if answered == silent {
 		t.Fatal("the verdict must take part in the transition check")
+	}
+}
+
+// erun#1572: an environment not open in this desktop is not the same as an
+// environment nobody is using. The activity lease this poller looks for is
+// environment-side state, held by whatever is driving the environment — a CLI
+// orchestrator, an agent over MCP from another machine — not by whoever
+// happened to open a local forward to it. These tests lock in the fallback
+// that asks such an environment directly, over its own runtime pod, instead
+// of reporting "not open here" about one that might be busy right now.
+
+func observeViaPodWith(
+	t *testing.T,
+	kubernetesContext string,
+	execRuntimePod func(context.Context, uiSelection, string) (string, error),
+) environmentActivityState {
+	t.Helper()
+	store := stubUIStore{envs: map[string]eruncommon.EnvConfig{
+		"acme/dev": {Name: "dev", KubernetesContext: kubernetesContext},
+	}}
+	app := NewApp(erunUIDeps{store: store, execRuntimePod: execRuntimePod})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	selection := uiSelection{Tenant: "acme", Environment: "dev"}
+	return app.observeEnvironmentActivityViaPod(selection, environmentActivity{selection: selection}).state
+}
+
+// TestObserveEnvironmentActivityViaPodReportsAHeldLease is the exact case that
+// was broken: an environment this desktop never opened, but that another
+// session is holding busy right now, must read as busy — not as unreachable.
+func TestObserveEnvironmentActivityViaPodReportsAHeldLease(t *testing.T) {
+	got := observeViaPodWith(t, "ctx", func(context.Context, uiSelection, string) (string, error) {
+		status := eruncommon.EnvironmentIdleStatus{
+			Leases: []eruncommon.EnvironmentActivityLease{
+				{ID: "job-fix-1570", Name: "job-fix-1570", ExpiresAt: time.Now().Add(time.Hour)},
+			},
+			Markers: []eruncommon.EnvironmentIdleMarker{{Name: "lease", Idle: false}},
+		}
+		data, err := json.Marshal(status)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		return string(data), nil
+	})
+	if !got.reachable || !got.observed {
+		t.Fatalf("a pod that answers is reachable and observed, got %+v", got)
+	}
+	if !got.busy || got.detail != "holding: job-fix-1570" {
+		t.Fatalf("a held lease must read as busy and name the holder, got %+v", got)
+	}
+	if got.checkFailed {
+		t.Fatalf("a successful probe is not a failed check, got %+v", got)
+	}
+}
+
+// TestObserveEnvironmentActivityViaPodReportsIdle is the other real answer: the
+// pod is reachable and genuinely has nothing running.
+func TestObserveEnvironmentActivityViaPodReportsIdle(t *testing.T) {
+	got := observeViaPodWith(t, "ctx", func(context.Context, uiSelection, string) (string, error) {
+		data, err := json.Marshal(eruncommon.EnvironmentIdleStatus{
+			Markers: []eruncommon.EnvironmentIdleMarker{{Name: eruncommon.ActivityKindProcess, Idle: true}},
+		})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		return string(data), nil
+	})
+	if !got.reachable || !got.observed || got.busy || got.checkFailed {
+		t.Fatalf("an idle pod answer must not read as busy or unconfirmed, got %+v", got)
+	}
+}
+
+// TestObserveEnvironmentActivityViaPodNamesAFailedCheckDistinctly is the third
+// state this fallback introduces: a real attempt that did not come back must
+// not collapse into "nobody asked" — see checkFailed's own comment.
+func TestObserveEnvironmentActivityViaPodNamesAFailedCheckDistinctly(t *testing.T) {
+	got := observeViaPodWith(t, "ctx", func(context.Context, uiSelection, string) (string, error) {
+		return "", errors.New("kubectl exec: the connection to the server was refused")
+	})
+	if got.reachable || got.observed || got.busy {
+		t.Fatalf("a failed probe carries no verdict about the environment, got %+v", got)
+	}
+	if !got.checkFailed {
+		t.Fatal("a real attempt that failed must be named distinctly from never asking")
+	}
+}
+
+// TestObserveEnvironmentActivityViaPodNamesAFailedCheckOnGarbledOutput covers
+// the other failure shape: the exec succeeded but what came back cannot be
+// trusted as the environment's answer.
+func TestObserveEnvironmentActivityViaPodNamesAFailedCheckOnGarbledOutput(t *testing.T) {
+	got := observeViaPodWith(t, "ctx", func(context.Context, uiSelection, string) (string, error) {
+		return "not json", nil
+	})
+	if got.reachable || got.observed || got.busy {
+		t.Fatalf("unparseable output carries no verdict about the environment, got %+v", got)
+	}
+	if !got.checkFailed {
+		t.Fatal("unparseable output must be named as a failed check, not silence")
+	}
+}
+
+// TestObserveEnvironmentActivityViaPodSkipsEnvironmentsWithNoCluster is the
+// cheap-common-case guard: an environment that has never named a cluster it
+// could run in has nothing to probe, so it must not pay for an exec attempt
+// that could only ever fail.
+func TestObserveEnvironmentActivityViaPodSkipsEnvironmentsWithNoCluster(t *testing.T) {
+	got := observeViaPodWith(t, "", func(context.Context, uiSelection, string) (string, error) {
+		t.Fatal("an environment with no kubernetes context must never be exec'd into")
+		return "", nil
+	})
+	if got.reachable || got.observed || got.busy || got.checkFailed {
+		t.Fatalf("an environment with no cluster reports nothing, got %+v", got)
 	}
 }

--- a/erun-ui/environment_forward_repair_test.go
+++ b/erun-ui/environment_forward_repair_test.go
@@ -243,16 +243,15 @@ func TestDroppedForwardIsNotRestartedTwiceByOverlappingSweeps(t *testing.T) {
 }
 
 // TestUnopenedEnvironmentIsProbedButNeverRebound is the guard the dropped case
-// makes load-bearing, updated for erun#1572: "no forward is bound" describes
-// an environment nobody opened here and an environment whose forward just
-// died equally well, and only the second may trigger the rebind/reconnect
-// machinery this file exists to test. It no longer describes "reports
-// nothing" — an environment nobody opened here can still be busy right now
-// (a CLI orchestrator, an agent driving it over MCP from another machine), so
-// the sweep asks it directly over its runtime pod instead of leaving it
-// silent. What must stay true is that this read-only ask never feeds the
-// forward-repair episode: no rebind, no outage, because there was never a
-// forward here to repair.
+// makes load-bearing: "no forward is bound" describes an environment nobody
+// opened here and an environment whose forward just died equally well, and
+// only the second may trigger the rebind/reconnect machinery this file exists
+// to test. It no longer describes "reports nothing" — an environment nobody
+// opened here can still be busy right now (a CLI orchestrator, an agent
+// driving it over MCP from another machine), so the sweep asks it directly
+// over its runtime pod instead of leaving it silent. What must stay true is
+// that this read-only ask never feeds the forward-repair episode: no rebind,
+// no outage, because there was never a forward here to repair.
 func TestUnopenedEnvironmentIsProbedButNeverRebound(t *testing.T) {
 	probe := &forwardRepairProbe{forwardDropped: true, repairs: true}
 	app, emits := forwardRepairTestApp(t, probe, nil)

--- a/erun-ui/environment_forward_repair_test.go
+++ b/erun-ui/environment_forward_repair_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -121,6 +122,21 @@ func forwardRepairTestApp(
 			return probe.reconnect()
 		},
 		readRuntimeRunState: readRunState,
+		// Only "erun/fresh" (no seeded forward) ever reaches this: every other
+		// selection in this file has a forward state file seeded above, so it
+		// resolves through the reachable/outage branches this file exists to
+		// test and never falls back to a pod probe. Idle-and-not-busy is a
+		// neutral default so that fallback answering does not itself look like
+		// a failure in tests that do not care about it.
+		execRuntimePod: func(context.Context, uiSelection, string) (string, error) {
+			data, err := json.Marshal(eruncommon.EnvironmentIdleStatus{
+				Markers: []eruncommon.EnvironmentIdleMarker{{Name: eruncommon.ActivityKindProcess, Idle: true}},
+			})
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
+		},
 	})
 	// A non-nil ctx un-gates the rebind (it no-ops while ctx is nil); the
 	// emitter must be stubbed alongside it or emits reach the real Wails
@@ -226,27 +242,36 @@ func TestDroppedForwardIsNotRestartedTwiceByOverlappingSweeps(t *testing.T) {
 	}
 }
 
-// TestUnopenedEnvironmentIsUntouched is the guard the dropped case makes
-// load-bearing. "No forward is bound" describes an environment nobody opened
-// and an environment whose forward just died equally well, and only the second
-// may be acted on. The recorded forward is the entire difference, so an
-// environment without one gets no rebind, no episode and no outage.
-func TestUnopenedEnvironmentIsUntouched(t *testing.T) {
+// TestUnopenedEnvironmentIsProbedButNeverRebound is the guard the dropped case
+// makes load-bearing, updated for erun#1572: "no forward is bound" describes
+// an environment nobody opened here and an environment whose forward just
+// died equally well, and only the second may trigger the rebind/reconnect
+// machinery this file exists to test. It no longer describes "reports
+// nothing" — an environment nobody opened here can still be busy right now
+// (a CLI orchestrator, an agent driving it over MCP from another machine), so
+// the sweep asks it directly over its runtime pod instead of leaving it
+// silent. What must stay true is that this read-only ask never feeds the
+// forward-repair episode: no rebind, no outage, because there was never a
+// forward here to repair.
+func TestUnopenedEnvironmentIsProbedButNeverRebound(t *testing.T) {
 	probe := &forwardRepairProbe{forwardDropped: true, repairs: true}
 	app, emits := forwardRepairTestApp(t, probe, nil)
 	unopened := uiSelection{Tenant: "erun", Environment: "fresh"}
 
 	for range forwardRepairAttempts + 2 {
 		state := sweepEnvUntilRebindSettles(t, app, unopened)
-		if state.reachable || state.observed || state.outage {
-			t.Fatalf("an environment nobody opened reports nothing, got %+v", state)
+		if state.outage || state.checkFailed {
+			t.Fatalf("a successful pod probe is neither an outage nor a failed check, got %+v", state)
+		}
+		if !state.reachable || !state.observed || state.busy {
+			t.Fatalf("an idle pod probe reports the environment idle, got %+v", state)
 		}
 	}
 	if got := probe.count(); got != 0 {
-		t.Fatalf("an environment nobody opened was opened by %d rebinds, want 0", got)
+		t.Fatalf("an environment with no recorded forward was rebound %d times, want 0", got)
 	}
 	if got := notificationsFromSource(emits, notificationSourceForwardOutage); len(got) != 0 {
-		t.Fatalf("an environment nobody opened reported %d outages, want 0", len(got))
+		t.Fatalf("an environment with no recorded forward reported %d outages, want 0", len(got))
 	}
 }
 

--- a/erun-ui/frontend/src/app/envActivitySeed.test.ts
+++ b/erun-ui/frontend/src/app/envActivitySeed.test.ts
@@ -29,7 +29,14 @@ test('an env with a busy observation seeds its activity from the snapshot alone'
   assert.deepEqual(seed, [
     {
       key: selectionKey({ tenant: 'acme', environment: 'dev' }),
-      activity: { reachable: true, observed: true, outage: false, busy: true, detail: 'ai' },
+      activity: {
+        reachable: true,
+        observed: true,
+        outage: false,
+        checkFailed: false,
+        busy: true,
+        detail: 'ai',
+      },
     },
   ]);
 });
@@ -51,11 +58,25 @@ test('mixed observed and unobserved envs across tenants seed only the observed o
   assert.deepEqual(seed, [
     {
       key: selectionKey({ tenant: 'acme', environment: 'dev' }),
-      activity: { reachable: true, observed: true, outage: false, busy: false, detail: '' },
+      activity: {
+        reachable: true,
+        observed: true,
+        outage: false,
+        checkFailed: false,
+        busy: false,
+        detail: '',
+      },
     },
     {
       key: selectionKey({ tenant: 'other', environment: 'main' }),
-      activity: { reachable: false, observed: false, outage: true, busy: false, detail: '' },
+      activity: {
+        reachable: false,
+        observed: false,
+        outage: true,
+        checkFailed: false,
+        busy: false,
+        detail: '',
+      },
     },
   ]);
 });

--- a/erun-ui/frontend/src/app/envActivitySeed.ts
+++ b/erun-ui/frontend/src/app/envActivitySeed.ts
@@ -22,7 +22,11 @@ export function planEnvActivitySeed(
       }
       seed.push({
         key: selectionKey({ tenant: tenant.name, environment: environment.name }),
-        activity: { ...environment.activity, detail: environment.activity.detail ?? '' },
+        activity: {
+          ...environment.activity,
+          detail: environment.activity.detail ?? '',
+          checkFailed: environment.activity.checkFailed === true,
+        },
       });
     }
   }

--- a/erun-ui/frontend/src/app/model/envActivityPayload.ts
+++ b/erun-ui/frontend/src/app/model/envActivityPayload.ts
@@ -11,6 +11,7 @@ export interface EnvActivityPayload {
   reachable: boolean;
   observed: boolean;
   outage?: boolean;
+  checkFailed?: boolean;
   busy: boolean;
   detail?: string;
 }

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
@@ -70,6 +70,48 @@ test('never observed (no activity at all) reads unreachable, not idle', () => {
   assert.notEqual(line.state, 'idle');
 });
 
+// erun#1572: an environment held busy by an agent driving it from elsewhere
+// (a CLI orchestrator, another machine over MCP) must not read as "not open
+// here" just because this desktop never opened a local forward to it. The
+// poller now asks such an environment directly and can still find it busy.
+test('a lease held by a session driving the environment from elsewhere still reads busy', () => {
+  const line = orchestratorEnvironmentLine(
+    env({
+      activity: {
+        reachable: true,
+        observed: true,
+        outage: false,
+        busy: true,
+        detail: 'holding: job-fix-1570',
+      },
+    }),
+  );
+  assert.equal(line.state, 'busy');
+  assert.equal(line.status, 'Busy — holding: job-fix-1570');
+  assert.notEqual(line.status, 'Not open here');
+});
+
+test('a failed attempt to reach an unopened environment reads distinctly from never asking', () => {
+  const line = orchestratorEnvironmentLine(
+    env({
+      activity: { reachable: false, observed: false, outage: false, checkFailed: true, busy: false },
+    }),
+  );
+  assert.equal(line.state, 'check-failed');
+  assert.notEqual(line.state, 'unreachable');
+  assert.notEqual(line.state, 'idle');
+  assert.ok(line.status.toLowerCase().includes('open it'), 'the message should name the recovery action');
+});
+
+test('an outage still wins over a failed check, the same way it wins over busy', () => {
+  const line = orchestratorEnvironmentLine(
+    env({
+      activity: { reachable: false, observed: false, outage: true, checkFailed: true, busy: false },
+    }),
+  );
+  assert.equal(line.state, 'outage');
+});
+
 test('a joined usage reading renders its compact headline on the line', () => {
   const line = orchestratorEnvironmentLine(
     env({

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
@@ -70,10 +70,10 @@ test('never observed (no activity at all) reads unreachable, not idle', () => {
   assert.notEqual(line.state, 'idle');
 });
 
-// erun#1572: an environment held busy by an agent driving it from elsewhere
-// (a CLI orchestrator, another machine over MCP) must not read as "not open
-// here" just because this desktop never opened a local forward to it. The
-// poller now asks such an environment directly and can still find it busy.
+// An environment held busy by an agent driving it from elsewhere (a CLI
+// orchestrator, another machine over MCP) must not read as "not open here"
+// just because this desktop never opened a local forward to it. The poller
+// now asks such an environment directly and can still find it busy.
 test('a lease held by a session driving the environment from elsewhere still reads busy', () => {
   const line = orchestratorEnvironmentLine(
     env({
@@ -94,13 +94,22 @@ test('a lease held by a session driving the environment from elsewhere still rea
 test('a failed attempt to reach an unopened environment reads distinctly from never asking', () => {
   const line = orchestratorEnvironmentLine(
     env({
-      activity: { reachable: false, observed: false, outage: false, checkFailed: true, busy: false },
+      activity: {
+        reachable: false,
+        observed: false,
+        outage: false,
+        checkFailed: true,
+        busy: false,
+      },
     }),
   );
   assert.equal(line.state, 'check-failed');
   assert.notEqual(line.state, 'unreachable');
   assert.notEqual(line.state, 'idle');
-  assert.ok(line.status.toLowerCase().includes('open it'), 'the message should name the recovery action');
+  assert.ok(
+    line.status.toLowerCase().includes('open it'),
+    'the message should name the recovery action',
+  );
 });
 
 test('an outage still wins over a failed check, the same way it wins over busy', () => {

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
@@ -14,7 +14,7 @@ import type { StatusDotState } from '@/components/app/Sidebar.StatusDot';
 // its own runtime pod), so a failed attempt to answer is its own state, not a
 // re-use of "unreachable" — an environment nobody opened here can be busy
 // right now, so "unreachable" must stay reserved for one nothing has ever
-// asked (erun#1572).
+// asked.
 export type OrchestratorEnvironmentState =
   | 'outage'
   | 'unreachable'

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
@@ -9,17 +9,28 @@ import type { StatusDotState } from '@/components/app/Sidebar.StatusDot';
 // to a naive summary, but they are different operator situations (a forward
 // that died vs. one that was never opened), and observed=false must not
 // collapse into idle just because busy is also false -- that would report a
-// state nobody actually confirmed.
-export type OrchestratorEnvironmentState = 'outage' | 'unreachable' | 'unknown' | 'busy' | 'idle';
+// state nobody actually confirmed. checkFailed is the same split applied to an
+// environment with no local forward: the poller still asks it directly (over
+// its own runtime pod), so a failed attempt to answer is its own state, not a
+// re-use of "unreachable" — an environment nobody opened here can be busy
+// right now, so "unreachable" must stay reserved for one nothing has ever
+// asked (erun#1572).
+export type OrchestratorEnvironmentState =
+  | 'outage'
+  | 'unreachable'
+  | 'check-failed'
+  | 'unknown'
+  | 'busy'
+  | 'idle';
 
 export interface OrchestratorEnvironmentLine {
   key: string;
   name: string;
   state: OrchestratorEnvironmentState;
   status: string;
-  // dot is omitted for the two states with no shared StatusDotGlyph shape
-  // (unreachable, unknown) rather than reusing 'stopped' or 'failed' for them
-  // and losing the distinction those two exist to preserve.
+  // dot is omitted for the three states with no shared StatusDotGlyph shape
+  // (unreachable, check-failed, unknown) rather than reusing 'stopped' or
+  // 'failed' for them and losing the distinction those exist to preserve.
   dot?: StatusDotState;
   // usage is the compact CPU/memory figure from the usage sweep's cached
   // reading for this env (environment_usage.go), '' when there is nothing
@@ -44,6 +55,21 @@ export function orchestratorEnvironmentLine(env: OrchestratorEnvRef): Orchestrat
       state: 'outage',
       status: 'Lost connection',
       dot: 'failed',
+      usage,
+      usageStale,
+    };
+  }
+  if (activity?.checkFailed) {
+    // Not the same silence as never asking: this desktop has no local
+    // forward, so it asked the environment directly instead, and the attempt
+    // itself did not come back. Naming the action (open it) is what the plain
+    // "Not open here" line below cannot do for an environment that might be
+    // busy right now and simply could not confirm it from here.
+    return {
+      key,
+      name,
+      state: 'check-failed',
+      status: "Can't confirm from here — open it to check directly",
       usage,
       usageStale,
     };

--- a/erun-ui/frontend/src/app/slices/envStatusSlice.ts
+++ b/erun-ui/frontend/src/app/slices/envStatusSlice.ts
@@ -33,6 +33,11 @@ export interface EnvObservedActivity {
   // it; note it can be true while reachable is false, which is the ordinary
   // shape after a pod replacement takes the forward with it.
   outage: boolean;
+  // checkFailed is outage's counterpart for an environment with no local
+  // forward: a real attempt to reach it over its own runtime pod that did not
+  // come back, as opposed to an environment nobody has asked about at all —
+  // see EnvActivityPayload for the full reasoning.
+  checkFailed: boolean;
   busy: boolean;
   detail: string;
 }
@@ -75,7 +80,7 @@ export const envStatusSlice = createSlice({
       // A quiet environment carries no entry, so a repeated "still quiet"
       // observation must leave the slice byte-identical rather than producing a
       // new state object every poll.
-      if (!activity.reachable && !activity.busy && !activity.outage) {
+      if (!activity.reachable && !activity.busy && !activity.outage && !activity.checkFailed) {
         if (key in state.activityByEnv) {
           Reflect.deleteProperty(state.activityByEnv, key);
         }
@@ -85,6 +90,7 @@ export const envStatusSlice = createSlice({
       if (
         current?.reachable === activity.reachable &&
         current.outage === activity.outage &&
+        current.checkFailed === activity.checkFailed &&
         current.busy === activity.busy &&
         current.detail === activity.detail
       ) {

--- a/erun-ui/frontend/src/app/slices/envStatusSlice.ts
+++ b/erun-ui/frontend/src/app/slices/envStatusSlice.ts
@@ -60,6 +60,26 @@ const initialState: EnvStatusState = {
   usageByEnv: {},
 };
 
+// A quiet environment carries no entry, so a repeated "still quiet"
+// observation must leave the slice byte-identical rather than producing a new
+// state object every poll.
+function isQuietEnvironmentActivity(activity: EnvObservedActivity): boolean {
+  return !activity.reachable && !activity.busy && !activity.outage && !activity.checkFailed;
+}
+
+function environmentActivityUnchanged(
+  current: EnvObservedActivity | undefined,
+  activity: EnvObservedActivity,
+): boolean {
+  return (
+    current?.reachable === activity.reachable &&
+    current.outage === activity.outage &&
+    current.checkFailed === activity.checkFailed &&
+    current.busy === activity.busy &&
+    current.detail === activity.detail
+  );
+}
+
 export const envStatusSlice = createSlice({
   name: 'envStatus',
   initialState,
@@ -77,23 +97,13 @@ export const envStatusSlice = createSlice({
       action: PayloadAction<{ key: string; activity: EnvObservedActivity }>,
     ) {
       const { key, activity } = action.payload;
-      // A quiet environment carries no entry, so a repeated "still quiet"
-      // observation must leave the slice byte-identical rather than producing a
-      // new state object every poll.
-      if (!activity.reachable && !activity.busy && !activity.outage && !activity.checkFailed) {
+      if (isQuietEnvironmentActivity(activity)) {
         if (key in state.activityByEnv) {
           Reflect.deleteProperty(state.activityByEnv, key);
         }
         return;
       }
-      const current = state.activityByEnv[key];
-      if (
-        current?.reachable === activity.reachable &&
-        current.outage === activity.outage &&
-        current.checkFailed === activity.checkFailed &&
-        current.busy === activity.busy &&
-        current.detail === activity.detail
-      ) {
+      if (environmentActivityUnchanged(state.activityByEnv[key], activity)) {
         return;
       }
       state.activityByEnv[key] = activity;

--- a/erun-ui/frontend/src/app/wailsEventThunks.ts
+++ b/erun-ui/frontend/src/app/wailsEventThunks.ts
@@ -147,6 +147,7 @@ export const handleEnvActivity =
       reachable: payload.reachable,
       observed: payload.observed,
       outage: payload.outage === true,
+      checkFailed: payload.checkFailed === true,
       busy: payload.busy,
       detail: (payload.detail ?? '').trim(),
     };

--- a/erun-ui/frontend/src/uiEnvironmentActivityTypes.ts
+++ b/erun-ui/frontend/src/uiEnvironmentActivityTypes.ts
@@ -10,6 +10,11 @@ export interface UIEnvironmentActivity {
   reachable: boolean;
   observed: boolean;
   outage: boolean;
+  // checkFailed is outage's counterpart for an environment with no local
+  // forward: a real attempt to ask it (over the environment's own runtime
+  // pod, not this desktop's connection) that did not come back, as opposed to
+  // an environment nobody has asked about at all.
+  checkFailed?: boolean;
   busy: boolean;
   detail?: string;
 }

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -986,11 +986,12 @@ func envInfos(envs []eruncommon.OrchestratorEnvConfig, envActivity map[string]en
 		key := selectionKey(uiSelection{Tenant: env.Tenant, Environment: env.Environment})
 		if state, ok := envActivity[key]; ok {
 			info.Activity = &uiEnvironmentActivitySnapshot{
-				Reachable: state.reachable,
-				Observed:  state.observed,
-				Outage:    state.outage,
-				Busy:      state.busy,
-				Detail:    state.detail,
+				Reachable:   state.reachable,
+				Observed:    state.observed,
+				Outage:      state.outage,
+				CheckFailed: state.checkFailed,
+				Busy:        state.busy,
+				Detail:      state.detail,
 			}
 		}
 		if reading, ok := envUsage[key]; ok {

--- a/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
@@ -217,6 +217,96 @@ test.describe('orchestrator hover card environment and pacing state', () => {
     });
   });
 
+  // The regression this locks in: an environment not open in this desktop —
+  // driven instead by a CLI orchestrator or an agent over MCP from another
+  // machine — used to read as "Not open here" even while genuinely busy,
+  // because the desktop never asked it anything without a local forward. The
+  // Go poller (environment_activity.go's observeEnvironmentActivityViaPod)
+  // now asks such an environment directly over its own runtime pod, so the
+  // activity this card renders can say "busy" for an environment this
+  // desktop never opened. Against the un-fixed reduction this env would
+  // carry no activity at all (undefined, the "never opened" shape above) and
+  // render "Not open here" instead.
+  test('an environment busy from elsewhere reads busy, not "Not open here"', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [
+          {
+            tenant: 'acme',
+            environment: 'ux',
+            directory: '/tmp/a',
+            activity: {
+              reachable: true,
+              observed: true,
+              outage: false,
+              busy: true,
+              detail: 'holding: full-test-suite',
+            },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    const environmentRow = dialog.locator('dd').filter({ hasText: 'acme / ux' });
+    await expect(environmentRow).toContainText('Busy — holding: full-test-suite');
+    await expect(environmentRow).not.toContainText('Not open here');
+
+    await dialog.screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/busy-from-elsewhere.png',
+    });
+  });
+
+  // The other half of the fix: a real attempt to reach an unopened environment
+  // that did not come back (a pod exec that errored, or the environment
+  // genuinely not running) must read distinctly from "nobody has ever asked",
+  // and must name the recovery action rather than leaving a dead end.
+  test('a failed attempt to confirm an unopened environment names the recovery action', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      snapshot({
+        environments: [
+          {
+            tenant: 'acme',
+            environment: 'stale',
+            directory: '/tmp/a',
+            activity: {
+              reachable: false,
+              observed: false,
+              outage: false,
+              checkFailed: true,
+              busy: false,
+            },
+          },
+        ],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+
+    const dialog = card(page);
+    await expect(dialog).toBeVisible();
+    const environmentRow = dialog.locator('dd').filter({ hasText: 'acme / stale' });
+    await expect(environmentRow).toContainText('open it to check directly');
+    await expect(environmentRow).not.toContainText('Not open here');
+
+    await dialog.screenshot({
+      path: '/home/erun/.erun/outputs/1383-visual/check-failed-environment.png',
+    });
+  });
+
   test('an environment in outage reads distinctly from idle and unreachable', async ({
     app,
     page,

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -52,11 +52,17 @@ type uiEnvironment struct {
 // for the event stream — here that identity is already the enclosing
 // uiEnvironment.
 type uiEnvironmentActivitySnapshot struct {
-	Reachable bool   `json:"reachable"`
-	Observed  bool   `json:"observed"`
-	Outage    bool   `json:"outage"`
-	Busy      bool   `json:"busy"`
-	Detail    string `json:"detail,omitempty"`
+	Reachable bool `json:"reachable"`
+	Observed  bool `json:"observed"`
+	Outage    bool `json:"outage"`
+	// CheckFailed mirrors environmentActivityState's own field: a real attempt
+	// to reach an environment with no local forward (over kubectl exec) that
+	// did not come back, as opposed to an environment nobody has asked about at
+	// all. Kept apart from Outage for the same reason Outage is kept apart from
+	// Reachable — the two failures name different remedies.
+	CheckFailed bool   `json:"checkFailed,omitempty"`
+	Busy        bool   `json:"busy"`
+	Detail      string `json:"detail,omitempty"`
 }
 
 // uiEnvironmentUsageSnapshot is the environment-usage poller's last cached
@@ -123,9 +129,12 @@ type envActivityPayload struct {
 	// like a quiet environment or an unopened one, which is how one stayed dead
 	// for hours. It is deliberately independent of Reachable: the dropped shape
 	// is unreachable *and* diagnosed, and only the second of those is news.
-	Outage bool   `json:"outage"`
-	Busy   bool   `json:"busy"`
-	Detail string `json:"detail,omitempty"`
+	Outage bool `json:"outage"`
+	// CheckFailed mirrors uiEnvironmentActivitySnapshot's own field; see there
+	// for why it is kept apart from both Reachable and Outage.
+	CheckFailed bool   `json:"checkFailed,omitempty"`
+	Busy        bool   `json:"busy"`
+	Detail      string `json:"detail,omitempty"`
 }
 
 // envUsagePayload is the usage-sweep counterpart to envActivityPayload: a


### PR DESCRIPTION
## Summary

- Fixes #1572: the orchestrator popover (and the plain sidebar env row, which reads the same activity join) reported "Not open here" for an environment holding an activity lease, whenever this desktop had not itself opened a local MCP port-forward to it — hiding an agent actively driving the environment over MCP or a CLI orchestrator elsewhere.
- `environment_activity.go`'s poller now falls back to asking the environment directly over its own runtime pod (`kubectl exec … erun idle --json`, the same no-forward-required channel `runtime_activity.go` already uses) whenever no local forward is established but the environment names a Kubernetes context. A held lease now reports "Busy — …" regardless of which client opened it; a genuinely idle environment reports idle.
- A real attempt that does not come back (the exec itself fails, or the answer can't be parsed) is surfaced as a new, distinct `checkFailed` state — "Can't confirm from here — open it to check directly" — rather than collapsing into the same "Not open here" an environment nobody has ever asked about gets. An environment with no configured Kubernetes context is left alone entirely (no exec attempt).

## Where the status is now derived from

- Previously: `reachable`/`observed`/`busy` were only ever set when this desktop had a local port-forward state file (`LoadPortForwardState`); their absence was indistinguishable from "not open" and "genuinely can't reach it".
- Now: `observeEnvironmentActivityViaPod` (`erun-ui/environment_activity.go`) is the fallback branch reached whenever no local forward exists. It loads the env's `KubernetesContext` from the config store, execs `erun idle <tenant> <env> --json` into the runtime pod (self-targeted, so it reads the pod's own local activity/lease store with no network hop), and folds the result through the same `environmentBusyFromIdleStatus` reduction the local-forward path already used.
- The frontend reduction (`orchestratorEnvironmentActivity.ts`) and the plain sidebar row (`Sidebar.EnvironmentRow.tsx`, via `envStatusSlice`) both read the same joined activity, so the fix applies uniformly to both surfaces — not just the orchestrator popover.

## The unreachable-but-not-open case

`checkFailed: true` — rendered as "Can't confirm from here — open it to check directly", distinct from both "Not open here" (never asked) and "Lost connection"/outage (had a forward, lost it). Set when the environment names a cluster but the pod exec fails or returns unparseable output.

## Negative test

- Go: `TestObserveEnvironmentActivityViaPodReportsAHeldLease` and siblings in `environment_activity_observed_test.go` cover the held-lease, idle, exec-failure, and garbled-output cases directly; `TestUnopenedEnvironmentIsProbedButNeverRebound` proves the fallback never touches the forward-repair/rebind machinery.
- Frontend unit: `orchestratorEnvironmentActivity.test.ts` — "a lease held by a session driving the environment from elsewhere still reads busy" and "a failed attempt to reach an unopened environment reads distinctly from never asking".
- Playwright (full suite run, see test plan): `sidebar-orchestrator-hover-card-activity.spec.ts` — `an environment busy from elsewhere reads busy, not "Not open here"` and `a failed attempt to confirm an unopened environment names the recovery action`.

## Test plan

- [x] `make check` — green (lint, erun-ui Go tests, erun-kit/erun-console gates, chart tests, integration suite, coverage 76.1%)
- [x] Full Playwright suite (`./run.sh --build`) — 411 passed, 0 failed

Closes #1572