### PR TITLE
Provision a tenant's Zitadel org through erun

### DIFF
--- a/erun-backend/erun-backend-api/internal/routes/identity.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity.go
@@ -25,6 +25,7 @@ type IdentityAdminClient interface {
 	UpdateOrgSettings(ctx context.Context, params zitadel.UpdateOrgSettingsParams) (zitadel.OrgSettings, error)
 	GetSMTPStatus(ctx context.Context) (zitadel.SMTPStatus, error)
 	UpdateSMTPConfig(ctx context.Context, params zitadel.SetSMTPConfigParams) (zitadel.SMTPStatus, error)
+	CreateOrg(ctx context.Context, name string) (zitadel.Org, error)
 }
 
 // IdentityEnroller creates an IdP identity and its erun user mapping as one
@@ -63,6 +64,13 @@ func RegisterIdentityRoutes(register ProtectedRouteRegistrar, admin IdentityAdmi
 	register(http.MethodPost, "/v1/identity/users", http.HandlerFunc(routes.createUser))
 	register(http.MethodPost, "/v1/identity/users/{external_id}/deactivate", http.HandlerFunc(routes.deactivateUser))
 	register(http.MethodPost, "/v1/identity/users/{external_id}/reactivate", http.HandlerFunc(routes.reactivateUser))
+	// Creating an org is what makes a *second* tenant possible on the
+	// platform's own IdP: an org-scoped issuer resolves tenants by the org
+	// claim, so a new tenant needs an org for its mapping to point at. Until
+	// this, that was a hand-made org in Zitadel's own console — erun could
+	// register the tenant and the issuer mapping and then had nowhere to
+	// point them (issue #1605).
+	register(http.MethodPost, "/v1/identity/orgs", http.HandlerFunc(routes.createOrg))
 	register(http.MethodGet, "/v1/identity/org-settings", http.HandlerFunc(routes.getOrgSettings))
 	register(http.MethodPatch, "/v1/identity/org-settings", http.HandlerFunc(routes.updateOrgSettings))
 	// The platform's honest answer to "can this instance send mail at all"
@@ -264,6 +272,39 @@ func (r IdentityRoutes) reactivateUser(w http.ResponseWriter, req *http.Request)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// createOrgRequest is the org-creation input. Name only: everything else
+// about a Zitadel org is policy this surface already administers separately.
+type createOrgRequest struct {
+	Name string `json:"name"`
+}
+
+// createOrg creates a Zitadel organization to hold a tenant's own identities.
+// It deliberately stops there rather than also registering the erun tenant:
+// the two are separate resources with separate gates, and an operator may be
+// creating an org for a tenant that already exists. Pair the returned id with
+// POST /v1/tenants orgFieldValue, or with PATCH /v1/tenant-issuers to convert
+// a single-tenant issuer first.
+func (r IdentityRoutes) createOrg(w http.ResponseWriter, req *http.Request) {
+	if _, ok := r.securityContext(w, req); !ok {
+		return
+	}
+	var input createOrgRequest
+	if err := decodeJSON(req, &input); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if strings.TrimSpace(input.Name) == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	org, err := r.admin.CreateOrg(req.Context(), input.Name)
+	if err != nil {
+		writeIdentityAdminError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, org)
 }
 
 func (r IdentityRoutes) getOrgSettings(w http.ResponseWriter, req *http.Request) {

--- a/erun-backend/erun-backend-api/internal/routes/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity_test.go
@@ -25,6 +25,8 @@ func (s *stubEnrolledUserLister) List(context.Context, repository.UserFilter) ([
 }
 
 type stubIdentityAdminClient struct {
+	createdOrgName    string
+	createOrgErr      error
 	users             []zitadel.User
 	listErr           error
 	deactivateErr     error
@@ -62,6 +64,14 @@ func (s *stubIdentityAdminClient) GetOrgSettings(context.Context) (zitadel.OrgSe
 func (s *stubIdentityAdminClient) UpdateOrgSettings(_ context.Context, params zitadel.UpdateOrgSettingsParams) (zitadel.OrgSettings, error) {
 	s.gotUpdateParams = params
 	return s.settings, s.updateSettingsErr
+}
+
+func (s *stubIdentityAdminClient) CreateOrg(_ context.Context, name string) (zitadel.Org, error) {
+	s.createdOrgName = name
+	if s.createOrgErr != nil {
+		return zitadel.Org{}, s.createOrgErr
+	}
+	return zitadel.Org{ID: "org-1", Name: name}, nil
 }
 
 func (s *stubIdentityAdminClient) GetSMTPStatus(context.Context) (zitadel.SMTPStatus, error) {
@@ -380,5 +390,60 @@ func TestUpdateSMTPSettingsPassesDeclaredFields(t *testing.T) {
 	}
 	if admin.gotSMTPParams.Host != "smtp.example.com:587" || admin.gotSMTPParams.Password != "s3cret" || !admin.gotSMTPParams.TLS {
 		t.Fatalf("gotSMTPParams = %+v, want the declared fields passed through", admin.gotSMTPParams)
+	}
+}
+
+// An org is the per-tenant identity boundary an org-scoped issuer resolves
+// by, so being unable to create one left tenant onboarding dependent on a
+// hand-made org in Zitadel's own console (issue #1605).
+func TestIdentityRoutesCreateOrg(t *testing.T) {
+	admin := &stubIdentityAdminClient{}
+	routes := IdentityRoutes{admin: admin}
+	rec := httptest.NewRecorder()
+
+	routes.createOrg(rec, identityRequest(http.MethodPost, "/v1/identity/orgs", `{"name":"validationagent"}`, string(model.TenantTypeOperations)))
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", rec.Code)
+	}
+	if admin.createdOrgName != "validationagent" {
+		t.Fatalf("created org name = %q", admin.createdOrgName)
+	}
+	var org zitadel.Org
+	if err := json.NewDecoder(rec.Body).Decode(&org); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if org.ID == "" {
+		t.Fatal("the response must carry the org id: it is what an org-scoped mapping points at")
+	}
+}
+
+func TestIdentityRoutesCreateOrgRequiresName(t *testing.T) {
+	admin := &stubIdentityAdminClient{}
+	rec := httptest.NewRecorder()
+
+	IdentityRoutes{admin: admin}.createOrg(rec, identityRequest(http.MethodPost, "/v1/identity/orgs", `{"name":"   "}`, string(model.TenantTypeOperations)))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if admin.createdOrgName != "" {
+		t.Fatal("a blank name must not reach the IdP")
+	}
+}
+
+// Administering the platform's own IdP is not a company tenant's business,
+// and creating orgs least of all.
+func TestIdentityRoutesCreateOrgRequiresOperationsTenant(t *testing.T) {
+	admin := &stubIdentityAdminClient{}
+	rec := httptest.NewRecorder()
+
+	IdentityRoutes{admin: admin}.createOrg(rec, identityRequest(http.MethodPost, "/v1/identity/orgs", `{"name":"acme"}`, string(model.TenantTypeCompany)))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if admin.createdOrgName != "" {
+		t.Fatal("a company tenant must not reach the IdP")
 	}
 }

--- a/erun-backend/erun-backend-api/internal/zitadel/client.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client.go
@@ -301,6 +301,37 @@ func (c *Client) CreateHumanUser(ctx context.Context, params CreateHumanUserPara
 	}, nil
 }
 
+// Org is a Zitadel organization. Its ID is what an org-scoped issuer's
+// org_field_value holds, and what the urn:zitadel:iam:user:resourceowner:id
+// claim carries for a user who belongs to it.
+type Org struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// CreateOrg creates a Zitadel organization, the per-tenant identity boundary
+// an org-scoped issuer resolves tenants by. Without it, onboarding a second
+// tenant onto the platform's own IdP needed a hand-made org in Zitadel's
+// console: erun could register the tenant and the issuer mapping, but had no
+// way to create the org the mapping points at (issue #1605).
+//
+// The org is created but deliberately not made the client's own: this
+// credential stays scoped to the platform's org, and the new org's first
+// erun caller becomes its admin through the per-tenant first-user bootstrap.
+func (c *Client) CreateOrg(ctx context.Context, name string) (Org, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Org{}, fmt.Errorf("org name is required to create a zitadel org")
+	}
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := c.call(ctx, http.MethodPost, "/management/v1/orgs", map[string]any{"name": name}, &resp); err != nil {
+		return Org{}, err
+	}
+	return Org{ID: resp.ID, Name: name}, nil
+}
+
 // DeactivateUser deactivates the IdP user, preventing their next sign-in.
 func (c *Client) DeactivateUser(ctx context.Context, userID string) error {
 	return c.call(ctx, http.MethodPost, fmt.Sprintf("/management/v1/users/%s/_deactivate", url.PathEscape(userID)), map[string]any{}, nil)

--- a/erun-docs/docs/agent-reference/identity-administration.md
+++ b/erun-docs/docs/agent-reference/identity-administration.md
@@ -20,6 +20,30 @@ Every operation is a named endpoint below, mapped to one specific Zitadel Manage
 
 Zitadel's built-in `ORG_USER_MANAGER` role would scope user create/list/deactivate/reactivate more narrowly than org-owner. Org policy management (login policy, password complexity) has no built-in role short of org-owner, though. Minting a second, narrower machine-user credential for only the user-CRUD half was considered and rejected for this increment: it would shrink the blast radius for half the surface while adding a second bootstrap-managed credential to operate, and the compensating control — an enumerated, non-proxying endpoint surface (previous section) — already applies uniformly. The single org-owner credential is used for the whole surface; this is a recorded decision, not a default.
 
+## `POST /v1/identity/orgs`
+
+Creates a Zitadel **organization** — the per-tenant identity boundary an org-scoped issuer resolves tenants by.
+
+```jsonc
+// POST /v1/identity/orgs body
+{ "name": "validationagent" }
+
+// 201 response
+{ "id": "386994597030592700", "name": "validationagent" }
+```
+
+Why it exists: a platform's own IdP serves every tenant from one issuer, so tenants are told apart by an org claim (`urn:zitadel:iam:user:resourceowner:id`). Registering a second tenant therefore needs an org for its mapping to point at — and until this endpoint, erun could create the tenant and the issuer mapping and then had nowhere to point them, leaving a hand-made org in Zitadel's own console as the only way through. That is the third of the three gaps in the multi-tenant onboarding path; see [erun API protocol · first-identity bootstrap](/agent-reference/api-protocol#tenant-issuers) and [`PATCH /v1/tenant-issuers`](/agent-reference/api-protocol#patch-v1tenant-issuers).
+
+The returned `id` is what you pass as `orgFieldValue` to [`POST /v1/tenants`](/agent-reference/api-protocol#post-v1tenants), or to `PATCH /v1/tenant-issuers` when converting a single-tenant issuer first.
+
+It creates the org and stops there. It does **not** register an erun tenant, move the caller into the new org, or enrol anyone: those are separate resources with separate gates, and the new org's first erun caller becomes that tenant's admin through the per-tenant first-user bootstrap. The org-owner credential this surface uses stays scoped to the platform's own org.
+
+| Status | Condition | Recovery |
+|---|---|---|
+| `201` | Org created. | — |
+| `400` | `name` is empty or blank. | Send a name. |
+| `403` | Caller's tenant is not `OPERATIONS`. | Call from an operations-tenant token. |
+
 ## `GET /v1/identity/users`
 
 Lists every identity (human and machine) the platform's IdP knows about, cross-referenced against erun's own `users` table for the caller's tenant so the response distinguishes an enrolled tenant member from an identity that merely exists in the IdP — the fix for a self-registered account (when `allowRegister` was left open, or an account created before it was closed) rendering identically to an actual member.


### PR DESCRIPTION
Closes the third and last gap in #1605's multi-tenant onboarding path — the one that still required a second browser tab.

## The gap

A platform's own IdP serves every tenant from one issuer, so tenants are told apart by an org claim (`urn:zitadel:iam:user:resourceowner:id`). Registering a second tenant therefore needs an **org** for its mapping to point at. erun could create the tenant row and the issuer mapping and then had nowhere to point them: `/v1/identity/*` administers users and policy for the platform's own org and cannot create one.

Measured, not assumed: minting a token with `urn:zitadel:iam:org:project:id:zitadel:aud` did not help either — Zitadel dropped the scope (audience came back as erun's three clients) and `GET /management/v1/orgs/me` returned **401**. So no erun-side caller could reach org creation at all.

## The change

`POST /v1/identity/orgs`, on the same operations-only surface, through the same org-owner credential the `erun-zitadel` chart already provisions:

```jsonc
// request                        // 201
{ "name": "validationagent" }     { "id": "386994597030592700", "name": "validationagent" }
```

The returned `id` is what `POST /v1/tenants` takes as `orgFieldValue`, or `PATCH /v1/tenant-issuers` when a single-tenant issuer has to be converted first.

**It creates the org and stops there** — no erun tenant, no moving the caller into the new org, no enrolment. Those are separate resources with separate gates, an operator may be creating an org for a tenant that already exists, and the new org's first erun caller becomes that tenant's admin through the per-tenant first-user bootstrap. The credential stays scoped to the platform's own org.

## Tests

The create; a blank name never reaching the IdP (`400`); the operations gate refusing a company tenant (`403`). `internal/routes` and `internal/zitadel` suites pass, `go build` and `gofmt` clean.

## What this completes

With #1588's two halves already released in 1.0.211, the sequence a second tenant needs is now entirely API-driven:

1. `POST /v1/identity/orgs` — create the org *(this PR)*
2. `PATCH /v1/tenant-issuers` with `orgFieldKey`/`orgFieldValue` — convert the issuer, if bootstrap registered it single-tenant *(1.0.211)*
3. `POST /v1/tenants` against that org
4. its first sign-in becomes that tenant's admin

Refs #1605