### PR TITLE
Resolve tenant component charts from the deploy registry and honor insecure cluster registries

### DIFF
--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -66,6 +66,13 @@ type RuntimeRegistryConfig struct {
 	BaseURL string `yaml:"baseurl,omitempty"`
 	// TokenURL is consulted only on the GHCR flow; defaults to https://ghcr.io.
 	TokenURL string `yaml:"tokenurl,omitempty"`
+	// Insecure marks Namespace as plain HTTP (a cluster registry marked
+	// `insecure: true`), so an unset BaseURL resolves to http:// instead of
+	// https:// for it. Never persisted -- only a caller that already knows the
+	// registry is insecure (e.g. probing a tenant's own published chart) sets
+	// it; the operator-configured mirror this struct otherwise describes is
+	// always addressed over HTTPS.
+	Insecure bool `yaml:"-"`
 }
 
 type SSHDConfig struct {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1247,19 +1247,11 @@ func resolvePublishedDeploySpecs(ctx Context, store DeployStore, findProjectRoot
 	// half-apply before a mid-rollout chart pull aborts the deploy. An erun-only /
 	// bootstrap deploy (no tenant components) keeps the published-fallback path.
 	if len(tenantComponents) > 0 {
-		// Tenant component charts (and the tenant's own runtime chart) resolve
-		// from the DEPLOY registry, which for a `--cluster-registry` env is a
-		// cluster: entry that only concretizes to a real host/insecure marker
-		// here -- the runtime-chart-only path never needed this, since its own
-		// candidate ladder already tolerates an unconcretized entry.
-		var err error
-		resolvedTarget, err = concretizeDeployTargetRegistries(ctx, resolvedTarget)
+		concretized, err := ensureTenantChartsPublishedFromDeployRegistry(ctx, resolvedTarget, target.VersionOverride, runtimeSelected, tenantComponents)
 		if err != nil {
 			return nil, err
 		}
-		if err := ensureTenantChartsPublished(ctx, resolvedTarget, target.VersionOverride, runtimeSelected, tenantComponents); err != nil {
-			return nil, err
-		}
+		resolvedTarget = concretized
 	}
 
 	specs := make([]DeploySpec, 0, len(tenantComponents)+1)
@@ -1285,6 +1277,24 @@ func resolvePublishedDeploySpecs(ctx Context, store DeployStore, findProjectRoot
 		return nil, fmt.Errorf("deploy: no components selected for %s/%s — pass --components with a publishable component, save a default selection, or select the runtime to bootstrap the environment", resolvedTarget.Tenant, resolvedTarget.Environment)
 	}
 	return specs, nil
+}
+
+// ensureTenantChartsPublishedFromDeployRegistry concretizes target's registries
+// (a cluster: entry only resolves to a real host/insecure marker here — the
+// runtime-chart-only path never needed this, since its own candidate ladder
+// already tolerates an unconcretized entry) so tenant component charts (and
+// the tenant's own runtime chart) verify against the DEPLOY registry `erun
+// push` actually publishes them to, then runs that verification. Returns the
+// concretized target so the caller's subsequent chart resolution reuses it.
+func ensureTenantChartsPublishedFromDeployRegistry(ctx Context, target OpenResult, versionOverride string, runtimeSelected bool, tenantComponents []string) (OpenResult, error) {
+	target, err := concretizeDeployTargetRegistries(ctx, target)
+	if err != nil {
+		return OpenResult{}, err
+	}
+	if err := ensureTenantChartsPublished(ctx, target, versionOverride, runtimeSelected, tenantComponents); err != nil {
+		return OpenResult{}, err
+	}
+	return target, nil
 }
 
 // appendRuntimeFallbackSpecs appends the published erun-devops runtime spec when

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1247,6 +1247,16 @@ func resolvePublishedDeploySpecs(ctx Context, store DeployStore, findProjectRoot
 	// half-apply before a mid-rollout chart pull aborts the deploy. An erun-only /
 	// bootstrap deploy (no tenant components) keeps the published-fallback path.
 	if len(tenantComponents) > 0 {
+		// Tenant component charts (and the tenant's own runtime chart) resolve
+		// from the DEPLOY registry, which for a `--cluster-registry` env is a
+		// cluster: entry that only concretizes to a real host/insecure marker
+		// here -- the runtime-chart-only path never needed this, since its own
+		// candidate ladder already tolerates an unconcretized entry.
+		var err error
+		resolvedTarget, err = concretizeDeployTargetRegistries(ctx, resolvedTarget)
+		if err != nil {
+			return nil, err
+		}
 		if err := ensureTenantChartsPublished(ctx, resolvedTarget, target.VersionOverride, runtimeSelected, tenantComponents); err != nil {
 			return nil, err
 		}

--- a/erun-common/published_devops_chart.go
+++ b/erun-common/published_devops_chart.go
@@ -107,7 +107,7 @@ func resolvePublishedRuntimeChartReference(ctx Context, target OpenResult, chart
 	outcomes := make([]string, 0, len(probed))
 	inconclusive := false
 	for _, candidate := range probed {
-		found, err := probeChartVersion(context.Background(), candidate.registry, candidate.chart, version)
+		found, err := probeChartVersion(context.Background(), candidate.registry, candidate.chart, version, chartRegistryInsecure(target, candidate.registry))
 		if err != nil {
 			ctx.Trace("deploy: runtime chart " + candidate.chart + " " + version + " could not be confirmed in " + candidate.registry + " (" + candidate.why + "): " + err.Error())
 			outcomes = append(outcomes, candidate.describe()+": could not determine: "+err.Error())
@@ -220,7 +220,12 @@ func ensureTenantChartsPublished(ctx Context, target OpenResult, versionOverride
 		ctx.Trace("deploy: no version resolved; cannot verify the tenant's charts are published")
 		return fmt.Errorf("version is required to deploy the tenant's charts: pass --version or persist runtimeversion in the env config")
 	}
-	registry := publishedDevopsChartRegistry(target)
+	// Components are published to the DEPLOY registry by `erun push`, never the
+	// platform-chart registry publishedDevopsChartRegistry resolves (an explicit
+	// runtimeregistry, or the runtime image's own registry for a
+	// cluster-registry env) -- a tenant's own artifacts are never published
+	// beside the platform image.
+	registry := publishedTenantComponentChartRegistry(target)
 
 	required := make([]string, 0, len(components)+1)
 	runtimeChart := RuntimeReleaseName(target.Tenant)
@@ -229,17 +234,64 @@ func ensureTenantChartsPublished(ctx Context, target OpenResult, versionOverride
 	// coherent: the components run on the tenant's line, the runtime chart on the
 	// line the env named. Its components are still verified.
 	runtimeChartStated := strings.TrimSpace(target.EnvConfig.RuntimeChart) != ""
+	runtimeRegistry := registry
 	switch {
 	case runtimeSelected && runtimeChartStated:
 		ctx.Trace("deploy: the env states its runtime chart " + strings.TrimSpace(target.EnvConfig.RuntimeChart) + "; verifying only the tenant's component charts at " + version)
 	case runtimeSelected && runtimeChart != DevopsComponentName:
-		required = append(required, runtimeChart)
+		// The tenant's own runtime chart is normally published alongside its
+		// components by the same `erun push`, so it usually shares their
+		// registry and is verified together, below. When it doesn't -- an
+		// explicit runtimeregistry, or the cluster-registry env's platform-chart
+		// fallback -- it is verified separately, against the same registry
+		// resolvePublishedDevopsDeploySpecWithReason's own ladder actually
+		// installs it from.
+		runtimeRegistry = publishedDevopsChartRegistry(target)
+		if runtimeRegistry == registry {
+			required = append(required, runtimeChart)
+		}
 	}
 	required = append(required, components...)
 
 	ctx.Trace("deploy: deploying tenant artifacts; verifying charts published at " + version + " in " + registry + ": " + strings.Join(required, ", "))
+	if err := reportUnconfirmedTenantCharts(required, registry, chartRegistryInsecure(target, registry), version); err != nil {
+		return err
+	}
 
-	return reportUnconfirmedTenantCharts(required, registry, version)
+	if runtimeRegistry != registry {
+		ctx.Trace("deploy: deploying tenant artifacts; verifying the runtime chart " + runtimeChart + " published at " + version + " in " + runtimeRegistry)
+		return reportUnconfirmedTenantCharts([]string{runtimeChart}, runtimeRegistry, chartRegistryInsecure(target, runtimeRegistry), version)
+	}
+	return nil
+}
+
+// publishedTenantComponentChartRegistry answers where a tenant's own
+// component charts (and its own runtime chart, when it publishes one) are
+// published: `erun push` writes them to the DEPLOY registry -- concretized to
+// its in-cluster pull host for a cluster-registry env -- never the
+// runtimeregistry override or the runtime-image fallback
+// publishedDevopsChartRegistry applies for the shared platform chart. A
+// tenant's own artifacts are never published beside the platform image, so
+// following that registry here probed a registry the tenant's charts were
+// never going to be in.
+func publishedTenantComponentChartRegistry(target OpenResult) string {
+	if registry, ok := target.EnvConfig.ContainerRegistries.DeployRegistry(); ok {
+		return registry
+	}
+	if registry := resolveProjectContainerRegistry(target.RepoPath, target.Environment); registry != "" {
+		return registry
+	}
+	return DefaultContainerRegistry
+}
+
+// chartRegistryInsecure reports whether registry is the deploy target's own
+// concretized cluster registry, marked insecure (plain HTTP) on its cluster:
+// entry. It is the only registry a chart probe can ever need to address over
+// plain HTTP -- erun's own platform registries (ghcr.io, an ECR account, a
+// project's static `registry:` entry) are always TLS.
+func chartRegistryInsecure(target OpenResult, registry string) bool {
+	registry = strings.TrimSpace(registry)
+	return registry != "" && target.ClusterRegistryInsecure && registry == strings.TrimSpace(target.ClusterPullRegistry)
 }
 
 // reportUnconfirmedTenantCharts probes each chart in required and returns an
@@ -248,11 +300,11 @@ func ensureTenantChartsPublished(ctx Context, target OpenResult, versionOverride
 // as "not published") from "confirmed absent" (missing). A probe that could not
 // answer takes priority: it is not evidence the chart is missing, so refusing on
 // it takes precedence over refusing on a genuine miss.
-func reportUnconfirmedTenantCharts(required []string, registry, version string) error {
+func reportUnconfirmedTenantCharts(required []string, registry string, insecure bool, version string) error {
 	missing := make([]string, 0, len(required))
 	unresolved := make([]string, 0, len(required))
 	for _, chart := range required {
-		found, err := probeChartVersion(context.Background(), registry, chart, version)
+		found, err := probeChartVersion(context.Background(), registry, chart, version, insecure)
 		switch {
 		case err != nil:
 			unresolved = append(unresolved, chart+": could not determine: "+err.Error())
@@ -274,11 +326,15 @@ func reportUnconfirmedTenantCharts(required []string, registry, version string) 
 // credentials, network, or an unreachable registry -- and must never be read as
 // "not found": a blind probe is not evidence of absence, only a definitive read
 // that excludes the version is.
-func probeChartVersion(ctx context.Context, containerRegistry, chartName, version string) (bool, error) {
+func probeChartVersion(ctx context.Context, containerRegistry, chartName, version string, insecure bool) (bool, error) {
 	if override, ok := os.LookupEnv(publishedChartProbeOverrideEnv); ok {
 		return publishedChartOverrideHasVersion(override, containerRegistry, chartName, version), nil
 	}
-	versions, err := ResolveRuntimeImageRegistryVersions(ctx, containerRegistry, "charts/"+chartName)
+	versions, err := ResolveConfiguredRuntimeRegistryVersions(ctx, RuntimeRegistryConfig{
+		Namespace:  containerRegistry,
+		Repository: "charts/" + chartName,
+		Insecure:   insecure,
+	})
 	if err != nil {
 		return false, err
 	}
@@ -434,7 +490,7 @@ func resolvePublishedDevopsDeploySpecWithReason(ctx Context, target OpenResult, 
 // command() re-scopes them and the subchart's required tenant/environment are
 // satisfied. The release is named <tenant>-<component> so it is tenant-clear.
 func resolvePublishedComponentDeploySpec(ctx Context, target OpenResult, componentName, versionOverride string) (DeploySpec, error) {
-	registry := publishedDevopsChartRegistry(target)
+	registry := publishedTenantComponentChartRegistry(target)
 	version := strings.TrimSpace(versionOverride)
 	if version == "" {
 		version = strings.TrimSpace(target.EnvConfig.RuntimeVersion)

--- a/erun-common/published_devops_chart_test.go
+++ b/erun-common/published_devops_chart_test.go
@@ -85,6 +85,64 @@ func TestPublishedDevopsChartRegistry(t *testing.T) {
 	})
 }
 
+// TestPublishedTenantComponentChartRegistry pins erun#1598 defect 1: a
+// tenant's own component charts are published by `erun push` to the DEPLOY
+// registry, never wherever publishedDevopsChartRegistry resolves the SHARED
+// platform chart to (an explicit runtimeregistry, or -- for a
+// cluster-registry env -- the runtime image's own registry). Before the fix,
+// a cluster-registry env with an explicit runtimeregistry (a realistic
+// pairing: runtimeregistry for the platform chart, containerregistries for
+// the tenant's own images) probed the platform-chart registry for the
+// tenant's component chart and could never find it there.
+func TestPublishedTenantComponentChartRegistry(t *testing.T) {
+	t.Run("cluster-registry env with an explicit runtimeregistry still resolves components from the deploy registry", func(t *testing.T) {
+		target := OpenResult{
+			ClusterPullRegistry: "10.43.0.100:5000",
+			EnvConfig: EnvConfig{
+				RuntimeRegistry:     "ghcr.io/sophium",
+				ContainerRegistries: ContainerRegistries{{Registry: "10.43.0.100:5000", Roles: []RegistryRole{RegistryRoleDeploy}}},
+			},
+		}
+		if got := publishedTenantComponentChartRegistry(target); got != "10.43.0.100:5000" {
+			t.Fatalf("component chart registry = %q, want the deploy registry 10.43.0.100:5000, not the platform runtimeregistry", got)
+		}
+		if got := publishedDevopsChartRegistry(target); got != "ghcr.io/sophium" {
+			t.Fatalf("platform chart registry = %q, want the explicit runtimeregistry ghcr.io/sophium (unchanged)", got)
+		}
+	})
+
+	t.Run("plain env resolves components from the same deploy registry as the platform chart", func(t *testing.T) {
+		target := OpenResult{EnvConfig: EnvConfig{
+			ContainerRegistries: ContainerRegistries{{Registry: "registry.example/test", Roles: []RegistryRole{RegistryRoleBuild, RegistryRoleDeploy}}},
+		}}
+		if got := publishedTenantComponentChartRegistry(target); got != "registry.example/test" {
+			t.Fatalf("component chart registry = %q, want registry.example/test", got)
+		}
+	})
+}
+
+// TestChartRegistryInsecure pins the other half of erun#1598: only the deploy
+// target's own concretized cluster registry can ever be insecure, and only
+// when the registry under test is that exact resolved host -- a platform
+// registry (ghcr.io) that merely happens to be probed in the same search must
+// never be treated as insecure just because the env also has an insecure
+// cluster entry.
+func TestChartRegistryInsecure(t *testing.T) {
+	target := OpenResult{
+		ClusterPullRegistry:     "10.43.0.100:5000",
+		ClusterRegistryInsecure: true,
+	}
+	if !chartRegistryInsecure(target, "10.43.0.100:5000") {
+		t.Fatal("the concretized insecure cluster registry must report insecure")
+	}
+	if chartRegistryInsecure(target, "ghcr.io/sophium") {
+		t.Fatal("a different registry (the platform chart's) must never be reported insecure")
+	}
+	if chartRegistryInsecure(OpenResult{}, "") {
+		t.Fatal("an empty registry must never be reported insecure")
+	}
+}
+
 // TestResolveDeployRuntimeImageHonoursTenantsOwnVersionLine pins #1265: a
 // tenant's own <tenant>-devops image is versioned on the tenant's own release
 // line, independent of the erun version the environment runs (as erun pin

--- a/erun-common/registry_versions.go
+++ b/erun-common/registry_versions.go
@@ -78,6 +78,7 @@ func (c RuntimeRegistryConfig) Resolved() RuntimeRegistryConfig {
 		Repository: strings.TrimSpace(c.Repository),
 		BaseURL:    strings.TrimSpace(c.BaseURL),
 		TokenURL:   strings.TrimSpace(c.TokenURL),
+		Insecure:   c.Insecure,
 	}
 	if resolved.Namespace == "" {
 		resolved.Namespace = DefaultContainerRegistry
@@ -92,8 +93,14 @@ func (c RuntimeRegistryConfig) Resolved() RuntimeRegistryConfig {
 		case isRegistryHost:
 			// A namespace that names its own registry host is served by that host,
 			// not by Docker Hub; defaulting to the Hub sent the listing to a
-			// repository named after the host and answered 404.
-			resolved.BaseURL = "https://" + host
+			// repository named after the host and answered 404. That host may speak
+			// plain HTTP only (an insecure in-cluster registry), so honor Insecure
+			// rather than always assuming TLS.
+			scheme := "https://"
+			if resolved.Insecure {
+				scheme = "http://"
+			}
+			resolved.BaseURL = scheme + host
 		default:
 			resolved.BaseURL = defaultDockerHubRegistryBaseURL
 		}

--- a/erun-common/registry_versions_oci_test.go
+++ b/erun-common/registry_versions_oci_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -83,20 +84,62 @@ func TestResolveOCIRegistryBasicAuthFallsBackToECRLogin(t *testing.T) {
 // A namespace that names its own registry host must resolve against that host.
 // Defaulting it to Docker Hub sent the tags request to hub.docker.com and 404ed,
 // which is what made a private image look unreachable.
+//
+// The insecure rows pin erun#1598: a cluster registry marked `insecure: true`
+// serves plain HTTP, so a chart-verification probe that always forced HTTPS
+// against it could never succeed (http: server gave HTTP response to HTTPS
+// client). ghcr.io and Docker Hub are never an insecure cluster registry, so
+// Insecure must not affect those two branches even if set.
 func TestResolvedBaseURLFollowsTheRegistryHost(t *testing.T) {
 	for _, tc := range []struct {
 		namespace string
+		insecure  bool
 		want      string
 	}{
-		{"020362606330.dkr.ecr.eu-west-2.amazonaws.com", "https://020362606330.dkr.ecr.eu-west-2.amazonaws.com"},
-		{"registry.example/team", "https://registry.example"},
-		{"localhost:5000", "https://localhost:5000"},
-		{"ghcr.io/sophium", "https://ghcr.io"},
-		{"sophium", "https://hub.docker.com"},
+		{"020362606330.dkr.ecr.eu-west-2.amazonaws.com", false, "https://020362606330.dkr.ecr.eu-west-2.amazonaws.com"},
+		{"registry.example/team", false, "https://registry.example"},
+		{"localhost:5000", false, "https://localhost:5000"},
+		{"ghcr.io/sophium", false, "https://ghcr.io"},
+		{"sophium", false, "https://hub.docker.com"},
+		{"10.43.0.100:5000", true, "http://10.43.0.100:5000"},
+		{"10.43.0.100:5000/charts", true, "http://10.43.0.100:5000"},
+		{"ghcr.io/sophium", true, "https://ghcr.io"},
 	} {
-		got := RuntimeRegistryConfig{Namespace: tc.namespace, Repository: "petios-devops"}.Resolved().BaseURL
+		got := RuntimeRegistryConfig{Namespace: tc.namespace, Insecure: tc.insecure, Repository: "petios-devops"}.Resolved().BaseURL
 		if got != tc.want {
-			t.Errorf("namespace %q resolved base %q, want %q", tc.namespace, got, tc.want)
+			t.Errorf("namespace %q insecure=%v resolved base %q, want %q", tc.namespace, tc.insecure, got, tc.want)
 		}
+	}
+}
+
+// TestResolveConfiguredRuntimeRegistryVersionsHonoursInsecure locks the live
+// half of erun#1598: an insecure cluster registry serves plain HTTP with no
+// TLS listener at all, so a probe that ignores Insecure and always dials
+// HTTPS cannot even complete a handshake against it, let alone read tags.
+// httptest.NewServer here speaks HTTP only, so this fails exactly the way the
+// bug did before the fix -- proving the probe now actually reaches the
+// registry rather than merely computing the right string.
+func TestResolveConfiguredRuntimeRegistryVersionsHonoursInsecure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"charts/team-backend-api","tags":["1.0.0"]}`))
+	}))
+	defer server.Close()
+
+	restore := dockerConfigDir
+	dockerConfigDir = func() string { return t.TempDir() }
+	defer func() { dockerConfigDir = restore }()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	versions, err := ResolveConfiguredRuntimeRegistryVersions(context.Background(), RuntimeRegistryConfig{
+		Namespace:  host,
+		Repository: "charts/team-backend-api",
+		Insecure:   true,
+	})
+	if err != nil {
+		t.Fatalf("resolve versions over the registry's plain-HTTP listener: %v", err)
+	}
+	if !versions.HasVersion("1.0.0") {
+		t.Fatalf("versions %+v missing 1.0.0", versions)
 	}
 }

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -1517,6 +1517,63 @@ func TestDeploy(t *testing.T) {
 		golden.Equal(t, "deploy/dry_run_remote_env_deploys_tenant_component_charts_by_reference", normalize.Apply(result.Combined))
 	})
 
+	t.Run("dry_run_remote_env_tenant_component_verifies_against_the_cluster_registry", func(t *testing.T) {
+		// erun#1598: a `--cluster-registry` env with an explicit runtimeregistry
+		// (a realistic pairing -- runtimeregistry names where the shared
+		// platform chart lives, containerregistries names the in-cluster
+		// registry the tenant's own images and component charts publish to)
+		// could never confirm its own component chart, because verification
+		// probed the platform-chart registry (runtimeregistry) instead of the
+		// registry `erun push` actually publishes tenant charts to. The
+		// registry-qualified ERUN_PUBLISHED_CHART_PROBE_OVERRIDE entry below is
+		// published only at the concretized cluster pull address (the dry-run
+		// placeholder <cluster-ip>:5000), never at the runtimeregistry, so this
+		// only passes when resolution reaches the cluster registry -- exactly
+		// the registry the cluster entry is marked insecure for, which
+		// erun-common's registry-scheme unit tests cover directly (a live HTTPS
+		// probe against a plain-HTTP registry cannot be observed from this
+		// harness; see erun-integration/AGENTS.md's coverage-gaps section).
+		setup := env.New(t)
+		root := filepath.Join(setup.ConfigHome, "erun")
+		tenantDir := filepath.Join(root, "team")
+		envDir := filepath.Join(tenantDir, "dev")
+		for _, dir := range []string{root, tenantDir, envDir} {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", dir, err)
+			}
+		}
+		mustWriteFile(t, filepath.Join(root, "config.yaml"), "defaulttenant: team\n")
+		mustWriteFile(t, filepath.Join(tenantDir, "config.yaml"), "projectroot: "+setup.Cwd+"\nname: team\ndefaultenvironment: dev\n")
+		mustWriteFile(t, filepath.Join(envDir, "config.yaml"),
+			"name: dev\n"+
+				"repopath: /nonexistent-remote/team\n"+
+				"kubernetescontext: test-context\n"+
+				"runtimeimage: ghcr.io/sophium/erun-devops\n"+
+				"runtimeregistry: ghcr.io/sophium\n"+
+				"runtimeversion: 1.0.0\n"+
+				"type: remote-agent\n"+
+				"containerregistries:\n"+
+				"    - cluster: {insecure: true}\n"+
+				"      roles:\n"+
+				"        - build\n"+
+				"        - deploy\n",
+		)
+		envVars := append(setup.Env(), "ERUN_PUBLISHED_CHART_PROBE_OVERRIDE=<cluster-ip>:5000/team-backend-api:1.0.0")
+		result := erun.Run(t, []string{
+			"deploy", "team", "dev",
+			"--version", "1.0.0",
+			"--components", "team-backend-api",
+			"--dry-run",
+		}, erun.RunOptions{Cwd: setup.Home, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "verifying charts published at 1.0.0 in <cluster-ip>:5000: team-backend-api") {
+			t.Fatalf("expected verification against the concretized cluster registry, not the platform runtimeregistry:\n%s", result.Combined)
+		}
+		golden.Equal(t, "deploy/dry_run_remote_env_tenant_component_verifies_against_the_cluster_registry", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_remote_env_component_threads_resolved_oidc_issuer", func(t *testing.T) {
 		// Regression: an empty computed api.oidcAllowedIssuers used
 		// to be passed as `--set-string api.oidcAllowedIssuers=` regardless, and

--- a/erun-integration/testdata/deploy/dry_run_remote_env_tenant_component_verifies_against_the_cluster_registry.txt
+++ b/erun-integration/testdata/deploy/dry_run_remote_env_tenant_component_verifies_against_the_cluster_registry.txt
@@ -1,0 +1,17 @@
+audit: erun deploy --components [team-backend-api] --dry-run --version <VERSION> team dev
+trace-log: would append the full trace to <TMP>
+deploy: tenant=team environment=dev version-override=<VERSION> components=[team-backend-api] force=false current=false
+deploy: configured repo path /nonexistent-remote/team is not present on this machine; no k8s.deployments plan could be read
+deploy: component selection source --components flag; components team-backend-api
+kubectl --context test-context -n kube-system get svc erun-registry -o 'jsonpath={.spec.clusterIP}'
+kubectl --context test-context -n kube-system port-forward svc/erun-registry :5000
+deploy: deploying tenant artifacts; verifying charts published at <VERSION> in <cluster-ip>:5000: team-backend-api
+deploy: no local chart for team-backend-api; using published chart oci://<cluster-ip>:5000/charts/team-backend-api version <VERSION>
+deploy: resolved 1 spec(s)
+kubectl --context test-context get namespace team-dev -o name
+deploy: namespace team-dev is created if the check above reports it missing
+helm pull 'oci://<cluster-ip>:5000/charts/team-backend-api' --version <VERSION> --untar --untardir <TMP>
+helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string erun-backend-api.tenant=team --set-string erun-backend-api.environment=dev --set-string erun-backend-api.worktreeStorage=pvc --set-string erun-backend-api.worktreeRepoName=team --set-string erun-backend-api.worktreeHostPath=/nonexistent-remote/team --set erun-backend-api.sshdEnabled=false --set erun-backend-api.mcpPort=17000 --set erun-backend-api.apiPort=17033 --set erun-backend-api.sshPort=17022 --set erun-backend-api.managedCloud=false --set-string erun-backend-api.cloudContext.name= --set-string erun-backend-api.cloudContext.provider= --set-string erun-backend-api.cloudContext.providerAlias= --set-string erun-backend-api.cloudContext.instanceId= --set erun-backend-api.cloudContext.useHostCredentials=false --set erun-backend-api.api.postgres.reset=false --set-string 'erun-backend-api.containerRegistry=<cluster-ip>:5000' --set-string erun-backend-api.runtimeRegistry=ghcr.io/sophium --set-string 'erun-backend-api.clusterRegistryInsecure=<cluster-ip>:5000' --set-json 'erun-backend-api.containerRegistries=[{"registry":"localhost:5000","roles":["build"]},{"registry":"\u003ccluster-ip\u003e:5000","roles":["deploy"]}]' --set erun-backend-api.disableBuildScript=false --set-string erun-backend-api.idle.timeout=5m0s --set-string erun-backend-api.idle.workingHours=08:00-20:00 --set-string erun-backend-api.idle.timezone= --set erun-backend-api.idle.trafficBytes=0 --set-string erun-backend-api.runtime.resources.limits.cpu=4 --set-string erun-backend-api.runtime.resources.limits.memory=8916Mi --set-string erun-backend-api.claude.useMantle=0 --set-string erun-backend-api.claude.useBedrock=0 team-backend-api 'oci://<cluster-ip>:5000/charts/team-backend-api' --version <VERSION>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-backend-api)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-backend-api, hash=<HASH>)


### PR DESCRIPTION
## Summary

Component-chart verification had two distinct defects in the same pre-flight (`ensureTenantChartsPublished` / `resolvePublishedComponentDeploySpec`, `erun-common/published_devops_chart.go`):

1. **Wrong registry.** Both functions resolved the probe/install registry via `publishedDevopsChartRegistry`, which prioritizes the env's `runtimeregistry` (correct for the shared platform chart `erun-devops`/`<tenant>-devops`'s own resolution ladder) or, for a `--cluster-registry` env, falls back to the runtime image's registry. Neither is where `erun push` actually publishes a tenant's own component charts and runtime chart — that's the environment's DEPLOY registry. A new `publishedTenantComponentChartRegistry` resolves that instead; `ensureTenantChartsPublished` only falls back to `publishedDevopsChartRegistry` for the tenant's own runtime-chart entry when that genuinely differs (explicit `runtimeregistry`, or the cluster-registry platform-chart fallback), matching the registry `resolvePublishedDevopsDeploySpecWithReason`'s own ladder actually installs it from.
2. **Forced HTTPS.** The registry probe (`ResolveConfiguredRuntimeRegistryVersions` → `resolveOCIRuntimeRegistryVersionsAt`) always built an HTTPS base URL, ignoring a cluster registry's `insecure: true` marker, so even pointing at the right registry failed with `http: server gave HTTP response to HTTPS client`. `RuntimeRegistryConfig` gained an `Insecure` field (never persisted) that `Resolved()` honors when computing the default scheme, mirroring how #1597 (`c503b00f`) added `--insecure` to every `docker manifest` call site for the same class of bug on the push path.

Since the DEPLOY registry for a `--cluster-registry` env is only ever a real host once its `cluster:` block is concretized (kube-context resolved), `resolvePublishedDeploySpecs` now concretizes the deploy target's registries before verifying/installing tenant components — the same step the local-repo deploy path already took, just never wired into the sourceless/remote path. `chartRegistryInsecure(target, registry)` then flags a registry as insecure only when it's exactly the target's own concretized (and marked-insecure) cluster registry — never a platform registry (ghcr.io) that happens to be probed in the same search.

`#1597` already covered the `docker manifest`/push half of this bug class; this closes the verification half.

## Test plan
- [x] New unit tests in `erun-common`: `TestPublishedTenantComponentChartRegistry`, `TestChartRegistryInsecure` (registry-split logic), and extended `TestResolvedBaseURLFollowsTheRegistryHost` + new `TestResolveConfiguredRuntimeRegistryVersionsHonoursInsecure` (asserts the negative: a plain-HTTP `httptest` registry, which has no TLS listener at all, is resolved successfully with `Insecure: true`, and would fail exactly as the bug did without the fix; a registry not marked insecure still defaults to HTTPS).
- [x] New integration scenario `deploy/dry_run_remote_env_tenant_component_verifies_against_the_cluster_registry`: a `--cluster-registry` env with an explicit `runtimeregistry` (the realistic pairing from the issue) and `--components`; verified it reproduces the exact reported failure (`ghcr.io/sophium` 403-shaped refusal) on `main`, and passes after the fix, verifying against the concretized cluster registry instead.
- [x] `make check` green (lint, erun-ui/erun-kit/erun-console gates, chart tests, full integration suite, coverage 76.2% ≥ 75.8%).

Closes #1598