### PR TITLE
Pass --insecure to docker manifest for insecure cluster registries

### DIFF
--- a/erun-common/build_configured_fingerprint.go
+++ b/erun-common/build_configured_fingerprint.go
@@ -67,7 +67,7 @@ func materializeBuildFingerprints(ctx Context, build DockerBuildSpec, hash strin
 			materialized[fpTag] = struct{}{}
 			continue
 		}
-		if err := pullAndTagConfiguredFingerprint(ctx, build.Image.Tag, fpTag, platform); err != nil {
+		if err := pullAndTagConfiguredFingerprint(ctx, build.Image.Tag, fpTag, platform, build.Image.Insecure); err != nil {
 			ctx.Trace(fmt.Sprintf("could not materialize configured fingerprint %s: %v", fpTag, err))
 			continue
 		}
@@ -75,10 +75,10 @@ func materializeBuildFingerprints(ctx Context, build DockerBuildSpec, hash strin
 	}
 }
 
-func pullAndTagConfiguredFingerprint(ctx Context, sourceTag, fpTag, platform string) error {
-	ctx.TraceCommand("", "docker", "manifest", "inspect", sourceTag)
+func pullAndTagConfiguredFingerprint(ctx Context, sourceTag, fpTag, platform string, insecure bool) error {
+	ctx.TraceCommand("", "docker", append(dockerManifestArgs("inspect", insecure), sourceTag)...)
 	if !ctx.DryRun {
-		exists, err := DockerManifestExists(sourceTag)
+		exists, err := DockerManifestExists(sourceTag, insecure)
 		if err != nil {
 			return err
 		}

--- a/erun-common/build_docker_commands.go
+++ b/erun-common/build_docker_commands.go
@@ -51,7 +51,7 @@ func runMultiPlatformBuild(buildInput DockerBuildSpec, stdout, stderr io.Writer)
 	if !buildInput.Push {
 		return nil
 	}
-	return assembleMultiPlatformManifest(buildInput.Image.Tag, perPlatformTags, buildInput.Verbosity, stdout, stderr)
+	return assembleMultiPlatformManifest(buildInput.Image.Tag, perPlatformTags, buildInput.Image.Insecure, buildInput.Verbosity, stdout, stderr)
 }
 
 func promoteDockerImage(buildInput DockerBuildSpec, stdout, stderr io.Writer) error {
@@ -78,7 +78,7 @@ func promoteDockerImage(buildInput DockerBuildSpec, stdout, stderr io.Writer) er
 	if !buildInput.Push {
 		return nil
 	}
-	return assembleMultiPlatformManifest(buildInput.Image.Tag, perPlatformTags, buildInput.Verbosity, stdout, stderr)
+	return assembleMultiPlatformManifest(buildInput.Image.Tag, perPlatformTags, buildInput.Image.Insecure, buildInput.Verbosity, stdout, stderr)
 }
 
 // pushPlatformImage publishes one platform the moment it is built, instead of
@@ -110,13 +110,30 @@ func pushPlatformImage(buildInput DockerBuildSpec, platformTag string, stdout, s
 // runs the previous image while every step reports success. Removing the cached
 // list makes the published tag a function of this run alone. It is absent on a
 // first publish, so its failure is not one.
-func assembleMultiPlatformManifest(tag string, perPlatformTags []string, verbosity int, stdout, stderr io.Writer) error {
+func assembleMultiPlatformManifest(tag string, perPlatformTags []string, insecure bool, verbosity int, stdout, stderr io.Writer) error {
+	// `docker manifest rm` only touches the local manifest-list store, never the
+	// registry, so it needs no --insecure of its own.
 	_ = runDockerSimpleCommandWithVerbosity([]string{"manifest", "rm", tag}, verbosity, io.Discard, io.Discard)
-	createArgs := append([]string{"manifest", "create", tag}, perPlatformTags...)
+	createArgs := append(dockerManifestArgs("create", insecure), tag)
+	createArgs = append(createArgs, perPlatformTags...)
 	if err := runDockerSimpleCommandWithVerbosity(createArgs, verbosity, stdout, stderr); err != nil {
 		return err
 	}
-	return runDockerSimpleCommandWithVerbosity([]string{"manifest", "push", tag}, verbosity, stdout, stderr)
+	pushArgs := append(dockerManifestArgs("push", insecure), tag)
+	return runDockerSimpleCommandWithVerbosity(pushArgs, verbosity, stdout, stderr)
+}
+
+// dockerManifestArgs builds a `docker manifest <sub>` argv, appending
+// --insecure when the registry is plain HTTP. Unlike the daemon (which reads
+// its own insecure-registry list), `docker manifest create/push/inspect` talk
+// to the registry directly over HTTPS by default and need the flag spelled
+// out on every invocation that touches an insecure registry.
+func dockerManifestArgs(sub string, insecure bool) []string {
+	args := []string{"manifest", sub}
+	if insecure {
+		args = append(args, "--insecure")
+	}
+	return args
 }
 
 func tagFingerprintAfterBuild(buildInput DockerBuildSpec, platform string, stdout, stderr io.Writer) error {
@@ -350,12 +367,13 @@ func DockerImageExists(tag string) (bool, error) {
 	return false, err
 }
 
-func DockerManifestExists(tag string) (bool, error) {
+func DockerManifestExists(tag string, insecure bool) (bool, error) {
 	tag = strings.TrimSpace(tag)
 	if tag == "" {
 		return false, nil
 	}
-	cmd := Command("docker", "manifest", "inspect", tag)
+	args := append(dockerManifestArgs("inspect", insecure), tag)
+	cmd := Command("docker", args...)
 	err := cmd.Run()
 	if err == nil {
 		return true, nil

--- a/erun-common/build_image_reference.go
+++ b/erun-common/build_image_reference.go
@@ -13,10 +13,10 @@ import (
 // resolveDockerBuildRegistryForEnvironment errors when no registry is marked
 // for the build role; that message is the user-facing contract and must read
 // identically in dry-run and real runs.
-func resolveDockerBuildRegistryForEnvironment(ctx Context, projectRoot, environment string) (string, error) {
+func resolveDockerBuildRegistryForEnvironment(ctx Context, projectRoot, environment string) (string, bool, error) {
 	list, err := effectiveContainerRegistries(projectRoot, environment)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	// A cluster registry resolves to its concrete push host: the ClusterIP
 	// directly for an in-pod build, or a host port-forward otherwise. Build uses
@@ -24,13 +24,13 @@ func resolveDockerBuildRegistryForEnvironment(ctx Context, projectRoot, environm
 	// kubectl's current-context on the host). Plain lists pass through unchanged.
 	list, err = concretizeRegistriesForContext(ctx, "", list)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	registry, ok := list.BuildRegistry()
 	if !ok {
-		return "", fmt.Errorf("environment %q has no build registry; mark a registry with the build role in .erun/config.yaml before building", strings.TrimSpace(environment))
+		return "", false, fmt.Errorf("environment %q has no build registry; mark a registry with the build role in .erun/config.yaml before building", strings.TrimSpace(environment))
 	}
-	return registry, nil
+	return registry, list.BuildRegistryInsecure(), nil
 }
 
 // dockerContextRepoRoot / dockerContextComponent are the accepted

--- a/erun-common/build_spec.go
+++ b/erun-common/build_spec.go
@@ -108,7 +108,7 @@ func resolveDockerBuildSpec(ctx Context, store DockerStore, findProjectRoot Proj
 }
 
 func resolveDockerImageReferenceForProject(ctx Context, now NowFunc, projectRoot, environment, buildDir, versionOverride string) (DockerImageReference, error) {
-	registry, err := resolveDockerBuildRegistryForEnvironment(ctx, projectRoot, environment)
+	registry, insecure, err := resolveDockerBuildRegistryForEnvironment(ctx, projectRoot, environment)
 	if err != nil {
 		return DockerImageReference{}, err
 	}
@@ -132,6 +132,7 @@ func resolveDockerImageReferenceForProject(ctx Context, now NowFunc, projectRoot
 		Tag:                 fmt.Sprintf("%s/%s:%s", strings.TrimRight(registry, "/"), imageName, version),
 		VersionFilePath:     versionFilePath,
 		VersionFromBuildDir: versionFromBuildDir,
+		Insecure:            insecure,
 	}
 	if baseVersion != version {
 		ref.BaseVersion = baseVersion
@@ -228,7 +229,7 @@ func multiPlatformTraceCommands(b DockerBuildSpec) []commandSpec {
 	if !b.Push {
 		return commands
 	}
-	commands = append(commands, multiPlatformManifestTraceCommands(b.ContextDir, b.Image.Tag, perPlatformTags)...)
+	commands = append(commands, multiPlatformManifestTraceCommands(b.ContextDir, b.Image.Tag, perPlatformTags, b.Image.Insecure)...)
 	return commands
 }
 
@@ -268,19 +269,23 @@ func promoteTraceCommands(b DockerBuildSpec) []commandSpec {
 	if !b.Push {
 		return commands
 	}
-	commands = append(commands, multiPlatformManifestTraceCommands(b.ContextDir, b.Image.Tag, perPlatformTags)...)
+	commands = append(commands, multiPlatformManifestTraceCommands(b.ContextDir, b.Image.Tag, perPlatformTags, b.Image.Insecure)...)
 	return commands
 }
 
 // multiPlatformManifestTraceCommands mirrors assembleMultiPlatformManifest so the
 // dry-run trace stays an honest preview, including the discard of the cached
 // manifest list that keeps a re-published version from resolving to the previous
-// one.
-func multiPlatformManifestTraceCommands(dir, tag string, perPlatformTags []string) []commandSpec {
+// one, and the --insecure flag a plain-HTTP registry needs on every subcommand
+// but rm (which never leaves the local manifest-list store).
+func multiPlatformManifestTraceCommands(dir, tag string, perPlatformTags []string, insecure bool) []commandSpec {
+	createArgs := append(dockerManifestArgs("create", insecure), tag)
+	createArgs = append(createArgs, perPlatformTags...)
+	pushArgs := append(dockerManifestArgs("push", insecure), tag)
 	return []commandSpec{
 		{Dir: dir, Name: "docker", Args: []string{"manifest", "rm", tag}},
-		{Dir: dir, Name: "docker", Args: append([]string{"manifest", "create", tag}, perPlatformTags...)},
-		{Dir: dir, Name: "docker", Args: []string{"manifest", "push", tag}},
+		{Dir: dir, Name: "docker", Args: createArgs},
+		{Dir: dir, Name: "docker", Args: pushArgs},
 	}
 }
 

--- a/erun-common/build_types.go
+++ b/erun-common/build_types.go
@@ -57,6 +57,11 @@ type DockerImageReference struct {
 	Tag                 string
 	VersionFilePath     string
 	VersionFromBuildDir bool
+	// Insecure marks Registry as plain HTTP (a cluster registry with
+	// `insecure: true`). `docker manifest` never consults the daemon's
+	// insecure-registry list, so anything that shells out to it for this
+	// image must pass its own `--insecure` explicitly.
+	Insecure bool
 }
 
 type DockerBuildSpec struct {

--- a/erun-common/container_registry.go
+++ b/erun-common/container_registry.go
@@ -33,6 +33,11 @@ type ContainerRegistryEntry struct {
 	Registry string           `yaml:"registry,omitempty" json:"registry,omitempty"`
 	Cluster  *ClusterRegistry `yaml:"cluster,omitempty" json:"cluster,omitempty"`
 	Roles    []RegistryRole   `yaml:"roles" json:"roles"`
+	// Insecure carries a cluster registry's plain-HTTP marker onto its
+	// concretized push/pull entries (expandClusterEntry). It is never set on a
+	// static `registry:` entry and never persisted — a raw config entry only
+	// ever carries insecurity under Cluster.Insecure.
+	Insecure bool `yaml:"-" json:"-"`
 }
 
 // ClusterRegistry describes an in-cluster image registry whose addresses are
@@ -105,15 +110,20 @@ func (r ContainerRegistries) IsZero() bool {
 	return len(r) == 0
 }
 
-func (r ContainerRegistries) registryWithRole(role RegistryRole) (string, bool) {
+func (r ContainerRegistries) registryEntryWithRole(role RegistryRole) (ContainerRegistryEntry, bool) {
 	for _, entry := range r {
 		if entry.hasRole(role) {
 			if registry := strings.TrimSpace(entry.Registry); registry != "" {
-				return registry, true
+				return entry, true
 			}
 		}
 	}
-	return "", false
+	return ContainerRegistryEntry{}, false
+}
+
+func (r ContainerRegistries) registryWithRole(role RegistryRole) (string, bool) {
+	entry, ok := r.registryEntryWithRole(role)
+	return strings.TrimSpace(entry.Registry), ok
 }
 
 // BuildRegistry returns the BUILD-marked registry. ok is false when no entry
@@ -121,6 +131,15 @@ func (r ContainerRegistries) registryWithRole(role RegistryRole) (string, bool) 
 // build".
 func (r ContainerRegistries) BuildRegistry() (string, bool) {
 	return r.registryWithRole(RegistryRoleBuild)
+}
+
+// BuildRegistryInsecure reports whether the BUILD-marked registry is plain
+// HTTP. `docker manifest` never consults the daemon's insecure-registry list
+// (it talks to the registry directly and defaults to HTTPS), so callers that
+// shell out to it need this alongside the registry host itself.
+func (r ContainerRegistries) BuildRegistryInsecure() bool {
+	entry, ok := r.registryEntryWithRole(RegistryRoleBuild)
+	return ok && entry.Insecure
 }
 
 // FromRegistry returns the FROM-marked copy source.
@@ -237,18 +256,19 @@ func expandClusterEntry(entry ContainerRegistryEntry, resolve ClusterRegistryRes
 			push = append(push, role)
 		}
 	}
+	insecure := entry.Cluster.Insecure
 	out := make(ContainerRegistries, 0, 2)
 	if len(push) > 0 {
 		if strings.TrimSpace(addrs.Push) == "" {
 			return nil, errors.New("cluster registry resolved an empty push address")
 		}
-		out = append(out, ContainerRegistryEntry{Registry: addrs.Push, Roles: push})
+		out = append(out, ContainerRegistryEntry{Registry: addrs.Push, Roles: push, Insecure: insecure})
 	}
 	if len(pull) > 0 {
 		if strings.TrimSpace(addrs.Pull) == "" {
 			return nil, errors.New("cluster registry resolved an empty pull address")
 		}
-		out = append(out, ContainerRegistryEntry{Registry: addrs.Pull, Roles: pull})
+		out = append(out, ContainerRegistryEntry{Registry: addrs.Pull, Roles: pull, Insecure: insecure})
 	}
 	return out, nil
 }

--- a/erun-common/container_registry_cluster_test.go
+++ b/erun-common/container_registry_cluster_test.go
@@ -93,6 +93,34 @@ func TestContainerRegistriesConcreteExpandsClusterEntry(t *testing.T) {
 	}
 }
 
+// TestContainerRegistriesConcretePreservesInsecure locks the fix for a cluster
+// registry marked `insecure: true`: expandClusterEntry must carry that marker
+// onto the concretized BUILD entry, since `docker manifest` (unlike the
+// daemon) never reads --insecure-registry and needs the flag passed
+// explicitly by anything that resolves a build registry.
+func TestContainerRegistriesConcretePreservesInsecure(t *testing.T) {
+	list := ContainerRegistries{
+		{Cluster: &ClusterRegistry{Insecure: true}, Roles: []RegistryRole{RegistryRoleBuild, RegistryRoleDeploy}},
+	}
+	resolve := func(c ClusterRegistry) (ClusterRegistryAddresses, error) {
+		return ClusterRegistryAddresses{Push: "localhost:41000", Pull: "10.43.0.50:5000"}, nil
+	}
+	concrete, err := list.Concrete(resolve)
+	if err != nil {
+		t.Fatalf("Concrete: %v", err)
+	}
+	if !concrete.BuildRegistryInsecure() {
+		t.Error("BuildRegistryInsecure() = false, want true for an insecure cluster registry")
+	}
+}
+
+func TestContainerRegistriesBuildRegistryInsecureFalseForPlainRegistry(t *testing.T) {
+	list := DefaultContainerRegistries()
+	if list.BuildRegistryInsecure() {
+		t.Error("BuildRegistryInsecure() = true for a plain registry, want false")
+	}
+}
+
 func TestContainerRegistriesConcreteRequiresResolver(t *testing.T) {
 	list := ContainerRegistries{{Cluster: &ClusterRegistry{}, Roles: []RegistryRole{RegistryRoleBuild, RegistryRoleDeploy}}}
 	if _, err := list.Concrete(nil); err == nil {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1454,7 +1454,7 @@ func resolveInstallExistingVersionDeploySpec(ctx Context, store DeployStore, tar
 		return DeploySpec{}, err
 	}
 	for _, image := range images {
-		if err := verifyExistingDeployImage(ctx, image, deployInput.Version, deployInput.ContainerRegistry); err != nil {
+		if err := verifyExistingDeployImage(ctx, image, deployInput.Version, deployInput.ContainerRegistry, target.ClusterRegistryInsecure); err != nil {
 			return DeploySpec{}, err
 		}
 	}
@@ -1479,7 +1479,7 @@ func resolveInstallExistingVersionDeploySpec(ctx Context, store DeployStore, tar
 // the lookup and skips the network so the plan stays offline and deterministic;
 // a registry error that is not a definitive "absent" does not block the deploy
 // (the rollout would surface a real pull failure).
-func verifyExistingDeployImage(ctx Context, ref, version, registry string) error {
+func verifyExistingDeployImage(ctx Context, ref, version, registry string, insecure bool) error {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return nil
@@ -1502,19 +1502,19 @@ func verifyExistingDeployImage(ctx Context, ref, version, registry string) error
 		tag = strings.TrimRight(strings.TrimSpace(registry), "/") + "/" + ref
 	}
 
-	ctx.TraceCommand("", "docker", "manifest", "inspect", tag)
+	ctx.TraceCommand("", "docker", append(dockerManifestArgs("inspect", insecure), tag)...)
 	if ctx.DryRun {
 		return nil
 	}
-	return confirmDeployImagePresent(ctx, tag, version)
+	return confirmDeployImagePresent(ctx, tag, version, insecure)
 }
 
 // confirmDeployImagePresent checks that the pinned tag exists locally or in the
 // registry, returning an error only when its absence is definitive. A registry
 // error that is not a "absent" verdict (network/auth) is traced and tolerated:
 // the rollout surfaces a real pull failure if the image is genuinely missing.
-func confirmDeployImagePresent(ctx Context, tag, version string) error {
-	remote, remoteErr := DockerManifestExists(tag)
+func confirmDeployImagePresent(ctx Context, tag, version string, insecure bool) error {
+	remote, remoteErr := DockerManifestExists(tag, insecure)
 	if remote {
 		return nil
 	}

--- a/erun-common/published_artifact_verify.go
+++ b/erun-common/published_artifact_verify.go
@@ -56,12 +56,12 @@ func VerifyPublishedHelmChart(ctx Context, ociRepo, chartName, version string) e
 // a tag. Nothing else proves the image half of a version exists, and a release
 // that assumed it does is how a tag gets announced for an image no deploy can
 // pull.
-func VerifyPublishedDockerImage(ctx Context, tag string) error {
+func VerifyPublishedDockerImage(ctx Context, tag string, insecure bool) error {
 	tag = strings.TrimSpace(tag)
 	if tag == "" {
 		return nil
 	}
-	spec := commandSpec{Name: "docker", Args: []string{"manifest", "inspect", tag}}
+	spec := commandSpec{Name: "docker", Args: append(dockerManifestArgs("inspect", insecure), tag)}
 	ctx.TraceCommand(spec.Dir, spec.Name, spec.Args...)
 	if ctx.DryRun {
 		return nil

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -1097,7 +1097,7 @@ func discoverReleaseDockerImages(ctx Context, projectRoot, releaseRoot, versionF
 		return nil, nil
 	}
 
-	registry, err := resolveDockerBuildRegistryForEnvironment(ctx, projectRoot, "")
+	registry, _, err := resolveDockerBuildRegistryForEnvironment(ctx, projectRoot, "")
 	if err != nil {
 		return nil, err
 	}

--- a/erun-common/release_publish.go
+++ b/erun-common/release_publish.go
@@ -10,20 +10,28 @@ import (
 // release runs it between its local stages and its outward-facing ones, so the
 // tag that announces a version is only ever pushed for a version that is
 // already deployable.
+// releasePublishTag is one image the publish step will push, alongside
+// whether its registry is plain HTTP — `docker manifest` needs that spelled
+// out on every invocation, unlike the daemon.
+type releasePublishTag struct {
+	Tag      string
+	Insecure bool
+}
+
 type ReleasePublisher struct {
 	// Tags names the image references the publish step will push. It is
 	// checked against the release's own resolved images before anything is
 	// mutated: a release whose images nothing publishes must fail while it is
 	// still private, not after it has announced them.
-	Tags    []string
+	Tags    []releasePublishTag
 	Publish func(Context) error
 	Verify  func(Context) error
 }
 
 func newReleasePublisher(execution BuildExecutionSpec, deploySpecs []DeploySpec, runScript BuildScriptRunnerFunc, build DockerImageBuilderFunc, push DockerPushFunc) ReleasePublisher {
-	tags := make([]string, 0, len(execution.dockerPushes))
+	tags := make([]releasePublishTag, 0, len(execution.dockerPushes))
 	for _, pushInput := range execution.dockerPushes {
-		tags = append(tags, strings.TrimSpace(pushInput.Image.Tag))
+		tags = append(tags, releasePublishTag{Tag: strings.TrimSpace(pushInput.Image.Tag), Insecure: pushInput.Image.Insecure})
 	}
 	return ReleasePublisher{
 		Tags: tags,
@@ -48,8 +56,8 @@ func ensureReleasePublishesResolvedImages(spec ReleaseSpec, publisher ReleasePub
 
 	publishable := make(map[string]struct{}, len(publisher.Tags))
 	if publisher.Publish != nil && publisher.Verify != nil {
-		for _, tag := range publisher.Tags {
-			publishable[strings.TrimSpace(tag)] = struct{}{}
+		for _, t := range publisher.Tags {
+			publishable[strings.TrimSpace(t.Tag)] = struct{}{}
 		}
 	}
 
@@ -102,17 +110,17 @@ func runReleasePublication(ctx Context, publisher ReleasePublisher) error {
 // tag existence. A probe here cannot tell "already published with exactly
 // this content" from "a tag with this name exists for some other reason", so
 // it is not trusted to skip work, only to report.
-func reportAlreadyPublishedReleaseArtifacts(ctx Context, tags []string) {
-	for _, tag := range tags {
-		tag = strings.TrimSpace(tag)
+func reportAlreadyPublishedReleaseArtifacts(ctx Context, tags []releasePublishTag) {
+	for _, t := range tags {
+		tag := strings.TrimSpace(t.Tag)
 		if tag == "" {
 			continue
 		}
-		ctx.TraceCommand("", "docker", "manifest", "inspect", tag)
+		ctx.TraceCommand("", "docker", append(dockerManifestArgs("inspect", t.Insecure), tag)...)
 		if ctx.DryRun {
 			continue
 		}
-		if dockerImageManifestResolves(ctx, tag) {
+		if dockerImageManifestResolves(ctx, tag, t.Insecure) {
 			ctx.Info("==> Already published: " + tag)
 		}
 	}
@@ -123,8 +131,8 @@ func reportAlreadyPublishedReleaseArtifacts(ctx Context, tags []string) {
 // a 404 is a transient read-after-write race worth retrying), a tag probed
 // before anything is published is expected to 404 on a first release, and
 // retrying that would slow down every release for the common case.
-func dockerImageManifestResolves(ctx Context, tag string) bool {
-	spec := commandSpec{Name: "docker", Args: []string{"manifest", "inspect", tag}}
+func dockerImageManifestResolves(ctx Context, tag string, insecure bool) bool {
+	spec := commandSpec{Name: "docker", Args: append(dockerManifestArgs("inspect", insecure), tag)}
 	_, err := runCommandCapturingOutput(ctx, spec)
 	return err == nil
 }
@@ -137,7 +145,7 @@ func dockerImageManifestResolves(ctx Context, tag string) bool {
 // how a tag gets announced for an image no deploy can pull.
 func verifyPublishedReleaseArtifacts(ctx Context, execution BuildExecutionSpec) error {
 	for _, pushInput := range execution.dockerPushes {
-		if err := VerifyPublishedDockerImage(ctx, pushInput.Image.Tag); err != nil {
+		if err := VerifyPublishedDockerImage(ctx, pushInput.Image.Tag, pushInput.Image.Insecure); err != nil {
 			return err
 		}
 	}

--- a/erun-integration/push_test.go
+++ b/erun-integration/push_test.go
@@ -169,6 +169,39 @@ func TestPush(t *testing.T) {
 		golden.Equal(t, "push/dry_run_single_image_from_dockerfile_cwd", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_insecure_cluster_registry_passes_insecure_to_manifest_commands", func(t *testing.T) {
+		// `docker manifest` never consults the daemon's --insecure-registry
+		// list — it talks to the registry directly and defaults to HTTPS — so a
+		// BUILD-role cluster registry marked `insecure: true` must still see
+		// `--insecure` on every manifest subcommand that hits the network
+		// (create/push), or assembly fails "no such manifest" against a plain
+		// HTTP in-cluster registry even though both per-arch pushes succeeded.
+		// `manifest rm` never leaves the local store, so it must stay bare.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedGitRepo(t, setup.Cwd)
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedProjectDockerfile(t, setup)
+		fixture.SeedProjectK8sConfig(t, setup, "containerregistries:\n    - cluster: {insecure: true}\n      roles:\n        - build\n        - deploy\n")
+		if err := os.WriteFile(filepath.Join(setup.Cwd, "VERSION"), []byte("1.0.0\n"), 0o644); err != nil {
+			t.Fatalf("write VERSION: %v", err)
+		}
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "docker", strings.Join([]string{
+			`case "$1" in`,
+			`  image)`,
+			`    case "$2" in inspect) exit 1 ;; *) exit 0 ;; esac ;;`,
+			`  *) exit 0 ;;`,
+			`esac`,
+		}, "\n"))
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "docker")...)
+		result := erun.Run(t, []string{"push", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "push/dry_run_insecure_cluster_registry_passes_insecure_to_manifest_commands", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_build_shortcut_builds_then_pushes_minted_version", func(t *testing.T) {
 		// `erun push --build` is the operator shortcut that builds the current
 		// source first (minting a snapshot version) and pushes that exact

--- a/erun-integration/testdata/push/dry_run_insecure_cluster_registry_passes_insecure_to_manifest_commands.txt
+++ b/erun-integration/testdata/push/dry_run_insecure_cluster_registry_passes_insecure_to_manifest_commands.txt
@@ -1,0 +1,17 @@
+audit: erun push --dry-run --version <VERSION>
+kubectl -n kube-system get svc erun-registry -o 'jsonpath={.spec.clusterIP}'
+kubectl -n kube-system port-forward svc/erun-registry :5000
+docker image inspect localhost:5000/cwd:fp-<HEX16>-amd64
+fingerprint image not found locally: localhost:5000/cwd:fp-<HEX16>-amd64
+docker image inspect localhost:5000/cwd:fp-<HEX16>-arm64
+fingerprint image not found locally: localhost:5000/cwd:fp-<HEX16>-arm64
+rebuilding localhost:5000/cwd:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t localhost:5000/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag localhost:5000/cwd:<VERSION> localhost:5000/cwd:fp-<HEX16>-amd64
+cd <TMP> && docker push localhost:5000/cwd:<VERSION>
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t localhost:5000/cwd:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag localhost:5000/cwd:<VERSION> localhost:5000/cwd:fp-<HEX16>-arm64
+cd <TMP> && docker push localhost:5000/cwd:<VERSION>
+cd <TMP> && docker manifest rm localhost:5000/cwd:<VERSION>
+cd <TMP> && docker manifest create --insecure localhost:5000/cwd:<VERSION> localhost:5000/cwd:<VERSION> localhost:5000/cwd:<VERSION>
+cd <TMP> && docker manifest push --insecure localhost:5000/cwd:<VERSION>


### PR DESCRIPTION
`erun push` assembles the multi-arch manifest list, but its `docker manifest` invocations did not carry `--insecure`, so a push to an insecure cluster registry failed — at the very end of a long multi-arch build, the most expensive place to discover anything.

## The sibling path mattered too

Fixing `push` alone would have **moved** the failure rather than removed it: `verify-publication` reads artifacts back with `docker manifest inspect`, and per the release rules *"a version whose artifacts cannot be resolved never reaches its tag"*. A registry that could be pushed to but not resolved would still block the release. `published_artifact_verify.go` is fixed alongside.

## Shape of the fix

`docker manifest`'s subcommands do not take a uniform flag set, so the flag is built in one place (`dockerManifestArgs`) and threaded through `assembleMultiPlatformManifest`, `DockerManifestExists` and the fingerprint pull/tag path from `Image.Insecure` — rather than each call site remembering, which is how it came to be dropped.

## Verification

- `erun-integration/push_test.go` plus a golden asserting an insecure registry passes `--insecure` to the manifest commands, and a secure one does not.
- `make check` green (exit 0), awaited directly as job `check-3f577b8d2e3d262b`.

Closes #1597