### PR TITLE
Claim the version being released so two orchestrators cannot race it

### DIFF
--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -221,6 +221,12 @@ func runReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 		syncPackagingChecksums = syncReleasePackagingChecksums
 	}
 
+	release, err := claimReleaseVersion(ctx, spec, os.Getenv)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	traceReleaseSpec(ctx, spec)
 	if err := ensureReleasePublishesResolvedImages(spec, publisher); err != nil {
 		return err

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -227,6 +227,12 @@ func runReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, 
 	}
 	defer release()
 
+	return runClaimedReleaseSpec(ctx, spec, runGit, runScript, syncPackagingChecksums, publisher)
+}
+
+// runClaimedReleaseSpec is the release's actual work, run only once
+// runReleaseSpec has claimed the version being released.
+func runClaimedReleaseSpec(ctx Context, spec ReleaseSpec, runGit GitCommandRunnerFunc, runScript BuildScriptRunnerFunc, syncPackagingChecksums ReleasePackagingSyncerFunc, publisher ReleasePublisher) error {
 	traceReleaseSpec(ctx, spec)
 	if err := ensureReleasePublishesResolvedImages(spec, publisher); err != nil {
 		return err

--- a/erun-common/release_claim.go
+++ b/erun-common/release_claim.go
@@ -1,0 +1,137 @@
+package eruncommon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// A release used to have nothing standing in for "I am releasing this
+// version" the way wip:<orchestrator> labels stand in for "I am working this
+// issue": every preflight check (worktree, VERSION, local tag, remote tag,
+// disk headroom) passed correctly for two orchestrators racing the same
+// version, because neither had pushed anything yet. The loser found out ~11
+// minutes later holding a local tag that disagreed with the one the winner
+// had already published.
+//
+// The exclusive activity lease is the existing primitive that already
+// answers this for a worktree (root AGENTS.md's "wip: labels" precedent,
+// generalized): environment-side, visible, and reconciled against its
+// holder. Scoping the claim to the version being released, rather than the
+// whole worktree, means two releases of different versions in the same
+// environment never collide.
+const (
+	// releaseVersionClaimTTL is generous relative to a real release's build
+	// time (multi-arch image builds routinely run past ten minutes) so a
+	// live release is never mistaken for an abandoned one. Renewal keeps a
+	// running release well inside it; a release that stops renewing —
+	// crashed, or its pod was replaced — is reclaimed once it lapses.
+	releaseVersionClaimTTL = 20 * time.Minute
+	// releaseVersionClaimRenewalInterval keeps the renewal comfortably
+	// inside the TTL, the same margin the job-lease heartbeat uses.
+	releaseVersionClaimRenewalInterval = releaseVersionClaimTTL / 3
+)
+
+// releaseVersionClaimScope names the exclusive lease scope a release of
+// version claims, so two releases of the same version collide and two
+// releases of different versions in the same environment never do.
+func releaseVersionClaimScope(version string) string {
+	return "release-version:" + strings.TrimSpace(version)
+}
+
+// releaseVersionClaimID is unique per attempt (the pid of the process making
+// it), not per version: the exclusive lease treats a second take with the
+// *same* id as this same claim renewing rather than a conflict, so two
+// different releases of the same version must never share one. It stays
+// stable across one release's own renewal ticks because those reuse the pid
+// that made the original claim.
+func releaseVersionClaimID(version string, pid int) string {
+	return fmt.Sprintf("release-%s-%d", sanitizeForFilename(strings.TrimSpace(version)), pid)
+}
+
+// takeReleaseVersionClaim is the thin wrapper over the exclusive activity
+// lease that names the claim's shape, kept separate from claimReleaseVersion
+// so the refuse/reclaim behavior can be exercised directly against a
+// controlled clock rather than through a real release run.
+func takeReleaseVersionClaim(tenant, environment, version string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time) (EnvironmentActivityLease, error) {
+	return TakeEnvironmentActivityLease(TakeEnvironmentActivityLeaseParams{
+		Tenant:      tenant,
+		Environment: environment,
+		Name:        "release " + strings.TrimSpace(version),
+		ID:          releaseVersionClaimID(version, pid),
+		PID:         pid,
+		TTL:         releaseVersionClaimTTL,
+		Exclusive:   true,
+		Scope:       releaseVersionClaimScope(version),
+		Holder:      holder,
+		Now:         now,
+	})
+}
+
+// releaseVersionClaimRefusalError turns a raw lease conflict into the
+// operator-facing refusal: it names the version and the holder, and says
+// what to do — wait, or nothing, since a dead holder reclaims itself.
+func releaseVersionClaimRefusalError(version string, err error) error {
+	var conflict *EnvironmentActivityLeaseConflictError
+	if !errors.As(err, &conflict) {
+		return err
+	}
+	return fmt.Errorf("%s is already being released by %s — wait for it to finish; a holder that crashes or whose pod is replaced is reclaimed automatically on the next attempt",
+		strings.TrimSpace(version), conflict.Holder.Holder.String())
+}
+
+// claimReleaseVersion takes the exclusive lease that stands in for "I am
+// releasing this version", before sync-remote does anything the loser of a
+// race would have to unwind. It returns a release func to defer, which stops
+// renewing and drops the claim; call it whether the release succeeds or
+// fails.
+//
+// The claim only applies inside a runtime pod: injectedRuntimePodIdentity
+// resolves ERUN_TENANT/ERUN_ENVIRONMENT, which only the runtime chart sets.
+// Off-pod (a developer's own laptop) there is exactly one caller by
+// construction, so this is a no-op — refusing a solo release against itself
+// would be a false positive, not a safety net.
+func claimReleaseVersion(ctx Context, spec ReleaseSpec, env func(string) string) (func(), error) {
+	tenant, environment, ok := injectedRuntimePodIdentity(env)
+	if !ok {
+		return func() {}, nil
+	}
+	ctx.Trace(fmt.Sprintf("release: claiming exclusive release lease for %s (tenant %s, environment %s)", spec.Version, tenant, environment))
+	if ctx.DryRun {
+		return func() {}, nil
+	}
+
+	holder := EnvironmentActivityLeaseHolder{Orchestrator: strings.TrimSpace(env("ERUN_ORCHESTRATOR_ID"))}
+	pid := os.Getpid()
+	if _, err := takeReleaseVersionClaim(tenant, environment, spec.Version, holder, pid, time.Time{}); err != nil {
+		return nil, releaseVersionClaimRefusalError(spec.Version, err)
+	}
+
+	stop := make(chan struct{})
+	var stopped sync.WaitGroup
+	stopped.Add(1)
+	go func() {
+		defer stopped.Done()
+		ticker := time.NewTicker(releaseVersionClaimRenewalInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				_, _ = takeReleaseVersionClaim(tenant, environment, spec.Version, holder, pid, time.Time{})
+			}
+		}
+	}()
+
+	scope := releaseVersionClaimScope(spec.Version)
+	id := releaseVersionClaimID(spec.Version, pid)
+	return func() {
+		close(stop)
+		stopped.Wait()
+		_ = ReleaseExclusiveEnvironmentActivityLease(tenant, environment, scope, id)
+	}, nil
+}

--- a/erun-common/release_claim_test.go
+++ b/erun-common/release_claim_test.go
@@ -1,0 +1,76 @@
+package eruncommon
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A test covering only "the first release claims it and nothing else races"
+// would pass while the bug this claim exists for still ships: two
+// orchestrators releasing the same version concurrently, discovered only by
+// a tag collision at the end. These two cover the refusal and the reclaim.
+
+func TestReleaseVersionClaimRefusesASecondReleaseAndNamesTheHolder(t *testing.T) {
+	isolateActivityCache(t)
+	now := time.Date(2026, 8, 29, 17, 0, 53, 0, time.UTC)
+
+	// Two distinct pids stand in for two distinct orchestrator processes
+	// releasing the same version concurrently, as erun#1619 actually happened.
+	firstPID, secondPID := os.Getpid(), os.Getpid()+1
+
+	firstHolder := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a"}
+	if _, err := takeReleaseVersionClaim("erun", "build", "1.0.211", firstHolder, firstPID, now); err != nil {
+		t.Fatalf("first release's claim: %v", err)
+	}
+
+	secondHolder := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b"}
+	_, err := takeReleaseVersionClaim("erun", "build", "1.0.211", secondHolder, secondPID, now.Add(time.Second))
+	if err == nil {
+		t.Fatal("expected a second concurrent release of the same version to be refused")
+	}
+	refusal := releaseVersionClaimRefusalError("1.0.211", err)
+	if !strings.Contains(refusal.Error(), "1.0.211") {
+		t.Errorf("refusal must name the version, got: %v", refusal)
+	}
+	if !strings.Contains(refusal.Error(), "orchestrator-a") {
+		t.Errorf("refusal must name the holder so a second orchestrator knows who to wait on, got: %v", refusal)
+	}
+
+	// A release of a different version in the same environment must not be
+	// affected: the claim is version-scoped, not worktree-wide.
+	if _, err := takeReleaseVersionClaim("erun", "build", "1.0.212", secondHolder, secondPID, now.Add(time.Second)); err != nil {
+		t.Fatalf("a release of a different version must not collide with an unrelated one in flight: %v", err)
+	}
+
+	// The same process renewing its own claim (same pid, hence same id) must
+	// keep succeeding rather than fighting its own lease.
+	if _, err := takeReleaseVersionClaim("erun", "build", "1.0.211", firstHolder, firstPID, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("the original holder renewing its own claim must succeed: %v", err)
+	}
+}
+
+func TestReleaseVersionClaimReclaimsAnAbandonedRelease(t *testing.T) {
+	isolateActivityCache(t)
+	start := time.Date(2026, 8, 29, 17, 0, 53, 0, time.UTC)
+
+	firstHolder := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a"}
+	if _, err := takeReleaseVersionClaim("erun", "build", "1.0.211", firstHolder, os.Getpid(), start); err != nil {
+		t.Fatalf("first release's claim: %v", err)
+	}
+
+	// The first holder crashed (or its pod was replaced) and stopped
+	// renewing. Nobody can delete its claim by hand from outside that
+	// environment, so the only way a second release ever proceeds is if the
+	// lease reclaims itself once it lapses.
+	afterLapse := start.Add(releaseVersionClaimTTL + time.Minute)
+	secondHolder := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b"}
+	claim, err := takeReleaseVersionClaim("erun", "build", "1.0.211", secondHolder, os.Getpid()+1, afterLapse)
+	if err != nil {
+		t.Fatalf("expected the abandoned claim to be reclaimed automatically, got refused: %v", err)
+	}
+	if claim.Holder.Orchestrator != "orchestrator-b" {
+		t.Fatalf("expected the new release to hold the claim, got %+v", claim)
+	}
+}

--- a/erun-integration/release_test.go
+++ b/erun-integration/release_test.go
@@ -821,6 +821,62 @@ exit 0
 		}
 	})
 
+	t.Run("dry_run_in_a_runtime_pod_claims_the_release_version_lease", func(t *testing.T) {
+		// Inside a runtime pod (ERUN_TENANT/ERUN_ENVIRONMENT injected by the
+		// chart), release claims an exclusive, version-scoped activity lease
+		// before doing anything else — the erun#1619 fix for two orchestrators
+		// racing the same release. No other release scenario sets these two
+		// vars, so this is the only golden that shows the claim trace; every
+		// other release scenario is exercising the off-pod, single-caller path
+		// where the claim is a no-op.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
+		envVars := append(releaseEnv(t, setup), "ERUN_TENANT=erun", "ERUN_ENVIRONMENT=build")
+		result := erun.Run(t, []string{"release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "release/dry_run_in_a_runtime_pod_claims_the_release_version_lease", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_refuses_when_another_orchestrator_is_already_releasing_the_version", func(t *testing.T) {
+		// Regression for erun#1619: two orchestrators driving the same runtime
+		// pod could both pass every preflight and race the same release, the
+		// loser discovering the collision only via a tag mismatch after minutes
+		// of wasted publishing. Pre-claiming the exact exclusive lease scope
+		// release itself takes — via the activity lease CLI, sharing this
+		// scenario's XDG_CACHE_HOME — simulates "another orchestrator got there
+		// first". release must refuse before it ever touches git — sync-remote
+		// never runs — though execution-plan resolution has already made its
+		// own read-only docker fingerprint check by this point, hence the
+		// docker stub.
+		setup := env.New(t)
+		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
+
+		blocker := erun.Run(t, []string{
+			"activity", "lease", "take", "--tenant", "erun", "--environment", "build",
+			"--name", "blocker", "--exclusive", "--scope", "release-version:1.4.2",
+			"--orchestrator", "existing-holder",
+		}, erun.RunOptions{Cwd: setup.Cwd, Env: inEnvironment(setup.Env())})
+		if blocker.ExitCode != 0 {
+			t.Fatalf("pre-claim: exit %d: %s", blocker.ExitCode, blocker.Combined)
+		}
+
+		envVars := append(releaseEnv(t, setup), "ERUN_TENANT=erun", "ERUN_ENVIRONMENT=build")
+		result := erun.Run(t, []string{"release"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit when the version is already being released, got 0: %s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "1.4.2 is already being released by orchestrator existing-holder") {
+			t.Fatalf("expected the refusal to name the version and the holder:\n%s", result.Combined)
+		}
+
+		// Outside the captured streams: the refusal must leave the version file
+		// untouched, so re-running retries once the other release finishes (or
+		// its claim is reclaimed automatically).
+		assertVersionFile(t, setup, "1.4.2\n")
+	})
+
 	t.Run("dry_run_refuses_to_release_an_image_it_would_not_publish", func(t *testing.T) {
 		// Run from inside one component's build context, release resolves only
 		// that component's build but still stamps and would tag every image on

--- a/erun-integration/testdata/release/dry_run_in_a_runtime_pod_claims_the_release_version_lease.txt
+++ b/erun-integration/testdata/release/dry_run_in_a_runtime_pod_claims_the_release_version_lease.txt
@@ -1,0 +1,84 @@
+release: resolving project root
+release: project root = <TMP>
+release: resolving release module root
+release: release root = <TMP>
+release: loading release config from project
+release: main branch = main, develop branch = develop
+release: resolving git branch and commit
+release: branch = main, commit = <SHORTSHA>
+release: resolving base version from VERSION file
+release: base version = <VERSION> (from <TMP>
+release: classified mode = stable
+release: develop branch "develop" exists = false
+<VERSION>
+audit: erun release --dry-run
+release: claiming exclusive release lease for <VERSION> (tenant erun, environment build)
+release: branch=main mode=stable version=<VERSION>
+next version: <VERSION>
+publishing image: ghcr.io/sophium/api:<VERSION>
+git -C <TMP> status --porcelain --untracked-files=no
+release: worktree clean = true
+stage: sync-remote
+cd <TMP> && git fetch origin
+cd <TMP> && git rebase origin/main
+stage: release
+write <TMP>
+  apiVersion: v2
+  appVersion: <VERSION>
+  name: api
+  version: <VERSION>
+write <TMP>
+  apiVersion: v2
+  appVersion: <VERSION>
+  name: base
+  version: <VERSION>
+cd <TMP> && git add erun-devops/k8s/api/Chart.yaml erun-devops/k8s/base/Chart.yaml
+cd <TMP> && git commit -m '[skip ci] release <VERSION>'
+git -C <TMP> rev-parse '<VERSION>^{}'
+cd <TMP> && git tag -a <VERSION> -m 'Release <VERSION>'
+cd <TMP> && git fetch origin main
+cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
+release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
+docker builder prune -f
+docker manifest inspect ghcr.io/sophium/api:<VERSION>
+stage: publish
+docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/api:fp-<HEX16>-arm64
+fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/api:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/api:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION> ghcr.io/sophium/api:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/api:<VERSION>
+docker image inspect ghcr.io/sophium/base:fp-<HEX16>-amd64
+fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-amd64
+docker image inspect ghcr.io/sophium/base:fp-<HEX16>-arm64
+fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
+rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
+cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
+cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
+cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
+helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
+cd <TMP> && helm package base --version <VERSION> --app-version <VERSION>
+cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
+helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
+stage: verify-publication
+docker manifest inspect ghcr.io/sophium/api:<VERSION>
+stage: post-release-version-bump
+write <TMP>
+  <VERSION>
+cd <TMP> && git add erun-devops/VERSION
+cd <TMP> && git commit -m '[skip ci] prepare <VERSION>'
+stage: push
+release: a push rejected by a branch that moved during the release is rebased onto origin/main and retried (up to 2 attempts)
+cd <TMP> && git push --follow-tags origin main
+release version: <VERSION>


### PR DESCRIPTION
## Summary
- Two orchestrators driving the same runtime pod could both pass every release preflight (worktree, VERSION, local/remote tag, disk headroom) and race the same version — the loser found out ~11 minutes in via a tag collision, after burning a full multi-arch build on a version that was already public.
- `release` now takes an exclusive, version-scoped activity lease (`erun-common/release_claim.go`) as the very first thing it does, before `sync-remote` or any other stage runs. The claim reuses the existing environment activity-lease primitive (the same mechanism `wip:<orchestrator>` labels generalize for issues), scoped by `tenant`/`environment` (resolved from the `ERUN_TENANT`/`ERUN_ENVIRONMENT` the runtime chart injects) and by the release version, so two releases of different versions in the same environment never collide.
- A refused release names the version and the holder: `<version> is already being released by orchestrator <id> — wait for it to finish; a holder that crashes or whose pod is replaced is reclaimed automatically on the next attempt`.
- A dead holder never wedges the version: the claim renews itself (well inside its TTL) for as long as the release runs, and a holder that stops renewing — crashed, or its pod was replaced — is reclaimed automatically once the claim lapses. No human action is ever required to clear it.
- Off-pod (a developer's own machine, no `ERUN_TENANT`/`ERUN_ENVIRONMENT`) the claim is a no-op: there is exactly one caller by construction, so nothing needs claiming.
- `runReleaseSpec`'s cyclomatic complexity crossed the lint cap once the claim's error check was added; split the claimed work into `runClaimedReleaseSpec` to restore it, rather than suppress the lint rule.

## Test plan
- [x] `erun-common/release_claim_test.go`: `TestReleaseVersionClaimRefusesASecondReleaseAndNamesTheHolder` — two concurrent claims of the same version refuse and name the holder; a different version and the same holder renewing its own claim both still succeed.
- [x] `erun-common/release_claim_test.go`: `TestReleaseVersionClaimReclaimsAnAbandonedRelease` — a claim whose holder stopped renewing past its TTL does not block a new release; no manual cleanup involved.
- [x] `erun-integration/release_test.go`: `TestRelease/dry_run_in_a_runtime_pod_claims_the_release_version_lease` — locks the new dry-run trace line when `ERUN_TENANT`/`ERUN_ENVIRONMENT` are set; every other release scenario is unaffected (off-pod no-op).
- [x] `erun-integration/release_test.go`: `TestRelease/real_run_refuses_when_another_orchestrator_is_already_releasing_the_version` — pre-claims the exact lease scope via `erun activity lease take --exclusive`, then a real `erun release` refuses immediately and names the holder; the version file is left untouched.
- [x] `make check` green: 0 lint issues across all modules, integration suite green, coverage 76.2% (>= 75.8% threshold).

Closes #1619