### PR TITLE
Add the environment read model (server-side half of #1105)

### DIFF
--- a/erun-common/environment_read_model.go
+++ b/erun-common/environment_read_model.go
@@ -57,22 +57,41 @@ type EnvironmentLifecycleInputs struct {
 // never used to distinguish Stopped or Idle from Unknown.
 func ResolveEnvironmentLifecycleState(in EnvironmentLifecycleInputs) EnvironmentLifecycleState {
 	if in.ManagedCloud {
-		if !in.CloudContextObserved {
-			return EnvironmentLifecycleUnknown
+		if state, resolved := resolveManagedCloudLifecycleState(in); resolved {
+			return state
 		}
-		switch in.CloudContextStatus {
-		case CloudContextStatusStopped:
-			return EnvironmentLifecycleStopped
-		case CloudContextStatusRunning:
-			// A running instance can still be deploy-failed or idle-eligible;
-			// fall through to the shared checks below.
-		default:
-			// Pending, unknown, or any unrecognized value: the power state is
-			// mid-transition or was never resolved past a guess.
-			return EnvironmentLifecycleUnknown
-		}
+		// Confirmed running: fall through to the shared workload checks
+		// below, since a running instance can still be deploy-failed or
+		// idle-eligible.
 	}
+	return resolveWorkloadLifecycleState(in)
+}
 
+// resolveManagedCloudLifecycleState resolves a managed-cloud environment's
+// power state. resolved is false only when the instance is confirmed
+// running, the one case the caller must still apply the shared workload
+// checks for.
+func resolveManagedCloudLifecycleState(in EnvironmentLifecycleInputs) (state EnvironmentLifecycleState, resolved bool) {
+	if !in.CloudContextObserved {
+		return EnvironmentLifecycleUnknown, true
+	}
+	switch in.CloudContextStatus {
+	case CloudContextStatusStopped:
+		return EnvironmentLifecycleStopped, true
+	case CloudContextStatusRunning:
+		return "", false
+	default:
+		// Pending, unknown, or any unrecognized value: the power state is
+		// mid-transition or was never resolved past a guess.
+		return EnvironmentLifecycleUnknown, true
+	}
+}
+
+// resolveWorkloadLifecycleState resolves everything a cloud-managed
+// environment's power state does not answer on its own: deploy health and
+// idle-policy eligibility. It is also the whole answer for a non-managed
+// environment, which has no separate power state to check first.
+func resolveWorkloadLifecycleState(in EnvironmentLifecycleInputs) EnvironmentLifecycleState {
 	switch {
 	case in.DeployHealthObserved && !in.DeployHealthy:
 		return EnvironmentLifecycleDeployFailed

--- a/erun-common/environment_read_model.go
+++ b/erun-common/environment_read_model.go
@@ -1,0 +1,233 @@
+package eruncommon
+
+import (
+	"strings"
+	"time"
+)
+
+// EnvironmentLifecycleState is the environment read model's single resolved
+// answer to "what is this environment doing right now?" -- composed from
+// cloud-context power state, deploy health, and idle-policy eligibility,
+// each of which alone only answers a narrower question.
+type EnvironmentLifecycleState string
+
+const (
+	EnvironmentLifecycleRunning      EnvironmentLifecycleState = "running"
+	EnvironmentLifecycleIdle         EnvironmentLifecycleState = "idle"
+	EnvironmentLifecycleDeployFailed EnvironmentLifecycleState = "deploy-failed"
+	EnvironmentLifecycleStopped      EnvironmentLifecycleState = "stopped"
+	// EnvironmentLifecycleUnknown is reported whenever a signal the state
+	// depends on was never observed -- e.g. a managed-cloud environment's
+	// power state is a live AWS reading this package never persists, so a
+	// caller that has not refreshed it sees a blank value here rather than a
+	// guess at "stopped" or "running".
+	EnvironmentLifecycleUnknown EnvironmentLifecycleState = "unknown"
+)
+
+// EnvironmentLifecycleInputs is the already-resolved signal set
+// ResolveEnvironmentLifecycleState composes into one state. Every signal
+// that can fail to be observed carries its own explicit "observed" bit, so a
+// caller that could not read a signal says so instead of leaving a zero
+// value indistinguishable from a real negative reading.
+type EnvironmentLifecycleInputs struct {
+	ManagedCloud bool
+
+	// CloudContextObserved is true only when a live cloud-context power
+	// state was actually read. A config-only match (the environment names a
+	// cloud context) is not an observation: CloudContextStatus is never
+	// persisted (see CloudContextStatus's own doc comment), so a caller that
+	// never refreshed it has nothing real to report.
+	CloudContextObserved bool
+	CloudContextStatus   string
+
+	// DeployHealthObserved is true only when a real (non-dry-run) deploy
+	// diagnosis ran for this environment.
+	DeployHealthObserved bool
+	DeployHealthy        bool
+
+	// IdleStatusObserved is true only when the environment's own idle policy
+	// resolved successfully.
+	IdleStatusObserved bool
+	StopEligible       bool
+}
+
+// ResolveEnvironmentLifecycleState is pure: it never reaches for a signal it
+// wasn't given, so it never has to guess at one. See the "observed" contract
+// on EnvironmentLifecycleInputs -- an input whose observed bit is false is
+// never used to distinguish Stopped or Idle from Unknown.
+func ResolveEnvironmentLifecycleState(in EnvironmentLifecycleInputs) EnvironmentLifecycleState {
+	if in.ManagedCloud {
+		if !in.CloudContextObserved {
+			return EnvironmentLifecycleUnknown
+		}
+		switch in.CloudContextStatus {
+		case CloudContextStatusStopped:
+			return EnvironmentLifecycleStopped
+		case CloudContextStatusRunning:
+			// A running instance can still be deploy-failed or idle-eligible;
+			// fall through to the shared checks below.
+		default:
+			// Pending, unknown, or any unrecognized value: the power state is
+			// mid-transition or was never resolved past a guess.
+			return EnvironmentLifecycleUnknown
+		}
+	}
+
+	switch {
+	case in.DeployHealthObserved && !in.DeployHealthy:
+		return EnvironmentLifecycleDeployFailed
+	case in.IdleStatusObserved && in.StopEligible:
+		return EnvironmentLifecycleIdle
+	case in.IdleStatusObserved || in.DeployHealthObserved || in.ManagedCloud:
+		return EnvironmentLifecycleRunning
+	default:
+		// Nothing at all was observed -- neither the cloud context, the
+		// deploy health, nor the idle policy. Reporting Running here would
+		// assert the environment is alive purely because nobody said
+		// otherwise.
+		return EnvironmentLifecycleUnknown
+	}
+}
+
+// EnvironmentHealth is the read-only doctor-derived health view: the root
+// config gate plus the current deploy diagnosis, with the single recovery
+// action RecommendedDeployRecovery would suggest layered on top so a caller
+// does not need to re-run that classification itself.
+type EnvironmentHealth struct {
+	RootConfig          RootConfigInspection  `json:"rootConfig"`
+	Deploy              DeployDiagnosisResult `json:"deploy"`
+	RecommendedRecovery DeployRecoveryAction  `json:"recommendedRecovery,omitempty"`
+}
+
+// ResolveEnvironmentHealth composes the doctor pieces callers already have
+// (RootConfigInspection and DeployDiagnosisResult) into one health view. It
+// runs no commands of its own; the caller is responsible for having run a
+// real diagnosis -- see EnvironmentHealth's doc comment.
+func ResolveEnvironmentHealth(rootConfig RootConfigInspection, deploy DeployDiagnosisResult) EnvironmentHealth {
+	recovery, _ := RecommendedDeployRecovery(deploy)
+	return EnvironmentHealth{RootConfig: rootConfig, Deploy: deploy, RecommendedRecovery: recovery}
+}
+
+// EnvironmentReadModel is the transport-neutral "what is this environment
+// doing" answer: an environment's list-style summary plus the deeper detail
+// -- cloud-context state, idle policy + activity snapshot, doctor health --
+// with a single resolved lifecycle state layered on top. Every piece here
+// reuses an existing resolver (ResolveListResult's per-environment entry,
+// EnvironmentIdleStatus, CloudContextStatus, doctor's diagnosis); this type
+// only composes them.
+type EnvironmentReadModel struct {
+	Tenant       string                    `json:"tenant"`
+	Environment  ListEnvironmentResult     `json:"environment"`
+	State        EnvironmentLifecycleState `json:"state"`
+	CloudContext *CloudContextStatus       `json:"cloudContext,omitempty"`
+	Idle         *EnvironmentIdleStatus    `json:"idle,omitempty"`
+	Health       *EnvironmentHealth        `json:"health,omitempty"`
+}
+
+// AssembleEnvironmentReadModel is pure: it composes already-resolved pieces
+// into one read model and derives the lifecycle state from exactly what was
+// passed in. A nil cloudContext/idle/health is not an error -- it means that
+// signal was not observed, and ResolveEnvironmentLifecycleState treats it
+// that way rather than defaulting it to a real reading.
+func AssembleEnvironmentReadModel(tenant string, environment ListEnvironmentResult, cloudContext *CloudContextStatus, idle *EnvironmentIdleStatus, health *EnvironmentHealth) EnvironmentReadModel {
+	inputs := EnvironmentLifecycleInputs{}
+	if idle != nil {
+		inputs.ManagedCloud = idle.ManagedCloud
+		inputs.IdleStatusObserved = true
+		inputs.StopEligible = idle.StopEligible
+	}
+	if cloudContext != nil {
+		if status := strings.TrimSpace(cloudContext.Status); status != "" {
+			inputs.CloudContextObserved = true
+			inputs.CloudContextStatus = status
+		}
+	}
+	if health != nil {
+		inputs.DeployHealthObserved = true
+		_, needsRecovery := RecommendedDeployRecovery(health.Deploy)
+		inputs.DeployHealthy = !needsRecovery
+	}
+	return EnvironmentReadModel{
+		Tenant:       strings.TrimSpace(tenant),
+		Environment:  environment,
+		State:        ResolveEnvironmentLifecycleState(inputs),
+		CloudContext: cloudContext,
+		Idle:         idle,
+		Health:       health,
+	}
+}
+
+// ResolveEnvironmentDetail resolves the same per-environment entry
+// ResolveListResult computes for every environment in a tenant, for exactly
+// one named tenant/environment -- the "environment detail" half of the read
+// model, as opposed to "tenant environment list" which ResolveListResult
+// already covers unmodified.
+func ResolveEnvironmentDetail(store ListStore, tenant, environment string) (ListEnvironmentResult, error) {
+	tenant = strings.TrimSpace(tenant)
+	environment = strings.TrimSpace(environment)
+	if err := errMissingTenantOrEnvironment("resolve environment detail", tenant, environment); err != nil {
+		return ListEnvironmentResult{}, err
+	}
+	tenantConfig, _, err := store.LoadTenantConfig(tenant)
+	if err != nil {
+		return ListEnvironmentResult{}, err
+	}
+	envConfig, _, err := store.LoadEnvConfig(tenant, environment)
+	if err != nil {
+		return ListEnvironmentResult{}, err
+	}
+	effective, effectiveErr := ResolveOpen(store, OpenParams{Tenant: tenant, Environment: environment})
+	portAllocations, err := ResolveAllEnvironmentLocalPorts(store)
+	if err != nil {
+		return ListEnvironmentResult{}, err
+	}
+	return listEnvironmentResult(store, tenantConfig, envConfig, effective, effectiveErr, portAllocations), nil
+}
+
+// ResolveEnvironmentReadModel is the read model's one impure entrypoint: it
+// resolves the environment detail, its idle status, its cloud-context
+// config (never a live power-state refresh -- see CloudContextObserved's
+// doc comment), and, on a real (non-dry-run) call, a doctor deploy
+// diagnosis, then assembles them. Every piece is an existing resolver; this
+// function only calls them and hands the results to AssembleEnvironmentReadModel.
+func ResolveEnvironmentReadModel(ctx Context, store ListStore, tenant, environment string, now time.Time) (EnvironmentReadModel, error) {
+	tenant = strings.TrimSpace(tenant)
+	environment = strings.TrimSpace(environment)
+	if err := errMissingTenantOrEnvironment("resolve environment read model", tenant, environment); err != nil {
+		return EnvironmentReadModel{}, err
+	}
+
+	entry, err := ResolveEnvironmentDetail(store, tenant, environment)
+	if err != nil {
+		return EnvironmentReadModel{}, err
+	}
+
+	idleStatus, err := ResolveStoredEnvironmentIdleStatus(store, tenant, environment, now)
+	if err != nil {
+		return EnvironmentReadModel{}, err
+	}
+
+	var cloudContext *CloudContextStatus
+	if status, ok, err := findCloudContextForKubernetesContext(store, entry.KubernetesContext); err != nil {
+		return EnvironmentReadModel{}, err
+	} else if ok {
+		cloudContext = &status
+	}
+
+	var health *EnvironmentHealth
+	if !ctx.DryRun {
+		rootConfig, err := InspectRootConfig(store)
+		if err != nil {
+			return EnvironmentReadModel{}, err
+		}
+		openResult, err := ResolveDoctorTarget(store, OpenParams{Tenant: tenant, Environment: environment})
+		if err != nil {
+			return EnvironmentReadModel{}, err
+		}
+		diagnosis := RunDeployDiagnosis(ctx, ShellLaunchParamsFromResult(openResult))
+		resolved := ResolveEnvironmentHealth(rootConfig, diagnosis)
+		health = &resolved
+	}
+
+	return AssembleEnvironmentReadModel(tenant, entry, cloudContext, &idleStatus, health), nil
+}

--- a/erun-common/environment_read_model_test.go
+++ b/erun-common/environment_read_model_test.go
@@ -1,0 +1,139 @@
+package eruncommon
+
+import "testing"
+
+// TestResolveEnvironmentLifecycleStateUnknownIsNotAFalseNegative is the
+// mandatory negative case: an environment whose power state was never
+// observed must read as Unknown, never as Stopped or Idle just because a
+// bool defaulted to false. CloudContextStatus is a live value this package
+// never persists (see CloudContextStatus's own doc comment), so a
+// managed-cloud environment queried without a fresh refresh is exactly the
+// realistic case this guards.
+func TestResolveEnvironmentLifecycleStateUnknownIsNotAFalseNegative(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   EnvironmentLifecycleInputs
+	}{
+		{
+			name: "managed cloud with no cloud-context observation at all",
+			in:   EnvironmentLifecycleInputs{ManagedCloud: true},
+		},
+		{
+			name: "managed cloud with a pending (mid-transition) power state",
+			in:   EnvironmentLifecycleInputs{ManagedCloud: true, CloudContextObserved: true, CloudContextStatus: CloudContextStatusPending},
+		},
+		{
+			name: "managed cloud with an explicitly unknown power state",
+			in:   EnvironmentLifecycleInputs{ManagedCloud: true, CloudContextObserved: true, CloudContextStatus: CloudContextStatusUnknown},
+		},
+		{
+			name: "non-managed with nothing observed at all",
+			in:   EnvironmentLifecycleInputs{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveEnvironmentLifecycleState(tc.in)
+			if got != EnvironmentLifecycleUnknown {
+				t.Fatalf("want unknown, got %s", got)
+			}
+			if got == EnvironmentLifecycleStopped || got == EnvironmentLifecycleIdle {
+				t.Fatalf("an unobserved signal must never resolve to a real state; got %s", got)
+			}
+		})
+	}
+}
+
+func TestResolveEnvironmentLifecycleStateManagedCloudPowerState(t *testing.T) {
+	stopped := ResolveEnvironmentLifecycleState(EnvironmentLifecycleInputs{
+		ManagedCloud: true, CloudContextObserved: true, CloudContextStatus: CloudContextStatusStopped,
+	})
+	if stopped != EnvironmentLifecycleStopped {
+		t.Fatalf("want stopped, got %s", stopped)
+	}
+
+	running := ResolveEnvironmentLifecycleState(EnvironmentLifecycleInputs{
+		ManagedCloud: true, CloudContextObserved: true, CloudContextStatus: CloudContextStatusRunning,
+	})
+	if running != EnvironmentLifecycleRunning {
+		t.Fatalf("want running, got %s", running)
+	}
+}
+
+func TestResolveEnvironmentLifecycleStateDeployFailedTakesPriorityOverIdle(t *testing.T) {
+	// A deploy diagnosis reporting unhealthy must win even when the idle
+	// policy would otherwise call the environment stop-eligible: an
+	// environment stuck on a bad release is not "idle", it is broken.
+	got := ResolveEnvironmentLifecycleState(EnvironmentLifecycleInputs{
+		DeployHealthObserved: true, DeployHealthy: false,
+		IdleStatusObserved: true, StopEligible: true,
+	})
+	if got != EnvironmentLifecycleDeployFailed {
+		t.Fatalf("want deploy-failed, got %s", got)
+	}
+}
+
+func TestResolveEnvironmentLifecycleStateIdleAndRunning(t *testing.T) {
+	idle := ResolveEnvironmentLifecycleState(EnvironmentLifecycleInputs{
+		IdleStatusObserved: true, StopEligible: true,
+	})
+	if idle != EnvironmentLifecycleIdle {
+		t.Fatalf("want idle, got %s", idle)
+	}
+
+	running := ResolveEnvironmentLifecycleState(EnvironmentLifecycleInputs{
+		IdleStatusObserved: true, StopEligible: false,
+	})
+	if running != EnvironmentLifecycleRunning {
+		t.Fatalf("want running, got %s", running)
+	}
+}
+
+func TestAssembleEnvironmentReadModelNilSignalsStayUnknown(t *testing.T) {
+	entry := ListEnvironmentResult{Name: "dev", Type: EnvironmentTypeRemoteAgent}
+	model := AssembleEnvironmentReadModel(" acme ", entry, nil, nil, nil)
+
+	if model.Tenant != "acme" {
+		t.Fatalf("tenant not trimmed: got %q", model.Tenant)
+	}
+	if model.State != EnvironmentLifecycleUnknown {
+		t.Fatalf("with no cloud context, idle, or health observed, want unknown, got %s", model.State)
+	}
+	if model.CloudContext != nil || model.Idle != nil || model.Health != nil {
+		t.Fatalf("nil inputs must stay nil on the assembled model, got %+v", model)
+	}
+}
+
+func TestAssembleEnvironmentReadModelUnrefreshedCloudContextIsUnknownNotStopped(t *testing.T) {
+	// CloudContextStatus.Status is blank whenever it was loaded from config
+	// only (findCloudContextForKubernetesContext never refreshes it) -- this
+	// is the realistic shape ResolveEnvironmentReadModel's default,
+	// no-live-refresh call produces for a managed-cloud environment.
+	entry := ListEnvironmentResult{Name: "dev", Type: EnvironmentTypeRuntime}
+	cloudContext := &CloudContextStatus{CloudContextConfig: CloudContextConfig{Name: "acme-dev"}}
+	idle := &EnvironmentIdleStatus{ManagedCloud: true, StopEligible: false}
+
+	model := AssembleEnvironmentReadModel("acme", entry, cloudContext, idle, nil)
+
+	if model.State != EnvironmentLifecycleUnknown {
+		t.Fatalf("a blank (unrefreshed) cloud-context status must read as unknown, got %s", model.State)
+	}
+	if model.CloudContext == nil {
+		t.Fatalf("the config-level cloud context should still be attached even though its power state is unknown")
+	}
+}
+
+func TestAssembleEnvironmentReadModelDeployFailedFromHealth(t *testing.T) {
+	entry := ListEnvironmentResult{Name: "dev", Type: EnvironmentTypeRemoteAgent}
+	idle := &EnvironmentIdleStatus{StopEligible: false}
+	resolvedHealth := ResolveEnvironmentHealth(RootConfigInspection{}, DeployDiagnosisResult{HelmStatus: "STATUS: pending-upgrade"})
+	health := &resolvedHealth
+
+	model := AssembleEnvironmentReadModel("acme", entry, nil, idle, health)
+
+	if model.State != EnvironmentLifecycleDeployFailed {
+		t.Fatalf("want deploy-failed, got %s", model.State)
+	}
+	if model.Health.RecommendedRecovery != DeployRecoveryClearPendingHelm {
+		t.Fatalf("want clear-pending-helm recommendation, got %s", model.Health.RecommendedRecovery)
+	}
+}

--- a/erun-common/mcp_tools.go
+++ b/erun-common/mcp_tools.go
@@ -170,17 +170,22 @@ var mcpToolDescriptors = map[string]MCPToolDescriptor{
 	"contribute_clone": {Family: "contribute", CLIPath: []string{"contribute", "clone"}, Title: "Clone the erun source into the environment", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
 	"version":          {Family: "", CLIPath: []string{"version"}, Title: "Report erun build metadata", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},
 	"list":             {Family: "", CLIPath: []string{"list"}, Title: "List tenants, environments, and the effective target", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false},
-	"init":             {Family: "", CLIPath: []string{"init"}, Title: "Initialise an environment", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: false},
-	"build":            {Family: "", CLIPath: []string{"build"}, Title: "Build the environment's images", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
-	"push":             {Family: "", CLIPath: []string{"push"}, Title: "Push built images to the registry", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
-	"deploy":           {Family: "", CLIPath: []string{"deploy"}, Title: "Deploy a version into an environment", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
-	"publish":          {Family: "", CLIPath: []string{"publish"}, Title: "Publish charts to the registry", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
-	"upgrade":          {Family: "", CLIPath: []string{"upgrade"}, Title: "Upgrade opted-in environments to the latest version", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
-	"release":          {Family: "", CLIPath: []string{"release"}, Title: "Cut a release and publish its artefacts", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
-	"pin":              {Family: "", CLIPath: []string{"pin"}, Title: "Pin an environment to a version", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: false},
-	"expose":           {Family: "", CLIPath: []string{"expose"}, Title: "Publish a service through the platform edge", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
-	"unexpose":         {Family: "", CLIPath: []string{"unexpose"}, Title: "Withdraw a published service", ReadOnly: false, Destructive: true, Idempotent: true, OpenWorld: true},
-	"terraform":        {Family: "", CLIPath: nil, Title: "Run the environment's Terraform root", ReadOnly: false, Destructive: true, Idempotent: false, OpenWorld: true},
+	// The environment read model composes list/idle/doctor into one resolved
+	// lifecycle state for an orchestrator or a future mobile client polling
+	// this environment -- there is no desktop UI over this specific tool call
+	// to reference, the same shape as ai_sessions above.
+	"environment": {Family: "", CLIPath: nil, Title: "Report the environment read model: list-style summary, resolved lifecycle state, idle status, cloud-context config, and doctor health", ReadOnly: true, Destructive: false, Idempotent: false, OpenWorld: false, AgentFacing: true},
+	"init":        {Family: "", CLIPath: []string{"init"}, Title: "Initialise an environment", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: false},
+	"build":       {Family: "", CLIPath: []string{"build"}, Title: "Build the environment's images", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
+	"push":        {Family: "", CLIPath: []string{"push"}, Title: "Push built images to the registry", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"deploy":      {Family: "", CLIPath: []string{"deploy"}, Title: "Deploy a version into an environment", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"publish":     {Family: "", CLIPath: []string{"publish"}, Title: "Publish charts to the registry", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"upgrade":     {Family: "", CLIPath: []string{"upgrade"}, Title: "Upgrade opted-in environments to the latest version", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
+	"release":     {Family: "", CLIPath: []string{"release"}, Title: "Cut a release and publish its artefacts", ReadOnly: false, Destructive: false, Idempotent: false, OpenWorld: true},
+	"pin":         {Family: "", CLIPath: []string{"pin"}, Title: "Pin an environment to a version", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: false},
+	"expose":      {Family: "", CLIPath: []string{"expose"}, Title: "Publish a service through the platform edge", ReadOnly: false, Destructive: false, Idempotent: true, OpenWorld: true},
+	"unexpose":    {Family: "", CLIPath: []string{"unexpose"}, Title: "Withdraw a published service", ReadOnly: false, Destructive: true, Idempotent: true, OpenWorld: true},
+	"terraform":   {Family: "", CLIPath: nil, Title: "Run the environment's Terraform root", ReadOnly: false, Destructive: true, Idempotent: false, OpenWorld: true},
 	// job_start has no working handler: it is a removed-tool stub (see
 	// mcpRemovedTools) whose only behavior is to name the tool that took over
 	// its capability.

--- a/erun-common/mcp_tools_test.go
+++ b/erun-common/mcp_tools_test.go
@@ -24,18 +24,20 @@ func TestToolNameEqualsItsCLIPath(t *testing.T) {
 }
 
 // TestMCPOnlyToolsAreTheKnownSet pins the tools with no erun command behind
-// them: eleven wire-level primitives the CLI deliberately expresses
-// differently for a human (or, for ai_sessions, exposes only through a
-// Hidden internal command a hook invokes), exec_agent (whose capability the
-// CLI already covers via `erun exec job start --agent`), and job_start (a
-// removed-tool stub with no handler at all, see MCPRemovedTools). Pinning
-// the set makes adding another one a decision rather than an accident.
+// them: wire-level primitives the CLI deliberately expresses differently for
+// a human (or, for ai_sessions and environment, exposes no CLI verb at all --
+// an orchestrator or a future mobile client is the only caller), exec_agent
+// (whose capability the CLI already covers via `erun exec job start
+// --agent`), and job_start (a removed-tool stub with no handler at all, see
+// MCPRemovedTools). Pinning the set makes adding another one a decision
+// rather than an accident.
 func TestMCPOnlyToolsAreTheKnownSet(t *testing.T) {
 	want := map[string]struct{}{
 		"activity_lease_list":          {},
 		"activity_lease_take":          {},
 		"activity_lease_release":       {},
 		"ai_sessions":                  {},
+		"environment":                  {},
 		"idle_stop_history":            {},
 		"idle_stop_record":             {},
 		"idle_stop_cancel":             {},

--- a/erun-docs/docs/mcp/overview.md
+++ b/erun-docs/docs/mcp/overview.md
@@ -140,6 +140,7 @@ MCP groups every tool into a family, carried on the wire as `_meta.family` so a 
 | `usage` | The env's live CPU, memory, and disk usage, read from the runtime container's own cgroup v2 accounting and a statfs of its workspace mount — no metrics-server required, so it works on clusters where `kubectl top` reports unavailable. Memory is reported against the container's own limit with a real OOM-kill count; CPU against its quota over a sample window. A named warning fires when memory, memory's peak, or disk usage cross a fixed threshold. |
 | `doctor` | In-pod health checks (config files, git checkout, SSH keys, docker daemon, workspace PVC). |
 | `list` | Same data as the CLI `erun list`, structured. |
+| `environment` | The environment read model: this environment's `list`-style summary, a resolved lifecycle state (`running`/`idle`/`deploy-failed`/`stopped`/`unknown`), its `idle` status, its cloud-context config, and a `doctor` deploy diagnosis — one call composing what `list`/`idle`/`doctor` already report, rather than three. |
 | `version` | Build version and commit of the MCP server. |
 | `outputs_list` | List the files an agent produced in the pod's outputs directory (`$ERUN_OUTPUTS_DIR`), newest-first. Read-only. |
 | `outputs_download` | Read one entry from the outputs directory and return its bytes inline as base64 (a folder as a `tar.gz`); the server is co-located with the files, so it returns the content directly. On a macOS host an arriving macOS binary carrying no code signature is signed first — the system kills an unsigned one on exec without printing anything — with the host's stable local identity when it has one and ad-hoc otherwise, and the optional `signing: {path, signed, identity, note}` field reports it (`identity` is empty for an ad-hoc signature); a signing failure is reported in `note` and never fails the call. `preview` returns name/type/size without the bytes. |
@@ -372,6 +373,7 @@ Every tool the server can register, one row each, grouped by `_meta.family` and 
 |---|---|---|---|
 | *(top-level)* | `version` | `erun version` | Read |
 | *(top-level)* | `list` | `erun list` | Read |
+| *(top-level)* | `environment` | *(MCP-only)* | Read |
 | *(top-level)* | `init` | `erun init` | Work |
 | *(top-level)* | `build` | `erun build` | Work |
 | *(top-level)* | `push` | `erun push` | Work |
@@ -460,7 +462,7 @@ Every tool the server can register, one row each, grouped by `_meta.family` and 
 | sshd | `sshd_sync` | `erun sshd sync` | Work |
 | contribute | `contribute_clone` | `erun contribute clone` | Work |
 
-76 tools in total. `inputs_upload` and `sshd_sync` are [host-served](#host-served): answered by `erun mcp proxy` on the operator's machine, not relayed to the pod edge.
+77 tools in total. `inputs_upload` and `sshd_sync` are [host-served](#host-served): answered by `erun mcp proxy` on the operator's machine, not relayed to the pod edge.
 
 ## Why typed tools
 
@@ -690,6 +692,35 @@ Same data as the CLI `erun list`, structured. Returns the caller's tenants, envs
       ]
     }
   ]
+}
+```
+
+### `environment`
+
+The environment read model: one call composing what `list`, `idle`, and `doctor` already report into a single resolved answer. `state` is the field the other three cannot give you on their own — `running`, `idle`, `deploy-failed`, `stopped`, or `unknown` — derived from the environment's cloud-context power state (when observed), its deploy health, and its idle-policy eligibility.
+
+`state` is `unknown` whenever a signal it depends on was never observed, rather than a guessed `stopped` or `idle`. This matters most for a managed-cloud environment: its cloud-context power state is a live AWS reading this package never persists to disk, and no AWS credential reaches inside this pod to refresh it — so unless something else already refreshed it in the same process, `cloudContext` carries the environment's cloud-context config with no `status`, and `state` reads `unknown`. Pass `preview: true` to skip the live `helm`/`kubectl` deploy diagnosis (the only part of this call that touches the cluster) and get `health: null` back instead of running it.
+
+```jsonc
+{
+  "tenant": "myapp",
+  "environment": {
+    "name": "local",
+    "type": "local-agent",
+    "runtimeVersion": "1.0.308",
+    "managedCloud": false,
+    "isDefault": true,
+    "isEffective": true
+  },
+  "state": "running",
+  "idle": {
+    "policy": { "timeout": "5m0s", "workingHours": "09:00-19:00" },
+    "stopEligible": false
+  },
+  "health": {
+    "rootConfig": { "configStatus": "ok" },
+    "deploy": { "helmStatus": "STATUS: deployed" }
+  }
 }
 ```
 

--- a/erun-mcp/environment.go
+++ b/erun-mcp/environment.go
@@ -1,0 +1,41 @@
+package erunmcp
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+type EnvironmentInput struct {
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant whose environment should be inspected; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment to inspect; defaults to the server environment context, and must match it: this server only acts on its own environment"`
+	Preview     bool   `json:"preview,omitempty" jsonschema:"when true, skip the live doctor deploy diagnosis (the only part of this call that runs helm/kubectl) and report health as not observed rather than run it"`
+}
+
+// environmentTool is the environment read model's one aggregate call: an
+// environment's list-style summary plus its resolved lifecycle state
+// (running/idle/deploy-failed/stopped/unknown), its idle policy + activity
+// snapshot, its cloud-context config, and a doctor deploy diagnosis -- each
+// reusing the existing list/idle/doctor resolvers rather than
+// re-implementing them. Cloud-context power state is never refreshed live
+// here (that needs the operator's own AWS credentials, which do not reach
+// inside this pod), so a managed-cloud environment reports state "unknown"
+// rather than guessing from a status this package never persists.
+func environmentTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, EnvironmentInput) (*mcp.CallToolResult, eruncommon.EnvironmentReadModel, error) {
+	return func(_ context.Context, _ *mcp.CallToolRequest, input EnvironmentInput) (*mcp.CallToolResult, eruncommon.EnvironmentReadModel, error) {
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, eruncommon.EnvironmentReadModel{}, err
+		}
+		traceOutput := strings.Builder{}
+		ctx := runtimeCallContext(input.Preview, 0, nil, &traceOutput, &traceOutput)
+		model, err := eruncommon.ResolveEnvironmentReadModel(ctx, runtime.Store, tenant, environment, time.Now())
+		if err != nil {
+			return nil, eruncommon.EnvironmentReadModel{}, err
+		}
+		return nil, model, nil
+	}
+}

--- a/erun-mcp/environment_test.go
+++ b/erun-mcp/environment_test.go
@@ -1,0 +1,66 @@
+package erunmcp
+
+import (
+	"context"
+	"testing"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// The environment read model composes list/idle/doctor; what matters here is
+// the transport contract (server-context defaulting, preview skipping the
+// live deploy diagnosis) -- see erun-common's own coverage of
+// ResolveEnvironmentLifecycleState for the state machine itself.
+func TestEnvironmentToolResolvesAgainstServerContext(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"},
+		Store: listToolStore{
+			tenantConfigs: map[string]eruncommon.TenantConfig{"tenant-a": {Name: "tenant-a"}},
+			envConfigs:    map[string]eruncommon.EnvConfig{"tenant-a/dev": {Name: "dev", Type: eruncommon.EnvironmentTypeLocalAgent}},
+		},
+	}
+
+	_, result, err := environmentTool(runtime)(context.Background(), nil, EnvironmentInput{Preview: true})
+	if err != nil {
+		t.Fatalf("resolve environment read model: %v", err)
+	}
+	if result.Tenant != "tenant-a" || result.Environment.Name != "dev" {
+		t.Fatalf("expected the server context to fill the target, got tenant=%q environment=%+v", result.Tenant, result.Environment)
+	}
+	if result.Health != nil {
+		t.Fatalf("preview must skip the live deploy diagnosis, got %+v", result.Health)
+	}
+	if result.State == eruncommon.EnvironmentLifecycleUnknown {
+		t.Fatalf("a resolvable non-managed environment with a real idle read should not report unknown")
+	}
+}
+
+// TestEnvironmentToolManagedCloudWithoutObservedPowerStateReadsUnknown is the
+// mandatory negative case at the transport level: a managed-cloud
+// environment with no matching cloud context configured (so its power state
+// was never, and can never be, observed by this call) must read as unknown,
+// not as stopped or idle.
+func TestEnvironmentToolManagedCloudWithoutObservedPowerStateReadsUnknown(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"},
+		Store: listToolStore{
+			tenantConfigs: map[string]eruncommon.TenantConfig{"tenant-a": {Name: "tenant-a"}},
+			envConfigs: map[string]eruncommon.EnvConfig{
+				"tenant-a/dev": {Name: "dev", Type: eruncommon.EnvironmentTypeRuntime, ManagedCloud: true},
+			},
+		},
+	}
+
+	_, result, err := environmentTool(runtime)(context.Background(), nil, EnvironmentInput{Preview: true})
+	if err != nil {
+		t.Fatalf("resolve environment read model: %v", err)
+	}
+	if result.State != eruncommon.EnvironmentLifecycleUnknown {
+		t.Fatalf("an unobserved managed-cloud power state must read as unknown, got %s", result.State)
+	}
+	if result.State == eruncommon.EnvironmentLifecycleStopped || result.State == eruncommon.EnvironmentLifecycleIdle {
+		t.Fatalf("an unobserved signal must never resolve to a real state; got %s", result.State)
+	}
+}

--- a/erun-mcp/server.go
+++ b/erun-mcp/server.go
@@ -227,6 +227,12 @@ func registerReadModelTools(reg toolRegistrar, info eruncommon.BuildInfo, runtim
 		Name:        "list",
 		Description: "List configured tenants and environments, defaults, and the effective target for the current runtime directory",
 	}, listTool(runtime))
+	addTool(reg, &mcp.Tool{
+		Name: "environment",
+		Description: "Return this environment's read model: its list-style summary (name, type, RuntimeVersion, default/effective markers), a resolved lifecycle state (running, idle, deploy-failed, stopped, or unknown), its idle policy + activity snapshot, its cloud-context config, and a doctor deploy diagnosis -- one call composing list/idle/doctor instead of three. " +
+			"Cloud-context power state is never refreshed live (no AWS credentials reach inside this pod), so a managed-cloud environment's state reads unknown rather than a guess unless something else already refreshed it. " +
+			"Pass preview=true to skip the live helm/kubectl deploy diagnosis.",
+	}, environmentTool(runtime))
 }
 
 func registerIdleStopTools(reg toolRegistrar, runtime RuntimeConfig) {

--- a/erun-mcp/server_test.go
+++ b/erun-mcp/server_test.go
@@ -159,7 +159,7 @@ var wantRegisteredTools = []string{
 	"cloud_init_cloudflare", "cloud_init_erun", "cloud_inject_aws_credentials",
 	"cloud_list", "cloud_login", "cloud_oidc", "cloud_set", "commit",
 	"context_init", "context_list", "context_start", "context_stop",
-	"contribute_clone", "delete", "deploy", "diff", "doctor", "exec_agent", "exec_commit",
+	"contribute_clone", "delete", "deploy", "diff", "doctor", "environment", "exec_agent", "exec_commit",
 	"exec_diff", "exec_gate-merge", "exec_job_attach", "exec_job_await", "exec_job_cancel", "exec_job_output", "exec_job_status",
 	"exec_merge", "exec_push", "exec_raw", "exec_write", "expose", "idle", "idle_stop_cancel",
 	"idle_stop_history", "idle_stop_record", "init", "job_attach", "job_await",


### PR DESCRIPTION
## Summary

The other half of #1105 (iOS companion Phase 1) that #1627 explicitly left undone: the "environment read model" — a transport-neutral read model in `erun-common`, exposed over the same authenticated per-environment MCP edge `idle`/`doctor`/`ai_sessions` already ride.

- `erun-common/environment_read_model.go`:
  - `EnvironmentLifecycleState` (`running`/`idle`/`deploy-failed`/`stopped`/`unknown`) resolved by `ResolveEnvironmentLifecycleState`, a pure function over `EnvironmentLifecycleInputs`. Every signal that can fail to be observed (cloud-context power state, deploy health, idle status) carries its own explicit `Observed` bit, so an environment whose state could not be determined reports `unknown` rather than a defaulted `stopped`/`idle`/`running`.
  - `EnvironmentHealth` composes the doctor pieces that already exist (`RootConfigInspection`, `DeployDiagnosisResult`, `RecommendedDeployRecovery`) into one health view.
  - `EnvironmentReadModel` + `AssembleEnvironmentReadModel` (pure composer) + `ResolveEnvironmentReadModel` (the one impure entrypoint) tie it together: an environment's `list`-style summary, its `idle` status, its cloud-context config, and its doctor health, all reused as-is.
  - `ResolveEnvironmentDetail` is new but thin: it's `ResolveListResult`'s per-environment computation, run for one named tenant/environment instead of every environment in every tenant.
- `erun-mcp/environment.go`: a new read-only `environment` MCP tool, scoped to the server's own environment (same `resolveLocalTarget` restriction as `idle`/`doctor`/`ai_sessions`). `preview: true` skips the only live call this makes (`RunDeployDiagnosis`'s helm/kubectl probe).
- Docs: `erun-docs/docs/mcp/overview.md` gains the tool's index rows (Inspection table + Full tool index) and a structured schema section, following #1627's precedent for `ai_sessions`.

### What was reused vs. written

Reused unmodified: `ResolveListResult`'s per-environment assembly (via the new `ResolveEnvironmentDetail`, which calls the same private `listEnvironmentResult` helper), `ResolveStoredEnvironmentIdleStatus`, `RunDeployDiagnosis`, `RecommendedDeployRecovery`, `InspectRootConfig`, `findCloudContextForKubernetesContext`. No live AWS refresh was added — a managed-cloud environment's cloud-context `Status` field is never persisted to disk (see `CloudContextStatus`'s own doc comment) and no AWS credential reaches inside a pod, so this tool reports `unknown` for that signal by default rather than performing a new kind of live probe.

Written: the lifecycle-state resolver, the health/read-model composition types, the new MCP tool, and `ResolveEnvironmentDetail`.

### How "could not be determined" is represented

`EnvironmentLifecycleInputs` pairs every fallible signal with an explicit `*Observed bool` (`CloudContextObserved`, `DeployHealthObserved`, `IdleStatusObserved`). `ResolveEnvironmentLifecycleState` never treats an unset bool as a negative reading — a managed-cloud environment with no live cloud-context refresh returns `unknown`, not `stopped`; a call with nothing observed at all (no idle read, no deploy diagnosis, not managed-cloud) also returns `unknown`, not `running`.

### Tests

- `erun-common/environment_read_model_test.go`: `TestResolveEnvironmentLifecycleStateUnknownIsNotAFalseNegative` is the mandatory negative case — table-driven over "no cloud-context observation", "pending power state", "explicitly unknown power state", and "nothing observed at all (non-managed)" — asserting `unknown` and explicitly asserting it is never `stopped` or `idle`. Plus tests for the managed-cloud running/stopped split, deploy-failed priority over idle, and the assembler's nil-signal handling.
- `erun-mcp/environment_test.go`: `TestEnvironmentToolManagedCloudWithoutObservedPowerStateReadsUnknown` pins the same property at the transport layer (a managed-cloud environment with no matching cloud context configured reads `unknown`, never `stopped`/`idle`).

### What remains (per #1105's own scope split)

- All Swift/Xcode/mobile-client work (this environment cannot build it; out of scope for both server-side halves).
- The structured AI-session status model (#1627, already landed).
- #1106's session gateway — the plumbing that lets a phone actually reach this MCP edge remotely. This PR only adds the contract types and their read-only exposure over the edge that already exists.

Not adding `Closes #1105` — the issue keeps its mobile-client scope, which this PR does not touch.

## Test plan

- [x] `erun-common`: `go test ./...` green, including the mandatory negative-case test above.
- [x] `erun-mcp`: `go test ./...` green, including the new tool's transport-contract tests and the updated `TestHTTPHandlerExposesVersionTool`/`TestMCPOverviewDocumentsEveryTool` goldens.
- [x] `make check`: green end-to-end — lint (all modules), `erun-ui` tests, frontend gates (erun-kit/erun-console: tsc, eslint, prettier, vite build, vitest), devops chart tests, and `erun-integration` (coverage 76.0% ≥ 75.8% threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)