### PR TITLE
Teach the release-claim golden that a release now pushes pinned wrappers

### DIFF
--- a/erun-integration/testdata/release/dry_run_in_a_runtime_pod_claims_the_release_version_lease.txt
+++ b/erun-integration/testdata/release/dry_run_in_a_runtime_pod_claims_the_release_version_lease.txt
@@ -41,6 +41,7 @@ cd <TMP> && git rev-list --count HEAD..FETCH_HEAD
 release: a base branch that moved since sync-remote refuses the release here, before the build spends anything
 docker builder prune -f
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: publish
 docker image inspect ghcr.io/sophium/api:fp-<HEX16>-amd64
 fingerprint image not found locally: ghcr.io/sophium/api:fp-<HEX16>-amd64
@@ -63,8 +64,13 @@ fingerprint image not found locally: ghcr.io/sophium/base:fp-<HEX16>-arm64
 rebuilding ghcr.io/sophium/base:<VERSION> because fingerprint image is missing for platforms [linux/amd64, linux/arm64]
 cd <TMP> && docker build --platform linux/amd64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-amd64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && docker build --platform linux/arm64 --provenance=false --progress=plain -t ghcr.io/sophium/base:<VERSION> --build-arg ERUN_VERSION=<VERSION> -f <TMP> .
 cd <TMP> && docker tag ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:fp-<HEX16>-arm64
+cd <TMP> && docker push ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest rm ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest create ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION> ghcr.io/sophium/base:<VERSION>
+cd <TMP> && docker manifest push ghcr.io/sophium/base:<VERSION>
 cd <TMP> && helm package api --version <VERSION> --app-version <VERSION>
 cd <TMP> && helm push api-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/api --version <VERSION> --destination <TMP>
@@ -73,6 +79,7 @@ cd <TMP> && helm push base-<VERSION>.tgz oci://ghcr.io/sophium/charts
 helm pull oci://ghcr.io/sophium/charts/base --version <VERSION> --destination <TMP>
 stage: verify-publication
 docker manifest inspect ghcr.io/sophium/api:<VERSION>
+docker manifest inspect ghcr.io/sophium/base:<VERSION>
 stage: post-release-version-bump
 write <TMP>
   <VERSION>


### PR DESCRIPTION
`make check` fails on `origin/main` at `0c93e3ad`:

```
--- FAIL: TestRelease/dry_run_in_a_runtime_pod_claims_the_release_version_lease
    golden mismatch
```

## Cause: a semantic merge conflict between two green PRs

- **#1620** (`c2543459`) added this golden, capturing a release's dry-run trace.
- **#1621** (`01c26f69`) changed *what a release pushes* — every image it builds, including version-pinned wrappers — and regenerated 23 goldens accordingly.

#1621's branch was cut before #1620's golden existed, so it could not regenerate a file it had never seen; #1620 gated against a `main` that did not yet push wrappers. **Both PRs were genuinely green on their own branches, and their combination is red.** No gate either PR could have run would have caught this.

The diff is purely additive (+7): the golden simply had not learned that `base`, the fixture's version-pinned wrapper, is now pushed and manifest-assembled.

## How it surfaced

The 1.0.212 release refused. The release image's own test stage runs `make check`, so a red trunk stops publication rather than shipping it — the gate working exactly as designed, and the reason this was caught in minutes rather than at a stranger's deploy.

## Note

This is the second red trunk today from the same failure mode (the first was three classes of failure arriving with #1588). It is precisely what **#1461** prevents: the merge queue gates *the prospective merge onto the target's current head*, not the source branch as its author left it. Until that is switched on, two independently-green PRs can always combine into a red `main`, and the only thing that catches it is someone running `make check` afterwards.

`make check`: **green, exit 0**.