### PR TITLE
Drive the environment-activity sweep deterministically in the idle-latch spec

### DIFF
--- a/erun-ui/environment_activity.go
+++ b/erun-ui/environment_activity.go
@@ -93,6 +93,20 @@ func (a *App) reconcileEnvironmentActivityOnce() {
 	}
 }
 
+// TriggerEnvironmentActivitySweep runs one sweep pass synchronously, the same
+// pass runEnvironmentActivityPoller's ticker runs on its own schedule. It
+// exists so a test can drive the sweep deterministically instead of waiting
+// on a tick it cannot see: emitEnvActivityIfChanged only emits on a
+// transition, so the very first observation of an environment this App has
+// never observed before always emits once regardless of what it finds, and a
+// test that later stages its own activity state for that environment must not
+// race that one-time emission. Calling this before staging any state consumes
+// it up front, so every later tick of the automatic ticker observes the same
+// unchanged environment and stays quiet for the rest of the test.
+func (a *App) TriggerEnvironmentActivitySweep() {
+	a.reconcileEnvironmentActivityOnce()
+}
+
 // configuredSelections lists every environment in the config store, not only the
 // ones with desktop tabs — an environment nobody opened here is exactly the case
 // this poller exists to make visible.

--- a/erun-ui/environment_activity_test.go
+++ b/erun-ui/environment_activity_test.go
@@ -204,3 +204,24 @@ func TestLoadStateSeedsEnvironmentActivityFromThePoller(t *testing.T) {
 		t.Fatalf("expected LoadState to seed the busy observation, got %+v", activity)
 	}
 }
+
+// TestTriggerEnvironmentActivitySweepRunsSynchronously locks in the contract
+// a deterministic caller needs: the sweep must run to completion, and emit
+// for every configured selection, within the call itself rather than waiting
+// for the poller's own ticker.
+func TestTriggerEnvironmentActivitySweepRunsSynchronously(t *testing.T) {
+	store := stubUIStore{
+		tenants: map[string]eruncommon.TenantConfig{"acme": {Name: "acme"}},
+		envs:    map[string]eruncommon.EnvConfig{"acme/dev": {Name: "dev"}},
+	}
+	app := NewApp(erunUIDeps{store: store})
+	t.Cleanup(func() { app.shutdown(context.Background()) })
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+
+	app.TriggerEnvironmentActivitySweep()
+
+	if len(emits.events(envActivityEvent)) == 0 {
+		t.Fatal("triggering a sweep must observe and emit for every configured selection before returning")
+	}
+}

--- a/erun-ui/frontend/src/app/slices/envStatusSlice.test.ts
+++ b/erun-ui/frontend/src/app/slices/envStatusSlice.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import reducer, { type EnvObservedActivity, setEnvActivityForEnv } from './envStatusSlice';
+
+function activity(overrides: Partial<EnvObservedActivity> = {}): EnvObservedActivity {
+  return {
+    reachable: true,
+    observed: false,
+    outage: false,
+    checkFailed: false,
+    busy: false,
+    detail: '',
+    ...overrides,
+  };
+}
+
+// The sidebar's busy row clears only when envObserved flips to true (see
+// environmentRowIsBusy in Sidebar.helpers.ts). A transition that changes
+// nothing else about the observation must still be recorded, or the row can
+// never learn the environment answered.
+test('a transition where only observed changes is not swallowed as unchanged', () => {
+  const seeded = reducer(undefined, setEnvActivityForEnv({ key: 'k', activity: activity() }));
+
+  const next = reducer(
+    seeded,
+    setEnvActivityForEnv({ key: 'k', activity: activity({ observed: true }) }),
+  );
+
+  assert.equal(next.activityByEnv.k?.observed, true);
+});
+
+test('an identical repeat is still suppressed', () => {
+  const seeded = reducer(
+    undefined,
+    setEnvActivityForEnv({ key: 'k', activity: activity({ observed: true }) }),
+  );
+
+  const next = reducer(
+    seeded,
+    setEnvActivityForEnv({ key: 'k', activity: activity({ observed: true }) }),
+  );
+
+  assert.equal(next.activityByEnv.k, seeded.activityByEnv.k);
+});

--- a/erun-ui/frontend/src/app/slices/envStatusSlice.ts
+++ b/erun-ui/frontend/src/app/slices/envStatusSlice.ts
@@ -73,6 +73,7 @@ function environmentActivityUnchanged(
 ): boolean {
   return (
     current?.reachable === activity.reachable &&
+    current.observed === activity.observed &&
     current.outage === activity.outage &&
     current.checkFailed === activity.checkFailed &&
     current.busy === activity.busy &&

--- a/erun-ui/playwright/tests/sidebar-env-idle-clears-latch.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-env-idle-clears-latch.spec.ts
@@ -15,28 +15,18 @@ import { expect, test } from '../fixtures/erunApp.js';
 // environment_activity_observed_test.go; what only the running app can show is
 // that the spinner an orphaned latch produces actually goes away.
 
-// The backend sweeps every environment on its own timer (environmentActivityInterval
-// in environment_activity.go) and reports these inert ones unreachable, so an emit
-// this spec makes can be overwritten before the row settles. Re-driving until it
-// converges is the right shape; the two budgets below are what make it converge.
-// The settle wait has to cover a loaded emit → event → re-render round-trip: at 1s
-// a loaded machine missed it, and because every retry re-emits the latch first, no
-// later attempt inherited the previous one's progress. The outer budget is sized to
-// the sweep, not guessed: at exactly one period it passes or fails on where the tick
-// happens to land — observed doing both, converging at 20.2s once and exhausting the
-// budget once. Two full periods plus margin means a sweep landing anywhere inside
-// the window still leaves a whole period for the emits to converge.
-const SWEEP_PERIOD_MS = 20_000;
-const SETTLE_TIMEOUT_MS = 5_000;
-// Four periods, not two. The sweep is what releases the latch, so convergence
-// needs a tick to land *and* the emit that follows it to settle inside the same
-// window. On an idle machine two periods was ample; once the suite runs specs
-// in parallel the settle is slow enough that two windows no longer reliably
-// contain one, and the budget expired rather than the logic failing. Widening
-// the window is the honest fix here -- the sweep cannot be shortened (it would
-// overwrite the staged state more often) nor lengthened (it would never release
-// the latch at all), so the only free variable is how long we let it converge.
-const CONVERGE_TIMEOUT_MS = SWEEP_PERIOD_MS * 4 + 20_000;
+// The backend's own sweep (environmentActivityInterval in
+// environment_activity.go) is not noise this spec has to survive -- it is the
+// mechanism that releases the latch, so it must keep running. What has to be
+// removed is the race: emitEnvActivityIfChanged only re-emits an environment's
+// activity on a transition, so the very first observation of a brand-new
+// environment always emits once, real or synthetic, and that one-time emit
+// could otherwise land at an arbitrary point later in the test and overwrite
+// state this spec has staged. TriggerEnvironmentActivitySweepNow drives that
+// one-time emit deterministically, before anything is staged, so every later
+// automatic tick observes the same (unreachable) environment, finds nothing
+// changed, and stays quiet for the rest of the test -- no timer to wait for,
+// no budget to size.
 
 test.describe('an idle environment clears a stale desktop latch', () => {
   test('an orphaned running entry stops spinning once the environment reports idle', async ({
@@ -44,12 +34,6 @@ test.describe('an idle environment clears a stale desktop latch', () => {
     page,
     seededEnv,
   }) => {
-    // Convergence is paced by the backend's own sweep, so this test outlasts the
-    // default budget by design rather than by accident.
-    // test.slow() triples the default budget, which is not enough to contain
-    // CONVERGE_TIMEOUT_MS above; an expect budget can never exceed the test
-    // budget holding it, so this is set explicitly rather than multiplied.
-    test.setTimeout(CONVERGE_TIMEOUT_MS + 60_000);
     // A per-test environment, not the restored one: the harness auto-opens that
     // one, and an open in flight is this desktop's own operation, which stays
     // authoritative by design and would hold the row busy for an unrelated
@@ -59,6 +43,8 @@ test.describe('an idle environment clears a stale desktop latch', () => {
     const spinner = sidebar.getByRole('status', {
       name: `Building ${tenant} / ${environment}`,
     });
+
+    await triggerEnvironmentActivitySweepNow(page);
 
     // The latch, and no ending for it — the desktop is left believing a build
     // it started is still running.
@@ -77,20 +63,15 @@ test.describe('an idle environment clears a stale desktop latch', () => {
     });
     await expect(spinner).toBeVisible();
 
-    // The environment's own answer. The backend's sweep also runs against these
-    // inert envs and reports them unreachable, so re-drive until it converges
-    // rather than racing a single emit — a row that never clears still fails.
-    await expect(async () => {
-      await emitRunningBuild(page, tenant, environment);
-      await emitEnvActivity(page, {
-        tenant,
-        environment,
-        reachable: true,
-        observed: true,
-        busy: false,
-      });
-      await expect(spinner).toHaveCount(0, { timeout: SETTLE_TIMEOUT_MS });
-    }).toPass({ timeout: CONVERGE_TIMEOUT_MS });
+    // The environment's own answer clears the latch.
+    await emitEnvActivity(page, {
+      tenant,
+      environment,
+      reachable: true,
+      observed: true,
+      busy: false,
+    });
+    await expect(spinner).toHaveCount(0);
   });
 
   test('an environment that reports work still spins, whoever started it', async ({
@@ -98,28 +79,27 @@ test.describe('an idle environment clears a stale desktop latch', () => {
     page,
     seededEnv,
   }) => {
-    test.slow();
     const { tenant, environment } = seededEnv;
     const sidebar = page.locator('aside').first();
+
+    await triggerEnvironmentActivitySweepNow(page);
 
     // Nothing was started from this desktop at all: the busy row here is
     // entirely the environment's own report, which is the case the corrective
     // must not be able to suppress.
-    await expect(async () => {
-      await emitEnvActivity(page, {
-        tenant,
-        environment,
-        reachable: true,
-        observed: true,
-        busy: true,
-        detail: 'holding: gradle-build',
-      });
-      await expect(
-        sidebar.getByRole('status', {
-          name: `${tenant} / ${environment} is busy — holding: gradle-build`,
-        }),
-      ).toBeVisible({ timeout: SETTLE_TIMEOUT_MS });
-    }).toPass({ timeout: CONVERGE_TIMEOUT_MS });
+    await emitEnvActivity(page, {
+      tenant,
+      environment,
+      reachable: true,
+      observed: true,
+      busy: true,
+      detail: 'holding: gradle-build',
+    });
+    await expect(
+      sidebar.getByRole('status', {
+        name: `${tenant} / ${environment} is busy — holding: gradle-build`,
+      }),
+    ).toBeVisible();
   });
 });
 
@@ -168,4 +148,25 @@ async function emitEnvActivity(
     ).runtime;
     runtime.EventsEmit('env-activity', event);
   }, payload);
+}
+
+// The desktop backend as the browser sees it, narrowed to the one call here.
+interface EnvironmentActivitySweepBridge {
+  go: {
+    main: {
+      App: {
+        TriggerEnvironmentActivitySweep: () => Promise<void>;
+      };
+    };
+  };
+}
+
+// Drives environment_activity.go's sweep synchronously (see the App method's
+// own doc comment for why this consumes the sweep's one-time emit up front
+// rather than parking or widening anything).
+async function triggerEnvironmentActivitySweepNow(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const bridge = window as unknown as EnvironmentActivitySweepBridge;
+    await bridge.go.main.App.TriggerEnvironmentActivitySweep();
+  });
 }


### PR DESCRIPTION
## Summary

- `sidebar-env-idle-clears-latch.spec.ts` raced the backend's own environment-activity sweep instead of driving it: `emitEnvActivityIfChanged` only re-emits on a transition, so the very first observation of a brand-new environment always emits once — real or synthetic — and that one-time emit could land at an arbitrary point later in the test and overwrite state the spec had staged. `App.TriggerEnvironmentActivitySweep` (new, `erun-ui/environment_activity.go`) runs the sweep pass synchronously so the spec can consume that one-time emit up front, before staging anything. Every later automatic tick then observes the same (unreachable) environment, finds nothing changed, and stays quiet for the rest of the test — no timer to wait for, no budget to size.
- Found and fixed the actual bug behind the flakiness while instrumenting the reducer: `environmentActivityUnchanged` (`erun-ui/frontend/src/app/slices/envStatusSlice.ts`) compared every `EnvObservedActivity` field except `observed`, so a transition where *only* `observed` flips — the exact case this spec exercises, and the exact case a wedged edge resolving to a genuine idle answer produces in production — was silently discarded as a no-op. The old retry loop only ever succeeded when the backend's own sweep happened to change an unrelated field (e.g. `checkFailed`) at the same time, accidentally unsticking the buggy equality check; that's why it needed a budget sized to multiple sweep periods under load.
- Simplified the spec accordingly: removed `SWEEP_PERIOD_MS`, `SETTLE_TIMEOUT_MS`, `CONVERGE_TIMEOUT_MS`, `test.slow()`/`test.setTimeout()`, the `toPass` re-drive loops, and the long comment block explaining budgets that no longer exist. Each test is now one emit sequence and one plain assertion.

## Why not what the issue body proposed

The issue description proposed making `environmentActivityInterval` overridable so the harness could park the sweep. That direction is wrong in both ends: shortening it overwrites staged state more often, and lengthening/parking it removes the only mechanism that ever clears the latch — confirmed by reproducing it (see the issue's own correcting comment). The sweep has to keep running; the fix is to drive it deterministically instead of waiting on (or disabling) its timer.

## How the sweep is triggered

`App.TriggerEnvironmentActivitySweep()` (new, exported, Wails/headless-bound like every other App method) calls the same `reconcileEnvironmentActivityOnce()` the poller's ticker calls on its own schedule. The spec calls it via the same `window.go.main.App.<Method>()` bridge pattern already used in `investigate-spawn-bounds.spec.ts`.

## Determinism

- Ran the two tests at `--repeat-each=10` under the default 6-worker parallel config (the exact condition that used to fail): 20/20 passed in 17.6s total, no retries, no timing budget anywhere in the assertion path.
- Ran the full Playwright suite (416 tests) clean, 4.3m.
- `go test ./...` in `erun-ui` green, including a new `TestTriggerEnvironmentActivitySweepRunsSynchronously` that locks in the "runs to completion and emits before returning" contract.
- Added `envStatusSlice.test.ts` covering the actual reducer bug (an observed-only transition is applied; an identical repeat is still suppressed).
- `make check` green.

## Test plan

- [x] `go test ./...` (erun-ui)
- [x] `yarn typecheck && yarn lint && yarn format:check && yarn test && yarn build` (erun-ui/frontend)
- [x] `./playwright/run.sh` full suite (416 passed)
- [x] `./playwright/run.sh -- --grep "idle environment clears" --repeat-each=10` under default parallel workers (20/20 passed)
- [x] `make check`

Closes #1566