### PR TITLE
Restore make check on main

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -400,7 +400,7 @@ func (r *IdentityRepository) bindSecurityContext(ctx context.Context, tx bun.Tx,
 // on an IdP erun itself ships. A platform's own IdP serves every tenant from
 // one issuer, so the bootstrap has to record which claim discriminates them —
 // otherwise the issuer is registered single-tenant and every later tenant on
-// it is permanently refused, with no API able to undo it (issue #1605).
+// it is permanently refused, with no API able to undo it.
 //
 // Only claims a shipped IdP is known to emit belong here. An unrecognised
 // issuer keeps the single-tenant registration, which is correct for a

--- a/erun-backend/erun-backend-api/internal/repository/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_test.go
@@ -63,7 +63,7 @@ func TestDefaultTenantIssuerNameFallsBackForEmptyIssuer(t *testing.T) {
 // A platform's own IdP serves every tenant from one issuer, so bootstrap has
 // to record the claim that discriminates them. Registering it single-tenant
 // permanently refuses every later tenant on that issuer, and no API can undo
-// it (issue #1605).
+// it.
 func TestBootstrapOrgScopeReadsTheShippedIdPOrgClaim(t *testing.T) {
 	claims := security.Claims{Issuer: "https://auth.example.com", Raw: map[string]any{
 		"urn:zitadel:iam:user:resourceowner:id":   " 386994597030592700 ",

--- a/erun-backend/erun-backend-api/internal/repository/tenant_issuers.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenant_issuers.go
@@ -46,7 +46,7 @@ func (r *TenantIssuerRepository) List(ctx context.Context) ([]model.TenantIssuer
 //
 // This exists because first-identity bootstrap registers a platform's own IdP
 // single-tenant, which permanently blocks every later tenant on that issuer
-// and cannot otherwise be undone through the API (issue #1605). Org-scoping
+// and cannot otherwise be undone through the API. Org-scoping
 // mode lives on the shared issuers row, so this is an operations-only
 // operation — the route enforces that.
 func (r *TenantIssuerRepository) UpdateOrgScope(ctx context.Context, issuer, orgFieldKey, orgFieldValue string) (model.TenantIssuer, error) {

--- a/erun-backend/erun-backend-api/internal/routes/tenant_issuers_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenant_issuers_test.go
@@ -108,7 +108,7 @@ func TestTenantIssuerRoutesUpdateTenantIssuerName(t *testing.T) {
 // changes how every tenant's tokens on that issuer resolve — not just the
 // caller's own mapping the way a rename does. It carries the same
 // operations-only gate POST /v1/tenants applies to these root resolution
-// tables (issue #1605).
+// tables.
 func TestTenantIssuerRoutesOrgScopeRequiresOperationsTenant(t *testing.T) {
 	repo := &stubTenantIssuerRepository{}
 	rec := httptest.NewRecorder()

--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -587,7 +587,15 @@ func runCloudLoginCommand(ctx common.Context, store common.CloudStore, promptRun
 	if status.Status == common.CloudTokenStatusActive && !params.Force {
 		return finishCloudLogin(ctx, store, status, deps)
 	}
-	login, err := confirmPrompt(promptRunner, fmt.Sprintf("Login to %s", provider.Alias))
+	return confirmAndLoginCloudProvider(ctx, store, promptRunner, alias, provider.Alias, status, params, deps)
+}
+
+// confirmAndLoginCloudProvider asks before starting an interactive login, and
+// reports the status unchanged when the operator declines — a refusal is the
+// current state, not a failure. Split out of runCloudLoginCommand so that
+// function stays under the cyclop threshold; the sequence is unchanged.
+func confirmAndLoginCloudProvider(ctx common.Context, store common.CloudStore, promptRunner PromptRunner, alias, providerAlias string, status common.CloudProviderStatus, params common.CloudLoginParams, deps common.CloudDependencies) error {
+	login, err := confirmPrompt(promptRunner, fmt.Sprintf("Login to %s", providerAlias))
 	if err != nil {
 		return err
 	}

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -117,7 +117,7 @@ type CloudLoginParams struct {
 // it prefers the device grant when the issuer advertises one, and falls back to
 // authorization code + PKCE when that grant cannot complete — a single
 // unusable authentication method must not lock the CLI out when a second,
-// working flow exists (issue #1603).
+// working flow exists.
 const (
 	ERunLoginFlowAuto     = "auto"
 	ERunLoginFlowDevice   = "device"

--- a/erun-common/cloud_erun.go
+++ b/erun-common/cloud_erun.go
@@ -143,30 +143,7 @@ func erunCloudProviderLogin(ctx Context, store CloudStore, provider CloudProvide
 		ctx.Trace("cloud login erun: requesting scope " + scope)
 	}
 
-	var tokens ERunTokens
-	switch {
-	case flow == ERunLoginFlowAuthCode:
-		ctx.Trace("cloud login erun: authorization code + PKCE requested explicitly")
-		tokens, err = deps.RunERunAuthCodeLogin(ctx, discovery, provider.ERun.ClientID, scope)
-	case flow == ERunLoginFlowDevice:
-		if !hasDeviceEndpoint {
-			return CloudProviderStatus{}, fmt.Errorf("issuer %s does not advertise a device authorization endpoint; retry with --flow %s", discovery.Issuer, ERunLoginFlowAuthCode)
-		}
-		tokens, err = erunDeviceFlowLogin(ctx, discovery, provider.ERun.ClientID, scope, deps)
-	case hasDeviceEndpoint:
-		// Auto: prefer the device grant, but a failure here is not the end of
-		// the road. The device page forces a fresh authentication, so an
-		// account whose only method there is broken can never finish it —
-		// while the authorization-code redirect reuses the browser session
-		// that same operator may already hold.
-		tokens, err = erunDeviceFlowLogin(ctx, discovery, provider.ERun.ClientID, scope, deps)
-		if err != nil {
-			ctx.Trace("cloud login erun: device flow did not complete (" + err.Error() + "); falling back to authorization code + PKCE")
-			tokens, err = deps.RunERunAuthCodeLogin(ctx, discovery, provider.ERun.ClientID, scope)
-		}
-	default:
-		tokens, err = deps.RunERunAuthCodeLogin(ctx, discovery, provider.ERun.ClientID, scope)
-	}
+	tokens, err := acquireERunLoginTokens(ctx, discovery, provider.ERun.ClientID, scope, flow, hasDeviceEndpoint, deps)
 	if err != nil {
 		return CloudProviderStatus{}, err
 	}
@@ -174,6 +151,38 @@ func erunCloudProviderLogin(ctx Context, store CloudStore, provider CloudProvide
 		return CloudProviderStatus{CloudProviderConfig: provider, Status: CloudTokenStatusActive}, nil
 	}
 	return persistERunLoginTokens(store, provider, deps, tokens)
+}
+
+// acquireERunLoginTokens picks the grant and runs it. An explicitly requested
+// flow is honoured exactly — including refusing the device grant against an
+// issuer that does not advertise one, rather than silently substituting a
+// different flow. Auto prefers the device grant but falls back to
+// authorization code + PKCE: the device page forces a fresh authentication, so
+// an account whose only method there is broken can never finish it, while the
+// redirect reuses the browser session that same operator may already hold.
+//
+// Split out of erunCloudProviderLogin to keep that function under the cyclop
+// threshold; the selection and its ordering are unchanged.
+func acquireERunLoginTokens(ctx Context, discovery OIDCDiscovery, clientID, scope, flow string, hasDeviceEndpoint bool, deps CloudDependencies) (ERunTokens, error) {
+	switch {
+	case flow == ERunLoginFlowAuthCode:
+		ctx.Trace("cloud login erun: authorization code + PKCE requested explicitly")
+		return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, scope)
+	case flow == ERunLoginFlowDevice:
+		if !hasDeviceEndpoint {
+			return ERunTokens{}, fmt.Errorf("issuer %s does not advertise a device authorization endpoint; retry with --flow %s", discovery.Issuer, ERunLoginFlowAuthCode)
+		}
+		return erunDeviceFlowLogin(ctx, discovery, clientID, scope, deps)
+	case hasDeviceEndpoint:
+		tokens, err := erunDeviceFlowLogin(ctx, discovery, clientID, scope, deps)
+		if err == nil {
+			return tokens, nil
+		}
+		ctx.Trace("cloud login erun: device flow did not complete (" + err.Error() + "); falling back to authorization code + PKCE")
+		return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, scope)
+	default:
+		return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, scope)
+	}
 }
 
 // persistERunLoginTokens saves a fresh refresh token (when the grant returned

--- a/erun-common/cloud_erun_test.go
+++ b/erun-common/cloud_erun_test.go
@@ -315,7 +315,7 @@ func TestERunCloudProviderTokenStatusReflectsResolution(t *testing.T) {
 		}
 	})
 
-	t.Run("unknown rather than expired when the secret store is absent (#1109)", func(t *testing.T) {
+	t.Run("unknown rather than expired when the secret store is absent", func(t *testing.T) {
 		provider := erunTestProvider()
 		provider.ERun.RefreshTokenRef = erunRefreshTokenRef(provider.Alias)
 		status := erunCloudProviderTokenStatus(provider, CloudDependencies{})
@@ -528,7 +528,7 @@ func TestNormalizeERunLoginFlow(t *testing.T) {
 // (Zitadel's urn:zitadel:* family is), so the operator must be able to ask for
 // one by name and have it actually reach the authorization request. Without
 // the org claim such a scope carries, an org-scoped issuer resolves nobody
-// (issue #1605).
+// .
 func TestERunCloudProviderLoginRequestsExtraScopes(t *testing.T) {
 	store := erunTestCloudStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{erunTestProvider()}}}
 	provider := erunTestProvider()

--- a/erun-integration/testdata/cloud/login_expired_confirms_relogin_via_stub.txt
+++ b/erun-integration/testdata/cloud/login_expired_confirms_relogin_via_stub.txt
@@ -1,4 +1,4 @@
 ? Login to test-user@aws? [Y/n] test-user@aws: expired (The SSO session associated with this profile has expired or is otherwise invalid.)
 audit: erun cloud login --alias test-user@aws
-cloud login: alias=test-user@aws force=true
+cloud login: alias=test-user@aws force=true flow=
 cloud login: resolved profile = test-profile

--- a/erun-integration/testdata/cloud/login_help.txt
+++ b/erun-integration/testdata/cloud/login_help.txt
@@ -4,9 +4,12 @@ Usage:
   erun cloud login [flags]
 
 Flags:
-      --alias string   Cloud provider alias to login
-      --dry-run        Resolve and trace mutating actions without executing them.
-  -h, --help           help for login
+      --alias string        Cloud provider alias to login
+      --dry-run             Resolve and trace mutating actions without executing them.
+      --flow string         OIDC grant for an erun-hosted alias: "device", "authcode", or "auto" (default) which prefers the device grant and falls back to authorization code + PKCE when it cannot complete. Use "authcode" when the device page's authentication method fails — its loopback redirect reuses a browser session you already hold
+      --force               Re-authenticate even when the stored session is still active. Needed to change the requested scopes or flow on an alias that is already signed in, since an active session otherwise short-circuits the login
+  -h, --help                help for login
+      --scope stringArray   Extra OAuth scope to request on top of "openid offline_access" (repeatable). A provider's reserved scopes are often absent from its discovery document, so they can only be asked for by name — e.g. urn:zitadel:iam:user:resourceowner, which makes a Zitadel token carry the org claim an org-scoped issuer resolves tenants by
 
 Global Flags:
       --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")

--- a/erun-integration/testdata/cloud/login_real_run_sso_login_failure_fails.txt
+++ b/erun-integration/testdata/cloud/login_real_run_sso_login_failure_fails.txt
@@ -1,5 +1,5 @@
 ? Login to test-user@aws? [Y/n] audit: erun cloud login --alias test-user@aws
-cloud login: alias=test-user@aws force=true
+cloud login: alias=test-user@aws force=true flow=
 cloud login: resolved profile = test-profile
 SSO authorization page failed to open
 aws sso login: SSO authorization page failed to open

--- a/erun-integration/testdata/cloud/login_real_run_unsupported_provider_fails.txt
+++ b/erun-integration/testdata/cloud/login_real_run_unsupported_provider_fails.txt
@@ -1,4 +1,4 @@
 ? Login to test-user@gcp? [Y/n] audit: erun cloud login --alias test-user@gcp
-cloud login: alias=test-user@gcp force=true
+cloud login: alias=test-user@gcp force=true flow=
 cloud login: resolved profile = test-profile
 unsupported cloud provider "gcp"


### PR DESCRIPTION
`make check` fails on `origin/main` at `69a0d9f6` in three separate ways. A red trunk is inherited by every branch cut from it — two lanes gated against it within minutes and both failed on violations neither had introduced.

## What was broken

| class | count | detail |
|---|---|---|
| `cyclop` lint | 2 | `runCloudLoginCommand` complexity 11, `erunCloudProviderLogin` complexity 14 (max 10) |
| issue references in code | 7 | `(issue #1605)`, `(issue #1603)`, and a subtest name carrying `(#1109)` |
| `TestCloud` | 4 | `login_help` and three siblings — goldens never regenerated after `--flow`/`--force`/`--scope` were added |

## Baseline

Measured, not assumed. The preceding commit `c503b00f` gated green. All three classes were reproduced on clean `origin/main` before any change here, so none originate from this PR.

## The fixes, deliberately conservative

- **Lint**: two pure extractions, no behaviour change — `confirmAndLoginCloudProvider` and `acquireERunLoginTokens`. Same remedy #1568 used when the identical check flagged `finishEnvironmentJob`. The login flow #1588 fixed keeps working exactly as it does now.
- **Goldens**: regenerated. The new flags are a real feature, so the goldens were genuinely stale rather than masking a regression — confirmed by reading the actual `got` output before updating.
- **Issue references**: only the trailing `(issue #NNNN)` citation is removed; the reasoning prose around it is untouched, since that is the part worth keeping.

## Note

This is what #1461 exists to prevent. With the merge queue switched on for this repository a gate build would have refused that merge; until then, as its issue puts it, *"the only thing standing between a red commit and `main` is a human remembering to run `make check`"*.

`make check`: **green, exit 0**.

Closes #1612