### PR TITLE
Contend the release claim on the repository, not the environment

### DIFF
--- a/erun-common/release_claim.go
+++ b/erun-common/release_claim.go
@@ -83,11 +83,15 @@ func releaseVersionClaimRefusalError(version string, err error) error {
 		strings.TrimSpace(version), conflict.Holder.Holder.String())
 }
 
-// claimReleaseVersion takes the exclusive lease that stands in for "I am
-// releasing this version", before sync-remote does anything the loser of a
-// race would have to unwind. It returns a release func to defer, which stops
-// renewing and drops the claim; call it whether the release succeeds or
-// fails.
+// claimReleaseVersion takes both claims that stand in for "I am releasing
+// this version" — the local exclusive lease (environment-scoped: keeps this
+// environment from idling out mid-release and is visible to `erun` lease
+// listings) and the repository-global claim on a remote ref (release_repo_claim.go:
+// the one that actually stops two orchestrators driving different
+// environments from racing the same version) — before sync-remote does
+// anything the loser of a race would have to unwind. It returns a release
+// func to defer, which stops renewing and drops both claims; call it whether
+// the release succeeds or fails.
 //
 // The claim only applies inside a runtime pod: injectedRuntimePodIdentity
 // resolves ERUN_TENANT/ERUN_ENVIRONMENT, which only the runtime chart sets.
@@ -104,9 +108,17 @@ func claimReleaseVersion(ctx Context, spec ReleaseSpec, env func(string) string)
 		return func() {}, nil
 	}
 
-	holder := EnvironmentActivityLeaseHolder{Orchestrator: strings.TrimSpace(env("ERUN_ORCHESTRATOR_ID"))}
+	holder := EnvironmentActivityLeaseHolder{Orchestrator: strings.TrimSpace(env("ERUN_ORCHESTRATOR_ID")), Tenant: tenant}
 	pid := os.Getpid()
+
+	repoSHA, err := takeReleaseRepoClaim(ctx, spec.ProjectRoot, spec.Version, holder, pid, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	repo := &releaseRepoClaimHandle{sha: repoSHA}
+
 	if _, err := takeReleaseVersionClaim(tenant, environment, spec.Version, holder, pid, time.Time{}); err != nil {
+		releaseRepoClaimIfHeld(ctx, spec, repo)
 		return nil, releaseVersionClaimRefusalError(spec.Version, err)
 	}
 
@@ -122,7 +134,7 @@ func claimReleaseVersion(ctx Context, spec ReleaseSpec, env func(string) string)
 			case <-stop:
 				return
 			case <-ticker.C:
-				_, _ = takeReleaseVersionClaim(tenant, environment, spec.Version, holder, pid, time.Time{})
+				renewReleaseClaims(ctx, spec, tenant, environment, holder, pid, repo)
 			}
 		}
 	}()
@@ -133,5 +145,50 @@ func claimReleaseVersion(ctx Context, spec ReleaseSpec, env func(string) string)
 		close(stop)
 		stopped.Wait()
 		_ = ReleaseExclusiveEnvironmentActivityLease(tenant, environment, scope, id)
+		releaseRepoClaimIfHeld(ctx, spec, repo)
 	}, nil
+}
+
+// releaseRepoClaimHandle tracks the repository-global claim's current sha
+// across the renewal goroutine and the release func's cleanup, both of which
+// run concurrently with each other for the whole life of the release.
+type releaseRepoClaimHandle struct {
+	mu  sync.Mutex
+	sha string
+}
+
+func (h *releaseRepoClaimHandle) get() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.sha
+}
+
+func (h *releaseRepoClaimHandle) set(sha string) {
+	h.mu.Lock()
+	h.sha = sha
+	h.mu.Unlock()
+}
+
+// renewReleaseClaims is one renewal tick for both claims. The repository
+// claim is best-effort, matching the local lease's own renewal: a failed
+// renewal keeps the last-known sha and tries again next tick rather than
+// tearing down a release over a transient push failure.
+func renewReleaseClaims(ctx Context, spec ReleaseSpec, tenant, environment string, holder EnvironmentActivityLeaseHolder, pid int, repo *releaseRepoClaimHandle) {
+	_, _ = takeReleaseVersionClaim(tenant, environment, spec.Version, holder, pid, time.Time{})
+
+	sha := repo.get()
+	if sha == "" {
+		return
+	}
+	if renewed, err := renewReleaseRepoClaim(ctx, spec.ProjectRoot, spec.Version, holder, pid, time.Now(), sha); err == nil {
+		repo.set(renewed)
+	}
+}
+
+// releaseRepoClaimIfHeld drops the repository-global claim if this run ever
+// actually took one (an inconclusive remote read leaves repo holding "").
+func releaseRepoClaimIfHeld(ctx Context, spec ReleaseSpec, repo *releaseRepoClaimHandle) {
+	if sha := repo.get(); sha != "" {
+		_ = deleteReleaseRepoClaim(ctx, spec.ProjectRoot, spec.Version, sha)
+	}
 }

--- a/erun-common/release_remote.go
+++ b/erun-common/release_remote.go
@@ -1,8 +1,10 @@
 package eruncommon
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -128,16 +130,138 @@ func runReleaseBranchPush(ctx Context, spec ReleaseSpec, command ReleaseCommandS
 			return fmt.Errorf("%w\nrebasing onto origin/%s to absorb the move failed: %v\nversion %s is already published, so rebase the release's own commits onto origin/%s by hand and push them",
 				err, branch, rebaseErr, spec.Version, branch)
 		}
+		if repointErr := repointReleaseTagIfRebased(ctx, spec, command.Dir, runGit); repointErr != nil {
+			return fmt.Errorf("%w\nrebasing onto origin/%s absorbed the move, but re-pointing the already-published release tag failed: %v\nversion %s is already published, so move tag v%s onto the rebased release commit by hand and force-push it",
+				err, branch, repointErr, spec.Version, spec.Version)
+		}
 		err = runGit(command.Dir, ctx.Stdout, ctx.Stderr, releaseBranchPushArgs(spec, command)...)
 	}
 	return err
 }
 
-// releaseBranchPushArgs is the retried push. A rebase rewrites the commit the
-// release tag points at, so --follow-tags no longer considers the tag reachable
-// and would silently leave it behind. The tag object still names the version that
-// is already published, so the retry pushes it by name; a tag origin already has
-// makes that a no-op.
+// repointReleaseTagIfRebased brings the release's own annotated tag back onto
+// the branch's history after a rebase rewrote the commit it named. A rebase
+// replays every commit from the release's own fork point forward, including
+// the one push-release-tag already published the tag under, so an already-public
+// tag can end up naming a commit reachable from nothing once that commit is
+// replayed under a new sha. The remote already holds the tag at the old
+// commit, and an annotated tag update is never a fast-forward, so bringing it
+// back onto the branch always needs a force.
+func repointReleaseTagIfRebased(ctx Context, spec ReleaseSpec, projectRoot string, runGit GitCommandRunnerFunc) error {
+	version := strings.TrimSpace(spec.Version)
+	if version == "" {
+		return nil
+	}
+	tag := "v" + version
+
+	tagCommit, ok, err := gitResolvedRef(ctx, projectRoot, tag+"^{commit}")
+	if err != nil || !ok {
+		return nil
+	}
+	ancestor, err := gitIsAncestorOfHead(projectRoot, tagCommit)
+	if err != nil || ancestor {
+		return err
+	}
+
+	newCommit, err := findReplayedReleaseTagCommit(projectRoot, spec.Branch, tag, tagCommit)
+	if err != nil {
+		return err
+	}
+	return moveReleaseTagOnto(ctx, projectRoot, runGit, tag, newCommit)
+}
+
+// findReplayedReleaseTagCommit locates the commit a rebase gave the release's
+// own tagged commit under its new sha, by the message the two must share
+// (see findCommitBySubjectReachableFromHead).
+func findReplayedReleaseTagCommit(projectRoot, branch, tag, tagCommit string) (string, error) {
+	subject, err := gitCommitSubject(projectRoot, tagCommit)
+	if err != nil {
+		return "", err
+	}
+	newCommit, found, err := findCommitBySubjectReachableFromHead(projectRoot, subject)
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", fmt.Errorf("tag %q named a commit the rebase rewrote, but no commit with its original message %q could be found on %s; move the tag onto the right commit by hand and push it",
+			tag, subject, branch)
+	}
+	return newCommit, nil
+}
+
+// moveReleaseTagOnto re-creates tag at newCommit, preserving its original
+// annotation message, and force-publishes it: the remote already has this
+// tag at the pre-rebase commit, and an annotated tag update is never a
+// fast-forward.
+func moveReleaseTagOnto(ctx Context, projectRoot string, runGit GitCommandRunnerFunc, tag, newCommit string) error {
+	message, err := gitTagAnnotationSubject(projectRoot, tag)
+	if err != nil {
+		return err
+	}
+	ctx.Info(fmt.Sprintf("release: rebase moved the commit tag %s named; re-pointing it onto %s and force-pushing", tag, newCommit))
+	ctx.TraceCommand(projectRoot, "git", "tag", "-f", "-a", tag, newCommit, "-m", message)
+	if err := runGit(projectRoot, ctx.Stdout, ctx.Stderr, "tag", "-f", "-a", tag, newCommit, "-m", message); err != nil {
+		return err
+	}
+	ctx.TraceCommand(projectRoot, "git", "push", "--force", "origin", "refs/tags/"+tag)
+	return runGit(projectRoot, ctx.Stdout, ctx.Stderr, "push", "--force", "origin", "refs/tags/"+tag)
+}
+
+// gitIsAncestorOfHead reports whether commit is already part of HEAD's own
+// history — true for a tag a rebase left untouched (it named a commit at or
+// before the merge-base, which every rebase leaves alone), false once the
+// commit it used to name was replayed under a new sha.
+func gitIsAncestorOfHead(projectRoot, commit string) (bool, error) {
+	err := Command("git", "-C", projectRoot, "merge-base", "--is-ancestor", commit, "HEAD").Run()
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+func gitCommitSubject(projectRoot, commit string) (string, error) {
+	output, err := Command("git", "-C", projectRoot, "show", "-s", "--format=%s", commit).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// findCommitBySubjectReachableFromHead re-locates the release's own commit
+// after a rebase gave it a new sha. A rebase replays commits in order without
+// changing their message, and the release's generated commit subjects always
+// carry the version being released, so the exact subject the tag's old
+// commit had is unique enough to find its replayed successor.
+func findCommitBySubjectReachableFromHead(projectRoot, subject string) (string, bool, error) {
+	output, err := Command("git", "-C", projectRoot, "log", "--format=%H%x01%s", "HEAD").Output()
+	if err != nil {
+		return "", false, err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(output), "\n"), "\n") {
+		hash, lineSubject, ok := strings.Cut(line, "\x01")
+		if ok && lineSubject == subject {
+			return hash, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func gitTagAnnotationSubject(projectRoot, tag string) (string, error) {
+	output, err := Command("git", "-C", projectRoot, "for-each-ref", "--format=%(contents:subject)", "refs/tags/"+tag).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// releaseBranchPushArgs is the retried push. repointReleaseTagIfRebased has
+// already re-pointed and force-pushed the release tag by the time this runs
+// if the rebase moved it, so appending the tag by name here only matters when
+// the tag never needed to move — a no-op against what origin already has.
 func releaseBranchPushArgs(spec ReleaseSpec, command ReleaseCommandSpec) []string {
 	version := strings.TrimSpace(spec.Version)
 	if version == "" {

--- a/erun-common/release_remote.go
+++ b/erun-common/release_remote.go
@@ -171,22 +171,31 @@ func repointReleaseTagIfRebased(ctx Context, spec ReleaseSpec, projectRoot strin
 }
 
 // findReplayedReleaseTagCommit locates the commit a rebase gave the release's
-// own tagged commit under its new sha, by the message the two must share
-// (see findCommitBySubjectReachableFromHead).
+// own tagged commit under its new sha, by the message the two must share (see
+// findCommitsBySubjectInRange). The search is bounded to FETCH_HEAD..HEAD —
+// the commits the rebase moments earlier in rebaseReleaseOntoRemoteBranch
+// actually replayed onto the upstream it just fetched — rather than all of
+// history, so an unrelated older commit that happens to share the subject can
+// never be mistaken for the replayed one.
 func findReplayedReleaseTagCommit(projectRoot, branch, tag, tagCommit string) (string, error) {
 	subject, err := gitCommitSubject(projectRoot, tagCommit)
 	if err != nil {
 		return "", err
 	}
-	newCommit, found, err := findCommitBySubjectReachableFromHead(projectRoot, subject)
+	matches, err := findCommitsBySubjectInRange(projectRoot, "FETCH_HEAD..HEAD", subject)
 	if err != nil {
 		return "", err
 	}
-	if !found {
+	switch len(matches) {
+	case 0:
 		return "", fmt.Errorf("tag %q named a commit the rebase rewrote, but no commit with its original message %q could be found on %s; move the tag onto the right commit by hand and push it",
 			tag, subject, branch)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("tag %q named a commit the rebase rewrote, but %d commits with its original message %q were found on %s; move the tag onto the right commit by hand and push it",
+			tag, len(matches), subject, branch)
 	}
-	return newCommit, nil
 }
 
 // moveReleaseTagOnto re-creates tag at newCommit, preserving its original
@@ -231,23 +240,25 @@ func gitCommitSubject(projectRoot, commit string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// findCommitBySubjectReachableFromHead re-locates the release's own commit
-// after a rebase gave it a new sha. A rebase replays commits in order without
+// findCommitsBySubjectInRange returns every commit in revRange whose subject
+// is an exact match, newest first. A rebase replays commits in order without
 // changing their message, and the release's generated commit subjects always
-// carry the version being released, so the exact subject the tag's old
-// commit had is unique enough to find its replayed successor.
-func findCommitBySubjectReachableFromHead(projectRoot, subject string) (string, bool, error) {
-	output, err := Command("git", "-C", projectRoot, "log", "--format=%H%x01%s", "HEAD").Output()
+// carry the version being released, so the subject is normally unique within
+// the commits a rebase just replayed — but the caller decides what to do with
+// more than one match rather than this function silently picking one.
+func findCommitsBySubjectInRange(projectRoot, revRange, subject string) ([]string, error) {
+	output, err := Command("git", "-C", projectRoot, "log", "--format=%H%x01%s", revRange).Output()
 	if err != nil {
-		return "", false, err
+		return nil, err
 	}
+	var matches []string
 	for _, line := range strings.Split(strings.TrimRight(string(output), "\n"), "\n") {
 		hash, lineSubject, ok := strings.Cut(line, "\x01")
 		if ok && lineSubject == subject {
-			return hash, true, nil
+			matches = append(matches, hash)
 		}
 	}
-	return "", false, nil
+	return matches, nil
 }
 
 func gitTagAnnotationSubject(projectRoot, tag string) (string, error) {

--- a/erun-common/release_repo_claim.go
+++ b/erun-common/release_repo_claim.go
@@ -1,0 +1,236 @@
+package eruncommon
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// The exclusive activity lease release_claim.go added scopes its claim to one
+// environment's own on-disk store, so two orchestrators driving different
+// environments take their claims in different scopes and are structurally
+// invisible to each other — the collision that actually happens in
+// production, since a release can run from any environment. The resource
+// genuinely being contended is the repository itself: one VERSION, one tag
+// namespace, one main. This file adds a second, repository-global claim on a
+// remote git ref, which every orchestrator that can push to the release's
+// origin can see and contend on, with no shared store beyond the repository
+// they are already racing to change.
+//
+// A plain `git push <object>:<ref>` for a ref that does not yet exist is
+// git's own compare-and-swap: the client claims the ref currently has no
+// value, and the server rejects the update the instant somebody else's push
+// already gave it one — the same atomicity O_CREATE|O_EXCL gives the local
+// exclusive lease's file create. `--force-with-lease=<ref>:<expected>` gives
+// the identical compare-and-swap for a renewal or a reclaim, so a stale
+// holder can never be overwritten by a caller racing another live one.
+const (
+	// releaseRepoClaimRemote is the remote every release publishes through,
+	// so it is the one namespace every orchestrator racing this repository
+	// can actually reach.
+	releaseRepoClaimRemote = "origin"
+	// releaseRepoClaimRefPrefix namespaces the claim refs away from tags and
+	// branches a human would create.
+	releaseRepoClaimRefPrefix = "refs/erun/release-claim/"
+	// releaseRepoClaimProbeRefPrefix is a throwaway local ref used only to
+	// read a remote claim's content without writing FETCH_HEAD, which the
+	// release's own git commands (running concurrently with this claim's
+	// renewal ticker, in the same checkout) read and rely on.
+	releaseRepoClaimProbeRefPrefix = "refs/erun/_release-claim-probe/"
+	// releaseRepoClaimMaxAttempts bounds the retry when a create or a reclaim
+	// loses a race: one retry re-reads and reacts to whoever just won.
+	releaseRepoClaimMaxAttempts = 3
+)
+
+// releaseRepoClaimRecord is the JSON stored in the claim ref's blob.
+type releaseRepoClaimRecord struct {
+	Holder    EnvironmentActivityLeaseHolder `json:"holder"`
+	PID       int                            `json:"pid,omitempty"`
+	StartedAt time.Time                      `json:"startedAt"`
+	ExpiresAt time.Time                      `json:"expiresAt"`
+}
+
+// ReleaseRepoClaimConflictError names the still-live holder of the
+// repository-global claim, in the same wording the local lease's refusal
+// uses, so a second orchestrator sees one consistent message regardless of
+// which of the two claims refused it.
+type ReleaseRepoClaimConflictError struct {
+	Version   string
+	Holder    EnvironmentActivityLeaseHolder
+	ExpiresAt time.Time
+}
+
+func (e *ReleaseRepoClaimConflictError) Error() string {
+	return fmt.Sprintf("%s is already being released by %s — wait for it to finish; a holder that crashes or whose pod is replaced is reclaimed automatically on the next attempt",
+		strings.TrimSpace(e.Version), e.Holder.String())
+}
+
+func releaseRepoClaimRef(version string) string {
+	return releaseRepoClaimRefPrefix + sanitizeForFilename(strings.TrimSpace(version))
+}
+
+func releaseRepoClaimProbeRef(version string) string {
+	return releaseRepoClaimProbeRefPrefix + sanitizeForFilename(strings.TrimSpace(version))
+}
+
+// takeReleaseRepoClaim resolves the remote claim ref's current state and
+// either creates it, reclaims it from an expired holder, or refuses in favor
+// of a still-live one. An empty sha with a nil error means the remote could
+// not be read at all (no network, no origin, no push access) — indistinguishable
+// from a solo caller with nothing to contend against, so it is treated the
+// same way: proceed without the repository-global claim rather than invent a
+// refusal nothing confirms.
+func takeReleaseRepoClaim(ctx Context, projectRoot, version string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time) (string, error) {
+	ref := releaseRepoClaimRef(version)
+
+	for attempt := 0; attempt < releaseRepoClaimMaxAttempts; attempt++ {
+		existingSHA, exists, err := gitLsRemoteRef(ctx, projectRoot, releaseRepoClaimRemote, ref)
+		if err != nil {
+			ctx.Trace("release: could not read " + ref + " on " + releaseRepoClaimRemote + "; proceeding without the repository-global release claim")
+			return "", nil
+		}
+
+		if !exists {
+			newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, holder, pid, now)
+			if err != nil {
+				return "", err
+			}
+			if err := gitPushCreateRef(ctx, projectRoot, releaseRepoClaimRemote, newSHA, ref); err == nil {
+				return newSHA, nil
+			}
+			continue // somebody else's create landed first; loop and re-read who holds it.
+		}
+
+		record, err := loadReleaseRepoClaimRecord(ctx, projectRoot, releaseRepoClaimRemote, ref, version)
+		if err != nil {
+			return "", fmt.Errorf("release: %s exists on %s but its content could not be read: %w", ref, releaseRepoClaimRemote, err)
+		}
+		if releaseRepoClaimHeld(record, now) {
+			return "", &ReleaseRepoClaimConflictError{Version: version, Holder: record.Holder, ExpiresAt: record.ExpiresAt}
+		}
+
+		newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, holder, pid, now)
+		if err != nil {
+			return "", err
+		}
+		if err := gitPushUpdateRefWithLease(ctx, projectRoot, releaseRepoClaimRemote, newSHA, ref, existingSHA); err == nil {
+			return newSHA, nil
+		}
+		// somebody else's reclaim (or fresh claim) landed first; loop and re-read.
+	}
+	return "", fmt.Errorf("release: could not take the repository-global claim for %s: contended", version)
+}
+
+// renewReleaseRepoClaim extends the caller's own claim, compare-and-swapping
+// against the sha it last wrote so a claim that was reclaimed out from under
+// it (its own renewal having lapsed past the TTL) is never silently
+// overwritten. A failure here is best-effort, matching the local lease's
+// renewal: the caller keeps its last-known sha and tries again next tick.
+func renewReleaseRepoClaim(ctx Context, projectRoot, version string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time, currentSHA string) (string, error) {
+	newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, holder, pid, now)
+	if err != nil {
+		return "", err
+	}
+	ref := releaseRepoClaimRef(version)
+	if err := gitPushUpdateRefWithLease(ctx, projectRoot, releaseRepoClaimRemote, newSHA, ref, currentSHA); err != nil {
+		return "", err
+	}
+	return newSHA, nil
+}
+
+// deleteReleaseRepoClaim drops the caller's own claim so the next release
+// does not have to wait out the TTL. Idempotent by construction: the
+// force-with-lease only removes the ref if it still holds the caller's own
+// sha, so a claim already reclaimed by someone else (this caller's TTL having
+// lapsed) is left alone rather than deleting a legitimate new holder.
+func deleteReleaseRepoClaim(ctx Context, projectRoot, version, currentSHA string) error {
+	ref := releaseRepoClaimRef(version)
+	lease := fmt.Sprintf("--force-with-lease=%s:%s", ref, currentSHA)
+	ctx.TraceCommand(projectRoot, "git", "push", lease, releaseRepoClaimRemote, "--delete", ref)
+	return Command("git", "-C", projectRoot, "push", lease, releaseRepoClaimRemote, "--delete", ref).Run()
+}
+
+func releaseRepoClaimHeld(record releaseRepoClaimRecord, now time.Time) bool {
+	return !record.ExpiresAt.IsZero() && now.Before(record.ExpiresAt)
+}
+
+func writeReleaseRepoClaimBlob(ctx Context, projectRoot string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time) (string, error) {
+	record := releaseRepoClaimRecord{
+		Holder:    holder,
+		PID:       pid,
+		StartedAt: now,
+		ExpiresAt: now.Add(releaseVersionClaimTTL),
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return "", err
+	}
+	ctx.TraceCommand(projectRoot, "git", "hash-object", "-w", "--stdin")
+	cmd := Command("git", "-C", projectRoot, "hash-object", "-w", "--stdin")
+	cmd.Stdin = strings.NewReader(string(data))
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// gitLsRemoteRef reads a single ref's current sha directly from the remote,
+// with no local repo state written — safe to call while the release's own
+// git commands run concurrently in the same checkout. ok is false both when
+// the ref does not exist and when the read failed outright; the caller tells
+// these apart via err.
+func gitLsRemoteRef(ctx Context, projectRoot, remote, ref string) (sha string, ok bool, err error) {
+	ctx.TraceCommand(projectRoot, "git", "ls-remote", remote, ref)
+	output, err := Command("git", "-C", projectRoot, "ls-remote", remote, ref).Output()
+	if err != nil {
+		return "", false, err
+	}
+	line := strings.TrimSpace(string(output))
+	if line == "" {
+		return "", false, nil
+	}
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return "", false, nil
+	}
+	return fields[0], true, nil
+}
+
+// loadReleaseRepoClaimRecord fetches ref's current object into a throwaway
+// local probe ref (never FETCH_HEAD — see releaseRepoClaimProbeRefPrefix)
+// and reads its content back, cleaning up the probe ref afterward regardless
+// of outcome.
+func loadReleaseRepoClaimRecord(ctx Context, projectRoot, remote, ref, version string) (releaseRepoClaimRecord, error) {
+	probe := releaseRepoClaimProbeRef(version)
+	defer func() {
+		_ = Command("git", "-C", projectRoot, "update-ref", "-d", probe).Run()
+	}()
+
+	fetchSpec := "+" + ref + ":" + probe
+	ctx.TraceCommand(projectRoot, "git", "fetch", "--no-write-fetch-head", remote, fetchSpec)
+	if err := Command("git", "-C", projectRoot, "fetch", "--no-write-fetch-head", remote, fetchSpec).Run(); err != nil {
+		return releaseRepoClaimRecord{}, err
+	}
+	output, err := Command("git", "-C", projectRoot, "cat-file", "-p", probe).Output()
+	if err != nil {
+		return releaseRepoClaimRecord{}, err
+	}
+	var record releaseRepoClaimRecord
+	if err := json.Unmarshal(output, &record); err != nil {
+		return releaseRepoClaimRecord{}, err
+	}
+	return record, nil
+}
+
+func gitPushCreateRef(ctx Context, projectRoot, remote, sha, ref string) error {
+	ctx.TraceCommand(projectRoot, "git", "push", remote, sha+":"+ref)
+	return Command("git", "-C", projectRoot, "push", remote, sha+":"+ref).Run()
+}
+
+func gitPushUpdateRefWithLease(ctx Context, projectRoot, remote, sha, ref, expectedSHA string) error {
+	lease := fmt.Sprintf("--force-with-lease=%s:%s", ref, expectedSHA)
+	ctx.TraceCommand(projectRoot, "git", "push", lease, remote, sha+":"+ref)
+	return Command("git", "-C", projectRoot, "push", lease, remote, sha+":"+ref).Run()
+}

--- a/erun-common/release_repo_claim_test.go
+++ b/erun-common/release_repo_claim_test.go
@@ -1,0 +1,171 @@
+package eruncommon
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The environment-scoped exclusive lease in release_claim_test.go passed
+// while two orchestrators driving different environments still raced the
+// same release, because its scope lived in each environment's own store.
+// These tests exercise the repository-global claim directly against a real
+// git remote, from two separate checkouts, so a scope mistake shows up the
+// same way it did in production instead of passing by construction.
+
+func newTestClaimContext() Context {
+	return Context{Logger: NewLoggerWithWriters(0, io.Discard, io.Discard)}
+}
+
+// cloneRepoForTest gives a second independent checkout of remote, standing in
+// for a second environment's own worktree of the same repository.
+func cloneRepoForTest(t *testing.T, remote string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitForTest(t, filepath.Dir(dir), "clone", "-q", remote, dir)
+	runGitForTest(t, dir, "config", "user.email", "test@example.com")
+	runGitForTest(t, dir, "config", "user.name", "Test")
+	// The bare remote's own HEAD symref still names whatever
+	// init.defaultBranch produced, not "main", so a fresh clone checks out
+	// nothing; check out the branch this suite actually pushes explicitly.
+	runGitForTest(t, dir, "checkout", "-q", "-b", "main", "--track", "origin/main")
+	return dir
+}
+
+func TestReleaseRepoClaimRefusesASecondReleaseFromADifferentCheckoutAndNamesTheHolder(t *testing.T) {
+	envA := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, envA)
+	runGitForTest(t, envA, "push", "-q", "-u", "origin", "main")
+	envB := cloneRepoForTest(t, remote)
+
+	now := time.Date(2026, 8, 29, 17, 0, 53, 0, time.UTC)
+	ctx := newTestClaimContext()
+
+	holderA := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a", Tenant: "erun"}
+	sha, err := takeReleaseRepoClaim(ctx, envA, "1.0.213", holderA, os.Getpid(), now)
+	if err != nil {
+		t.Fatalf("first environment's claim: %v", err)
+	}
+	if sha == "" {
+		t.Fatalf("expected a real repository claim, got an inconclusive no-op")
+	}
+
+	holderB := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b", Tenant: "erun"}
+	_, err = takeReleaseRepoClaim(ctx, envB, "1.0.213", holderB, os.Getpid()+1, now.Add(time.Second))
+	if err == nil {
+		t.Fatal("expected a second release of the same version from a different checkout to be refused")
+	}
+	if !strings.Contains(err.Error(), "1.0.213") {
+		t.Errorf("refusal must name the version, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "orchestrator-a") {
+		t.Errorf("refusal must name the holder so the second environment knows who to wait on, got: %v", err)
+	}
+
+	// A release of a different version must not be affected: the claim is
+	// scoped to the version's own ref, not the whole repository.
+	if _, err := takeReleaseRepoClaim(ctx, envB, "1.0.214", holderB, os.Getpid()+1, now.Add(time.Second)); err != nil {
+		t.Fatalf("a release of a different version must not collide with an unrelated one in flight: %v", err)
+	}
+}
+
+func TestReleaseRepoClaimReclaimsAnAbandonedReleaseFromADifferentCheckout(t *testing.T) {
+	envA := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, envA)
+	runGitForTest(t, envA, "push", "-q", "-u", "origin", "main")
+	envB := cloneRepoForTest(t, remote)
+
+	start := time.Date(2026, 8, 29, 17, 0, 53, 0, time.UTC)
+	ctx := newTestClaimContext()
+
+	holderA := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a", Tenant: "erun"}
+	if _, err := takeReleaseRepoClaim(ctx, envA, "1.0.213", holderA, os.Getpid(), start); err != nil {
+		t.Fatalf("first environment's claim: %v", err)
+	}
+
+	// envA crashed (or its pod was replaced) and never renewed or deleted its
+	// claim. Nobody outside envA can remove the ref by hand, so the only way
+	// envB's release ever proceeds is if the claim reclaims itself once it
+	// lapses.
+	afterLapse := start.Add(releaseVersionClaimTTL + time.Minute)
+	holderB := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b", Tenant: "erun"}
+	sha, err := takeReleaseRepoClaim(ctx, envB, "1.0.213", holderB, os.Getpid()+1, afterLapse)
+	if err != nil {
+		t.Fatalf("expected the abandoned claim to be reclaimed automatically, got refused: %v", err)
+	}
+	if sha == "" {
+		t.Fatalf("expected a real repository claim, got an inconclusive no-op")
+	}
+
+	remoteSHA, exists, err := gitLsRemoteRef(ctx, envB, releaseRepoClaimRemote, releaseRepoClaimRef("1.0.213"))
+	if err != nil || !exists {
+		t.Fatalf("expected the reclaimed ref to be published, exists=%v err=%v", exists, err)
+	}
+	if remoteSHA != sha {
+		t.Fatalf("remote claim ref = %s, want the reclaiming holder's sha %s", remoteSHA, sha)
+	}
+}
+
+// TestReleaseBranchPushRebaseKeepsTheReleaseTagOnTheTargetBranch reproduces
+// the second defect from the same run: the branch push absorbs a moved base
+// branch by rebasing and retrying, but the release tag was already published
+// under the pre-rebase commit. Left unfixed, the tag names a commit reachable
+// from nothing once the rebase replays it under a new sha.
+func TestReleaseBranchPushRebaseKeepsTheReleaseTagOnTheTargetBranch(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "main")
+
+	// The release's own commit and its already-published tag, as they exist
+	// once ensureReleaseReadyToPublish has passed and push-release-tag has run.
+	if err := os.WriteFile(filepath.Join(repo, "VERSION"), []byte("1.0.213\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	runGitForTest(t, repo, "add", "VERSION")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] release 1.0.213")
+	runGitForTest(t, repo, "tag", "-a", "v1.0.213", "-m", "Release 1.0.213")
+	runGitForTest(t, repo, "push", "-q", "origin", "v1.0.213")
+
+	// An unrelated commit lands on origin/main while this release is still
+	// running, so this checkout's eventual push is rejected. It touches a
+	// different file than the release's own commits, the same way an
+	// unrelated mainline change would in production — the rebase this test
+	// exercises is about any base-branch move, not specifically a race
+	// between two releases of the same version.
+	other := cloneRepoForTest(t, remote)
+	if err := os.WriteFile(filepath.Join(other, "OTHER.txt"), []byte("unrelated change\n"), 0o644); err != nil {
+		t.Fatalf("write unrelated file in the other checkout: %v", err)
+	}
+	runGitForTest(t, other, "add", "OTHER.txt")
+	runGitForTest(t, other, "commit", "-q", "-m", "unrelated mainline change")
+	runGitForTest(t, other, "push", "-q", "origin", "main")
+
+	// This checkout's own post-release-version-bump commit, made on top of
+	// the now-stale base before the push discovers the rejection.
+	if err := os.WriteFile(filepath.Join(repo, "VERSION"), []byte("1.0.214-next\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION bump: %v", err)
+	}
+	runGitForTest(t, repo, "add", "VERSION")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] prepare 1.0.214-next")
+
+	ctx := newTestClaimContext()
+	spec := ReleaseSpec{ProjectRoot: repo, Branch: "main", Version: "1.0.213", Mode: ReleaseModeStable}
+	command := ReleaseCommandSpec{Dir: repo, Name: "git", Args: []string{"push", "--follow-tags", "origin", "main"}}
+
+	if err := runReleaseBranchPush(ctx, spec, command, GitCommandRunner); err != nil {
+		t.Fatalf("runReleaseBranchPush: %v", err)
+	}
+
+	runGitForTest(t, repo, "fetch", "-q", "origin", "main")
+	if err := runGitCheckForTest(repo, "merge-base", "--is-ancestor", "v1.0.213", "FETCH_HEAD"); err != nil {
+		t.Fatalf("expected v1.0.213 to remain reachable from origin/main after the rebase, but it does not: %v", err)
+	}
+}
+
+func runGitCheckForTest(dir string, args ...string) error {
+	cmd := Command("git", append([]string{"-C", dir}, args...)...)
+	return cmd.Run()
+}

--- a/erun-common/release_repo_claim_test.go
+++ b/erun-common/release_repo_claim_test.go
@@ -169,3 +169,110 @@ func runGitCheckForTest(dir string, args ...string) error {
 	cmd := Command("git", append([]string{"-C", dir}, args...)...)
 	return cmd.Run()
 }
+
+// TestReleaseBranchPushRebaseIgnoresAnOlderCommitWithTheSameSubjectOutsideTheRebasedRange
+// guards the bound itself: an older commit sharing the release commit's exact
+// subject, already common history before this release ever started, must not
+// be mistaken for the commit the rebase just replayed.
+func TestReleaseBranchPushRebaseIgnoresAnOlderCommitWithTheSameSubjectOutsideTheRebasedRange(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+
+	// A prior release of the same version, already part of history before
+	// this run starts. It carries the exact subject this run's own release
+	// commit will carry too, but it sits outside anything a rebase replays.
+	if err := os.WriteFile(filepath.Join(repo, "OLD.txt"), []byte("old\n"), 0o644); err != nil {
+		t.Fatalf("write old file: %v", err)
+	}
+	runGitForTest(t, repo, "add", "OLD.txt")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] release 1.0.213")
+
+	remote := newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "main")
+
+	if err := os.WriteFile(filepath.Join(repo, "VERSION"), []byte("1.0.213\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	runGitForTest(t, repo, "add", "VERSION")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] release 1.0.213")
+	runGitForTest(t, repo, "tag", "-a", "v1.0.213", "-m", "Release 1.0.213")
+	runGitForTest(t, repo, "push", "-q", "origin", "v1.0.213")
+
+	other := cloneRepoForTest(t, remote)
+	if err := os.WriteFile(filepath.Join(other, "OTHER.txt"), []byte("unrelated change\n"), 0o644); err != nil {
+		t.Fatalf("write unrelated file in the other checkout: %v", err)
+	}
+	runGitForTest(t, other, "add", "OTHER.txt")
+	runGitForTest(t, other, "commit", "-q", "-m", "unrelated mainline change")
+	runGitForTest(t, other, "push", "-q", "origin", "main")
+
+	if err := os.WriteFile(filepath.Join(repo, "VERSION"), []byte("1.0.214-next\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION bump: %v", err)
+	}
+	runGitForTest(t, repo, "add", "VERSION")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] prepare 1.0.214-next")
+
+	ctx := newTestClaimContext()
+	spec := ReleaseSpec{ProjectRoot: repo, Branch: "main", Version: "1.0.213", Mode: ReleaseModeStable}
+	command := ReleaseCommandSpec{Dir: repo, Name: "git", Args: []string{"push", "--follow-tags", "origin", "main"}}
+
+	if err := runReleaseBranchPush(ctx, spec, command, GitCommandRunner); err != nil {
+		t.Fatalf("runReleaseBranchPush: %v", err)
+	}
+
+	runGitForTest(t, repo, "fetch", "-q", "origin", "main")
+	if err := runGitCheckForTest(repo, "merge-base", "--is-ancestor", "v1.0.213", "FETCH_HEAD"); err != nil {
+		t.Fatalf("expected v1.0.213 to remain reachable from origin/main after the rebase, but it does not: %v", err)
+	}
+}
+
+// TestReleaseBranchPushRebaseRefusesAnAmbiguousReplayedTagSubject guards the
+// refusal itself: two commits inside the range the rebase just replayed share
+// the tagged commit's exact subject, and the repoint must refuse rather than
+// silently retag onto whichever one it happened to see first.
+func TestReleaseBranchPushRebaseRefusesAnAmbiguousReplayedTagSubject(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "main")
+
+	if err := os.WriteFile(filepath.Join(repo, "VERSION"), []byte("1.0.213\n"), 0o644); err != nil {
+		t.Fatalf("write VERSION: %v", err)
+	}
+	runGitForTest(t, repo, "add", "VERSION")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] release 1.0.213")
+	runGitForTest(t, repo, "tag", "-a", "v1.0.213", "-m", "Release 1.0.213")
+	runGitForTest(t, repo, "push", "-q", "origin", "v1.0.213")
+
+	// A second commit that happens to carry the exact same subject as the
+	// tagged one, replayed by the same rebase alongside it.
+	if err := os.WriteFile(filepath.Join(repo, "DUPLICATE.txt"), []byte("duplicate\n"), 0o644); err != nil {
+		t.Fatalf("write duplicate-subject file: %v", err)
+	}
+	runGitForTest(t, repo, "add", "DUPLICATE.txt")
+	runGitForTest(t, repo, "commit", "-q", "-m", "[skip ci] release 1.0.213")
+
+	other := cloneRepoForTest(t, remote)
+	if err := os.WriteFile(filepath.Join(other, "OTHER.txt"), []byte("unrelated change\n"), 0o644); err != nil {
+		t.Fatalf("write unrelated file in the other checkout: %v", err)
+	}
+	runGitForTest(t, other, "add", "OTHER.txt")
+	runGitForTest(t, other, "commit", "-q", "-m", "unrelated mainline change")
+	runGitForTest(t, other, "push", "-q", "origin", "main")
+
+	ctx := newTestClaimContext()
+	spec := ReleaseSpec{ProjectRoot: repo, Branch: "main", Version: "1.0.213", Mode: ReleaseModeStable}
+	command := ReleaseCommandSpec{Dir: repo, Name: "git", Args: []string{"push", "--follow-tags", "origin", "main"}}
+
+	err := runReleaseBranchPush(ctx, spec, command, GitCommandRunner)
+	if err == nil {
+		t.Fatal("expected an ambiguous replayed tag subject to refuse rather than silently retag")
+	}
+	if !strings.Contains(err.Error(), "v1.0.213") {
+		t.Errorf("refusal must name the tag, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "release 1.0.213") {
+		t.Errorf("refusal must name the subject, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "by hand") {
+		t.Errorf("refusal must tell the operator to move the tag by hand, got: %v", err)
+	}
+}

--- a/erun-integration/internal/normalize/normalize.go
+++ b/erun-integration/internal/normalize/normalize.go
@@ -131,6 +131,13 @@ var defaultRules = []Replacement{
 	// a diff's `index <blob>..<blob>` — content-derived and stable — survives.
 	{regexp.MustCompile(`\[([^\s\]]+) [0-9a-f]{7,40}\]`), "[$1 <SHORTSHA>]"},
 	{regexp.MustCompile(`(?m)^(\s+)[0-9a-f]{7,40}\.\.[0-9a-f]{7,40}\b`), "${1}<SHORTSHA>..<SHORTSHA>"},
+	// A forced ref update (`git push --force`/`--force-with-lease`, as the
+	// release tag's repoint-after-rebase does) prints a three-dot range, not
+	// the fast-forward push status line's two-dot range above, and
+	// `git tag -f` separately prints the commit it moved the tag away from.
+	// Both carry a commit the fixture repo happened to produce on this run.
+	{regexp.MustCompile(`(?m)^(\s*\+ )[0-9a-f]{7,40}\.\.\.[0-9a-f]{7,40}\b`), "${1}<SHORTSHA>...<SHORTSHA>"},
+	{regexp.MustCompile(`\(was [0-9a-f]{7,40}\)`), "(was <SHORTSHA>)"},
 	// Safety net for a real home path that leaks despite the test HOME override.
 	{regexp.MustCompile(`/Users/[^/\s'"]+`), "<HOME>"},
 	{regexp.MustCompile(`/home/[^/\s'"]+`), "<HOME>"},

--- a/erun-integration/testdata/release/real_run_absorbs_a_base_branch_that_moved_during_the_build.txt
+++ b/erun-integration/testdata/release/real_run_absorbs_a_base_branch_that_moved_during_the_build.txt
@@ -47,6 +47,10 @@ To <TMP>
  ! [rejected]        main -> main (fetch first)
 error: failed to push some refs to '<TMP>'
 release: push rejected; origin/main moved during the release, rebasing onto it and retrying (1/2)
+release: rebase moved the commit tag <VERSION> named; re-pointing it onto <HEX> and force-pushing
+Updated tag '<VERSION>' (was <SHORTSHA>)
+To <TMP>
+ + <SHORTSHA>...<SHORTSHA> <VERSION> -> <VERSION> (forced update)
 To <TMP>
    <SHORTSHA>..<SHORTSHA>  main -> main
 release version: <VERSION>


### PR DESCRIPTION
## Summary

Closes #1631. Two real defects from one observed release run, both landing in this PR since they arise from the same ordering.

**1. The release claim was scoped on the wrong axis.** #1620 added an exclusive claim scoped to `Tenant`/`Environment` via `TakeEnvironmentActivityLease`, so it only protects two releases *within one environment*. Two orchestrators driving *different* environments take claims in different environment-scoped stores and are structurally invisible to each other — the actual topology that raced `1.0.213` (and `1.0.211` before it).

The contended resource is the repository itself: one `VERSION`, one tag namespace, one `main`. `erun-common/release_repo_claim.go` adds a second, repository-global claim on a remote git ref (`refs/erun/release-claim/<version>`):

- **Contends on**: a plain `git push <object>:<ref>` to create a ref that doesn't yet exist is git's own compare-and-swap (the client claims "no value yet"; the server rejects the instant somebody else's push already gave it one) — verified empirically against a real bare repo. `--force-with-lease=<ref>:<expected>` gives the identical CAS for a renewal or a reclaim. No shared store beyond the repository both orchestrators are already racing to change.
- **Dead holder reclaim**: the claim blob carries an expiry; a claim past its TTL is reclaimed via `--force-with-lease` against the stale sha, so a crashed/replaced orchestrator can never wedge the version — no human ever deletes anything.
- **Off-pod/off-repo stays a no-op**: an inconclusive remote read (no network, no origin, no push access) proceeds without the repository-global claim rather than inventing a refusal nothing confirms — same policy `ensureReleaseBaseBranchUnmoved` already uses for its own remote read.
- The existing environment-scoped lease is kept as-is (it still drives idle-prevention and `erun` lease listings); the repo-global claim is additive, taken first, released/cleaned up alongside it.

**2. The published tag didn't point at a commit on `main`.** When the final branch push is rejected and rebases onto the moved base branch (existing, correct behavior), every commit from the release's own fork point — including the one `push-release-tag` already published the tag under — gets replayed under a new sha. The already-public tag is left naming a commit reachable from nothing. `git merge-base --is-ancestor v1.0.213 origin/main` was false for both `v1.0.213` and `v1.0.211`.

Fix: after each rebase in the retry loop, `repointReleaseTagIfRebased` (`erun-common/release_remote.go`) checks whether the tag's commit is still an ancestor of HEAD; if not, it locates the replayed commit by its unique generated commit message (rebase preserves commit messages), re-creates the tag there with its original annotation message, and force-pushes just that ref (an annotated tag update is never a fast-forward, and the remote already has the tag at the old commit).

**Hardening: the replayed-commit lookup is now bounded and refuses on ambiguity.** The lookup originally ran `git log HEAD` over all of history and returned the first subject match. That picked correctly in practice — `git log` is newest-first, so the replayed commit sits at or near HEAD — but a wrong match would have silently force-pushed the tag onto the wrong commit, with no error. `findCommitsBySubjectInRange` now bounds the search to `FETCH_HEAD..HEAD`: the commits the rebase, moments earlier in `rebaseReleaseOntoRemoteBranch`, actually replayed onto the upstream it just fetched. If more than one commit in that bounded range shares the subject, the lookup refuses with the same explicit, actionable error shape the not-found case already used (names the tag, the subject, and tells the operator to move the tag by hand) instead of silently choosing one.

## Tests

- `TestReleaseRepoClaimRefusesASecondReleaseFromADifferentCheckoutAndNamesTheHolder` — two independent clones of the same bare origin; the second checkout's claim is refused and the refusal names the first holder. This is the exact case #1620's same-environment tests couldn't catch.
- `TestReleaseRepoClaimReclaimsAnAbandonedReleaseFromADifferentCheckout` — a claim past its TTL, from a different checkout, is reclaimed without any manual intervention.
- `TestReleaseBranchPushRebaseKeepsTheReleaseTagOnTheTargetBranch` — drives `runReleaseBranchPush` against a real git remote where an unrelated commit lands on `origin/main` mid-release, forcing the rebase-and-retry path; asserts the tag is an ancestor of `origin/main` afterward. Verified this test fails without the fix (reverted the repoint call locally, confirmed red, restored it).
- `TestReleaseBranchPushRebaseIgnoresAnOlderCommitWithTheSameSubjectOutsideTheRebasedRange` — an older commit sharing the release commit's exact subject, already part of history before the run starts and outside anything the rebase replays; the repoint still lands the tag on the correct, actually-replayed commit.
- `TestReleaseBranchPushRebaseRefusesAnAmbiguousReplayedTagSubject` — two commits *inside* the bounded replayed range share the tagged commit's exact subject; the repoint refuses with the explicit error rather than tagging either one. Verified this test fails (silently retags instead of refusing) against the unbounded, first-match lookup.

Also added two normalization rules to `erun-integration/internal/normalize` for the new `git push --force`/`git tag -f` output the tag fix introduces (a forced ref-update range and a "was `<sha>`" line), so the affected release golden (`real_run_absorbs_a_base_branch_that_moved_during_the_build`) stays deterministic across runs — confirmed by comparing it clean across 5 consecutive runs.

## Test plan
- [x] `go test ./... -race` in `erun-common` green
- [x] `go build`/`go vet` green in `erun-cli` and `erun-mcp` (release behavior validated repository-wide per AGENTS.md)
- [x] `golangci-lint run ./...` clean in `erun-common` and `erun-integration`
- [x] `make check` green (lint across all modules, erun-ui, frontend gates, devops chart tests, full integration suite, coverage threshold)
- [x] Confirmed the new tag-repoint integration golden is deterministic across 5 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
