### PR TITLE
Stop a lint that finds nothing from failing the release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,15 @@
 #
 # erun-backend-db has no Go module at all (Atlas migrations + SQL only), so
 # there is nothing here for golangci-lint to run against.
+# An outer bound on a single module's lint, passed explicitly because the
+# default is short enough that the largest module (erun-backend-api, which
+# carries the AWS SDK) exceeds it on a modest build host -- and golangci-lint
+# reports that as a failure *after* printing "0 issues", so a clean analysis
+# reads as a red gate and a release aborts for no finding at all. Modules with
+# their own .golangci.yml set a shorter run.timeout; this is the ceiling, not a
+# replacement for it.
+LINT_TIMEOUT ?= 15m
+
 LINT_MODULES := erun-common erun-cli erun-mcp erun-integration erun-backend/erun-backend-api erun-ui
 
 # Run golangci-lint across the gated modules, each against its own
@@ -58,7 +67,7 @@ lint:
 	@failed=""; \
 	for m in $(LINT_MODULES); do \
 		echo ">> golangci-lint $$m"; \
-		if ! (cd $$m && golangci-lint run ./...); then \
+		if ! (cd $$m && golangci-lint run --timeout $(LINT_TIMEOUT) ./...); then \
 			failed="$$failed $$m"; \
 		fi; \
 	done; \


### PR DESCRIPTION
`make check` runs inside the `erun-devops` image build, so it gates every release — and it failed one on a module that had just printed `0 issues.`

```
>> golangci-lint erun-backend/erun-backend-api
0 issues.
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
>> golangci-lint erun-ui
0 issues.
lint failed in: erun-backend/erun-backend-api
```

The analysis completed and was clean; golangci-lint exceeded its own default timeout and exited non-zero anyway, aborting the release 22 minutes in for no finding at all.

Four of the six `LINT_MODULES` carry a `.golangci.yml` with an explicit `run.timeout: 3m`. `erun-backend/erun-backend-api` and `erun-integration` carry none, so they run on the default — and `erun-backend-api` is the largest module in the repo, pulling the AWS SDK, which puts it right at the edge on a modest build host. Intermittent rather than reproducible: the worst shape for a release gate. It misreads easily too, since the module is named in `lint failed in:` several lines after its own `0 issues.`, so the natural conclusion is that a *later* module found something.

`LINT_TIMEOUT`, defaulting to `15m` and passed on every invocation, is the ceiling. It changes no linter's behaviour and leaves the per-module `run.timeout` values as the shorter bound they already are.

A `.golangci.yml` for `erun-backend-api` would arguably be tidier, but adding one means choosing its `linters.enable` set, which would newly apply `funlen`/`gocyclo`/`cyclop` to that module and surface a batch of unrelated findings — a separate decision, not a timeout fix.

Found while cutting 1.0.212 (1.0.211 released from the same host minutes earlier).

Closes #1625