### PR TITLE
Push every image a release builds, including version-pinned wrappers

### DIFF
--- a/erun-common/build.go
+++ b/erun-common/build.go
@@ -186,17 +186,10 @@ func BuildExecutionSpecFromDockerBuilds(builds []DockerBuildSpec) BuildExecution
 func BuildExecutionSpecWithRelease(execution BuildExecutionSpec, release ReleaseSpec) BuildExecutionSpec {
 	execution.release = &release
 	if len(execution.dockerBuilds) > 0 && len(execution.dockerPushes) == 0 {
-		execution.dockerPushes = releaseDockerPushSpecs(execution.dockerBuilds, release.DockerImages)
+		execution.dockerPushes = releaseDockerPushSpecs(execution.dockerBuilds)
 	}
 	if len(execution.dockerBuilds) > 0 && len(execution.dockerPushes) > 0 {
-		releaseTags := make(map[string]struct{}, len(execution.dockerPushes))
-		for _, pushInput := range execution.dockerPushes {
-			releaseTags[strings.TrimSpace(pushInput.Image.Tag)] = struct{}{}
-		}
 		for i := range execution.dockerBuilds {
-			if _, ok := releaseTags[strings.TrimSpace(execution.dockerBuilds[i].Image.Tag)]; !ok {
-				continue
-			}
 			execution.dockerBuilds[i].Push = true
 		}
 	}
@@ -207,60 +200,26 @@ func BuildExecutionUsesBuildScript(execution BuildExecutionSpec) bool {
 	return execution.script != nil
 }
 
-func releaseDockerPushSpecs(builds []DockerBuildSpec, images []ReleaseDockerImageSpec) []DockerPushSpec {
+// releaseDockerPushSpecs publishes every image a release builds, not only the
+// images stamped with the release's own version. A version-pinned wrapper
+// (erun-backend-postgres, erun-powerdns, erun-zitadel, erun-oci-registry — see
+// erun-devops/AGENTS.md § "Wrapping And Pinning Third-Party Service Images")
+// keeps its own VERSION file and is therefore never in release.DockerImages,
+// but it is still a real release build whose chart is published and whose
+// image must exist for that chart's deploy to work. Fingerprint promote-and-skip
+// already makes a re-push of an unchanged pinned image a cheap no-op, so
+// pushing everything costs nothing for the common case and closes the gap for
+// the uncommon one: a wrapper published for the first time.
+func releaseDockerPushSpecs(builds []DockerBuildSpec) []DockerPushSpec {
 	if len(builds) == 0 {
 		return nil
 	}
 
-	releaseTags := make(map[string]struct{}, len(images))
-	for _, image := range images {
-		releaseTags[strings.TrimSpace(image.Tag)] = struct{}{}
-	}
-	releaseTags = expandLocalReleaseImageDependencies(builds, releaseTags)
-
-	pushes := make([]DockerPushSpec, 0, len(releaseTags))
+	pushes := make([]DockerPushSpec, 0, len(builds))
 	for _, build := range builds {
-		if _, ok := releaseTags[strings.TrimSpace(build.Image.Tag)]; !ok {
-			continue
-		}
 		pushes = append(pushes, NewDockerPushSpec(build.ContextDir, build.Image))
 	}
 	return pushes
-}
-
-func expandLocalReleaseImageDependencies(builds []DockerBuildSpec, releaseTags map[string]struct{}) map[string]struct{} {
-	if len(builds) == 0 || len(releaseTags) == 0 {
-		return releaseTags
-	}
-
-	buildsByTag := dockerBuildsByTag(builds)
-	expanded, queue := queuedReleaseTags(releaseTags)
-
-	for len(queue) > 0 {
-		tag := queue[0]
-		queue = queue[1:]
-
-		build, ok := buildsByTag[tag]
-		if !ok {
-			continue
-		}
-		for _, dependencyTag := range dockerfileLocalBaseImageTags(build.DockerfilePath, buildsByTag) {
-			if _, exists := expanded[dependencyTag]; exists {
-				continue
-			}
-			expanded[dependencyTag] = struct{}{}
-			queue = append(queue, dependencyTag)
-		}
-	}
-
-	for _, build := range builds {
-		if !strings.Contains(strings.TrimSpace(build.Image.ImageName), "dind") {
-			continue
-		}
-		expanded[strings.TrimSpace(build.Image.Tag)] = struct{}{}
-	}
-
-	return expanded
 }
 
 func dockerBuildsByTag(builds []DockerBuildSpec) map[string]DockerBuildSpec {
@@ -269,16 +228,6 @@ func dockerBuildsByTag(builds []DockerBuildSpec) map[string]DockerBuildSpec {
 		buildsByTag[strings.TrimSpace(build.Image.Tag)] = build
 	}
 	return buildsByTag
-}
-
-func queuedReleaseTags(releaseTags map[string]struct{}) (map[string]struct{}, []string) {
-	expanded := make(map[string]struct{}, len(releaseTags))
-	queue := make([]string, 0, len(releaseTags))
-	for tag := range releaseTags {
-		expanded[tag] = struct{}{}
-		queue = append(queue, tag)
-	}
-	return expanded, queue
 }
 
 func ResolveDockerBuildTarget(findProjectRoot ProjectFinderFunc, target DockerCommandTarget) (DockerCommandTarget, *ReleaseSpec, error) {

--- a/erun-integration/build_test.go
+++ b/erun-integration/build_test.go
@@ -1324,12 +1324,20 @@ func TestBuild(t *testing.T) {
 	t.Run("dry_run_release_pushes_release_tagged_docker_builds", func(t *testing.T) {
 		// --release dry-run must trace the per-platform docker build + docker push
 		// for the release-tagged image, plus the local tag for downstream
-		// dependencies.
+		// dependencies. "base" (fixture.SeedReleaseRepo) is a version-pinned
+		// wrapper carrying its own VERSION rather than the release's: a release
+		// must still publish it, not only build and locally tag it, or a
+		// component whose chart is published never gets an image the registry
+		// actually has (erun-oci-registry's own defect, see erun-devops/AGENTS.md
+		// "Wrapping And Pinning Third-Party Service Images").
 		setup := env.New(t)
 		fixture.SeedReleaseRepo(t, setup.Cwd, "main")
 		result := erun.Run(t, []string{"build", "--release", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: append(setup.Env(), stubDockerNoLocalImages(t, setup)...)})
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "docker manifest push ghcr.io/sophium/base:") {
+			t.Fatalf("expected the version-pinned wrapper image \"base\" to be pushed and assembled into a manifest, not only built and locally tagged: %s", result.Combined)
 		}
 		golden.Equal(t, "build/dry_run_release_pushes_release_tagged_docker_builds", normalize.Apply(result.Combined))
 	})

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -771,9 +771,10 @@ func SeedReleaseRepo(t testing.TB, dir, branch string) string {
 	}
 	mustWrite(t, filepath.Join(releaseRoot, "VERSION"), "1.4.2\n")
 	mustWrite(t, filepath.Join(releaseRoot, "k8s", "api", "Chart.yaml"), "apiVersion: v2\nname: api\nversion: 0.1.0\nappVersion: 0.1.0\n")
-	// base is a version-pinned base: its image carries its own VERSION (9.9.9)
-	// and is not re-pushed at the release version, but its co-located chart must
-	// still publish at the release version so platform deploys resolve it.
+	// base is a version-pinned base: its image carries its own VERSION (9.9.9),
+	// tagged and published at that version rather than the release's, same as
+	// its co-located chart, which publishes at the release version so platform
+	// deploys resolve it.
 	mustWrite(t, filepath.Join(releaseRoot, "k8s", "base", "Chart.yaml"), "apiVersion: v2\nname: base\nversion: 0.1.0\nappVersion: 0.1.0\n")
 	mustWrite(t, filepath.Join(releaseRoot, "docker", "api", "Dockerfile"), "FROM alpine:3.22\n")
 	mustWrite(t, filepath.Join(releaseRoot, "docker", "base", "Dockerfile"), "FROM alpine:3.22\n")

--- a/erun-integration/testdata/build/dry_run_release_ignores_configured_platforms.txt
+++ b/erun-integration/testdata/build/dry_run_release_ignores_configured_platforms.txt
@@ -38,6 +38,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -60,8 +61,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -70,6 +76,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/build/dry_run_release_includes_release_and_build_traces.txt
+++ b/erun-integration/testdata/build/dry_run_release_includes_release_and_build_traces.txt
@@ -38,6 +38,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -60,8 +61,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -70,6 +76,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/build/dry_run_release_publishes_runtime_chart.txt
+++ b/erun-integration/testdata/build/dry_run_release_publishes_runtime_chart.txt
@@ -45,6 +45,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 docker manifest inspect ghcr.io/sophium/erun-devops:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -68,8 +69,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 docker image inspect ghcr.io/sophium/erun-devops:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/erun-devops:fp-<HEX16>-amd64
 docker image inspect ghcr.io/sophium/erun-devops:fp-<HEX16>-arm64
@@ -95,6 +101,7 @@ cd <TMP> && helm push erun-devops-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/erun-devops --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 docker manifest inspect ghcr.io/sophium/erun-devops:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)

--- a/erun-integration/testdata/build/dry_run_release_pushes_release_tagged_docker_builds.txt
+++ b/erun-integration/testdata/build/dry_run_release_pushes_release_tagged_docker_builds.txt
@@ -39,6 +39,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -61,8 +62,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -71,6 +77,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 write <TMP>
   <VERSION>

--- a/erun-integration/testdata/build/real_run_release_push_auth_failure_retries_after_gh_login.txt
+++ b/erun-integration/testdata/build/real_run_release_push_auth_failure_retries_after_gh_login.txt
@@ -35,6 +35,7 @@ release tag already exists at HEAD; skipping <VERSION>
 docker builder prune -f
 release: docker root free disk space is not observable from this process; skipping the headroom check
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -59,8 +60,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 ==> Publishing api <VERSION> to oci://ghcr.io/sophium/charts
@@ -74,6 +80,8 @@ helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <T
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
 ==> Verified published image ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
+==> Verified published image ghcr.io/sophium/base:<VERSION>
 release version: <VERSION>
 ==> Built in <ELAPSED>
 step timing (ordered by duration):

--- a/erun-integration/testdata/build/real_run_release_pushes_multi_platform_manifest.txt
+++ b/erun-integration/testdata/build/real_run_release_pushes_multi_platform_manifest.txt
@@ -31,6 +31,7 @@ rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing f
 ==> Verified published chart base <VERSION>
 stage: verify-publication
 ==> Verified published image ghcr.io/sophium/api:<VERSION>
+==> Verified published image ghcr.io/sophium/base:<VERSION>
 release version: <VERSION>
 ==> Built in <ELAPSED>
 step timing (ordered by duration):

--- a/erun-integration/testdata/release/dry_run_darwin_host_skips_linux_release_scripts.txt
+++ b/erun-integration/testdata/release/dry_run_darwin_host_skips_linux_release_scripts.txt
@@ -39,6 +39,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -61,8 +62,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -71,6 +77,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/release/dry_run_develop_emits_candidate_plan.txt
+++ b/erun-integration/testdata/release/dry_run_develop_emits_candidate_plan.txt
@@ -39,6 +39,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -61,8 +62,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -71,6 +77,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/release/dry_run_force_includes_tag_deletion_for_stale_release_tag.txt
+++ b/erun-integration/testdata/release/dry_run_force_includes_tag_deletion_for_stale_release_tag.txt
@@ -43,6 +43,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -65,8 +66,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -75,6 +81,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 write <TMP>
   <VERSION>

--- a/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
+++ b/erun-integration/testdata/release/dry_run_includes_linux_release_scripts.txt
@@ -39,6 +39,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -61,8 +62,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -71,6 +77,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/release/dry_run_main_with_all_packaging_artifacts_syncs_them.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_all_packaging_artifacts_syncs_them.txt
@@ -81,6 +81,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -103,8 +104,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -113,6 +119,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push-release-tag
 cd <TMP> && git push origin <VERSION>
 stage: sync-packaging-checksums

--- a/erun-integration/testdata/release/dry_run_main_with_develop_emits_stable_plan.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_develop_emits_stable_plan.txt
@@ -40,6 +40,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -62,8 +63,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -72,6 +78,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 write <TMP>
   <VERSION>

--- a/erun-integration/testdata/release/dry_run_main_with_marketplace_emits_sha_sync.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_marketplace_emits_sha_sync.txt
@@ -40,6 +40,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -62,8 +63,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -72,6 +78,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push-release-tag
 cd <TMP> && git push origin <VERSION>
 stage: sync-packaging-checksums

--- a/erun-integration/testdata/release/dry_run_main_with_scoop_manifest_validates_and_syncs.txt
+++ b/erun-integration/testdata/release/dry_run_main_with_scoop_manifest_validates_and_syncs.txt
@@ -69,6 +69,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -91,8 +92,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -101,6 +107,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push-release-tag
 cd <TMP> && git push origin <VERSION>
 stage: sync-packaging-checksums

--- a/erun-integration/testdata/release/dry_run_main_without_develop_pushes_only_main.txt
+++ b/erun-integration/testdata/release/dry_run_main_without_develop_pushes_only_main.txt
@@ -40,6 +40,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -62,8 +63,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -72,6 +78,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 write <TMP>
   <VERSION>

--- a/erun-integration/testdata/release/dry_run_release_tag_at_head_skips_tag_creation.txt
+++ b/erun-integration/testdata/release/dry_run_release_tag_at_head_skips_tag_creation.txt
@@ -41,6 +41,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -63,8 +64,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -73,6 +79,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 write <TMP>
   <VERSION>

--- a/erun-integration/testdata/release/dry_run_skips_release_roots_in_gitignored_trees.txt
+++ b/erun-integration/testdata/release/dry_run_skips_release_roots_in_gitignored_trees.txt
@@ -39,6 +39,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -61,8 +62,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -71,6 +77,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/release/dry_run_with_untracked_file_reports_worktree_clean.txt
+++ b/erun-integration/testdata/release/dry_run_with_untracked_file_reports_worktree_clean.txt
@@ -39,6 +39,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -61,8 +62,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -71,6 +77,7 @@ cd <TMP> && helm push base-<VERSION> oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: push
 release: a push rejected by a branch that moved during the release is rebased onto origin/develop and retried (up to 2 attempts)
 cd <TMP> && git push --follow-tags origin develop

--- a/erun-integration/testdata/release/real_run_absorbs_a_base_branch_that_moved_during_the_build.txt
+++ b/erun-integration/testdata/release/real_run_absorbs_a_base_branch_that_moved_during_the_build.txt
@@ -37,6 +37,7 @@ promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
 ==> Verified published chart base <VERSION>
 stage: verify-publication
 ==> Verified published image ghcr.io/sophium/api:<VERSION>
+==> Verified published image ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 [main <SHORTSHA>] [skip ci] prepare <VERSION>
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/erun-integration/testdata/release/real_run_emits_release_lifecycle_traces.txt
+++ b/erun-integration/testdata/release/real_run_emits_release_lifecycle_traces.txt
@@ -33,6 +33,7 @@ promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
 ==> Verified published chart base <VERSION>
 stage: verify-publication
 ==> Verified published image ghcr.io/sophium/api:<VERSION>
+==> Verified published image ghcr.io/sophium/base:<VERSION>
 stage: push
 release version: <VERSION>
 ==> Released <VERSION> in <ELAPSED>

--- a/erun-integration/testdata/release/real_run_force_stable_syncs_marketplace_and_bumps_version.txt
+++ b/erun-integration/testdata/release/real_run_force_stable_syncs_marketplace_and_bumps_version.txt
@@ -34,6 +34,7 @@ promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
 ==> Verified published chart base <VERSION>
 stage: verify-publication
 ==> Verified published image ghcr.io/sophium/api:<VERSION>
+==> Verified published image ghcr.io/sophium/base:<VERSION>
 stage: push-release-tag
 stage: sync-packaging-checksums
 stage: post-release-version-bump

--- a/erun-integration/testdata/release/real_run_publish_failure_leaves_no_public_tag.txt
+++ b/erun-integration/testdata/release/real_run_publish_failure_leaves_no_public_tag.txt
@@ -26,6 +26,7 @@ release: origin/main has not moved since sync-remote
 release: docker builder prune failed, continuing: exit status 1
 release: docker root free disk space is not observable from this process; skipping the headroom check
 simulated docker failure
+simulated docker failure
 stage: publish
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-arm64

--- a/erun-integration/testdata/release/real_run_publishes_before_the_tag_reaches_origin.txt
+++ b/erun-integration/testdata/release/real_run_publishes_before_the_tag_reaches_origin.txt
@@ -37,6 +37,7 @@ promoting from cached fingerprint image: ghcr.io/sophium/base:<VERSION>
 ==> Verified published chart base <VERSION>
 stage: verify-publication
 ==> Verified published image ghcr.io/sophium/api:<VERSION>
+==> Verified published image ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 [main <SHORTSHA>] [skip ci] prepare <VERSION>
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
## Summary

- `erun-oci-registry` could never be deployed: its image was never published. `releaseDockerPushSpecs` only pushed images stamped with the release's own version (plus their local `FROM` dependencies and a hardcoded `dind` special case), so a version-pinned wrapper — its own `VERSION` file, per `erun-devops/AGENTS.md` § "Wrapping And Pinning Third-Party Service Images" — was built and locally tagged every release but never pushed or assembled into a manifest, even though its chart published every release. `erun-common/build.go` now pushes every image a release builds instead of the version-stamped subset; fingerprint promote-and-skip already makes a re-push of unchanged content cheap.
- **Why the release's own "images nothing publishes" refusal never fired**: `ensureReleasePublishesResolvedImages` only checks `spec.DockerImages`, which is populated by `discoverReleaseDockerImages` from contexts sharing the release's own `VERSION` file — a version-pinned wrapper (its own separate `VERSION`) is excluded from that list by construction, so the refusal never even considered it. It's still a valid guard for the case it's designed for (a `--dry-run`/cwd-scoped release resolving fewer local builds than it stamps — see `dry_run_refuses_to_release_an_image_it_would_not_publish`, unchanged and still passing).
- The probe half of the reported defect (readiness/startup probes asserting an HTTP 2xx a bearer-authenticated zot must never return) was already fixed on `main` before this work started, in #1500 (merged 2026-08-27) — `erun-devops/k8s/erun-oci-registry/templates/registry.yaml` already uses `tcpSocket` probes.
- Fixed a stale comment in `erun-integration`'s `SeedReleaseRepo` fixture that claimed the version-pinned "base" component is "not re-pushed at the release version" — that was describing the bug, not the intended contract.

## What changed vs. left alone

- Changed: `releaseDockerPushSpecs` (erun-common/build.go) now pushes every build the release resolves; deleted the now-dead dependency-expansion machinery (`expandLocalReleaseImageDependencies`, `queuedReleaseTags`) that existed only to compute the old, narrower push set.
- Left alone: the probe fix (already on `main` via #1500) and the `ensureReleasePublishesResolvedImages` guard's shape (still correct for its own failure mode).

## Test plan

- [x] New regression assertion in `erun-integration/build_test.go`'s `dry_run_release_pushes_release_tagged_docker_builds`: asserts the version-pinned wrapper image is pushed and manifest-assembled, not only built and locally tagged. Verified it fails on the pre-fix code and passes after.
- [x] Updated 23 pre-existing goldens (all additive — the release now also publishes the pinned wrapper image already present in those fixtures) after reviewing every diff.
- [x] `go build ./...` / `go test ./...` clean in `erun-common`.
- [x] `make check` green (lint × 5 modules, erun-ui tests, frontend gates, all `erun-devops/k8s/*chart_test.sh` including `erun-oci-registry-chart_test.sh`, integration suite, coverage 76.2% >= 75.8%).

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)