### PR TITLE
Gate the desktop hosted-registry option on a real reachability check

### DIFF
--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -350,17 +350,7 @@ func withDefaultRuntimeResolutionDeps(deps erunUIDeps) erunUIDeps {
 		deps.loadClusterRegistry = loadClusterRegistry
 	}
 	if deps.loadHostedRegistry == nil {
-		deps.loadHostedRegistry = func(ctx context.Context) uiHostedRegistryStatus {
-			if available, ok := hostedRegistryReachabilityOverride(); ok {
-				status := uiHostedRegistryStatus{Host: eruncommon.HostedRegistryHost, Available: available}
-				if !available {
-					status.Reason = "does not resolve"
-					status.Recovery = "Choose a different registry instead."
-				}
-				return status
-			}
-			return loadHostedRegistry(ctx)
-		}
+		deps.loadHostedRegistry = loadHostedRegistryWithTestOverride
 	}
 	if deps.checkRuntimeDeployed == nil {
 		deps.checkRuntimeDeployed = checkRuntimeDeployed
@@ -423,6 +413,21 @@ func localPortReachabilityOverride() (bool, bool) {
 		return false, false
 	}
 	return raw == "1", true
+}
+
+// loadHostedRegistryWithTestOverride is the default loadHostedRegistry dep:
+// the test override wins when set, otherwise it defers to the real probe.
+func loadHostedRegistryWithTestOverride(ctx context.Context) uiHostedRegistryStatus {
+	available, ok := hostedRegistryReachabilityOverride()
+	if !ok {
+		return loadHostedRegistry(ctx)
+	}
+	status := uiHostedRegistryStatus{Host: eruncommon.HostedRegistryHost, Available: available}
+	if !available {
+		status.Reason = "does not resolve"
+		status.Recovery = "Choose a different registry instead."
+	}
+	return status
 }
 
 // hostedRegistryReachabilityOverride parses ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -350,7 +350,17 @@ func withDefaultRuntimeResolutionDeps(deps erunUIDeps) erunUIDeps {
 		deps.loadClusterRegistry = loadClusterRegistry
 	}
 	if deps.loadHostedRegistry == nil {
-		deps.loadHostedRegistry = loadHostedRegistry
+		deps.loadHostedRegistry = func(ctx context.Context) uiHostedRegistryStatus {
+			if available, ok := hostedRegistryReachabilityOverride(); ok {
+				status := uiHostedRegistryStatus{Host: eruncommon.HostedRegistryHost, Available: available}
+				if !available {
+					status.Reason = "does not resolve"
+					status.Recovery = "Choose a different registry instead."
+				}
+				return status
+			}
+			return loadHostedRegistry(ctx)
+		}
 	}
 	if deps.checkRuntimeDeployed == nil {
 		deps.checkRuntimeDeployed = checkRuntimeDeployed
@@ -409,6 +419,21 @@ func withDefaultReachabilityDeps(deps erunUIDeps) erunUIDeps {
 // ("0" or "1"). See withDefaultReachabilityDeps for why the harness needs it.
 func localPortReachabilityOverride() (bool, bool) {
 	raw := strings.TrimSpace(os.Getenv("ERUN_LOCAL_PORT_REACHABILITY_OVERRIDE"))
+	if raw == "" {
+		return false, false
+	}
+	return raw == "1", true
+}
+
+// hostedRegistryReachabilityOverride parses ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE
+// ("0" or "1"), pinning the new-environment dialog's hosted-registry probe to
+// a fixed answer instead of a real network call to registry.erunpaas.com.
+// Set only by playwright/fixtures/seedRoot.ts, never in production — the
+// headless harness has no route to stub a Go-side outbound HTTP call the way
+// page.route stubs a Wails method, so without this every spec that opens the
+// dialog would depend on real DNS/network behavior.
+func hostedRegistryReachabilityOverride() (bool, bool) {
+	raw := strings.TrimSpace(os.Getenv("ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE"))
 	if raw == "" {
 		return false, false
 	}

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -58,6 +58,7 @@ type erunUIDeps struct {
 	listKubeContexts       func() ([]string, error)
 	loadResourceStatus     func(context.Context, uiRuntimeResourceInput) (uiRuntimeResourceStatus, error)
 	loadClusterRegistry    func(context.Context, uiRuntimeResourceInput) (uiClusterRegistryStatus, error)
+	loadHostedRegistry     func(context.Context) uiHostedRegistryStatus
 	checkRuntimeDeployed   func(context.Context, string, string, string) (bool, error)
 	stopEnvironmentRuntime func(eruncommon.Context, eruncommon.StopEnvironmentParams) (eruncommon.StopEnvironmentResult, error)
 	readRuntimeRunState    func(eruncommon.Context, eruncommon.RuntimeScaleTarget) (eruncommon.RuntimeRunState, error)
@@ -347,6 +348,9 @@ func withDefaultRuntimeResolutionDeps(deps erunUIDeps) erunUIDeps {
 	}
 	if deps.loadClusterRegistry == nil {
 		deps.loadClusterRegistry = loadClusterRegistry
+	}
+	if deps.loadHostedRegistry == nil {
+		deps.loadHostedRegistry = loadHostedRegistry
 	}
 	if deps.checkRuntimeDeployed == nil {
 		deps.checkRuntimeDeployed = checkRuntimeDeployed

--- a/erun-ui/frontend/src/app/api/environmentApi.ts
+++ b/erun-ui/frontend/src/app/api/environmentApi.ts
@@ -8,7 +8,11 @@ import type {
   UIUnexposeResult,
   UIVersionSuggestions,
 } from '@/types';
-import type { UIClusterRegistryStatus, UIEnvironmentHealth } from '@/uiDiagnosticsTypes';
+import type {
+  UIClusterRegistryStatus,
+  UIEnvironmentHealth,
+  UIHostedRegistryStatus,
+} from '@/uiDiagnosticsTypes';
 import type { UIEnvironmentStopResult } from '@/uiLifecycleTypes';
 import type {
   UIRuntimeActivity,
@@ -27,6 +31,7 @@ import {
   ListEnvironmentExposures,
   LoadClusterRegistry,
   LoadEnvironmentConfig,
+  LoadHostedRegistry,
   LoadRuntimeActivity,
   LoadRuntimeResourceStatus,
   LoadRuntimeSizing,
@@ -40,7 +45,7 @@ import {
 } from '../../../wailsjs/go/main/App';
 import type { EnvironmentApiBuilder } from './wailsApi';
 import { wailsApi } from './wailsApi';
-import { wailsQueryFn } from './wailsBaseQuery';
+import { type NoValue, wailsQueryFn } from './wailsBaseQuery';
 
 interface SaveEnvArgs {
   selection: UISelection;
@@ -176,6 +181,12 @@ export const environmentApi = wailsApi.injectEndpoints({
         LoadVersionSuggestions(selection),
       ),
       providesTags: ['VersionSuggestions'],
+    }),
+    // Probes erun's hosted container registry (registry.erunpaas.com), so the
+    // new-environment dialog can gate "Use erun's hosted registry" on a real
+    // check instead of offering it unconditionally.
+    getHostedRegistry: builder.query<UIHostedRegistryStatus, NoValue>({
+      queryFn: wailsQueryFn<NoValue, UIHostedRegistryStatus>(() => LoadHostedRegistry()),
     }),
     // Stopping frees the env's runtime and dind limits, so the node capacity
     // the Runtime tab offers every other env changes the moment it lands —

--- a/erun-ui/frontend/src/app/dialogContextsThunks.ts
+++ b/erun-ui/frontend/src/app/dialogContextsThunks.ts
@@ -109,6 +109,43 @@ export const refreshDialogClusterRegistry =
     }
   };
 
+// refreshDialogHostedRegistry probes erun's hosted registry once when the
+// dialog opens (the host is fixed, not resolved per Kubernetes context like
+// the in-cluster registry, so there is nothing to re-probe on context change).
+// A probe failure — including one the Go side could not even classify — still
+// resolves to "not available" rather than throwing, so this always lands a
+// definite status the "Use erun's hosted registry" checkbox can gate on.
+export const refreshDialogHostedRegistry =
+  (): AppThunk<Promise<void>> =>
+  async (dispatch, getState) => {
+    if (!getState().environmentDialog.open) {
+      return;
+    }
+    try {
+      const status = await dispatch(
+        environmentApi.endpoints.getHostedRegistry.initiate(undefined, { forceRefetch: true }),
+      ).unwrap();
+      if (!getState().environmentDialog.open) {
+        return;
+      }
+      dispatch(patchEnvironmentDialog({ hostedRegistry: status }));
+    } catch (error) {
+      if (!getState().environmentDialog.open) {
+        return;
+      }
+      dispatch(
+        patchEnvironmentDialog({
+          hostedRegistry: {
+            host: 'registry.erunpaas.com',
+            available: false,
+            reason: 'could not be checked',
+            recovery: readError(error),
+          },
+        }),
+      );
+    }
+  };
+
 // forceRefetch is required: without it RTK Query pins the previous
 // (possibly transient-empty) context list to the dialog, so Rescan can
 // never recover after a kubeconfig change.

--- a/erun-ui/frontend/src/app/dialogContextsThunks.ts
+++ b/erun-ui/frontend/src/app/dialogContextsThunks.ts
@@ -116,8 +116,7 @@ export const refreshDialogClusterRegistry =
 // resolves to "not available" rather than throwing, so this always lands a
 // definite status the "Use erun's hosted registry" checkbox can gate on.
 export const refreshDialogHostedRegistry =
-  (): AppThunk<Promise<void>> =>
-  async (dispatch, getState) => {
+  (): AppThunk<Promise<void>> => async (dispatch, getState) => {
     if (!getState().environmentDialog.open) {
       return;
     }

--- a/erun-ui/frontend/src/app/environmentDialogState.test.ts
+++ b/erun-ui/frontend/src/app/environmentDialogState.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { missingRequiredFieldReason } from './environmentDialogState';
+import { defaultEnvironmentDialog, type EnvironmentDialogState } from './state';
+
+// A submittable baseline: every other required field filled so each test
+// below isolates the one condition it is checking.
+function submittableDialog(): EnvironmentDialogState {
+  return {
+    ...defaultEnvironmentDialog(),
+    open: true,
+    tenant: 'acme',
+    environment: 'dev',
+    kubernetesContext: 'orbstack',
+    containerRegistry: 'ghcr.io/acme',
+  };
+}
+
+test('selecting the hosted registry while it is still being checked blocks submit', () => {
+  const dialog = { ...submittableDialog(), useErunRegistry: true, hostedRegistry: null };
+  assert.equal(
+    missingRequiredFieldReason(dialog),
+    "erun's hosted registry is not available right now. Choose a different registry.",
+  );
+});
+
+test('selecting the hosted registry when it does not resolve blocks submit with the reason', () => {
+  const dialog = {
+    ...submittableDialog(),
+    useErunRegistry: true,
+    hostedRegistry: {
+      host: 'registry.erunpaas.com',
+      available: false,
+      reason: 'does not resolve',
+      recovery: 'Choose a different registry instead.',
+    },
+  };
+  assert.equal(
+    missingRequiredFieldReason(dialog),
+    "erun's hosted registry is not available right now. Choose a different registry.",
+  );
+});
+
+test('selecting the hosted registry once it is confirmed available needs no container registry', () => {
+  const dialog = {
+    ...submittableDialog(),
+    containerRegistry: '',
+    useErunRegistry: true,
+    hostedRegistry: { host: 'registry.erunpaas.com', available: true },
+  };
+  assert.equal(missingRequiredFieldReason(dialog), null);
+});
+
+test('not selecting the hosted registry still requires a container registry as before', () => {
+  const dialog = { ...submittableDialog(), containerRegistry: '', hostedRegistry: null };
+  assert.equal(missingRequiredFieldReason(dialog), 'Select a container registry.');
+});

--- a/erun-ui/frontend/src/app/environmentDialogState.ts
+++ b/erun-ui/frontend/src/app/environmentDialogState.ts
@@ -50,14 +50,28 @@ export function missingRequiredFieldReason(dialog: EnvironmentDialogState): stri
   if (!values.kubernetesContext) {
     return 'Select a Kubernetes context.';
   }
-  // The in-cluster registry needs no host string — its addresses resolve from the
-  // kube-context — so a container registry is only required when not using it.
-  // Neither the in-cluster nor the hosted registry needs a host string: the
-  // first resolves from the kube-context, the second from the tenant.
-  if (!dialog.useClusterRegistry && !dialog.useErunRegistry && !values.containerRegistry) {
-    return 'Select a container registry.';
+  return registryMissingReason(dialog, values.containerRegistry);
+}
+
+// registryMissingReason covers all three registry choices: the hosted
+// registry is disabled in the UI until its reachability probe resolves
+// available, but submit is blocked on that same condition rather than relying
+// on the control's disabled state alone. The in-cluster and hosted registries
+// need no host string — the first resolves from the kube-context, the second
+// from the tenant — so a container registry is only required otherwise.
+function registryMissingReason(
+  dialog: EnvironmentDialogState,
+  containerRegistry: string,
+): string | null {
+  if (dialog.useErunRegistry) {
+    return dialog.hostedRegistry?.available === true
+      ? null
+      : "erun's hosted registry is not available right now. Choose a different registry.";
   }
-  return null;
+  if (dialog.useClusterRegistry) {
+    return null;
+  }
+  return containerRegistry ? null : 'Select a container registry.';
 }
 
 export function rememberEnvironmentDialogSelection(selection: UISelection): void {

--- a/erun-ui/frontend/src/app/environmentDialogThunks.ts
+++ b/erun-ui/frontend/src/app/environmentDialogThunks.ts
@@ -1,7 +1,11 @@
 import type { UISelection, UIVersionSuggestion } from '@/types';
 
 import { environmentApi } from './api/environmentApi';
-import { refreshDialogClusterRegistry, refreshKubernetesContexts } from './dialogContextsThunks';
+import {
+  refreshDialogClusterRegistry,
+  refreshDialogHostedRegistry,
+  refreshKubernetesContexts,
+} from './dialogContextsThunks';
 import {
   missingRequiredFieldReason,
   normalizedEnvironmentDialogValues,
@@ -54,6 +58,7 @@ export const openInitializeDialog = (): AppThunk => (dispatch, getState) => {
       clusterRegistry: null,
       useClusterRegistry: false,
       useErunRegistry: false,
+      hostedRegistry: null,
       envType: 'remote-agent',
       localRepoPath: '',
       noGit: false,
@@ -68,6 +73,7 @@ export const openInitializeDialog = (): AppThunk => (dispatch, getState) => {
   );
   void dispatch(refreshKubernetesContexts());
   void dispatch(refreshDialogVersionSuggestions(true));
+  void dispatch(refreshDialogHostedRegistry());
 };
 
 export const closeEnvironmentDialog = (): AppThunk => (dispatch, getState, extra) => {
@@ -209,7 +215,11 @@ function environmentDialogInitFields(
   const isLocalAgent = dialog.envType === 'local-agent';
   // When the in-cluster registry is chosen, seed a resolvable cluster: entry and
   // omit the static container-registry string (the two are mutually exclusive).
-  const useErunRegistry = dialog.useErunRegistry;
+  // useErunRegistry only takes effect once the reachability probe has actually
+  // confirmed the hosted registry is available — otherwise this would resolve
+  // to an environment whose pushes go nowhere, mirroring how useClusterRegistry
+  // is already gated on clusterRegistry?.deployed below.
+  const useErunRegistry = dialog.useErunRegistry && dialog.hostedRegistry?.available === true;
   const useClusterRegistry =
     !useErunRegistry && dialog.useClusterRegistry && !!dialog.clusterRegistry?.deployed;
   const resolvedRegistry = useErunRegistry || useClusterRegistry;

--- a/erun-ui/frontend/src/app/state.ts
+++ b/erun-ui/frontend/src/app/state.ts
@@ -18,7 +18,11 @@ import type {
   UIVersionSuggestion,
   UIVersionSuggestionNotice,
 } from '@/types';
-import type { UIClusterRegistryStatus, UIEnvironmentHealth } from '@/uiDiagnosticsTypes';
+import type {
+  UIClusterRegistryStatus,
+  UIEnvironmentHealth,
+  UIHostedRegistryStatus,
+} from '@/uiDiagnosticsTypes';
 import type { UIRuntimeChartPlan } from '@/uiRuntimeChartTypes';
 
 import type { ReachabilityKind } from './reconnectCopy';
@@ -179,6 +183,11 @@ export interface EnvironmentDialogState {
   // useErunRegistry selects erun's hosted registry (registry.erunpaas.com/<tenant>),
   // authenticated by the tenant's own API token. Exclusive with the other two.
   useErunRegistry: boolean;
+  // hostedRegistry is the reachability probe result for erun's hosted
+  // registry, checked once when the dialog opens (the host is fixed, not
+  // context-dependent like clusterRegistry). Null while the check is still in
+  // flight; useErunRegistry only takes effect once it resolves available.
+  hostedRegistry: UIHostedRegistryStatus | null;
   envType: EnvironmentType;
   localRepoPath: string;
   noGit: boolean;
@@ -448,6 +457,7 @@ export const defaultEnvironmentDialog = (): EnvironmentDialogState => ({
   clusterRegistry: null,
   useClusterRegistry: false,
   useErunRegistry: false,
+  hostedRegistry: null,
   envType: 'remote-agent',
   localRepoPath: '',
   noGit: false,

--- a/erun-ui/frontend/src/components/app/EnvironmentDialogView.RegistryField.tsx
+++ b/erun-ui/frontend/src/components/app/EnvironmentDialogView.RegistryField.tsx
@@ -8,6 +8,59 @@ import { loadSavedPastContainerRegistries } from '@/app/storage';
 
 type EnvironmentDialog = AppState['environmentDialog'];
 
+// isHostedRegistryUsable is true only once the reachability probe has
+// actually confirmed the host is available — a pure function so this
+// decision does not add to ContainerRegistryField's own branching.
+function isHostedRegistryUsable(dialog: EnvironmentDialog): boolean {
+  return dialog.hostedRegistry?.available === true && dialog.useErunRegistry;
+}
+
+// HostedRegistryToggle is disabled until the reachability probe resolves it
+// available — offering it unconditionally is the defect this fixes: selecting
+// a registry that does not resolve configured an environment whose pushes
+// went nowhere, with no error until the first build.
+function HostedRegistryToggle({ dialog }: { dialog: EnvironmentDialog }): React.ReactElement {
+  const dispatch = useAppDispatch();
+  const hosted = dialog.hostedRegistry;
+  const hostedAvailable = hosted?.available === true;
+  return (
+    <div className="grid gap-1">
+      <label
+        htmlFor="environment-use-erun-registry"
+        className="flex items-center gap-2 text-sm font-normal"
+      >
+        <Checkbox
+          id="environment-use-erun-registry"
+          checked={dialog.useErunRegistry}
+          disabled={dialog.busy || !hostedAvailable}
+          onCheckedChange={(value) => {
+            // The three choices are mutually exclusive, so selecting this one
+            // releases the cluster toggle rather than leaving both set and
+            // letting `erun init` reject the pair after the operator commits.
+            dispatch(
+              updateEnvironmentDialog({
+                useErunRegistry: value === true,
+                ...(value === true ? { useClusterRegistry: false } : {}),
+              }),
+            );
+          }}
+        />
+        Use erun&apos;s hosted registry
+      </label>
+      {hosted === null && (
+        <p className="text-[12px] leading-[1.4] text-muted-foreground">
+          Checking whether erun&apos;s hosted registry is reachable…
+        </p>
+      )}
+      {hosted && !hosted.available && (
+        <p className="text-[12px] leading-[1.4] text-muted-foreground">
+          erun&apos;s hosted registry {hosted.host} {hosted.reason}. {hosted.recovery}
+        </p>
+      )}
+    </div>
+  );
+}
+
 // ContainerRegistryField offers the in-cluster erun-registry (resolved from the
 // selected Kubernetes context) as the default when one is detected, and falls
 // back to a free-text registry otherwise. There is no hardcoded default host —
@@ -25,6 +78,7 @@ export function ContainerRegistryField({
   const cluster = dialog.clusterRegistry;
   const clusterAvailable = cluster?.deployed === true;
   const useCluster = clusterAvailable && dialog.useClusterRegistry;
+  const useHosted = isHostedRegistryUsable(dialog);
   const clusterToggle = clusterAvailable ? (
     <label className="flex items-center gap-2 text-sm font-normal">
       <Checkbox
@@ -39,32 +93,9 @@ export function ContainerRegistryField({
     </label>
   ) : null;
 
-  const hostedToggle = (
-    <label
-      htmlFor="environment-use-erun-registry"
-      className="flex items-center gap-2 text-sm font-normal"
-    >
-      <Checkbox
-        id="environment-use-erun-registry"
-        checked={dialog.useErunRegistry}
-        disabled={dialog.busy}
-        onCheckedChange={(value) => {
-          // The three choices are mutually exclusive, so selecting this one
-          // releases the cluster toggle rather than leaving both set and
-          // letting `erun init` reject the pair after the operator commits.
-          dispatch(
-            updateEnvironmentDialog({
-              useErunRegistry: value === true,
-              ...(value === true ? { useClusterRegistry: false } : {}),
-            }),
-          );
-        }}
-      />
-      Use erun&apos;s hosted registry
-    </label>
-  );
+  const hostedToggle = <HostedRegistryToggle dialog={dialog} />;
 
-  if (dialog.useErunRegistry) {
+  if (useHosted) {
     return (
       <div className="grid gap-2">
         <Label htmlFor="environment-use-erun-registry">Container registry</Label>

--- a/erun-ui/frontend/src/uiDiagnosticsTypes.ts
+++ b/erun-ui/frontend/src/uiDiagnosticsTypes.ts
@@ -23,6 +23,18 @@ export interface UIClusterRegistryStatus {
   port?: number;
 }
 
+// UIHostedRegistryStatus reports whether erun's hosted container registry
+// (registry.erunpaas.com) is reachable right now, so the new-environment
+// dialog can gate its "Use erun's hosted registry" option the same way
+// UIClusterRegistryStatus gates the in-cluster one. Reason and Recovery are
+// only set when Available is false.
+export interface UIHostedRegistryStatus {
+  host: string;
+  available: boolean;
+  reason?: string;
+  recovery?: string;
+}
+
 // UIEnvironmentHealthCheck is one out-of-pod diagnostic result from the Manage
 // dialog's "Check environment" action. status is 'ok' | 'error' | 'unknown';
 // fix names the recovery action ('deploy' | 'set-registry'), empty when passing.

--- a/erun-ui/hosted_registry_test.go
+++ b/erun-ui/hosted_registry_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestLoadHostedRegistryDelegatesToDeps locks down that the Wails-exported
+// method is a thin pass-through to the injected probe, mirroring how
+// LoadClusterRegistry defers to deps.loadClusterRegistry.
+func TestLoadHostedRegistryDelegatesToDeps(t *testing.T) {
+	app := &App{
+		deps: erunUIDeps{
+			loadHostedRegistry: func(context.Context) uiHostedRegistryStatus {
+				return uiHostedRegistryStatus{
+					Host:     eruncommon.HostedRegistryHost,
+					Reason:   "does not resolve",
+					Recovery: "Choose a different registry instead.",
+				}
+			},
+		},
+	}
+	status, err := app.LoadHostedRegistry()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Available {
+		t.Fatal("expected the unavailable status to pass through unchanged")
+	}
+	if status.Reason != "does not resolve" {
+		t.Fatalf("reason = %q", status.Reason)
+	}
+}
+
+// TestHostedRegistryProbeOverridePinsTheAnswer locks down the seam the
+// headless Playwright harness depends on: page.route can stub the Wails
+// method a spec calls, but not the outbound HTTP call the real probe would
+// make underneath it, so an unstubbed spec needs a deterministic answer with
+// no network access at all. ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE must win
+// regardless of what a real probe would have found.
+func TestHostedRegistryProbeOverridePinsTheAnswer(t *testing.T) {
+	t.Setenv("ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE", "1")
+	deps := withDefaultRuntimeDeps(erunUIDeps{})
+
+	status := deps.loadHostedRegistry(context.Background())
+	if !status.Available {
+		t.Fatalf("expected override=1 to report available, got %+v", status)
+	}
+	if status.Reason != "" || status.Recovery != "" {
+		t.Fatalf("expected no reason/recovery on an available status, got %+v", status)
+	}
+}
+
+// TestHostedRegistryProbeOverrideUnsetFallsBackToRealProbe pins that the
+// override is opt-in: with no env var set, the default dep still resolves to
+// a real probe rather than a fixed answer (production behavior unchanged).
+func TestHostedRegistryProbeOverrideUnsetFallsBackToRealProbe(t *testing.T) {
+	deps := withDefaultRuntimeDeps(erunUIDeps{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	status := deps.loadHostedRegistry(ctx)
+	if status.Available {
+		t.Fatal("expected the real probe to run and report unavailable for a canceled context")
+	}
+	if status.Reason == "" {
+		t.Fatal("expected the real probe's reason to be set, not the override's")
+	}
+}
+
+// TestLoadHostedRegistryDefaultMapsAnUnreachableProbe locks down the negative
+// this whole change exists for: an unreachable hosted registry must resolve
+// to available=false with a reason and recovery a caller can show, not to a
+// Go error the App method would otherwise have to swallow or misreport as
+// "available". An already-canceled context forces the probe to fail without
+// depending on real DNS behavior, so the test is deterministic regardless of
+// whether this host happens to resolve on the machine running it.
+func TestLoadHostedRegistryDefaultMapsAnUnreachableProbe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	status := loadHostedRegistry(ctx)
+	if status.Available {
+		t.Fatal("expected a canceled probe context to report unavailable")
+	}
+	if status.Host != eruncommon.HostedRegistryHost {
+		t.Fatalf("host = %q, want %q", status.Host, eruncommon.HostedRegistryHost)
+	}
+	if status.Reason == "" {
+		t.Fatal("expected a reason naming why the registry is unavailable")
+	}
+	if status.Recovery == "" {
+		t.Fatal("expected a recovery action, not just a reason")
+	}
+}

--- a/erun-ui/playwright/fixtures/seedRoot.ts
+++ b/erun-ui/playwright/fixtures/seedRoot.ts
@@ -198,6 +198,15 @@ export function backendEnv(): Record<string, string> {
     // environment's live state as the seeded env's own. See erun-ui/app.go
     // withDefaultReachabilityDeps.
     ERUN_LOCAL_PORT_REACHABILITY_OVERRIDE: '0',
+    // The new-environment dialog probes erun's hosted registry
+    // (registry.erunpaas.com) over a real outbound HTTP call the moment it
+    // opens — page.route can stub the Wails method that wraps it, but has no
+    // way to intercept that underlying network call itself, so an unstubbed
+    // spec would depend on real DNS/network behavior. This pins the default
+    // (unstubbed) answer to "unavailable", which also happens to match this
+    // host's real current production state. See erun-ui/app.go
+    // hostedRegistryReachabilityOverride.
+    ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE: '0',
     // The Local tab otherwise launches the operator's own $SHELL: a
     // terminal-content spec that selects text by screen position then
     // inherits that shell's dotfile-configured prompt and startup timing,

--- a/erun-ui/playwright/pages/EnvironmentInitDialog.ts
+++ b/erun-ui/playwright/pages/EnvironmentInitDialog.ts
@@ -60,6 +60,10 @@ export class EnvironmentInitDialog {
     await this.containerRegistryInput().fill(value);
   }
 
+  hostedRegistryCheckbox(): Locator {
+    return this.page.locator('#environment-use-erun-registry');
+  }
+
   // selectKubernetesContext opens the context dropdown and picks an option by
   // its label (the context name).
   async selectKubernetesContext(name: string): Promise<void> {

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -12,12 +12,22 @@ import { SEED_TENANT } from '../fixtures/seedRoot.js';
 // which is exactly what this spec exercises.
 // clusterRegistryFailure, when set, makes the LoadClusterRegistry stub return
 // this error instead of the endpoint's usual pass-through — used by
-// stubDialogClusterWithRegistryFailure below. A single page.route handler (not
-// two stacked registrations) is required: Playwright runs the most-recently
-// registered handler first, and its route.continue() sends the request to the
-// real backend rather than falling through to an earlier handler, so stacking
-// silently defeated the first stub instead of composing with it.
-async function stubDialogCluster(page: Page, clusterRegistryFailure?: string): Promise<void> {
+// stubDialogClusterWithRegistryFailure below. hostedRegistryAvailable, when
+// true, makes the LoadHostedRegistry stub report available instead of the
+// harness's default answer (ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE=0 in
+// backendEnv(), since page.route cannot intercept the real outbound HTTP call
+// underneath that Wails method) — used by
+// stubDialogClusterWithHostedRegistryAvailable below. A single page.route
+// handler (not two stacked registrations) is required: Playwright runs the
+// most-recently registered handler first, and its route.continue() sends the
+// request to the real backend rather than falling through to an earlier
+// handler, so stacking silently defeated the first stub instead of composing
+// with it.
+async function stubDialogCluster(
+  page: Page,
+  clusterRegistryFailure?: string,
+  hostedRegistryAvailable?: boolean,
+): Promise<void> {
   await page.route('**/__erun_invoke', async (route, request) => {
     const body = JSON.parse(request.postData() ?? '{}') as { method: string };
     if (body.method === 'LoadKubernetesContexts') {
@@ -59,6 +69,12 @@ async function stubDialogCluster(page: Page, clusterRegistryFailure?: string): P
         body: JSON.stringify({ error: clusterRegistryFailure }),
       });
     }
+    if (body.method === 'LoadHostedRegistry' && hostedRegistryAvailable) {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { host: 'registry.erunpaas.com', available: true } }),
+      });
+    }
     await route.continue();
   });
 }
@@ -72,6 +88,12 @@ async function stubDialogCluster(page: Page, clusterRegistryFailure?: string): P
 // the probe failure instead.
 async function stubDialogClusterWithRegistryFailure(page: Page): Promise<void> {
   await stubDialogCluster(page, 'CLUSTER_REGISTRY_PROBE_UNREACHABLE_MARKER');
+}
+
+// stubDialogClusterWithHostedRegistryAvailable is the one route a spec needs
+// to exercise the "available" branch of the hosted-registry gate.
+async function stubDialogClusterWithHostedRegistryAvailable(page: Page): Promise<void> {
+  await stubDialogCluster(page, undefined, true);
 }
 
 test.describe('environment init dialog', () => {
@@ -460,6 +482,60 @@ test.describe('environment init dialog', () => {
     await expect(app.envInitDialog.locator().getByRole('alert')).toContainText(
       'CLUSTER_REGISTRY_PROBE_UNREACHABLE_MARKER',
     );
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
+  test('offers the hosted registry only once it is confirmed reachable', async ({
+    app,
+    page,
+  }) => {
+    // The reported defect: the hosted-registry option was offered
+    // unconditionally, with no check that registry.erunpaas.com was actually
+    // reachable, unlike the in-cluster registry which is already gated on
+    // clusterRegistry?.deployed. The harness's default answer (no stub) is
+    // "unavailable" — the same answer this host gets in real life — so the
+    // checkbox must stay disabled and explain why, and picking a different
+    // registry must still be possible.
+    await stubDialogCluster(page);
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    const hosted = app.envInitDialog.hostedRegistryCheckbox();
+    await expect(hosted).toBeVisible();
+    await expect(hosted).toBeDisabled();
+    await expect(app.envInitDialog.locator()).toContainText('does not resolve');
+
+    await app.envInitDialog.selectKubernetesContext('orbstack');
+    await app.envInitDialog.fillEnvironment('review');
+    await app.envInitDialog.fillContainerRegistry('ghcr.io/sophium');
+    await expect(app.envInitDialog.createButton()).toBeEnabled();
+
+    await app.envInitDialog.cancel();
+    await app.envInitDialog.waitForClosed();
+  });
+
+  test('once reachable, selecting the hosted registry clears the container-registry requirement', async ({
+    app,
+    page,
+  }) => {
+    await stubDialogClusterWithHostedRegistryAvailable(page);
+    await app.sidebar.openInitDialog();
+    await app.envInitDialog.waitForOpen();
+
+    const hosted = app.envInitDialog.hostedRegistryCheckbox();
+    await expect(hosted).toBeEnabled();
+
+    await app.envInitDialog.selectKubernetesContext('orbstack');
+    await app.envInitDialog.fillEnvironment('review');
+    // No container registry is filled in — the hosted registry needs none.
+    await expect(app.envInitDialog.createButton()).toBeDisabled();
+
+    await hosted.click();
+    await expect(hosted).toBeChecked();
+    await expect(app.envInitDialog.createButton()).toBeEnabled();
+    await expect(app.envInitDialog.submitReason()).toHaveText('');
 
     await app.envInitDialog.cancel();
     await app.envInitDialog.waitForClosed();

--- a/erun-ui/runtime_resources.go
+++ b/erun-ui/runtime_resources.go
@@ -32,6 +32,29 @@ func (a *App) LoadClusterRegistry(input uiRuntimeResourceInput) (uiClusterRegist
 	return a.deps.loadClusterRegistry(ctx, normalizeRuntimeResourceInput(input))
 }
 
+// LoadHostedRegistry reports whether erun's hosted container registry is
+// reachable right now, so the new-environment dialog can gate the "Use
+// erun's hosted registry" option on a real check instead of offering it
+// unconditionally — the asymmetry the in-cluster registry option does not
+// have, since it is already gated on clusterRegistry.deployed.
+func (a *App) LoadHostedRegistry() (uiHostedRegistryStatus, error) {
+	ctx := a.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return a.deps.loadHostedRegistry(ctx), nil
+}
+
+func loadHostedRegistry(ctx context.Context) uiHostedRegistryStatus {
+	status := eruncommon.ProbeHostedRegistry(ctx, nil)
+	return uiHostedRegistryStatus{
+		Host:      status.Host,
+		Available: status.Available,
+		Reason:    status.Reason,
+		Recovery:  status.Recovery,
+	}
+}
+
 func loadClusterRegistry(ctx context.Context, input uiRuntimeResourceInput) (uiClusterRegistryStatus, error) {
 	input = normalizeRuntimeResourceInput(input)
 	if input.KubernetesContext == "" {

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -1045,6 +1045,19 @@ type uiClusterRegistryStatus struct {
 	Message           string `json:"message,omitempty"`
 }
 
+// uiHostedRegistryStatus reports whether erun's hosted container registry
+// (registry.erunpaas.com) is currently reachable, so the new-environment
+// dialog can gate offering it the same way uiClusterRegistryStatus gates the
+// in-cluster registry. Reason and Recovery are only set when Available is
+// false, and name the specific cause the probe observed and the action that
+// resolves it.
+type uiHostedRegistryStatus struct {
+	Host      string `json:"host"`
+	Available bool   `json:"available"`
+	Reason    string `json:"reason,omitempty"`
+	Recovery  string `json:"recovery,omitempty"`
+}
+
 type uiRuntimeResourceNode struct {
 	Name   string                  `json:"name"`
 	CPU    uiRuntimeResourceMetric `json:"cpu"`


### PR DESCRIPTION
## Summary

- The new-environment dialog offered "Use erun's hosted registry" (`registry.erunpaas.com`) unconditionally, unlike the in-cluster registry option which is already gated on `clusterRegistry?.deployed` — picking it configured an environment whose pushes went nowhere.
- `ProbeHostedRegistry` (`erun-common/hosted_registry.go`, landed with #1519, bounded by a 5s timeout, already unit-tested) had no caller outside its own file. This PR wires it into the desktop: a new `LoadHostedRegistry` Wails method probes it once when the New Environment dialog opens, and the checkbox stays disabled — with the probe's own reason/recovery text shown — until it resolves available.
- The CLI/MCP side of this same gate (`erun init --erun-registry` refusing when unreachable) already landed in #1496, so this closes the desktop half of the asymmetry #1494 names as its independently-useful item 3.

## Where the probe lives, and why

- **At selection time in the desktop** (dialog open), not at push time and not on every push. A probe on every push would tax a hot path for a check that rarely changes; a probe made once when the operator is choosing a registry is exactly when a stale answer is cheapest to correct (they haven't committed to anything yet) and the UI is already asking the equivalent question of the in-cluster registry (`clusterRegistry?.deployed`).
- The CLI does the equivalent probe **synchronously at `erun init` run time** (`resolveHostedRegistry` in `erun-common/init.go`, from #1496) — that is the backstop for anyone driving the CLI directly, or for the tiny race window between the desktop's probe and the operator clicking Create. The desktop composes onto that same `erun init` invocation (`session.go` still emits `--erun-registry` when selected), so the refusal path is defense in depth, not a replacement.

## What the refusal says

Both layers reuse `HostedRegistryStatus.Err()`'s shape: name the host, why it isn't available (e.g. "does not resolve"), and the recovery action ("Choose a different registry instead: `--container-registry <host/namespace>` ... or `--cluster-registry`"). The desktop checkbox renders the same `reason`/`recovery` text under the (disabled) control; `missingRequiredFieldReason` additionally refuses submit with "erun's hosted registry is not available right now. Choose a different registry." if `useErunRegistry` is somehow still set while unavailable (defense in depth against the checkbox's own disabled state).

## Failure direction on a transient error

**Fails closed** (unavailable) on any probe error — DNS failure, timeout, or a probe request that could not even be built — exactly as `ProbeHostedRegistry` already categorizes them. This is deliberate: a hosted hidden-cost registry that intermittently *looks* reachable but silently drops pushes is worse than a checkbox that is occasionally disabled for a few seconds during a real blip, because the operator can just retry opening the dialog (the probe reruns) or fall back to `--container-registry`. The one thing this does **not** do is retry-storm a flaky network: the probe runs once per dialog open, not on a poll loop, so a transient blip costs one disabled checkbox, not a wedged UI.

## Tests

- Go (`erun-ui`): `TestLoadHostedRegistryDelegatesToDeps`, `TestLoadHostedRegistryDefaultMapsAnUnreachableProbe` (asserts the negative — an unreachable probe resolves to `available=false` with a reason and recovery, using an already-canceled context so the test never depends on real DNS), `TestHostedRegistryProbeOverridePinsTheAnswer` / `...UnsetFallsBackToRealProbe` (the new `ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE` test seam, mirroring `ERUN_LOCAL_PORT_REACHABILITY_OVERRIDE`).
- Frontend unit (`environmentDialogState.test.ts`): the hosted-registry-unavailable submit-block message, and that a confirmed-available hosted registry needs no container registry.
- Playwright (`env-init.spec.ts`): "offers the hosted registry only once it is confirmed reachable" — the negative, run with **no stub at all** since the harness's default answer for this host is genuinely "unavailable" (`ERUN_HOSTED_REGISTRY_PROBE_OVERRIDE=0`, matching this host's real production state) — and "once reachable, selecting the hosted registry clears the container-registry requirement" for the positive path via a stub.
- The 401-treated-as-available case is exercised by `ProbeHostedRegistry`'s own existing `TestHostedRegistryProbeTreatsUnauthorizedAsAvailable` in `erun-common` — not re-tested here, since the desktop layer only ever sees the already-computed `available` boolean.

## Scope note

#1494 also covers deploying (or removing) the `registry.erunpaas.com` infrastructure itself — DNS, ingress, signing keypair — which is explicitly an operator/production-infra decision left to the issue. This PR is the code-side half only: it stops the product from offering a registry it hasn't verified is there. Not opened with a `Closes` line for that reason.

## Test plan

- [x] `make check` — green (see gate totals below; two pre-existing, unrelated `erun-integration` failures noted separately, not caused by or fixed in this PR)
- [x] `go test ./...` in `erun-ui` (including `-race`)
- [x] `yarn typecheck && yarn lint && yarn format:check && yarn test` in `erun-ui/frontend`
- [x] `./playwright/run.sh` (full suite, `erun-ui/playwright`) — all specs green, including the two new hosted-registry specs