### PR TITLE
Make a lane's uncommitted work observable and self-checkpointing

### DIFF
--- a/erun-cli/cmd/job.go
+++ b/erun-cli/cmd/job.go
@@ -435,7 +435,33 @@ func jobExitedLine(job common.EnvironmentJob) string {
 	if strings.TrimSpace(job.Signal) != "" {
 		line += fmt.Sprintf(" (signal %s)", job.Signal)
 	}
-	return line + jobAgentSuffix(job) + jobOutputSuffix(job)
+	return line + jobAgentSuffix(job) + jobWorktreeSuffix(job) + jobOutputSuffix(job)
+}
+
+// jobWorktreeSuffix surfaces a dirty working tree on any terminal line, so a
+// job that otherwise looks like a clean success still shows the one thing its
+// exit status cannot: uncommitted work in its own working directory, and
+// whether the supervisor managed to check-point it. See job_worktree.go in
+// erun-common for what this reports and why.
+func jobWorktreeSuffix(job common.EnvironmentJob) string {
+	if !job.WorktreeDirty {
+		return ""
+	}
+	return ", " + jobWorktreeSummary(job)
+}
+
+// jobWorktreeSummary is the human-readable half of jobWorktreeSuffix, reused
+// by jobAwaitExit's error text so the two surfaces never describe the same
+// outcome differently.
+func jobWorktreeSummary(job common.EnvironmentJob) string {
+	switch {
+	case job.WorktreePushed:
+		return fmt.Sprintf("working tree was dirty; checkpointed as %s and pushed to %s", job.WorktreeCommit, job.WorktreeRemote)
+	case job.WorktreeCommit != "":
+		return fmt.Sprintf("working tree was dirty; checkpointed as %s but not pushed: %s", job.WorktreeCommit, job.WorktreeReason)
+	default:
+		return fmt.Sprintf("working tree was dirty and left uncommitted: %s", job.WorktreeReason)
+	}
 }
 
 // jobAbandonedLine is rendered distinctly from both exited and unknown: the
@@ -449,7 +475,7 @@ func jobAbandonedLine(job common.EnvironmentJob) string {
 	if strings.TrimSpace(job.Reason) != "" {
 		line += " (" + job.Reason + ")"
 	}
-	return line + jobAgentSuffix(job) + jobOutputSuffix(job)
+	return line + jobAgentSuffix(job) + jobWorktreeSuffix(job) + jobOutputSuffix(job)
 }
 
 // jobGateIncompleteLine is rendered distinctly from abandoned: the still-running
@@ -463,7 +489,7 @@ func jobGateIncompleteLine(job common.EnvironmentJob) string {
 	if strings.TrimSpace(job.Reason) != "" {
 		line += " (" + job.Reason + ")"
 	}
-	return line + jobAgentSuffix(job) + jobOutputSuffix(job)
+	return line + jobAgentSuffix(job) + jobWorktreeSuffix(job) + jobOutputSuffix(job)
 }
 
 func jobUnknownLine(job common.EnvironmentJob) string {
@@ -616,6 +642,8 @@ func jobAwaitExit(result common.AwaitEnvironmentJobResult) error {
 		return fmt.Errorf("job %q abandoned background work: %s", result.Job.ID, result.Job.Reason)
 	case result.Job.State == common.EnvironmentJobStateGateIncomplete:
 		return fmt.Errorf("job %q ended while work it started was still running: %s", result.Job.ID, result.Job.Reason)
+	case result.Job.WorktreeDirty:
+		return fmt.Errorf("job %q ended with an uncommitted working tree: %s", result.Job.ID, jobWorktreeSummary(result.Job))
 	default:
 		return fmt.Errorf("job %q exited %d", result.Job.ID, jobExitCodeOrUnset(result.Job))
 	}

--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -236,6 +236,40 @@ type EnvironmentJob struct {
 	// synchronously. Nil for every other kind, and for a task that has not
 	// finished yet.
 	Result json.RawMessage `json:"result,omitempty"`
+
+	// WorktreeDirty is set only for a finished agent job whose Dir was a git
+	// working tree that still had uncommitted changes (tracked or untracked,
+	// respecting .gitignore) when the job ended. False for every command job,
+	// for an agent job with no working directory or one outside a git repo,
+	// and for an agent job that left its tree clean — none of those cases are
+	// distinguishable from each other, and none of them need to be: this field
+	// exists only to make "the agent's turn ended with unsaved work" visible,
+	// which an exit code alone cannot say. See job_worktree.go.
+	WorktreeDirty bool `json:"worktreeDirty,omitempty"`
+	// WorktreeBranch is the branch HEAD pointed at when the check ran, "HEAD"
+	// literal when detached, empty when WorktreeDirty is false.
+	WorktreeBranch string `json:"worktreeBranch,omitempty"`
+	// WorktreeDetached is true when HEAD was not on a branch at all. A
+	// checkpoint commit there would be unreachable the moment HEAD moves, so
+	// the supervisor never attempts one in that state.
+	WorktreeDetached bool `json:"worktreeDetached,omitempty"`
+	// WorktreeCommit is the machine-authored checkpoint commit the supervisor
+	// made to preserve a dirty tree, empty when it made none — whether because
+	// the tree was clean, committing was refused as unsafe, or the commit
+	// itself failed (see WorktreeReason for which).
+	WorktreeCommit string `json:"worktreeCommit,omitempty"`
+	// WorktreePushed reports whether WorktreeCommit reached WorktreeRemote. A
+	// commit that exists only in this working tree is exactly as exposed to a
+	// lost pod as the uncommitted changes it was meant to save.
+	WorktreePushed bool `json:"worktreePushed,omitempty"`
+	// WorktreeRemote is the remote WorktreeCommit was pushed to, empty when
+	// nothing was pushed.
+	WorktreeRemote string `json:"worktreeRemote,omitempty"`
+	// WorktreeReason explains a dirty tree the supervisor could not fully
+	// resolve: why no checkpoint commit was made, or why one was made but not
+	// pushed. Empty when WorktreeDirty is false, or when a commit was made and
+	// pushed cleanly.
+	WorktreeReason string `json:"worktreeReason,omitempty"`
 }
 
 // Finished reports whether the job reached a terminal state.
@@ -245,13 +279,18 @@ func (j EnvironmentJob) Finished() bool {
 }
 
 // Succeeded is the only definition of success: an outcome was captured and it
-// was zero, with nothing left running behind it. An unknown job is never a
-// success, and neither is an abandoned or gate-incomplete one — a zero exit
-// code from the process that started work it never waited for, whether that
-// work is an unreaped process in its own group or a sibling job record, is
-// not the same claim as a zero exit code from a job that finished cleanly.
+// was zero, with nothing left running behind it and nothing left uncommitted
+// in its own working tree. An unknown job is never a success, and neither is
+// an abandoned or gate-incomplete one — a zero exit code from the process
+// that started work it never waited for, whether that work is an unreaped
+// process in its own group or a sibling job record, is not the same claim as
+// a zero exit code from a job that finished cleanly. A dirty working tree is
+// the same shape of not-actually-clean finish: whatever the supervisor
+// managed to preserve on the agent's behalf (see job_worktree.go), the agent
+// itself did not commit its own work, and that is worth a caller's attention
+// even when everything else about the run looks fine.
 func (j EnvironmentJob) Succeeded() bool {
-	return j.State == EnvironmentJobStateExited && j.ExitCode != nil && *j.ExitCode == 0
+	return j.State == EnvironmentJobStateExited && j.ExitCode != nil && *j.ExitCode == 0 && !j.WorktreeDirty
 }
 
 // LoadEnvironmentJob returns one job with its state resolved, reconciling and

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -642,12 +642,17 @@ func RunEnvironmentJobSupervisor(params EnvironmentJobSupervisorParams) error {
 // that group after the leader is gone — work the leader backgrounded and
 // never waited for — is answered here, not left for the exit code alone to
 // misreport as a clean success.
+//
+// captureAgentJobWorktreeOutcome runs here too, before the exit code alone
+// could be read as the whole story: an agent job's own working tree is
+// something its exit status says nothing about at all (see job_worktree.go).
 func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *jobOutputWriter, childPID int, state *os.ProcessState, waitErr error) error {
 	// Fold the stream's tail before the outcome lands, so the finished record
 	// carries what the run last did rather than the poll's stale view of it.
 	beat.refresh(false)
 
 	code, signal, reason, jobState := resolveEnvironmentJobOutcome(recorder, childPID, state, waitErr)
+	worktree := captureAgentJobWorktreeOutcome(recorder.snapshot())
 	recorder.update(func(job *EnvironmentJob) {
 		job.State = jobState
 		job.EndedAt = time.Now()
@@ -659,6 +664,7 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		}
 		job.Reason = reason
 		job.ExitCode = &code
+		worktree.apply(job)
 	})
 	return nil
 }

--- a/erun-common/job_worktree.go
+++ b/erun-common/job_worktree.go
@@ -10,10 +10,10 @@ import (
 // An agent job's working tree is the one thing its own exit status says
 // nothing about: a clean exit and a tree with 1,200 uncommitted lines look
 // identical to a caller reading only State and ExitCode. This is that gap,
-// closed the same way #1568 closed gate-incomplete — a check the supervisor
-// makes on every agent job's own finish, folded into the record it already
-// writes, rather than a prompt instruction the agent has to remember under
-// turn pressure.
+// closed the same way gate-incomplete was — a check the supervisor makes on
+// every agent job's own finish, folded into the record it already writes,
+// rather than a prompt instruction the agent has to remember under turn
+// pressure.
 //
 // The supervisor does not just observe. Where it is safe to, it also makes a
 // machine-authored checkpoint commit and pushes it, because the agent that

--- a/erun-common/job_worktree.go
+++ b/erun-common/job_worktree.go
@@ -1,0 +1,209 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// An agent job's working tree is the one thing its own exit status says
+// nothing about: a clean exit and a tree with 1,200 uncommitted lines look
+// identical to a caller reading only State and ExitCode. This is that gap,
+// closed the same way #1568 closed gate-incomplete — a check the supervisor
+// makes on every agent job's own finish, folded into the record it already
+// writes, rather than a prompt instruction the agent has to remember under
+// turn pressure.
+//
+// The supervisor does not just observe. Where it is safe to, it also makes a
+// machine-authored checkpoint commit and pushes it, because the agent that
+// would otherwise do this by hand is already gone by the time anyone reads
+// the record. "Safe" is deliberately narrow: a real branch (not detached
+// HEAD, where a commit is unreachable the moment HEAD moves), not a branch
+// this job treats as protected (main/master/develop, or the remote's actual
+// default), and not mid-merge/rebase/cherry-pick (where committing over the
+// operation's own state could corrupt it). Outside that envelope the
+// supervisor only reports what it saw; it never guesses its way into a
+// commit that could do more harm than the dirty tree it was trying to save.
+
+// agentJobWorktreeCommitMessage marks a checkpoint commit as machine-authored
+// so nobody mistakes it for the agent's own work.
+const agentJobWorktreeCommitMessage = "WIP: checkpoint by the erun job supervisor\n\n" +
+	"The agent job that produced this working tree ended without committing\n" +
+	"its own changes. This commit exists only to keep that work from being\n" +
+	"lost, not as a finished change — rewrite, amend, or squash it freely."
+
+// environmentJobWorktreeOutcome is what an agent job's finish observed about
+// its working tree and, best-effort, did about it. The zero value means
+// "nothing to report": either the job was not an agent job, its Dir was not a
+// git working tree, or the tree was clean.
+type environmentJobWorktreeOutcome struct {
+	dirty    bool
+	branch   string
+	detached bool
+	commit   string
+	pushed   bool
+	remote   string
+	reason   string
+}
+
+func (o environmentJobWorktreeOutcome) apply(job *EnvironmentJob) {
+	job.WorktreeDirty = o.dirty
+	job.WorktreeBranch = o.branch
+	job.WorktreeDetached = o.detached
+	job.WorktreeCommit = o.commit
+	job.WorktreePushed = o.pushed
+	job.WorktreeRemote = o.remote
+	job.WorktreeReason = o.reason
+}
+
+// captureAgentJobWorktreeOutcome is called once, at the same point the
+// supervisor resolves the rest of a finished job's outcome. It runs plain git
+// plumbing directly rather than through a caller-supplied Context, because the
+// supervisor has none of its own beyond a discarded stdout/stderr — this is
+// not a user-facing trace, it is the same kind of internal bookkeeping call
+// finishEnvironmentJob already makes.
+func captureAgentJobWorktreeOutcome(job EnvironmentJob) environmentJobWorktreeOutcome {
+	if job.Kind != EnvironmentJobKindAgent {
+		return environmentJobWorktreeOutcome{}
+	}
+	dir := strings.TrimSpace(job.Dir)
+	if dir == "" {
+		return environmentJobWorktreeOutcome{}
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return environmentJobWorktreeOutcome{}
+	}
+	ctx := Context{Logger: NewLogger(VerbosityInfo)}
+	if inside, err := gitIsInsideWorkTree(ctx, dir); err != nil || !inside {
+		return environmentJobWorktreeOutcome{}
+	}
+	changed, err := gitChangedWorkingTreeFiles(ctx, dir)
+	if err != nil || len(changed) == 0 {
+		return environmentJobWorktreeOutcome{}
+	}
+	branch, err := GitCurrentBranch(ctx, dir)
+	if err != nil {
+		return environmentJobWorktreeOutcome{}
+	}
+
+	outcome := environmentJobWorktreeOutcome{dirty: true, branch: branch}
+	if branch == "HEAD" {
+		outcome.detached = true
+		outcome.reason = "the working tree had uncommitted changes when the job ended, but HEAD was detached; " +
+			"a checkpoint commit there would be unreachable the moment HEAD moves, so none was made"
+		return outcome
+	}
+	if repoDir, err := gitResolveGitDir(ctx, dir); err == nil && gitOperationInProgress(repoDir) {
+		outcome.reason = "the working tree had uncommitted changes when the job ended, but a git operation " +
+			"(merge, rebase, cherry-pick, or revert) was in progress; committing over it could corrupt that " +
+			"operation's own state, so none was made"
+		return outcome
+	}
+	if environmentJobWorktreeIsProtectedBranch(ctx, dir, branch) {
+		outcome.reason = fmt.Sprintf("the working tree had uncommitted changes when the job ended, on %q, which "+
+			"this job treats as a protected branch; an automatic checkpoint commit there is refused", branch)
+		return outcome
+	}
+
+	commitResult, err := CommitWorkingTree(ctx, dir, CommitWorkingTreeParams{
+		Branch:  branch,
+		Message: agentJobWorktreeCommitMessage,
+	}, CommitWorkingTreeDependencies{})
+	if err != nil {
+		outcome.reason = fmt.Sprintf("the working tree had uncommitted changes when the job ended and the "+
+			"automatic checkpoint commit failed: %v", err)
+		return outcome
+	}
+	outcome.commit = commitResult.Commit
+
+	pushResult, err := PushWorkingTreeBranch(ctx, dir, PushWorkingTreeBranchParams{Branch: branch}, PushWorkingTreeBranchDependencies{})
+	if err != nil {
+		outcome.reason = fmt.Sprintf("the job made a checkpoint commit (%s) for its uncommitted changes but could "+
+			"not push it: %v; that commit is only as safe as this one working tree", commitResult.Commit, err)
+		return outcome
+	}
+	outcome.pushed = true
+	outcome.remote = pushResult.Remote
+	return outcome
+}
+
+// gitIsInsideWorkTree reports whether dir sits inside a git working tree at
+// all — an agent job's Dir is not guaranteed to be one, and this is what lets
+// every other check in this file no-op cleanly instead of misreading git's
+// own "not a git repository" error as some other failure.
+func gitIsInsideWorkTree(ctx Context, dir string) (bool, error) {
+	ctx.TraceCommand("", "git", "-C", dir, "rev-parse", "--is-inside-work-tree")
+	output, err := Command("git", "-C", dir, "rev-parse", "--is-inside-work-tree").Output()
+	if err != nil {
+		return false, nil
+	}
+	return strings.TrimSpace(string(output)) == "true", nil
+}
+
+// gitResolveGitDir resolves dir's actual .git directory, following the
+// pointer file a linked worktree uses instead of a real .git directory, so the
+// in-progress-operation check below looks in the right place for a lane
+// checked out as a worktree rather than a plain clone.
+func gitResolveGitDir(ctx Context, dir string) (string, error) {
+	ctx.TraceCommand("", "git", "-C", dir, "rev-parse", "--git-dir")
+	output, err := Command("git", "-C", dir, "rev-parse", "--git-dir").Output()
+	if err != nil {
+		return "", err
+	}
+	resolved := strings.TrimSpace(string(output))
+	if resolved == "" {
+		return "", fmt.Errorf("git rev-parse --git-dir returned an empty path")
+	}
+	if !filepath.IsAbs(resolved) {
+		resolved = filepath.Join(dir, resolved)
+	}
+	return resolved, nil
+}
+
+// gitOperationInProgressMarkers are the state files git leaves in the git dir
+// while a merge, rebase, cherry-pick, or revert is unresolved.
+var gitOperationInProgressMarkers = []string{
+	"MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD", "rebase-merge", "rebase-apply",
+}
+
+func gitOperationInProgress(gitDir string) bool {
+	for _, marker := range gitOperationInProgressMarkers {
+		if _, err := os.Stat(filepath.Join(gitDir, marker)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// environmentJobWorktreeIsProtectedBranch reports whether branch is one this
+// job refuses to leave an automatic checkpoint commit on. The remote's own
+// default branch is authoritative when it can be read; the common names cover
+// the case where origin/HEAD's symref was never set locally (e.g. a shallow
+// or single-branch fetch), which is a real layout this repository's own lanes
+// use.
+func environmentJobWorktreeIsProtectedBranch(ctx Context, dir, branch string) bool {
+	if def, ok := gitRemoteDefaultBranch(ctx, dir, "origin"); ok {
+		return branch == def
+	}
+	switch branch {
+	case "main", "master", "develop":
+		return true
+	default:
+		return false
+	}
+}
+
+func gitRemoteDefaultBranch(ctx Context, dir, remote string) (string, bool) {
+	ctx.TraceCommand("", "git", "-C", dir, "symbolic-ref", "refs/remotes/"+remote+"/HEAD")
+	output, err := Command("git", "-C", dir, "symbolic-ref", "refs/remotes/"+remote+"/HEAD").Output()
+	if err != nil {
+		return "", false
+	}
+	ref := strings.TrimSpace(string(output))
+	prefix := "refs/remotes/" + remote + "/"
+	if !strings.HasPrefix(ref, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(ref, prefix), true
+}

--- a/erun-common/job_worktree.go
+++ b/erun-common/job_worktree.go
@@ -64,48 +64,73 @@ func (o environmentJobWorktreeOutcome) apply(job *EnvironmentJob) {
 // not a user-facing trace, it is the same kind of internal bookkeeping call
 // finishEnvironmentJob already makes.
 func captureAgentJobWorktreeOutcome(job EnvironmentJob) environmentJobWorktreeOutcome {
-	if job.Kind != EnvironmentJobKindAgent {
+	ctx := Context{Logger: NewLogger(VerbosityInfo)}
+	dir, branch, dirty := agentJobDirtyWorktree(ctx, job)
+	if !dirty {
 		return environmentJobWorktreeOutcome{}
 	}
-	dir := strings.TrimSpace(job.Dir)
+	outcome := environmentJobWorktreeOutcome{dirty: true, branch: branch, detached: branch == "HEAD"}
+	if reason, refused := refuseAgentJobWorktreeCheckpoint(ctx, dir, branch); refused {
+		outcome.reason = reason
+		return outcome
+	}
+	return checkpointAgentJobWorktree(ctx, dir, branch, outcome)
+}
+
+// agentJobDirtyWorktree reports whether job is a finished agent job whose Dir
+// is a git working tree with uncommitted changes, and if so, its directory
+// and current branch ("HEAD" literal when detached).
+func agentJobDirtyWorktree(ctx Context, job EnvironmentJob) (dir, branch string, dirty bool) {
+	if job.Kind != EnvironmentJobKindAgent {
+		return "", "", false
+	}
+	dir = strings.TrimSpace(job.Dir)
 	if dir == "" {
-		return environmentJobWorktreeOutcome{}
+		return "", "", false
 	}
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
-		return environmentJobWorktreeOutcome{}
+		return "", "", false
 	}
-	ctx := Context{Logger: NewLogger(VerbosityInfo)}
 	if inside, err := gitIsInsideWorkTree(ctx, dir); err != nil || !inside {
-		return environmentJobWorktreeOutcome{}
+		return "", "", false
 	}
 	changed, err := gitChangedWorkingTreeFiles(ctx, dir)
 	if err != nil || len(changed) == 0 {
-		return environmentJobWorktreeOutcome{}
+		return "", "", false
 	}
-	branch, err := GitCurrentBranch(ctx, dir)
+	branch, err = GitCurrentBranch(ctx, dir)
 	if err != nil {
-		return environmentJobWorktreeOutcome{}
+		return "", "", false
 	}
+	return dir, branch, true
+}
 
-	outcome := environmentJobWorktreeOutcome{dirty: true, branch: branch}
+// refuseAgentJobWorktreeCheckpoint reports whether an automatic checkpoint
+// commit in dir on branch would be unsafe, and if so, why: a detached HEAD
+// (unreachable the moment HEAD moves), a merge/rebase/cherry-pick/revert in
+// progress (committing over it could corrupt that operation's own state), or
+// a branch this job treats as protected.
+func refuseAgentJobWorktreeCheckpoint(ctx Context, dir, branch string) (string, bool) {
 	if branch == "HEAD" {
-		outcome.detached = true
-		outcome.reason = "the working tree had uncommitted changes when the job ended, but HEAD was detached; " +
-			"a checkpoint commit there would be unreachable the moment HEAD moves, so none was made"
-		return outcome
+		return "the working tree had uncommitted changes when the job ended, but HEAD was detached; " +
+			"a checkpoint commit there would be unreachable the moment HEAD moves, so none was made", true
 	}
 	if repoDir, err := gitResolveGitDir(ctx, dir); err == nil && gitOperationInProgress(repoDir) {
-		outcome.reason = "the working tree had uncommitted changes when the job ended, but a git operation " +
+		return "the working tree had uncommitted changes when the job ended, but a git operation " +
 			"(merge, rebase, cherry-pick, or revert) was in progress; committing over it could corrupt that " +
-			"operation's own state, so none was made"
-		return outcome
+			"operation's own state, so none was made", true
 	}
 	if environmentJobWorktreeIsProtectedBranch(ctx, dir, branch) {
-		outcome.reason = fmt.Sprintf("the working tree had uncommitted changes when the job ended, on %q, which "+
-			"this job treats as a protected branch; an automatic checkpoint commit there is refused", branch)
-		return outcome
+		return fmt.Sprintf("the working tree had uncommitted changes when the job ended, on %q, which "+
+			"this job treats as a protected branch; an automatic checkpoint commit there is refused", branch), true
 	}
+	return "", false
+}
 
+// checkpointAgentJobWorktree makes the machine-authored commit and pushes it,
+// folding whichever step fails into outcome.reason so a caller always learns
+// what the supervisor actually managed to preserve.
+func checkpointAgentJobWorktree(ctx Context, dir, branch string, outcome environmentJobWorktreeOutcome) environmentJobWorktreeOutcome {
 	commitResult, err := CommitWorkingTree(ctx, dir, CommitWorkingTreeParams{
 		Branch:  branch,
 		Message: agentJobWorktreeCommitMessage,

--- a/erun-common/job_worktree_test.go
+++ b/erun-common/job_worktree_test.go
@@ -1,0 +1,254 @@
+package eruncommon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The reproduction this closes: an agent job's own exit status says nothing
+// about the state of the working tree it ran in. Six lanes in one session
+// each ended a turn with substantial work sitting uncommitted, and every one
+// of them read as a plain "exited 0" -- indistinguishable from a lane that
+// committed everything it did. A test that only proves the clean-finish case
+// still passes would leave every one of those cases shipping silently; the
+// dirty case below is the one that has to fail loudly.
+
+func runGitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// newAgentJobTestRepo creates a real git working tree with one commit on
+// branch "main", so tests exercise the actual git plumbing job_worktree.go
+// runs rather than a mocked stand-in for it.
+func newAgentJobTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitForTest(t, dir, "init", "-q", "-b", "main")
+	runGitForTest(t, dir, "config", "user.email", "test@example.com")
+	runGitForTest(t, dir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGitForTest(t, dir, "add", "seed.txt")
+	runGitForTest(t, dir, "commit", "-q", "-m", "seed")
+	return dir
+}
+
+// newBareRemoteForTest creates a bare repo elsewhere and wires it as dir's
+// "origin", so a checkpoint's push has a real remote to land on rather than
+// a stub that merely returns zero.
+func newBareRemoteForTest(t *testing.T, dir string) string {
+	t.Helper()
+	remote := t.TempDir()
+	runGitForTest(t, remote, "init", "-q", "--bare")
+	runGitForTest(t, dir, "remote", "add", "origin", remote)
+	return remote
+}
+
+func dirtyWorkingTree(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "uncommitted.txt"), []byte("lane work\n"), 0o644); err != nil {
+		t.Fatalf("write uncommitted file: %v", err)
+	}
+}
+
+func TestAgentJobWithADirtyWorkingTreeIsNotReportedAsSuccessAndIsCheckpointedAndPushed(t *testing.T) {
+	isolateActivityCache(t)
+	repo := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+
+	const tenant = "worktree-contract"
+	const environment = "dirty-checkpointed"
+	const id = "job"
+
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Name:        id,
+		Dir:         repo,
+		Agent:       "claude",
+		Command:     []string{"sh", "-c", "printf 'lane work\\n' > uncommitted.txt"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.Succeeded() {
+		t.Fatalf("job reported success even though it ended with an uncommitted working tree: %+v", job)
+	}
+	if !job.WorktreeDirty {
+		t.Fatalf("WorktreeDirty = false, want true: %+v", job)
+	}
+	if job.WorktreeBranch != "feature/lane" {
+		t.Fatalf("WorktreeBranch = %q, want %q", job.WorktreeBranch, "feature/lane")
+	}
+	if job.WorktreeCommit == "" {
+		t.Fatalf("WorktreeCommit is empty, want a checkpoint commit: %+v", job)
+	}
+	if !job.WorktreePushed {
+		t.Fatalf("WorktreePushed = false, want true (reason: %s): %+v", job.WorktreeReason, job)
+	}
+	if job.WorktreeRemote != "origin" {
+		t.Fatalf("WorktreeRemote = %q, want %q", job.WorktreeRemote, "origin")
+	}
+
+	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", "refs/heads/feature/lane")
+	cmd.Dir = remote
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("checkpoint commit did not reach the real remote: %v", err)
+	}
+}
+
+func TestAgentJobWithACleanWorkingTreeStillSucceeds(t *testing.T) {
+	isolateActivityCache(t)
+	repo := newAgentJobTestRepo(t)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+
+	const tenant = "worktree-contract"
+	const environment = "clean"
+	const id = "job"
+
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Name:        id,
+		Dir:         repo,
+		Agent:       "claude",
+		Command:     []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if !job.Succeeded() {
+		t.Fatalf("job with a clean working tree did not report success: %+v", job)
+	}
+	if job.WorktreeDirty {
+		t.Fatalf("WorktreeDirty = true for a clean working tree: %+v", job)
+	}
+}
+
+func TestAgentJobWithADirtyDetachedHeadIsReportedButNotCheckpointed(t *testing.T) {
+	isolateActivityCache(t)
+	repo := newAgentJobTestRepo(t)
+	runGitForTest(t, repo, "checkout", "-q", "--detach", "HEAD")
+
+	const tenant = "worktree-contract"
+	const environment = "detached"
+	const id = "job"
+
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Name:        id,
+		Dir:         repo,
+		Agent:       "claude",
+		Command:     []string{"sh", "-c", "printf 'lane work\\n' > uncommitted.txt"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.Succeeded() {
+		t.Fatalf("job reported success even though it ended with an uncommitted, detached-HEAD working tree: %+v", job)
+	}
+	if !job.WorktreeDirty || !job.WorktreeDetached {
+		t.Fatalf("WorktreeDirty/WorktreeDetached = %v/%v, want true/true: %+v", job.WorktreeDirty, job.WorktreeDetached, job)
+	}
+	if job.WorktreeCommit != "" {
+		t.Fatalf("WorktreeCommit = %q, want empty: a detached HEAD must never get an automatic checkpoint commit", job.WorktreeCommit)
+	}
+	if !strings.Contains(job.WorktreeReason, "detached") {
+		t.Fatalf("WorktreeReason %q does not explain the detached HEAD", job.WorktreeReason)
+	}
+}
+
+func TestAgentJobWithADirtyWorkingTreeOnAProtectedBranchIsReportedButNotCheckpointed(t *testing.T) {
+	isolateActivityCache(t)
+	repo := newAgentJobTestRepo(t)
+	dirtyWorkingTree(t, repo)
+
+	const tenant = "worktree-contract"
+	const environment = "protected-branch"
+	const id = "job"
+
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Name:        id,
+		Dir:         repo,
+		Agent:       "claude",
+		Command:     []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.Succeeded() {
+		t.Fatalf("job reported success even though it left main dirty: %+v", job)
+	}
+	if job.WorktreeCommit != "" {
+		t.Fatalf("WorktreeCommit = %q, want empty: main must never get an automatic checkpoint commit", job.WorktreeCommit)
+	}
+	if !strings.Contains(job.WorktreeReason, "protected") {
+		t.Fatalf("WorktreeReason %q does not explain the refusal", job.WorktreeReason)
+	}
+}
+
+func TestCommandJobIgnoresItsWorkingTreeState(t *testing.T) {
+	isolateActivityCache(t)
+	repo := newAgentJobTestRepo(t)
+	dirtyWorkingTree(t, repo)
+
+	const tenant = "worktree-contract"
+	const environment = "command-kind"
+	const id = "job"
+
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant:      tenant,
+		Environment: environment,
+		ID:          id,
+		Name:        id,
+		Dir:         repo,
+		Command:     []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if !job.Succeeded() {
+		t.Fatalf("a plain command job must not have its own working tree checked: %+v", job)
+	}
+	if job.WorktreeDirty {
+		t.Fatalf("WorktreeDirty = true for a command job, want false (only agent jobs are checked)")
+	}
+}

--- a/erun-docs/docs/agent-reference/cli-flags.md
+++ b/erun-docs/docs/agent-reference/cli-flags.md
@@ -1137,6 +1137,33 @@ The supervisor folds the stream every 2 seconds and rewrites the record only whe
 
 `job output` needs no special handling for an agent job: the log is the event stream, so the existing incremental read returns events while the agent works.
 
+### Working tree checkpoints {#worktree-checkpoints}
+
+An agent job's exit status says nothing about the state of the working tree it ran in — a clean `exited 0` and a tree with a thousand uncommitted lines are otherwise indistinguishable. When an [agent job](#agent-jobs) (`kind: agent`) with a `--dir` finishes, the supervisor checks that directory's git state once, before the record is written, and folds what it found into seven more fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `worktreeDirty` | bool | `true` only when `--dir` was a git working tree with uncommitted changes (tracked or untracked, respecting `.gitignore`) at the moment the job ended. `false` — meaning absent from the record — covers every other case identically: a command job (never checked), an agent job with no `--dir` or a `--dir` outside a git repo, and an agent job that left its tree clean. |
+| `worktreeBranch` | string | The branch HEAD pointed at when the check ran; the literal `"HEAD"` when detached. Empty when `worktreeDirty` is `false`. |
+| `worktreeDetached` | bool | `true` when HEAD was not on a branch at all. |
+| `worktreeCommit` | string | The checkpoint commit the supervisor made, empty when it made none. |
+| `worktreePushed` | bool | Whether `worktreeCommit` reached `worktreeRemote`. A commit that exists only in the working tree is exactly as exposed to a lost pod as the uncommitted changes it was meant to save. |
+| `worktreeRemote` | string | The remote `worktreeCommit` was pushed to (`origin`), empty when nothing was pushed. |
+| `worktreeReason` | string | Why no checkpoint was made, or why one was made but not pushed. Empty when `worktreeDirty` is `false`, or when a commit was made and pushed cleanly. |
+
+When the tree is dirty, the supervisor does not just report — it makes a machine-authored checkpoint commit (message: `WIP: checkpoint by the erun job supervisor`, explicitly inviting the reader to rewrite or squash it) and pushes it to `origin`, because the agent that would otherwise do this by hand is already gone by the time anyone reads the record. It only does this where committing is actually safe:
+
+| Condition | What happens |
+|---|---|
+| HEAD is detached (`worktreeBranch: "HEAD"`) | No commit: it would be unreachable the moment HEAD moves. `worktreeDetached: true`, `worktreeReason` explains it. |
+| A merge, rebase, cherry-pick, or revert is in progress | No commit: committing over the operation's own state could corrupt it. |
+| The branch is one this job treats as protected — the remote's actual default branch (`origin/HEAD`) when it can be read, else `main`/`master`/`develop` | No commit: refused rather than depositing a WIP commit directly on a protected branch. |
+| None of the above, and the commit itself fails | `worktreeCommit` empty, `worktreeReason` names the failure. |
+| The commit succeeds but the push fails | `worktreeCommit` set, `worktreePushed: false`, `worktreeReason` names the push failure — the commit still exists locally, but "only as safe as this one working tree". |
+| The commit succeeds and the push succeeds | `worktreeCommit` and `worktreeRemote` set, `worktreePushed: true`, `worktreeReason` empty. |
+
+A dirty working tree is never a success, whatever `exitCode` says: `job.Succeeded()`'s single definition folds `!worktreeDirty` in alongside `state == exited && exitCode == 0`, the same way it already folds in "nothing left running behind it" for `abandoned`/`gate-incomplete`. `job status`/`job await`'s text line appends `working tree was dirty; checkpointed as <sha> and pushed to <remote>` (or `but not pushed: <reason>`, or `and left uncommitted: <reason>`) to whatever state line it would otherwise render — including a plain `exited 0` line, since a checkpointed-and-pushed tree is still worth an orchestrator's attention even though nothing was lost.
+
 ### `erun job attach`
 
 Registers work erun did **not** start, so it is visible and holds an activity lease.
@@ -1186,8 +1213,8 @@ The call returns inside the timeout either way, so no connection is held open fo
 
 | Exit code | Meaning |
 |---|---|
-| `0` | The job reached `exited` with code `0`. |
-| `1` | The job reached `exited` with a non-zero code, or its state is `abandoned` or `gate-incomplete` — work it started (a process it left running, or a job it started that has not finished) outlived it, so even a captured `exitCode` of `0` is never a success. `job.exitCode` carries the captured code either way; the message text says which case it is. |
+| `0` | The job reached `exited` with code `0` and, for an agent job, `worktreeDirty` is `false`. |
+| `1` | The job reached `exited` with a non-zero code, its state is `abandoned` or `gate-incomplete` — work it started (a process it left running, or a job it started that has not finished) outlived it — or `worktreeDirty` is `true` — see [Working tree checkpoints](#worktree-checkpoints). Any of these is never a success, even at a captured `exitCode` of `0`. `job.exitCode` carries the captured code either way; the message text says which case it is. |
 | `124` | The timeout elapsed with the job still running. Matches `timeout(1)`. |
 | `125` | The job's state is `unknown` — no outcome was ever recorded. |
 

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -825,6 +825,15 @@ The immediate response only confirms the job started; `exec_job_status` returns 
 { "job": { "id": "suite", "state": "unknown", "exitCode": null, "aliveAgeMs": 6120,
            "reason": "job supervisor 4242 is gone without recording an exit status; the runtime pod was most likely replaced" },
   "timedOut": false, … }
+
+// an agent job (kind: agent) whose working tree still had uncommitted
+// changes when it ended: exitCode 0, state exited, but never a success —
+// the supervisor made a checkpoint commit and pushed it on the agent's
+// behalf. See [Agent reference · Working tree checkpoints](/agent-reference/cli-flags#worktree-checkpoints).
+{ "job": { "id": "sweep", "state": "exited", "exitCode": 0, "kind": "agent",
+           "worktreeDirty": true, "worktreeBranch": "feature/1564-checkpoint",
+           "worktreeCommit": "a1b2c3d", "worktreePushed": true, "worktreeRemote": "origin" },
+  "timedOut": false, … }
 ```
 
 `exec_job_output` pages through the merged stdout + stderr:

--- a/erun-integration/internal/normalize/normalize.go
+++ b/erun-integration/internal/normalize/normalize.go
@@ -121,6 +121,9 @@ var defaultRules = []Replacement{
 	{regexp.MustCompile(`-[0-9a-f]{16}\b`), "-<HEX16>"},
 	{regexp.MustCompile(`\b[0-9a-f]{32,}\b`), "<HEX>"},
 	{regexp.MustCompile(`\bcommit = [0-9a-f]{7,12}\b`), "commit = <SHORTSHA>"},
+	// A job's dirty-working-tree checkpoint names the real commit it made,
+	// which is content-derived and differs per run of the same fixture repo.
+	{regexp.MustCompile(`\bcheckpointed as [0-9a-f]{7,12}\b`), "checkpointed as <SHORTSHA>"},
 	// Real git output in a real-run scenario: `git commit` prints
 	// `[<branch> <sha>]` and `git push` prints an indented `<old>..<new>` range
 	// per ref. Both carry the commit the fixture repo happened to produce on

--- a/erun-integration/job_test.go
+++ b/erun-integration/job_test.go
@@ -766,6 +766,61 @@ func TestJob(t *testing.T) {
 		golden.Equal(t, "job/a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete", normalize.Apply(status.Combined+await.Combined))
 	})
 
+	t.Run("an_agent_job_that_ends_with_an_uncommitted_working_tree_is_checkpointed_pushed_and_not_reported_as_success", func(t *testing.T) {
+		// The reproduction this closes: an agent's own turn ends after it edited
+		// files but before it committed them, and the job's exit code alone reads
+		// as a plain success. The agent here is a stubbed "claude" binary (routed
+		// through the ERUN_CLAUDE_BIN seam, same as kubectl/helm elsewhere in this
+		// suite) that just writes an uncommitted file and exits 0 -- standing in
+		// for an agent turn that produced real, uncommitted work. The lane's
+		// working tree and remote are real git repositories, not stubs, so "the
+		// checkpoint commit actually landed on the remote" is an observable fact.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+
+		lane := filepath.Join(setup.Cwd, "lane")
+		fixture.SeedGitRepo(t, lane)
+		fixture.RunGit(t, lane, "checkout", "-q", "-b", "feature/lane")
+		remote := filepath.Join(setup.Home, "lane-origin.git")
+		fixture.RunGit(t, setup.Home, "init", "-q", "--bare", remote)
+		fixture.RunGit(t, lane, "remote", "add", "origin", remote)
+
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinaryWithScript(t, stubs, "claude", "printf 'lane work\\n' > uncommitted.txt\nexit 0\n")
+		envVars := inEnvironment(append(setup.Env(), fixture.StubEnv(stubs, "claude")...))
+
+		start := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "lane",
+			"--dir", lane, "--agent", "claude", "--", "do the lane's work"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if start.ExitCode != 0 {
+			t.Fatalf("start: exit %d: %s", start.ExitCode, start.Combined)
+		}
+		t.Cleanup(func() {
+			erun.Run(t, []string{"job", "cancel", "--tenant", "team", "--environment", "dev", "--id", "lane", "--signal", "KILL"},
+				erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		})
+
+		var status erun.Result
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			status = erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "lane"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+			if !strings.HasPrefix(status.Combined, "running:") {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("job never left running: %s", status.Combined)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "lane", "--timeout", "1s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if await.ExitCode == 0 {
+			t.Fatalf("expected a dirty-worktree job to report a failure outcome, got 0:\n%s", await.Combined)
+		}
+		// The checkpoint commit itself reached the real remote -- not stubbed,
+		// not asserted only through the job record.
+		fixture.RunGit(t, remote, "show-ref", "--verify", "--quiet", "refs/heads/feature/lane")
+		golden.Equal(t, "job/an_agent_job_that_ends_with_an_uncommitted_working_tree_is_checkpointed_pushed_and_not_reported_as_success", normalize.Apply(status.Combined+await.Combined))
+	})
+
 	t.Run("a_job_started_on_a_different_pod_reads_back_as_pod_replaced_not_a_guess", func(t *testing.T) {
 		// The supervisor stamps the pod's hostname at start, so a record
 		// read back from a different hostname is definitive proof of pod

--- a/erun-integration/testdata/job/an_agent_job_that_ends_with_an_uncommitted_working_tree_is_checkpointed_pushed_and_not_reported_as_success.txt
+++ b/erun-integration/testdata/job/an_agent_job_that_ends_with_an_uncommitted_working_tree_is_checkpointed_pushed_and_not_reported_as_success.txt
@@ -1,0 +1,5 @@
+exited 0: lane, agent claude, no events yet, working tree was dirty; checkpointed as <SHORTSHA> and pushed to origin, 0 bytes of output
+audit: erun job status --environment dev --id lane --tenant team
+exited 0: lane, agent claude, no events yet, working tree was dirty; checkpointed as <SHORTSHA> and pushed to origin, 0 bytes of output
+audit: erun job await --environment dev --id lane --tenant team --timeout 1s
+job "lane" ended with an uncommitted working tree: working tree was dirty; checkpointed as <SHORTSHA> and pushed to origin


### PR DESCRIPTION
## Summary

- An agent job's own exit status says nothing about the state of the working tree it ran in — an `exited 0` and a tree with 1,200 uncommitted lines are indistinguishable to a caller reading only `state`/`exitCode`. The job supervisor now checks, at the same point it resolves the rest of a finished job's outcome (mirroring #1568's `gate-incomplete`), whether a finished **agent** job's `--dir` is a dirty git working tree.
- **It preserves, not just observes.** Where it is safe to, the supervisor makes a machine-authored checkpoint commit (`WIP: checkpoint by the erun job supervisor`, explicitly inviting a rewrite/squash) and pushes it to `origin` — because by the time the record is dirty, the agent that would otherwise do this by hand is already gone. "Safe" is narrow on purpose: refused on a detached HEAD (a commit there is unreachable the moment HEAD moves), refused mid-merge/rebase/cherry-pick/revert (committing over that state could corrupt it), and refused on a branch this job treats as protected (the remote's actual default branch when readable, else `main`/`master`/`develop`). Untracked files are added via `git add -A`, so `.gitignore` is respected automatically.
- Seven new fields on the job record (`worktreeDirty`, `worktreeBranch`, `worktreeDetached`, `worktreeCommit`, `worktreePushed`, `worktreeRemote`, `worktreeReason`) carry what was found and what was done about it. `EnvironmentJob.Succeeded()` now folds in `!worktreeDirty`, so a dirty finish is never a success regardless of `exitCode` — the same shape `abandoned`/`gate-incomplete` already used for "something is still wrong even at exit 0". `job status`/`job await`'s text lines and `job await`'s exit code (`1`) both surface it.
- Limits, stated plainly: this only runs for `kind: agent` jobs with a `--dir` (a command job's tree is never checked); it cannot help a job whose supervisor never reaches its finish path (pod eviction, `SIGKILL` on the supervisor itself — that already reads as `unknown`, a separate, pre-existing gap); and refusing on detached HEAD / protected branches / mid-operation means those dirty trees are still reported but not preserved automatically — the record says so via `worktreeReason`.

## Docs

- `erun-docs/docs/agent-reference/cli-flags.md`: new "Working tree checkpoints" section (field table, the safety conditions, the exit-code/Succeeded() contract), plus updates to the `job await` exit-code table.
- `erun-docs/docs/mcp/overview.md`: a worked example of the dirty-worktree job record alongside the existing `abandoned`/`unknown` examples.

## Test plan

- [x] `erun-common/job_worktree_test.go` (unit, real git repos, no mocks): dirty tree on a feature branch is checkpointed and pushed to a real bare remote and is **not** `Succeeded()`; a clean tree still succeeds; a dirty detached HEAD is reported but never committed; a dirty protected branch (`main`) is reported but never committed; a plain command job's dirty tree is never even checked.
- [x] `erun-integration/job_test.go` new scenario: a real `job start --agent claude` (stubbed `claude` binary) against a real git lane + a real bare `origin`, driven end to end through `job status`/`job await` — asserts the checkpoint commit actually lands on the remote and `job await` exits non-zero.
- [x] `make check` green (verbatim tail below).

```
>> golangci-lint erun-common / erun-cli / erun-mcp / erun-integration / erun-backend-api / erun-ui
0 issues. (each)
>> go test erun-ui: ok
>> erun-kit / erun-console gates: tsc, eslint, prettier, vite build, vitest — all green
>> erun-devops chart tests: all PASS/OK
>> erun-integration suite: ok (87.5s)
>> coverage 76.2% (>= 75.8%)
make: exit 0
```

Closes #1564