### PR TITLE
Collapse echoed job commands in exec_job_status/exec_job_await

### DIFF
--- a/erun-mcp/job.go
+++ b/erun-mcp/job.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	eruncommon "github.com/sophium/erun/erun-common"
@@ -67,6 +68,32 @@ func jobAttachTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 	}
 }
 
+// jobCommandPreviewChars bounds how much of a job's command a status or await
+// response echoes back. A command job's argv is a few words; an agent job's
+// argv carries its entire dispatch prompt, so returning it unbounded turns
+// every poll and every bounded await into a multi-KB echo of text the caller
+// itself supplied moments earlier.
+const jobCommandPreviewChars = 240
+
+// previewJobForStatus returns job unchanged, or a copy with its command
+// collapsed to an identifying prefix when it exceeds the preview bound. It
+// never mutates the record a caller reads back from job_output or job_cancel.
+func previewJobForStatus(job eruncommon.EnvironmentJob) eruncommon.EnvironmentJob {
+	if preview, truncated := previewCommand(job.Command); truncated {
+		job.Command = preview
+	}
+	return job
+}
+
+func previewCommand(command []string) ([]string, bool) {
+	joined := strings.Join(command, " ")
+	if utf8.RuneCountInString(joined) <= jobCommandPreviewChars {
+		return command, false
+	}
+	runes := []rune(joined)
+	return []string{strings.TrimSpace(string(runes[:jobCommandPreviewChars])) + "…"}, true
+}
+
 // JobStatusInput selects one job or every retained job.
 type JobStatusInput struct {
 	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment to query; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
@@ -76,7 +103,9 @@ type JobStatusInput struct {
 
 // JobStatusResult is always a definite answer. A job whose supervisor vanished
 // reports state unknown with a reason; it never reports an outcome nobody
-// recorded, and the list is never silently shortened.
+// recorded, and the list is never silently shortened. Jobs is empty when id
+// selected one job: Job already carries that record, and echoing it twice in
+// one payload buys nothing.
 type JobStatusResult struct {
 	Tenant      string                      `json:"tenant"`
 	Environment string                      `json:"environment"`
@@ -97,16 +126,16 @@ func jobStatusTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolReq
 			if err != nil {
 				return nil, JobStatusResult{}, err
 			}
-			result.Job = &job
-			result.Jobs = append(result.Jobs, job)
+			preview := previewJobForStatus(job)
+			result.Job = &preview
 			return nil, result, nil
 		}
 		jobs, err := eruncommon.LoadEnvironmentJobs(tenant, environment, now)
 		if err != nil {
 			return nil, JobStatusResult{}, err
 		}
-		if jobs != nil {
-			result.Jobs = jobs
+		for _, job := range jobs {
+			result.Jobs = append(result.Jobs, previewJobForStatus(job))
 		}
 		return nil, result, nil
 	}
@@ -135,6 +164,7 @@ func jobAwaitTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequ
 		if err != nil {
 			return nil, eruncommon.AwaitEnvironmentJobResult{}, err
 		}
+		result.Job = previewJobForStatus(result.Job)
 		return nil, result, nil
 	}
 }

--- a/erun-mcp/job_status_test.go
+++ b/erun-mcp/job_status_test.go
@@ -1,0 +1,183 @@
+package erunmcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// exec_job_status and exec_job_await both echo back a job's command, and for
+// an agent job that command embeds the entire dispatch prompt (#1561): a
+// caller polling a lane, or re-awaiting one that keeps timing out, pays for
+// that prompt's tokens on every single call for a field it supplied itself.
+// These tests pin the two size/shape properties that fix relies on: the
+// command a status/await response carries never grows past the preview bound,
+// and asking for one job never smuggles a second copy of it into the list.
+
+// writeJobFixture plants a job record directly on disk in the shape
+// LoadEnvironmentJob/LoadEnvironmentJobs read back, without needing a real
+// supervisor process behind it -- job.State exited short-circuits the
+// liveness reconciliation that only applies to a job still claiming running.
+func writeJobFixture(t *testing.T, tenant, environment string, job eruncommon.EnvironmentJob) {
+	t.Helper()
+	dir, err := eruncommon.EnvironmentActivityDir(tenant, environment)
+	if err != nil {
+		t.Fatalf("EnvironmentActivityDir: %v", err)
+	}
+	jobsDir := filepath.Join(dir, "jobs")
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("Marshal job fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, job.ID+".json"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile job fixture: %v", err)
+	}
+}
+
+func finishedJobFixture(id string, command []string) eruncommon.EnvironmentJob {
+	zero := 0
+	now := time.Now()
+	return eruncommon.EnvironmentJob{
+		ID:        id,
+		Name:      id,
+		State:     eruncommon.EnvironmentJobStateExited,
+		Command:   command,
+		ExitCode:  &zero,
+		StartedAt: now.Add(-time.Minute),
+		EndedAt:   now,
+	}
+}
+
+func TestJobStatusCollapsesALongCommandByDefault(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	// Shaped like an agent job's argv: a tool invocation carrying a multi-KB
+	// prompt as one of its arguments.
+	prompt := strings.Repeat("investigate and fix the failing lane ", 200)
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("sweep", []string{"claude", "-p", prompt}))
+
+	_, result, err := jobStatusTool(runtime)(context.Background(), nil, JobStatusInput{ID: "sweep"})
+	if err != nil {
+		t.Fatalf("job_status: %v", err)
+	}
+	if result.Job == nil {
+		t.Fatalf("job_status returned no job for id %q", "sweep")
+	}
+	got := strings.Join(result.Job.Command, " ")
+	if len(got) >= len(prompt) {
+		t.Fatalf("command was not collapsed: got %d chars, original prompt alone was %d", len(got), len(prompt))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("collapsed command %q does not end in the truncation marker", got)
+	}
+}
+
+func TestJobStatusLeavesAShortCommandUntouched(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("suite", []string{"./gradlew", "test"}))
+
+	_, result, err := jobStatusTool(runtime)(context.Background(), nil, JobStatusInput{ID: "suite"})
+	if err != nil {
+		t.Fatalf("job_status: %v", err)
+	}
+	if result.Job == nil {
+		t.Fatalf("job_status returned no job for id %q", "suite")
+	}
+	want := []string{"./gradlew", "test"}
+	if len(result.Job.Command) != len(want) || result.Job.Command[0] != want[0] || result.Job.Command[1] != want[1] {
+		t.Fatalf("short command was altered: got %v, want %v", result.Job.Command, want)
+	}
+}
+
+func TestJobStatusByIDDoesNotDuplicateTheJob(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("suite", []string{"./gradlew", "test"}))
+
+	_, result, err := jobStatusTool(runtime)(context.Background(), nil, JobStatusInput{ID: "suite"})
+	if err != nil {
+		t.Fatalf("job_status: %v", err)
+	}
+	if result.Job == nil {
+		t.Fatalf("job_status returned no job for id %q", "suite")
+	}
+	if len(result.Jobs) != 0 {
+		t.Fatalf("expected jobs to stay empty when id selected one job, got %d entries", len(result.Jobs))
+	}
+}
+
+func TestJobStatusListsCollapseEveryJobsCommand(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	prompt := strings.Repeat("build the release image and push it ", 200)
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("sweep-a", []string{"claude", "-p", prompt}))
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("sweep-b", []string{"codex", "exec", prompt}))
+
+	_, result, err := jobStatusTool(runtime)(context.Background(), nil, JobStatusInput{})
+	if err != nil {
+		t.Fatalf("job_status: %v", err)
+	}
+	if len(result.Jobs) != 2 {
+		t.Fatalf("expected both fixtures listed, got %d", len(result.Jobs))
+	}
+	for _, job := range result.Jobs {
+		got := strings.Join(job.Command, " ")
+		if len(got) >= len(prompt) {
+			t.Fatalf("job %s command was not collapsed: got %d chars", job.ID, len(got))
+		}
+	}
+}
+
+func TestJobAwaitCollapsesALongCommand(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"}}
+
+	prompt := strings.Repeat("investigate and fix the failing lane ", 200)
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("sweep", []string{"claude", "-p", prompt}))
+
+	// The job is already finished, so await returns on its first read rather
+	// than actually waiting out the timeout.
+	_, result, err := jobAwaitTool(runtime)(context.Background(), nil, JobAwaitInput{ID: "sweep", TimeoutSeconds: 5})
+	if err != nil {
+		t.Fatalf("job_await: %v", err)
+	}
+	got := strings.Join(result.Job.Command, " ")
+	if len(got) >= len(prompt) {
+		t.Fatalf("command was not collapsed: got %d chars, original prompt alone was %d", len(got), len(prompt))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("collapsed command %q does not end in the truncation marker", got)
+	}
+}
+
+func TestPreviewCommandBoundary(t *testing.T) {
+	atBound := strings.Repeat("a", jobCommandPreviewChars)
+	if _, truncated := previewCommand([]string{atBound}); truncated {
+		t.Fatalf("a command exactly at the bound must not be reported as truncated")
+	}
+	overBound := strings.Repeat("a", jobCommandPreviewChars+1)
+	preview, truncated := previewCommand([]string{overBound})
+	if !truncated {
+		t.Fatalf("a command one rune over the bound must be reported as truncated")
+	}
+	if len(preview) != 1 {
+		t.Fatalf("expected a single collapsed element, got %v", preview)
+	}
+	if !strings.HasSuffix(preview[0], "…") {
+		t.Fatalf("collapsed command %q does not end in the truncation marker", preview[0])
+	}
+}

--- a/erun-mcp/job_status_test.go
+++ b/erun-mcp/job_status_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 // exec_job_status and exec_job_await both echo back a job's command, and for
-// an agent job that command embeds the entire dispatch prompt (#1561): a
-// caller polling a lane, or re-awaiting one that keeps timing out, pays for
-// that prompt's tokens on every single call for a field it supplied itself.
-// These tests pin the two size/shape properties that fix relies on: the
-// command a status/await response carries never grows past the preview bound,
-// and asking for one job never smuggles a second copy of it into the list.
+// an agent job that command embeds the entire dispatch prompt: a caller
+// polling a lane, or re-awaiting one that keeps timing out, pays for that
+// prompt's tokens on every single call for a field it supplied itself. These
+// tests pin the two size/shape properties the fix relies on: the command a
+// status/await response carries never grows past the preview bound, and
+// asking for one job never smuggles a second copy of it into the list.
 
 // writeJobFixture plants a job record directly on disk in the shape
 // LoadEnvironmentJob/LoadEnvironmentJobs read back, without needing a real

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -295,14 +295,16 @@ func registerJobTools(reg toolRegistrar, runtime RuntimeConfig) {
 			"It is never a truncated or partial answer, so it is safe to act on: unknown is exactly as terminal as exited — never a reason to keep waiting, and never inferred as 'not finished yet' just because it is not a success. Finished jobs stay readable for 24 hours, so an orchestrator reconnecting after the work ended can still learn what happened. " +
 			"aliveAgeMs is the milliseconds since the supervisor's last ~1s beat, computed by erun in its own clock so a caller never subtracts a pod timestamp from its own — the two clocks are not the same clock. Once it exceeds 5000, treat the job as failed (an unknown outcome, never a success, never a tool error) even if state has not caught up to say so yet; a silent-but-healthy command never trips this, because the beat has nothing to do with the work's own output. " +
 			"An agent job also carries progress — current activity (the last tool and its target), turns, tools run, and the last thing the agent said — normalized by erun from the tool's own event stream, so the shape is the same across AI tools. Poll this to report an in-pod agent's progress; do not scrape the agent's private transcript. " +
-			"A job started as a background task (build, deploy, doctor, and the rest of the job-envelope tools called with wait: false) carries its typed result on this record's result field once exited, in the same shape the tool would have returned synchronously.",
+			"A job started as a background task (build, deploy, doctor, and the rest of the job-envelope tools called with wait: false) carries its typed result on this record's result field once exited, in the same shape the tool would have returned synchronously. " +
+			"command is collapsed to a short identifying prefix once it runs past 240 characters -- an agent job's command embeds its whole dispatch prompt, and a status poll is never where that is needed back, since you already have it.",
 	}, jobStatusTool(runtime))
 	addTool(reg, &mcp.Tool{
 		Name: "exec_job_await",
 		Description: "Wait a bounded time (default 30s, max 600s) for a job to finish. " +
 			"The call always returns inside the timeout — either the outcome or timedOut=true with the job still running — so no connection is held open for the work's lifetime and a dropped stream is never confused with a dead job. " +
 			"timedOut is reported separately from every outcome, so 'not finished yet' can never be read as a failure — but it is not the only non-outcome case: a job whose supervisor died reads back as state=unknown with timedOut=false, its own third case, distinct from both success and 'still running'. Never re-await a job already reporting unknown expecting a different answer. Call it again only while the job is genuinely still running. " +
-			"The returned job's aliveAgeMs (see exec_job_status) is the faster of the two signals: it crosses the 5000ms caller threshold before state necessarily catches up, so a caller in a hurry can act on it directly instead of waiting for the next reconcile.",
+			"The returned job's aliveAgeMs (see exec_job_status) is the faster of the two signals: it crosses the 5000ms caller threshold before state necessarily catches up, so a caller in a hurry can act on it directly instead of waiting for the next reconcile. " +
+			"command is collapsed the same way exec_job_status collapses it (see there), so a bounded wait that times out on a long-running agent job never re-echoes its whole dispatch prompt.",
 	}, jobAwaitTool(runtime))
 	addTool(reg, &mcp.Tool{
 		Name: "exec_job_output",


### PR DESCRIPTION
## Summary
- `exec_job_status` and `exec_job_await` both echoed a job's full `command`, which for an agent job embeds the entire dispatch prompt — a bounded await that times out with `state: running` still cost the whole prompt in tokens, and listing all jobs could exceed the MCP result size limit entirely.
- `exec_job_status` with an `id` also duplicated the same record into both `job` and `jobs`.

## Fix
- Collapse `command` to an identifying 240-char prefix (`…`-terminated) once it exceeds that bound, in both tools. Chose truncation over an `includeCommand` opt-in: the desktop's own Jobs tab already treats an agent job's argv as never worth showing (it displays `progress`/`activity` instead), a plain command job's argv is normally a few words and never trips the bound, and the issue itself notes "the caller already knows what it dispatched" — there's no real case where a caller needs the *full* prompt echoed back from a status/await call, so no opt-in flag was needed. This also follows the same bounded-prefix-with-ellipsis convention `erun-common`'s `truncateAgentText` already uses for agent progress text.
- `exec_job_status` with `id` now leaves `jobs` empty instead of re-embedding the same record that `job` already carries.
- Updated both tools' MCP `Description:` to document the new truncation behavior.

## Test plan
- [x] New tests in `erun-mcp/job_status_test.go` assert the *size* property, not just field shape: a job fixture with a multi-KB prompt-shaped command comes back collapsed to well under its original length and ends in the truncation marker, for both `exec_job_status` (single job and the list-all case) and `exec_job_await`. A short, ordinary command (`["./gradlew", "test"]`) is asserted unchanged. A boundary test pins the exact 240-char cutoff. A separate test asserts `jobs` stays empty when `id` selects one job.
- [x] `make check` green (lint × 6 modules, `erun-ui` Go tests, frontend gates for `erun-kit`/`erun-console`, devops chart tests, `make integration-test`) — includes the existing `erun-integration` job scenarios (including the off-environment ones that round-trip through these exact MCP tools), all passing unmodified since no golden asserts `command`'s content. Coverage 76.1% (>= 75.8% threshold).

Closes #1561