### PR TITLE
Add a gate-incomplete job state so an ended agent job can't silently report success over a gate it started

### DIFF
--- a/erun-cli/cmd/job.go
+++ b/erun-cli/cmd/job.go
@@ -413,6 +413,8 @@ func jobStatusLine(job common.EnvironmentJob) string {
 		return jobExitedLine(job)
 	case common.EnvironmentJobStateAbandoned:
 		return jobAbandonedLine(job)
+	case common.EnvironmentJobStateGateIncomplete:
+		return jobGateIncompleteLine(job)
 	default:
 		return jobUnknownLine(job)
 	}
@@ -441,6 +443,20 @@ func jobExitedLine(job common.EnvironmentJob) string {
 // exited) -- the reason names the background work nothing will ever report on.
 func jobAbandonedLine(job common.EnvironmentJob) string {
 	line := fmt.Sprintf("abandoned %d: %s", jobExitCodeOrUnset(job), job.Name)
+	if strings.TrimSpace(job.Signal) != "" {
+		line += fmt.Sprintf(" (signal %s)", job.Signal)
+	}
+	if strings.TrimSpace(job.Reason) != "" {
+		line += " (" + job.Reason + ")"
+	}
+	return line + jobAgentSuffix(job) + jobOutputSuffix(job)
+}
+
+// jobGateIncompleteLine is rendered distinctly from abandoned: the still-running
+// work is a sibling job record this job started, not a process left behind in
+// its own process group.
+func jobGateIncompleteLine(job common.EnvironmentJob) string {
+	line := fmt.Sprintf("gate-incomplete %d: %s", jobExitCodeOrUnset(job), job.Name)
 	if strings.TrimSpace(job.Signal) != "" {
 		line += fmt.Sprintf(" (signal %s)", job.Signal)
 	}
@@ -598,6 +614,8 @@ func jobAwaitExit(result common.AwaitEnvironmentJobResult) error {
 		return nil
 	case result.Job.State == common.EnvironmentJobStateAbandoned:
 		return fmt.Errorf("job %q abandoned background work: %s", result.Job.ID, result.Job.Reason)
+	case result.Job.State == common.EnvironmentJobStateGateIncomplete:
+		return fmt.Errorf("job %q ended while work it started was still running: %s", result.Job.ID, result.Job.Reason)
 	default:
 		return fmt.Errorf("job %q exited %d", result.Job.ID, jobExitCodeOrUnset(result.Job))
 	}

--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -51,6 +51,17 @@ const (
 	// something the job started continues unsupervised, and nothing further
 	// will ever be reported for it.
 	EnvironmentJobStateAbandoned = "abandoned"
+	// EnvironmentJobStateGateIncomplete means this job's own process ended while
+	// a job it started (StartedByJobID names this job as the parent) was still
+	// running — an agent job that ran a gate through its own `job start`, then
+	// exited before the gate reached a verdict, is the motivating case. Unlike
+	// EnvironmentJobStateAbandoned, the still-running work is not a process in
+	// this job's own process group (which a detached job deliberately escapes,
+	// by design, so it survives the caller that started it) — it is a sibling
+	// record in the same job store. Never success, whatever the captured exit
+	// code says: the child job's own outcome has not been observed yet, and
+	// nothing about this job's own exit reports it.
+	EnvironmentJobStateGateIncomplete = "gate-incomplete"
 
 	// UnknownReasonKind values are what an orchestrator branches on instead of
 	// pattern-matching the free-text Reason. Each names a distinct,
@@ -120,6 +131,14 @@ const (
 
 	environmentJobDirName     = "jobs"
 	environmentJobLeasePrefix = "job-"
+
+	// environmentJobIDEnvVar is the env var a job's own supervisor sets on the
+	// work's process, naming the job the work is running as. Anything the work
+	// spawns inherits it the same way it inherits any other environment
+	// variable, so a nested `job start` run from inside it (agent-gate.sh's
+	// detach-and-await, or an agent's own Bash tool) reads it back and records
+	// StartedByJobID without either side threading it through explicitly.
+	environmentJobIDEnvVar = "ERUN_JOB_ID"
 )
 
 // EnvironmentJob is one unit of long work and its outcome.
@@ -173,6 +192,12 @@ type EnvironmentJob struct {
 	// pod instance, so a later read from a different hostname is definitive
 	// proof the runtime pod was replaced — not a guess.
 	Hostname string `json:"hostname,omitempty"`
+	// StartedByJobID names the job whose own process was running when this job
+	// was started (the parent's ERUN_JOB_ID, inherited down whatever it
+	// spawned), empty when this job was started from outside any other job.
+	// It is what lets the parent's own finish check tell "a job I started" from
+	// "an unrelated job that happens to share this environment".
+	StartedByJobID string `json:"startedByJobId,omitempty"`
 
 	LogPath          string `json:"logPath,omitempty"`
 	OutputBytes      int64  `json:"outputBytes"`
@@ -215,14 +240,16 @@ type EnvironmentJob struct {
 
 // Finished reports whether the job reached a terminal state.
 func (j EnvironmentJob) Finished() bool {
-	return j.State == EnvironmentJobStateExited || j.State == EnvironmentJobStateUnknown || j.State == EnvironmentJobStateAbandoned
+	return j.State == EnvironmentJobStateExited || j.State == EnvironmentJobStateUnknown ||
+		j.State == EnvironmentJobStateAbandoned || j.State == EnvironmentJobStateGateIncomplete
 }
 
 // Succeeded is the only definition of success: an outcome was captured and it
 // was zero, with nothing left running behind it. An unknown job is never a
-// success, and neither is an abandoned one — a zero exit code from the
-// process that started background work it never waited for is not the same
-// claim as a zero exit code from a job that finished cleanly.
+// success, and neither is an abandoned or gate-incomplete one — a zero exit
+// code from the process that started work it never waited for, whether that
+// work is an unreaped process in its own group or a sibling job record, is
+// not the same claim as a zero exit code from a job that finished cleanly.
 func (j EnvironmentJob) Succeeded() bool {
 	return j.State == EnvironmentJobStateExited && j.ExitCode != nil && *j.ExitCode == 0
 }
@@ -327,6 +354,37 @@ func reconcileEnvironmentJob(dir string, job EnvironmentJob, now time.Time, aliv
 	job.OutputBytes = environmentJobOutputSize(job.LogPath, job.OutputBytes)
 	_ = writeEnvironmentJob(dir, job)
 	return job
+}
+
+// environmentJobRunningChildren returns the jobs in dir that name parentID as
+// their StartedByJobID and are still not finished, reconciled against current
+// process liveness the same way every other read is — so a child whose own
+// supervisor died without recording an outcome reads as unknown here too, not
+// as still running. This is what lets a job's own finish check tell "work I
+// started is still going" from a plain directory listing, without needing the
+// parent to have tracked its children itself.
+func environmentJobRunningChildren(dir, parentID string, now time.Time) []EnvironmentJob {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	hostname := currentJobHostname()
+	var running []EnvironmentJob
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		job, err := readEnvironmentJob(filepath.Join(dir, entry.Name()))
+		if err != nil || job.StartedByJobID != parentID {
+			continue
+		}
+		job = reconcileEnvironmentJob(dir, job, now, processAlive, hostname)
+		if !job.Finished() {
+			running = append(running, job)
+		}
+	}
+	sort.Slice(running, func(i, j int) bool { return running[i].ID < running[j].ID })
+	return running
 }
 
 // environmentJobAliveAgeMs is nil only when the job has never beaten, so a

--- a/erun-common/job_abandoned_test.go
+++ b/erun-common/job_abandoned_test.go
@@ -2,8 +2,10 @@ package eruncommon
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -87,5 +89,105 @@ func TestEnvironmentJobThatExitsCleanlyStillSucceeds(t *testing.T) {
 	}
 	if job.State != EnvironmentJobStateExited {
 		t.Fatalf("State = %q, want %q", job.State, EnvironmentJobStateExited)
+	}
+}
+
+// An agent job that runs a gate through its own `job start` (agent-gate.sh's
+// detach-and-await, or an agent driving the same primitive directly) and then
+// ends -- however that end comes about: the agent backgrounding the run
+// itself, exhausting its turns, or an outer `timeout` killing the foreground
+// wait -- must not read as a clean success while the gate it started has not
+// reached a verdict. That gate runs as its own job, detached into its own
+// session on purpose so it survives the caller; it is never a member of the
+// caller's process group, so the process-group survivor check above cannot
+// see it. The record relationship (StartedByJobID) is what makes it visible
+// instead. The gate job is seeded directly rather than started for real,
+// because the property under test is what the *parent's* finish check does
+// when a sibling record says still running, not how the sibling got there.
+func TestEnvironmentJobThatEndsWhileAJobItStartedIsStillRunningIsNotReportedAsSuccess(t *testing.T) {
+	isolateActivityCache(t)
+
+	const tenant = "gate-incomplete-contract"
+	const environment = "seeded-child-test"
+	const parentID = "outer"
+	const childID = "gate"
+
+	dir, err := environmentJobDir(tenant, environment)
+	if err != nil {
+		t.Fatalf("environmentJobDir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	// A pid of this test process itself reads as alive for as long as the test
+	// runs, which is what keeps the seeded child's state at "running" through
+	// the parent's own finish check below without needing a real process.
+	child := EnvironmentJob{
+		ID:             childID,
+		Name:           childID,
+		State:          EnvironmentJobStateRunning,
+		PID:            os.Getpid(),
+		StartedAt:      time.Now(),
+		StartedByJobID: parentID,
+		LeaseID:        environmentJobLeaseID(childID),
+	}
+	if err := writeEnvironmentJob(dir, child); err != nil {
+		t.Fatalf("seed child job record: %v", err)
+	}
+
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          parentID,
+		Name:        parentID,
+		Command:     []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	parent, err := LoadEnvironmentJob(tenant, environment, parentID, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if parent.Succeeded() {
+		t.Fatalf("job reported success (state=%q, exitCode=%v) even though a job it started was still running: %+v", parent.State, parent.ExitCode, parent)
+	}
+	if parent.State != EnvironmentJobStateGateIncomplete {
+		t.Fatalf("State = %q, want %q", parent.State, EnvironmentJobStateGateIncomplete)
+	}
+	if !strings.Contains(parent.Reason, childID) {
+		t.Fatalf("Reason %q does not name the still-running job %q", parent.Reason, childID)
+	}
+}
+
+// The gate-incomplete detection above depends on a nested `job start` reading
+// back the parent job's id from its own environment, exactly the way
+// agent-gate.sh's `erun exec job start` (run from inside the agent's own Bash
+// tool) reads it back today. This locks that half of the wiring directly:
+// the job's own child process must see ERUN_JOB_ID naming this job.
+func TestEnvironmentJobSupervisorPropagatesItsOwnIDToTheWorksProcess(t *testing.T) {
+	isolateActivityCache(t)
+
+	const tenant = "gate-incomplete-contract"
+	const environment = "env-propagation-test"
+	const id = "outer"
+
+	idFile := filepath.Join(t.TempDir(), "observed-job-id.txt")
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Name:        id,
+		Command:     []string{"sh", "-c", fmt.Sprintf("printf '%%s' \"$ERUN_JOB_ID\" > %s", idFile)},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	observed, err := os.ReadFile(idFile)
+	if err != nil {
+		t.Fatalf("read observed job id: %v", err)
+	}
+	if string(observed) != id {
+		t.Fatalf("the work's process observed ERUN_JOB_ID=%q, want %q", observed, id)
 	}
 }

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -647,35 +647,7 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 	// carries what the run last did rather than the poll's stale view of it.
 	beat.refresh(false)
 
-	code := -1
-	var signal, reason string
-	switch {
-	case state != nil:
-		code = state.ExitCode()
-		if signal = environmentJobExitSignal(state); signal != "" {
-			reason = "terminated by signal " + signal
-		}
-	case waitErr != nil:
-		reason = "failed to start: " + waitErr.Error()
-	}
-	jobState := EnvironmentJobStateExited
-	if state != nil && environmentJobProcessGroupSurvivors(childPID) {
-		jobState = EnvironmentJobStateAbandoned
-		reason = "the job's own process exited, but it left other processes still running in its process group — background work it started and never waited for; nothing further will be reported for that work"
-	}
-	// A gate a job started through its own `job start` (agent-gate.sh's
-	// detach-and-await, or an agent driving it directly) runs as its own
-	// detached, unrelated-process-group job, so it never shows up in the
-	// process-group check above -- this is the second, independent way a job
-	// can end while work it started has not: a sibling job record, not a
-	// process. It takes priority over a plain abandoned verdict because a
-	// still-running job record is something a caller can actually await for a
-	// real outcome, unlike an orphaned process group member.
-	self := recorder.snapshot()
-	if running := environmentJobRunningChildren(recorder.dir, self.ID, time.Now()); len(running) > 0 {
-		jobState = EnvironmentJobStateGateIncomplete
-		reason = environmentJobGateIncompleteReason(running)
-	}
+	code, signal, reason, jobState := resolveEnvironmentJobOutcome(recorder, childPID, state, waitErr)
 	recorder.update(func(job *EnvironmentJob) {
 		job.State = jobState
 		job.EndedAt = time.Now()
@@ -689,6 +661,37 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		job.ExitCode = &code
 	})
 	return nil
+}
+
+// resolveEnvironmentJobOutcome decides the exit code, signal, reason, and
+// terminal state finishEnvironmentJob records. State and reason can be
+// overridden twice, independently, by work the job left behind that it never
+// waited for: a process still alive in its own process group (abandoned), or
+// a sibling job record naming this job as its StartedByJobID (gate-incomplete,
+// which takes priority — a still-running job record is something a caller can
+// actually await for a real outcome, unlike an orphaned process group member).
+func resolveEnvironmentJobOutcome(recorder *jobRecorder, childPID int, state *os.ProcessState, waitErr error) (code int, signal, reason, jobState string) {
+	code = -1
+	switch {
+	case state != nil:
+		code = state.ExitCode()
+		if signal = environmentJobExitSignal(state); signal != "" {
+			reason = "terminated by signal " + signal
+		}
+	case waitErr != nil:
+		reason = "failed to start: " + waitErr.Error()
+	}
+	jobState = EnvironmentJobStateExited
+	if state != nil && environmentJobProcessGroupSurvivors(childPID) {
+		jobState = EnvironmentJobStateAbandoned
+		reason = "the job's own process exited, but it left other processes still running in its process group — background work it started and never waited for; nothing further will be reported for that work"
+	}
+	self := recorder.snapshot()
+	if running := environmentJobRunningChildren(recorder.dir, self.ID, time.Now()); len(running) > 0 {
+		jobState = EnvironmentJobStateGateIncomplete
+		reason = environmentJobGateIncompleteReason(running)
+	}
+	return code, signal, reason, jobState
 }
 
 // environmentJobGateIncompleteReason names the still-running job(s) a caller

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -554,6 +554,11 @@ func registerEnvironmentJob(params EnvironmentJobSupervisorParams) (*jobRecorder
 		OutputLimitBytes: limit,
 		LeaseID:          environmentJobLeaseID(id),
 		Hostname:         currentJobHostname(),
+		// This supervisor's own process inherited ERUN_JOB_ID from whatever job
+		// started it (see the env this job's own child process is given below),
+		// so a value here means this job was started from inside another job's
+		// work rather than from outside any job.
+		StartedByJobID: strings.TrimSpace(os.Getenv(environmentJobIDEnvVar)),
 	}
 	if err := writeEnvironmentJob(dir, job); err != nil {
 		return nil, err
@@ -605,9 +610,12 @@ func RunEnvironmentJobSupervisor(params EnvironmentJobSupervisorParams) error {
 
 	cmd := Command(params.Command[0], params.Command[1:]...)
 	cmd.Dir = params.Dir
-	if len(params.Env) > 0 {
-		cmd.Env = append(os.Environ(), sortedEnvironmentJobEnvPairs(params.Env)...)
-	}
+	// ERUN_JOB_ID always rides along, not only when the caller sets Env: it is
+	// what lets a nested `job start` run from inside this work (agent-gate.sh's
+	// detach-and-await, or an agent driving it directly) record this job as its
+	// StartedByJobID, so this job's own finish check can tell that nested job
+	// apart from an unrelated one sharing the environment.
+	cmd.Env = append(append(os.Environ(), sortedEnvironmentJobEnvPairs(params.Env)...), environmentJobIDEnvVar+"="+job.ID)
 	cmd.Stdin = nil
 	cmd.Stdout = writer
 	cmd.Stderr = writer
@@ -655,6 +663,19 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		jobState = EnvironmentJobStateAbandoned
 		reason = "the job's own process exited, but it left other processes still running in its process group — background work it started and never waited for; nothing further will be reported for that work"
 	}
+	// A gate a job started through its own `job start` (agent-gate.sh's
+	// detach-and-await, or an agent driving it directly) runs as its own
+	// detached, unrelated-process-group job, so it never shows up in the
+	// process-group check above -- this is the second, independent way a job
+	// can end while work it started has not: a sibling job record, not a
+	// process. It takes priority over a plain abandoned verdict because a
+	// still-running job record is something a caller can actually await for a
+	// real outcome, unlike an orphaned process group member.
+	self := recorder.snapshot()
+	if running := environmentJobRunningChildren(recorder.dir, self.ID, time.Now()); len(running) > 0 {
+		jobState = EnvironmentJobStateGateIncomplete
+		reason = environmentJobGateIncompleteReason(running)
+	}
 	recorder.update(func(job *EnvironmentJob) {
 		job.State = jobState
 		job.EndedAt = time.Now()
@@ -668,6 +689,21 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		job.ExitCode = &code
 	})
 	return nil
+}
+
+// environmentJobGateIncompleteReason names the still-running job(s) a caller
+// needs to await for a real outcome, so the reason is actionable rather than
+// just a label.
+func environmentJobGateIncompleteReason(running []EnvironmentJob) string {
+	ids := make([]string, 0, len(running))
+	for _, job := range running {
+		ids = append(ids, job.ID)
+	}
+	noun := "job"
+	if len(ids) != 1 {
+		noun = "jobs"
+	}
+	return fmt.Sprintf("this job ended while the %s it started (%s) had not reached a verdict; await it directly for the real outcome instead of treating this job's own exit as the answer", noun, strings.Join(ids, ", "))
 }
 
 // startEnvironmentJobAliveBeat stamps the job's alive fields immediately and

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -1051,11 +1051,14 @@ Use it instead of hand-rolling detachment, a log redirect, a polling loop, a sen
 | `running` | The recorded process is alive and no outcome has been observed. | `null` |
 | `exited` | The work finished and the supervisor captured its status. `-1` means it was terminated by a signal, which `signal` names. | integer |
 | `abandoned` | The job's own process exited and the supervisor captured its exit status, but it left something it spawned still running in its process group — background work started and never waited for, e.g. a gate a job backgrounded and then exited past. `reason` describes it. Never a success, whatever `exitCode` says. | integer |
+| `gate-incomplete` | The job's own process exited and the supervisor captured its exit status, but a job *it started* (via `job start`, e.g. a gate run through `agent-gate.sh`) had not reached a verdict yet. `reason` names the still-running job(s). Never a success, whatever `exitCode` says. | integer |
 | `unknown` | The record outlived whatever was meant to finish it — the supervisor is gone without recording an outcome (most often because the runtime pod was replaced), or an attached job's tracked process is gone. `reason` says which. | `null` |
 
 The demotion to `unknown` happens on the next read and is persisted, so every later read gives the same answer. An `unknown` job is never a success: `job await` exits `125` for it, distinct from both `0` and a failure.
 
 `abandoned` sits between the two: like `exited`, the supervisor did observe the process end and recorded a real `exitCode` for it; like `unknown`, it is never a success — even an `exitCode` of `0` is not one, because something the job started is still running and nothing will ever report on it again. Detection happens once, right after the supervisor reaps the job's own process, by checking whether its process group still has a live member; that check is POSIX-only, so on Windows a job that backgrounds work this way still reads back as a plain `exited`. `job status`/`job await` render it as `abandoned <exitCode>: <name> (<reason>)`, distinct from both `exited <exitCode>: <name>` and `unknown: <name> (<reason>)`.
+
+`gate-incomplete` is `abandoned`'s sibling for a different shape of leftover work: not a process in the job's own process group, but a *sibling job record* — one started through `job start` from inside this job's own work, most commonly an agent running its `make check` gate through `agent-gate.sh` (which detaches the gate as its own job precisely so it survives the caller). That detachment is also what makes `abandoned`'s process-group check blind to it: the child job runs in its own session on purpose. Every job's own process carries `ERUN_JOB_ID` naming the job it is running as, so a nested `job start` reached from inside it — directly, or through anything it spawns — records that value as its own `startedByJobId`. When a job's process ends, the supervisor checks the job store for any job naming it as `startedByJobId` that has not finished; finding one sets `gate-incomplete` instead of `exited`, even at `exitCode: 0`. This is what turns "an agent ended its turn while the gate it started was still running" from a silent, unnoticed success into a state an orchestrator can poll for. `job status`/`job await` render it as `gate-incomplete <exitCode>: <name> (<reason>)`.
 
 ### The alive contract {#alive-contract}
 
@@ -1184,7 +1187,7 @@ The call returns inside the timeout either way, so no connection is held open fo
 | Exit code | Meaning |
 |---|---|
 | `0` | The job reached `exited` with code `0`. |
-| `1` | The job reached `exited` with a non-zero code, or its state is `abandoned` — background work it started outlived it, so even a captured `exitCode` of `0` is never a success. `job.exitCode` carries the captured code either way; the message text says which case it is. |
+| `1` | The job reached `exited` with a non-zero code, or its state is `abandoned` or `gate-incomplete` — work it started (a process it left running, or a job it started that has not finished) outlived it, so even a captured `exitCode` of `0` is never a success. `job.exitCode` carries the captured code either way; the message text says which case it is. |
 | `124` | The timeout elapsed with the job still running. Matches `timeout(1)`. |
 | `125` | The job's state is `unknown` — no outcome was ever recorded. |
 

--- a/erun-integration/job_test.go
+++ b/erun-integration/job_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -710,6 +711,59 @@ func TestJob(t *testing.T) {
 			t.Fatalf("expected an abandoned job to report a failure outcome, got %d:\n%s", await.ExitCode, await.Combined)
 		}
 		golden.Equal(t, "job/a_job_that_backgrounds_work_and_exits_reads_as_abandoned_not_success", normalize.Apply(status.Combined+await.Combined))
+	})
+
+	t.Run("a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete", func(t *testing.T) {
+		// The reproduction this closes: an agent job runs a gate through its own
+		// `job start` (exactly what agent-gate.sh's detach-and-await does from
+		// inside an agent's Bash tool) and then ends -- by backgrounding itself,
+		// running out of turns, or an outer `timeout` killing the foreground
+		// wait -- while the gate has not reached a verdict. The gate is a
+		// separate, detached job on purpose, so it is never a member of the
+		// outer job's process group and the abandoned scenario above cannot see
+		// it; only the StartedByJobID record relationship can. The nested
+		// `job start` here runs through the real compiled binary rather than a
+		// seeded record, so this locks the whole wiring end to end: the outer
+		// job's supervisor has to actually propagate ERUN_JOB_ID to the "work"
+		// stub's process, and the stub's own nested erun call has to actually
+		// read it back onto the gate job it starts.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		bin := erun.BinaryPath(t)
+		// The nested job start's own stdout (a "job started: ..." line naming its
+		// log path) is discarded rather than left to land in outer's captured
+		// output: the log path's length varies with the test's own tempdir name,
+		// which would make outer's recorded outputBytes -- and so the golden --
+		// flaky across runs.
+		script := fmt.Sprintf("%q job start --tenant team --environment dev --name gate --id gate -- sleep 30 >/dev/null 2>&1\nexit 0\n", bin)
+		envVars := jobStubEnv(t, setup, script)
+
+		start := startJob(t, setup, envVars, "outer", "--", "work")
+		if start.ExitCode != 0 {
+			t.Fatalf("start: exit %d: %s", start.ExitCode, start.Combined)
+		}
+		t.Cleanup(func() {
+			erun.Run(t, []string{"job", "cancel", "--tenant", "team", "--environment", "dev", "--id", "gate", "--signal", "KILL"},
+				erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		})
+
+		var status erun.Result
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			status = erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "outer"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+			if !strings.HasPrefix(status.Combined, "running:") {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("job never left running: %s", status.Combined)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "outer", "--timeout", "1s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if await.ExitCode != 1 {
+			t.Fatalf("expected a gate-incomplete job to report a failure outcome, got %d:\n%s", await.ExitCode, await.Combined)
+		}
+		golden.Equal(t, "job/a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete", normalize.Apply(status.Combined+await.Combined))
 	})
 
 	t.Run("a_job_started_on_a_different_pod_reads_back_as_pod_replaced_not_a_guess", func(t *testing.T) {

--- a/erun-integration/testdata/job/a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete.txt
+++ b/erun-integration/testdata/job/a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete.txt
@@ -1,0 +1,5 @@
+gate-incomplete 0: outer (this job ended while the job it started (gate) had not reached a verdict; await it directly for the real outcome instead of treating this job's own exit as the answer), 0 bytes of output
+audit: erun job status --environment dev --id outer --tenant team
+gate-incomplete 0: outer (this job ended while the job it started (gate) had not reached a verdict; await it directly for the real outcome instead of treating this job's own exit as the answer), 0 bytes of output
+audit: erun job await --environment dev --id outer --tenant team --timeout 1s
+job "outer" ended while work it started was still running: this job ended while the job it started (gate) had not reached a verdict; await it directly for the real outcome instead of treating this job's own exit as the answer

--- a/scripts/agent-gate.sh
+++ b/scripts/agent-gate.sh
@@ -62,6 +62,31 @@ fi
 : "${ERUN_TENANT:?agent-gate.sh: ERUN_TENANT is not set (expected inside an agent pod)}"
 : "${ERUN_ENVIRONMENT:?agent-gate.sh: ERUN_ENVIRONMENT is not set (expected inside an agent pod)}"
 
+# warn_if_wrapped_in_timeout looks a few hops up the process tree for an
+# ancestor named `timeout`. An outer `timeout` around this script can only
+# ever truncate the bounded await below -- it has no way to extend it -- so
+# wrapping a call meant to protect a gate in a second, shorter deadline can
+# only defeat the protection, never help it. This is a warning, not a refusal:
+# the ancestor walk is a `ps` heuristic (best-effort if `ps` is unavailable),
+# and a caller who genuinely wants a hard outer bound has a real use for it
+# (e.g. bounding total wall-clock across several agent-gate.sh re-invocations).
+warn_if_wrapped_in_timeout() {
+	pid="$PPID"
+	hops=0
+	while [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "1" ] && [ "$hops" -lt 8 ]; do
+		comm=$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ') || return 0
+		case "$comm" in
+		timeout|*/timeout)
+			printf 'agent-gate: this invocation appears to run under an outer '\''timeout'\'' (pid %s) -- timeout can only truncate the bounded await below, never extend it, so it can end up killing the gate this script exists to protect. Run agent-gate.sh directly in the foreground and re-invoke it again if it reports "still running" instead.\n' "$pid" >&2
+			return 0
+			;;
+		esac
+		pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+		hops=$((hops + 1))
+	done
+}
+warn_if_wrapped_in_timeout
+
 # hash_stdin prints the sha256 of stdin. Prefers sha256sum (the Linux runtime
 # image); falls back to shasum so this runs on a macOS dev host too.
 hash_stdin() {

--- a/scripts/agent-gate_test.sh
+++ b/scripts/agent-gate_test.sh
@@ -225,6 +225,62 @@ stub_erun "${case_dir}/bin"
 	grep -q 'exec job output' "$STUB_ARGV_FILE" || fail "happy path: job output was never read back"
 )
 
+# --- an outer `timeout` wrapping this invocation is warned about: it can only
+# ever truncate the bounded await below, never extend it, so it risks killing
+# exactly the gate this script exists to protect. The warning must not change
+# the outcome -- the happy path underneath still runs and reports normally.
+case_dir="${work_root}/outer-timeout-warning"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+if ! command -v timeout >/dev/null 2>&1; then
+	echo "skip: outer-timeout-warning (no timeout(1) on this host)" >&2
+else
+	(
+		export PATH="${case_dir}/bin:$PATH"
+		export STUB_ARGV_FILE
+		export ERUN_ENV_TYPE=local-agent
+		export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+		export STUB_AWAIT_STATUS=0
+		export STUB_JOB_OUTPUT='job output line'
+		set +e
+		OUT=$(timeout 30 "$gate" check "make check" -- make check-gate 2>&1)
+		STATUS=$?
+		set -e
+		[ "$STATUS" -eq 0 ] || fail "outer timeout warning: expected exit 0, got $STATUS ($OUT)"
+		case "$OUT" in
+		*"appears to run under an outer"*) ;;
+		*) fail "outer timeout warning: expected the outer-timeout warning, got: $OUT" ;;
+		esac
+		case "$OUT" in
+		*"job output line"*) ;;
+		*) fail "outer timeout warning: expected the job's captured output despite the warning, got: $OUT" ;;
+		esac
+	)
+fi
+
+# --- no outer timeout: the warning must not fire for a plain foreground call.
+case_dir="${work_root}/no-outer-timeout-no-warning"
+mkdir -p "$case_dir"
+STUB_ARGV_FILE="${case_dir}/argv"
+: >"$STUB_ARGV_FILE"
+stub_erun "${case_dir}/bin"
+(
+	export PATH="${case_dir}/bin:$PATH"
+	export STUB_ARGV_FILE
+	export ERUN_ENV_TYPE=local-agent
+	export ERUN_TENANT=acme ERUN_ENVIRONMENT=dev
+	export STUB_AWAIT_STATUS=0
+	export STUB_JOB_OUTPUT='job output line'
+	run_gate check "make check" -- make check-gate
+	[ "$STATUS" -eq 0 ] || fail "no outer timeout: expected exit 0, got $STATUS ($OUT)"
+	case "$OUT" in
+	*"appears to run under an outer"*) fail "no outer timeout: warning fired with no outer timeout present: $OUT" ;;
+	*) ;;
+	esac
+)
+
 # --- a job already running from a prior invocation: start refuses, and the
 # script must fall through to await rather than treating that as fatal.
 case_dir="${work_root}/already-running"


### PR DESCRIPTION
## Summary

Four times in one day, an agent job ended `subtype: success` while the gate meant to justify its work (`make check` via `agent-gate.sh`) was still running, orphaned, or killed — by four different mechanisms (backgrounding, turn exhaustion, an outer `timeout`, backgrounding again). The common shape: the gate runs as its own separately-tracked `EnvironmentJob`, detached into its own session on purpose (so it survives the caller) — which is exactly what makes it invisible to the existing process-group-based `abandoned` check. A human had to notice a missing activity lease to catch it.

- **New terminal state: `gate-incomplete`.** Every job's own process now carries `ERUN_JOB_ID` naming the job it's running as (`erun-common/job_supervisor.go`). A nested `job start` reached from inside that process — directly, or through anything it spawns, e.g. `agent-gate.sh`'s own `erun exec job start` — inherits that env var and records it as its `StartedByJobID`. When a job's own process ends, the supervisor now checks the job store for any job naming it as `StartedByJobID` that hasn't finished; if one is found, the job reads back as `gate-incomplete`, never `exited 0`, however it actually ended. An orchestrator observes this the same way it observes every other job state: `job status`/`job await --output json`'s `state` field (also passed through verbatim by the `exec_agent`/`exec_raw` MCP tools), or the plain-text `gate-incomplete <exitCode>: <name> (<reason>)` rendering; `job await`'s exit code stays `1` (grouped with `abandoned`, distinct from `0`/`124`/`125`).
- **Item 2 (register ownership) — done, via a stronger mechanism than the issue's own suggestion.** Rather than teaching `agent-gate.sh` itself to register ownership, the `ERUN_JOB_ID`/`StartedByJobID` plumbing lives in the shared job primitive (`erun-common`), so *any* nested `job start` from inside *any* job's process tree is automatically attributed — not just the `agent-gate.sh` case.
- **Item 3 (warn on outer `timeout`) — done.** `agent-gate.sh` now walks a few hops up its own process tree and warns on stderr if it finds an ancestor named `timeout`, since that combination can only ever truncate the bounded await it exists to protect. It's a warning, not a refusal (`scripts/agent-gate.sh`, tested in `scripts/agent-gate_test.sh`).
- Docs: `erun-docs/docs/agent-reference/cli-flags.md`'s job-states table and `job await` exit-code table now cover `gate-incomplete`.

## Tests

- `erun-common/job_abandoned_test.go`:
  - `TestEnvironmentJobThatEndsWhileAJobItStartedIsStillRunningIsNotReportedAsSuccess` — the mandatory negative case: a job ends cleanly (`exit 0`) while a sibling job record naming it as `StartedByJobID` is still running; asserts `!Succeeded()` and `State == gate-incomplete`.
  - `TestEnvironmentJobSupervisorPropagatesItsOwnIDToTheWorksProcess` — locks the `ERUN_JOB_ID` wiring itself.
- `erun-integration/job_test.go::a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete` — end-to-end through the compiled binary: an outer job's stub work nests a real `job start` for a "gate" job, exits immediately, and `job status`/`job await` on the outer job report `gate-incomplete`, never a clean exit. Golden added.
- `scripts/agent-gate_test.sh` — two new cases: the outer-`timeout` warning fires under `timeout` and does not fire without it, in both cases without changing the happy-path outcome.

`golangci-lint`'s `cyclop` check flagged `finishEnvironmentJob` once the new check landed (complexity 11 > 10); split the decision logic into `resolveEnvironmentJobOutcome` (no behavior change) to bring it back under the threshold — verified green afterward.

## Verbatim gate totals (this run, foreground, via `scripts/agent-gate.sh check check -- make check`)

```
exited 0: check, 6526 bytes of output
```
Full run: `golangci-lint` 0 issues across all six modules, `go test erun-ui` ok, `erun-kit`/`erun-console` gates (tsc/eslint/prettier/vitest) all green, every `erun-devops/k8s/*_test.sh` PASS/OK, integration suite `ok` (88.082s) with coverage `76.2% (>= 75.8%)`.

Closes #1568