### PR TITLE
Enforce a configured token audience on the backend API's OIDC path

### DIFF
--- a/erun-backend/erun-backend-api/bearer_token_verifier.go
+++ b/erun-backend/erun-backend-api/bearer_token_verifier.go
@@ -3,6 +3,7 @@ package backendapi
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 // resolved from the verified issuer downstream.
 type BearerTokenVerifier struct {
 	allowedIssuers    map[string]struct{}
+	allowedAudiences  []string
 	trustedFileIssuer string
 	audience          string
 	verifier          *eruncommon.OIDCVerifier
@@ -42,10 +44,17 @@ type awsSTSClaims struct {
 }
 
 // BearerTokenVerifierOptions configures the API verifier. An empty AllowedIssuers
-// allows any issuer a token resolves to; an empty Audience defaults to
-// eruncommon.APITokenAudience.
+// allows any issuer a token resolves to, and an empty AllowedAudiences likewise
+// allows any audience an OIDC token carries; an empty Audience defaults to
+// eruncommon.APITokenAudience, which only the desktop file:// path uses.
+//
+// AllowedAudiences is deliberately separate from Audience: the desktop mints its
+// own tokens and can be held to erun's own audience, while a hosted IdP puts the
+// registered client id in `aud`, so which clients may reach the API is a
+// deployment fact rather than a constant.
 type BearerTokenVerifierOptions struct {
 	AllowedIssuers       []string
+	AllowedAudiences     []string
 	DesktopPublicKeyPath string
 	Audience             string
 }
@@ -55,6 +64,15 @@ func NewBearerTokenVerifier(options BearerTokenVerifierOptions) *BearerTokenVeri
 	for _, issuer := range options.AllowedIssuers {
 		if issuer = strings.TrimSpace(issuer); issuer != "" {
 			allowed[issuer] = struct{}{}
+		}
+	}
+	// Kept as an ordered slice rather than a set: a rejection names the expected
+	// audiences, and an operator reading that message should see them in the
+	// order they configured them.
+	allowedAudiences := make([]string, 0, len(options.AllowedAudiences))
+	for _, audience := range options.AllowedAudiences {
+		if audience = strings.TrimSpace(audience); audience != "" {
+			allowedAudiences = append(allowedAudiences, audience)
 		}
 	}
 	audience := strings.TrimSpace(options.Audience)
@@ -67,6 +85,7 @@ func NewBearerTokenVerifier(options BearerTokenVerifierOptions) *BearerTokenVeri
 	}
 	return &BearerTokenVerifier{
 		allowedIssuers:    allowed,
+		allowedAudiences:  allowedAudiences,
 		trustedFileIssuer: trustedFileIssuer,
 		audience:          audience,
 		verifier:          eruncommon.NewOIDCVerifier(),
@@ -103,11 +122,44 @@ func (v *BearerTokenVerifier) VerifyBearerToken(ctx context.Context, token strin
 	if err != nil {
 		return Claims{}, err
 	}
+	if err := v.checkOIDCAudience(verified.Audience); err != nil {
+		return Claims{}, err
+	}
 
 	// Keep the raw claim map alongside the decoded struct: the identity resolver
 	// reads a per-issuer org claim whose name is configured in the DB, not here.
 	claims := oidcTokenClaimsFromRaw(verified.Raw)
 	return claimsFromOIDCTokenClaims(claims, verified.Raw), nil
+}
+
+// checkOIDCAudience applies the API's audience policy to the OIDC path, the
+// same policy the desktop path above already applies to its own tokens. The
+// issuer allow-list cannot separate two clients of one shared IdP; `aud` is the
+// claim that draws that boundary, so a token an issuer minted for another of its
+// clients is not an API bearer token.
+//
+// An unconfigured allow-list accepts any audience, matching the issuer
+// allow-list's empty-means-any rule — the startup log is what says which of the
+// two is in force, so the permissive default is never silent. A rejection names
+// the carried and expected audiences (never anything else from the token),
+// because a generic auth failure turns a one-line config problem into a long
+// debugging session.
+func (v *BearerTokenVerifier) checkOIDCAudience(audiences []string) error {
+	if len(v.allowedAudiences) == 0 {
+		return nil
+	}
+	for _, audience := range audiences {
+		if slices.Contains(v.allowedAudiences, strings.TrimSpace(audience)) {
+			return nil
+		}
+	}
+	// A token that names no audience cannot intersect an explicit allow-list, so
+	// it is refused for the same reason a wrong one is; it gets its own message
+	// because "[] is not allowed" reads as a bug rather than a diagnosis.
+	if len(audiences) == 0 {
+		return fmt.Errorf("oidc token carries no audience; expected one of %v", v.allowedAudiences)
+	}
+	return fmt.Errorf("oidc token audience %v is not allowed; expected one of %v", audiences, v.allowedAudiences)
 }
 
 func oidcTokenClaimsFromRaw(raw map[string]any) oidcTokenClaims {

--- a/erun-backend/erun-backend-api/bearer_token_verifier_test.go
+++ b/erun-backend/erun-backend-api/bearer_token_verifier_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,6 +179,88 @@ func TestVerifyBearerTokenDelegatesToSharedVerifier(t *testing.T) {
 	})
 }
 
+// mustRejectWith fails unless the verifier rejects the token with an error
+// mentioning every want. The rejection has to name the audience the token
+// carried and the ones configured, or an operator is left guessing at a
+// one-line config problem.
+func mustRejectWith(t *testing.T, verifier *BearerTokenVerifier, token string, wants ...string) {
+	t.Helper()
+	_, err := verifier.VerifyBearerToken(context.Background(), token)
+	if err == nil {
+		t.Fatal("expected the token to be rejected")
+	}
+	for _, want := range wants {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("rejection %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// TestVerifyBearerTokenOIDCAudience exercises the audience policy on the OIDC
+// path. The issuer allow-list cannot tell two clients of one IdP apart, so
+// without this a token that issuer minted for any of its clients authenticates
+// against the API.
+func TestVerifyBearerTokenOIDCAudience(t *testing.T) {
+	provider := newMockOIDCProvider(t)
+	now := time.Now()
+	token := func(audience any) string {
+		claims := map[string]any{
+			"iss": provider.issuer(),
+			"sub": "user-1",
+			"iat": now.Unix(),
+			"exp": now.Add(time.Hour).Unix(),
+		}
+		if audience != nil {
+			claims["aud"] = audience
+		}
+		return provider.sign(t, claims)
+	}
+
+	t.Run("a configured audience accepts a token minted for it", func(t *testing.T) {
+		verifier := NewBearerTokenVerifier(BearerTokenVerifierOptions{
+			AllowedIssuers:   []string{provider.issuer()},
+			AllowedAudiences: []string{"console-client", "cli-client"},
+		})
+		if claims := mustVerify(t, verifier, token("cli-client")); claims.Subject != "user-1" {
+			t.Fatalf("claims = %+v", claims)
+		}
+	})
+
+	t.Run("an OIDC aud listing several audiences passes on any one of them", func(t *testing.T) {
+		verifier := NewBearerTokenVerifier(BearerTokenVerifierOptions{
+			AllowedIssuers:   []string{provider.issuer()},
+			AllowedAudiences: []string{"console-client"},
+		})
+		mustVerify(t, verifier, token([]string{"some-other-client", "console-client"}))
+	})
+
+	t.Run("the same trusted issuer's token for another audience is rejected, naming both", func(t *testing.T) {
+		verifier := NewBearerTokenVerifier(BearerTokenVerifierOptions{
+			AllowedIssuers:   []string{provider.issuer()},
+			AllowedAudiences: []string{"console-client", "cli-client"},
+		})
+		mustRejectWith(t, verifier, token("some-other-client"), "some-other-client", "console-client", "cli-client")
+	})
+
+	// Fail closed: an explicit allow-list is a statement about which audiences
+	// may call, and a token naming none cannot satisfy it.
+	t.Run("a token with no aud claim is rejected once an allow-list is configured", func(t *testing.T) {
+		verifier := NewBearerTokenVerifier(BearerTokenVerifierOptions{
+			AllowedIssuers:   []string{provider.issuer()},
+			AllowedAudiences: []string{"console-client"},
+		})
+		mustRejectWith(t, verifier, token(nil), "carries no audience", "console-client")
+	})
+
+	// Empty means any, matching the issuer allow-list beside it, so a deployment
+	// that has not established its client ids keeps working exactly as before.
+	t.Run("an unconfigured allow-list accepts any audience", func(t *testing.T) {
+		verifier := NewBearerTokenVerifier(BearerTokenVerifierOptions{AllowedIssuers: []string{provider.issuer()}})
+		mustVerify(t, verifier, token("some-other-client"))
+		mustVerify(t, verifier, token(nil))
+	})
+}
+
 // TestVerifyBearerTokenFileIssuer exercises the file:// desktop path: a
 // desktop-signed EdDSA token authenticates to the API with no live IdP,
 // the same auth the MCP edge uses, with the API audience enforced.
@@ -229,6 +312,35 @@ func TestVerifyBearerTokenFileIssuer(t *testing.T) {
 			ExpiresAt: now.Add(-time.Minute).Unix(),
 		})
 		mustReject(t, verifier, token, "expected an expired token to be rejected")
+	})
+
+	// The OIDC audience allow-list is policy for the hosted IdP's clients only.
+	// The desktop signs its own tokens and keeps being held to erun's own API
+	// audience, whatever that allow-list says.
+	t.Run("an OIDC audience allow-list leaves the desktop path's own audience check alone", func(t *testing.T) {
+		verifier := NewBearerTokenVerifier(BearerTokenVerifierOptions{
+			DesktopPublicKeyPath: keyPath,
+			AllowedAudiences:     []string{"console-client"},
+		})
+		accepted := signDesktopToken(t, privatePEM, eruncommon.MCPTokenClaims{
+			Issuer:    issuer,
+			Subject:   "dev-user",
+			Audience:  eruncommon.APITokenAudience,
+			ExpiresAt: now.Add(time.Hour).Unix(),
+		})
+		mustVerify(t, verifier, accepted)
+
+		// Neither the desktop's own MCP audience nor the OIDC allow-list's
+		// entry is an API audience for a desktop-signed token.
+		for _, audience := range []string{eruncommon.MCPTokenAudience("acme", "prod"), "console-client"} {
+			rejected := signDesktopToken(t, privatePEM, eruncommon.MCPTokenClaims{
+				Issuer:    issuer,
+				Subject:   "dev-user",
+				Audience:  audience,
+				ExpiresAt: now.Add(time.Hour).Unix(),
+			})
+			mustReject(t, verifier, rejected, "expected the desktop path to keep enforcing the API audience: "+audience)
+		}
 	})
 
 	t.Run("a desktop token from an untrusted file issuer is rejected", func(t *testing.T) {

--- a/erun-backend/erun-backend-api/cmd/eapi/main.go
+++ b/erun-backend/erun-backend-api/cmd/eapi/main.go
@@ -55,6 +55,7 @@ func run(args []string) error {
 	handler, err := backendapi.NewHandler(backendapi.HandlerOptions{
 		TokenVerifier: backendapi.NewBearerTokenVerifier(backendapi.BearerTokenVerifierOptions{
 			AllowedIssuers:       splitCSV(cfg.AllowedIssuers),
+			AllowedAudiences:     splitCSV(cfg.AllowedAudiences),
 			DesktopPublicKeyPath: cfg.DesktopPublicKeyPath,
 		}),
 		IdentityCache: backendapi.NewIdentityResolutionCache(backendapi.IdentityCacheOptions{}),
@@ -118,7 +119,7 @@ func run(args []string) error {
 		Handler:           handler,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-	log.Printf("erun api listening on %s; database=postgres audit=postgres oidc allowed issuers=%d", server.Addr, len(splitCSV(cfg.AllowedIssuers)))
+	log.Printf("erun api listening on %s; database=postgres audit=postgres oidc allowed issuers=%d %s", server.Addr, len(splitCSV(cfg.AllowedIssuers)), oidcAudiencePolicy(splitCSV(cfg.AllowedAudiences)))
 	log.Print(identityBootstrapStatus(context.Background(), db))
 	return server.ListenAndServe()
 }
@@ -131,6 +132,7 @@ func resolveConfig(args []string) (apiConfig, error) {
 	flags.IntVar(&cfg.Port, "port", cfg.Port, "Port to bind the backend API HTTP server to")
 	flags.StringVar(&cfg.DatabaseURL, "database-url", cfg.DatabaseURL, "Backend PostgreSQL database URL")
 	flags.StringVar(&cfg.AllowedIssuers, "oidc-allowed-issuers", cfg.AllowedIssuers, "Comma-separated OIDC issuer allow-list; empty allows any issuer resolved from a token")
+	flags.StringVar(&cfg.AllowedAudiences, "oidc-allowed-audiences", cfg.AllowedAudiences, "Comma-separated allow-list of token audiences (aud) accepted on the OIDC issuer path, typically the IdP client ids permitted to call this API; empty accepts any audience an allowed issuer minted")
 	flags.StringVar(&cfg.DesktopPublicKeyPath, "desktop-public-key-path", cfg.DesktopPublicKeyPath, "Path to the desktop Ed25519 public key; when set, the API trusts file://<path> desktop-signed tokens (issue #674), the same auth the MCP edge uses")
 	flags.StringVar(&cfg.MCPSigningKeyPath, "mcp-signing-key-path", cfg.MCPSigningKeyPath, "Path to the backend's Ed25519 MCP signing private key; when set, the mcp-token endpoint mints per-env MCP bearer tokens for the console (unset disables it: the endpoint reports 501)")
 	flags.StringVar(&cfg.PlatformIssuer, "platform-issuer", cfg.PlatformIssuer, "This instance's OIDC issuer URL, served unauthenticated at GET /v1/platform")
@@ -213,6 +215,17 @@ func optionalIdentityAdmin(cfg apiConfig) (*zitadel.Client, error) {
 	})
 }
 
+// oidcAudiencePolicy states the audience boundary in the startup log instead of
+// leaving an operator to read it out of a count of zero: an unenforced boundary
+// and one that happens to be passing look identical in the logs otherwise, and
+// which of the two a deployment is in is exactly what an operator needs to know.
+func oidcAudiencePolicy(audiences []string) string {
+	if len(audiences) == 0 {
+		return "oidc audience enforcement=off (any audience from an allowed issuer is accepted)"
+	}
+	return fmt.Sprintf("oidc audience enforcement=on (allowed: %s)", strings.Join(audiences, ", "))
+}
+
 func identityBootstrapStatus(ctx context.Context, db *sql.DB) string {
 	tenants, tenantErr := countRows(ctx, db, "tenants")
 	users, userErr := countRows(ctx, db, "users")
@@ -245,10 +258,16 @@ func countStatus(count int, err error) string {
 }
 
 type apiConfig struct {
-	Host                 string
-	Port                 int
-	DatabaseURL          string
-	AllowedIssuers       string
+	Host           string
+	Port           int
+	DatabaseURL    string
+	AllowedIssuers string
+	// AllowedAudiences narrows the OIDC path to tokens minted for named
+	// audiences — the boundary between clients of one shared IdP, which the
+	// issuer allow-list cannot draw. Empty accepts any audience, so a deployment
+	// that has not established which client ids its IdP mints behaves as it
+	// always did; the startup log reports which of the two applies.
+	AllowedAudiences     string
 	DesktopPublicKeyPath string
 	MCPSigningKeyPath    string
 	// DNS-01 broker write path, injected at deploy from the platform env's
@@ -337,6 +356,7 @@ func configFromEnv() apiConfig {
 		Port:                  intEnvOrDefault("ERUN_API_PORT", 17033),
 		DatabaseURL:           strings.TrimSpace(os.Getenv("ERUN_DATABASE_URL")),
 		AllowedIssuers:        strings.TrimSpace(os.Getenv("ERUN_OIDC_ALLOWED_ISSUERS")),
+		AllowedAudiences:      strings.TrimSpace(os.Getenv("ERUN_OIDC_ALLOWED_AUDIENCES")),
 		DesktopPublicKeyPath:  strings.TrimSpace(os.Getenv("ERUN_API_DESKTOP_PUBLIC_KEY_PATH")),
 		MCPSigningKeyPath:     strings.TrimSpace(os.Getenv("ERUN_API_MCP_SIGNING_KEY_PATH")),
 		SecretsKey:            strings.TrimSpace(os.Getenv("ERUN_SECRETS_KEY")),

--- a/erun-backend/erun-backend-api/cmd/eapi/main_test.go
+++ b/erun-backend/erun-backend-api/cmd/eapi/main_test.go
@@ -16,6 +16,43 @@ func TestInferDialectRecognizesPostgresURLs(t *testing.T) {
 	}
 }
 
+// An unenforced audience boundary and one that is merely passing look identical
+// in the logs unless the startup line says which it is, so the permissive
+// default has to announce itself rather than print a count of zero.
+func TestOIDCAudiencePolicySaysWhetherTheBoundaryIsUp(t *testing.T) {
+	off := oidcAudiencePolicy(splitCSV(""))
+	if off != "oidc audience enforcement=off (any audience from an allowed issuer is accepted)" {
+		t.Fatalf("unconfigured policy = %q", off)
+	}
+
+	on := oidcAudiencePolicy(splitCSV("console-client, cli-client"))
+	if on != "oidc audience enforcement=on (allowed: console-client, cli-client)" {
+		t.Fatalf("configured policy = %q", on)
+	}
+}
+
+// The flag name is a contract with the API image's entrypoint, which translates
+// ERUN_OIDC_ALLOWED_AUDIENCES into it; a rename on either side leaves the
+// boundary unconfigurable through the chart.
+func TestResolveConfigReadsTheOIDCAudienceAllowList(t *testing.T) {
+	cfg, err := resolveConfig([]string{"--oidc-allowed-audiences", "console-client,cli-client"})
+	if err != nil {
+		t.Fatalf("resolve config: %v", err)
+	}
+	if cfg.AllowedAudiences != "console-client,cli-client" {
+		t.Fatalf("allowed audiences = %q", cfg.AllowedAudiences)
+	}
+
+	t.Setenv("ERUN_OIDC_ALLOWED_AUDIENCES", "console-client")
+	cfg, err = resolveConfig(nil)
+	if err != nil {
+		t.Fatalf("resolve config: %v", err)
+	}
+	if cfg.AllowedAudiences != "console-client" {
+		t.Fatalf("allowed audiences from env = %q", cfg.AllowedAudiences)
+	}
+}
+
 func TestOpenDatabaseRejectsNonPostgresURL(t *testing.T) {
 	_, err := openDatabase("file:erun.db")
 	if err == nil || !strings.Contains(err.Error(), "database URL must be PostgreSQL") {

--- a/erun-devops/docker/erun-backend-api/entrypoint.sh
+++ b/erun-devops/docker/erun-backend-api/entrypoint.sh
@@ -13,6 +13,9 @@ fi
 if [ -n "${ERUN_OIDC_ALLOWED_ISSUERS:-}" ]; then
     set -- --oidc-allowed-issuers "${ERUN_OIDC_ALLOWED_ISSUERS}" "$@"
 fi
+if [ -n "${ERUN_OIDC_ALLOWED_AUDIENCES:-}" ]; then
+    set -- --oidc-allowed-audiences "${ERUN_OIDC_ALLOWED_AUDIENCES}" "$@"
+fi
 
 echo "starting erun API on ${ERUN_API_HOST:-0.0.0.0}:${ERUN_API_PORT:-17033}"
 

--- a/erun-devops/k8s/erun-backend-api-chart_test.sh
+++ b/erun-devops/k8s/erun-backend-api-chart_test.sh
@@ -467,4 +467,22 @@ grep -A1 'name: ERUN_PLATFORM_TAGLINE' "${core}" | grep -q 'value: "Example ship
 grep -A1 'name: ERUN_PLATFORM_LOGO_URL' "${core}" | grep -q 'value: "https://cdn.example.com/logo.svg"' ||
     fail "platform.logoUrl must render as ERUN_PLATFORM_LOGO_URL"
 
-echo "PASS: erun-backend-api DBOS wiring + public API edge + retraction RBAC + identity admin wiring + platform white-label discovery"
+# --- 19. The OIDC audience allow-list, the sibling of the issuer allow-list
+#         beside it. It must always render, so an unset value reaches the API
+#         as "" (its documented accept-any default) rather than a missing key,
+#         and it must default to empty: which client ids a deployment's IdP
+#         mints is an infrastructure fact, and a guessed default here would
+#         refuse every caller at once. ---
+rendered=$(render)
+container "${rendered}" >"${core}"
+grep -q 'name: ERUN_OIDC_ALLOWED_AUDIENCES' "${core}" ||
+    fail "ERUN_OIDC_ALLOWED_AUDIENCES must always render, mirroring ERUN_OIDC_ALLOWED_ISSUERS beside it"
+grep -A1 'name: ERUN_OIDC_ALLOWED_AUDIENCES' "${core}" | grep -q 'value: ""' ||
+    fail "the audience allow-list must default to empty -- enforcing a guessed client id would lock out every caller"
+
+rendered=$(render --set-string 'api.oidcAllowedAudiences=console-client\,cli-client')
+container "${rendered}" >"${core}"
+grep -A1 'name: ERUN_OIDC_ALLOWED_AUDIENCES' "${core}" | grep -q 'value: "console-client,cli-client"' ||
+    fail "api.oidcAllowedAudiences must render as ERUN_OIDC_ALLOWED_AUDIENCES, or the boundary can never be turned on"
+
+echo "PASS: erun-backend-api DBOS wiring + public API edge + retraction RBAC + identity admin wiring + platform white-label discovery + oidc audience allow-list"

--- a/erun-devops/k8s/erun-backend-api/templates/api.yaml
+++ b/erun-devops/k8s/erun-backend-api/templates/api.yaml
@@ -2,6 +2,13 @@
 {{- $apiPort := default 17033 .Values.apiPort -}}
 {{- $api := default dict .Values.api -}}
 {{- $oidcAllowedIssuers := default "" $api.oidcAllowedIssuers -}}
+{{- /* Which token audiences the API accepts on its OIDC path — the boundary
+       between clients of one shared IdP, which the issuer allow-list above
+       cannot draw. Empty by default and deliberately so: the client ids a
+       deployment's IdP actually mints are an infrastructure fact, and guessing
+       them here would lock out every caller. Set it per env once those ids are
+       established; the API's startup log reports whether it is enforcing. */ -}}
+{{- $oidcAllowedAudiences := default "" $api.oidcAllowedAudiences -}}
 {{- /* GET /v1/platform discovery: served unauthenticated so a client can
        discover this instance before it has a token. issuer derives from the
        env's platform.authHost (the hosted IdP host every platform deploy
@@ -516,6 +523,8 @@ spec:
             {{- end }}
             - name: ERUN_OIDC_ALLOWED_ISSUERS
               value: {{ $oidcAllowedIssuers | quote }}
+            - name: ERUN_OIDC_ALLOWED_AUDIENCES
+              value: {{ $oidcAllowedAudiences | quote }}
             - name: ERUN_PLATFORM_ISSUER
               value: {{ $platformIssuer | quote }}
             - name: ERUN_PLATFORM_API_URL

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -49,13 +49,46 @@ For every authenticated request:
 2. Extract `iss` from the JWT payload. The API trusts two kinds of issuer (issue #674), dispatched on scheme — the same multi-issuer model as the [MCP edge](#mcp-edge), so the API and every edge authenticate identically:
    - **`file://` desktop key** — when `iss` equals the configured trusted `file://<path>` desktop issuer (`ERUN_API_DESKTOP_PUBLIC_KEY_PATH`): verify the EdDSA signature against the injected public key (`alg` hard-locked to `EdDSA`, closing the alg-confusion class), and enforce `exp` and the `erun-api` audience. This is the desktop / e2e path — a desktop-signed token authenticates with **no live IdP**, exactly as for the MCP edge.
    - **`https://` OIDC issuer** — otherwise: if an allowed-issuers allow-list is configured and `iss` is not on it → `401`.
-3. (OIDC path) Fetch (or read from cache) the issuer's `<iss>/.well-known/openid-configuration` and its `jwks_uri` JWKS, and verify the JWT signature and registered claims (`exp`, `nbf`, `iat`). Failure → `401`. (For OIDC tokens, audience/`aud` is **not** currently enforced — the verifier skips the client-ID check; `aud` validation for OIDC is `(Planned.)`. The `file://` desktop path **does** enforce the `erun-api` audience, so a token minted for an MCP env — audience `erun-mcp:<tenant>/<env>` — cannot be replayed against the API.)
+3. (OIDC path) Fetch (or read from cache) the issuer's `<iss>/.well-known/openid-configuration` and its `jwks_uri` JWKS, and verify the JWT signature and registered claims (`exp`, `nbf`, `iat`). Failure → `401`. Then apply the **audience allow-list** below. (The `file://` desktop path enforces its own fixed `erun-api` audience instead, so a token minted for an MCP env — audience `erun-mcp:<tenant>/<env>` — cannot be replayed against the API. That check is independent of the allow-list and unaffected by it.)
 4. Look up `issuers.org_field_key` for `iss`.
    - If `iss` is **not registered**: unauthorized (`401`) — **unless** the `tenants` table is empty, which triggers first-identity bootstrap (below).
    - If `org_field_key` is **NULL**: resolve `tenant_issuers` where `issuer = iss` and `org_field_value IS NULL` → tenant.
    - If `org_field_key` is **set**: read that claim's value (`org`) from the token. Empty/absent → `401`. Otherwise resolve `tenant_issuers` where `issuer = iss` and `org_field_value = org` → tenant.
 5. Resolve the ERun user from `(tenant, iss, sub)` via `user_external_ids`. Unknown subject → `401` — **except** when the resolved tenant has **no users yet**, in which case the first valid token for it is enrolled as that tenant's first user with both `ReadAll` and `WriteAll` (per-tenant first-user bootstrap, below). Once a tenant has any user, unknown subjects for it stay unauthorized.
 6. Authorize the request against the user's roles/permissions; on success, allow and write the audit event.
+
+#### The OIDC audience allow-list {#oidc-audience-allow-list}
+
+The issuer allow-list in step 2 answers "which IdP minted this?", not "which of that IdP's clients is calling?". A hosted IdP puts the registered **client id** in `aud`, so every client of a trusted issuer clears the issuer check — the `aud` claim is what separates them. The API applies that policy as a configured allow-list:
+
+| Setting | Where |
+|---|---|
+| `--oidc-allowed-audiences <csv>` | `eapi` flag |
+| `ERUN_OIDC_ALLOWED_AUDIENCES` | env var; the API image's entrypoint translates it into the flag |
+| `api.oidcAllowedAudiences` | `erun-backend-api` chart value; **empty by default** |
+
+Resolution:
+
+1. **Empty (the default)** → no audience check on the OIDC path. Any audience an allowed issuer minted is accepted, matching the issuer allow-list's own empty-means-any rule.
+2. **Non-empty** → the token's `aud` must contain at least one listed value. An OIDC `aud` may list several audiences; intersecting on any one of them passes.
+3. **A token with no `aud` claim** is rejected whenever the allow-list is non-empty — an explicit statement of which audiences may call cannot be satisfied by a token that names none.
+
+Which state is in force is reported on the API's own startup line, so it is readable from the logs rather than inferred:
+
+```
+oidc audience enforcement=off (any audience from an allowed issuer is accepted)
+oidc audience enforcement=on (allowed: console-client, cli-client)
+```
+
+**Error behaviour**
+
+| Failure mode | What happens | Recovery |
+|---|---|---|
+| Allow-list set; token's `aud` matches none of it | `401`; the rejection names the audiences the token carried and the ones configured (never any other token content) | Add the client id to `api.oidcAllowedAudiences`, or call with a token minted for a listed client |
+| Allow-list set; token carries no `aud` | `401` naming the expected audiences | Configure the IdP client to mint an `aud`, or clear the allow-list |
+| Allow-list unset | Request proceeds; no audience check | Set `api.oidcAllowedAudiences` to turn the boundary on |
+
+Turning it on is a **configuration change**, not a code change: the client ids a given deployment's IdP mints are a fact about that deployment, so a wrong list refuses every caller at once. Read the ids off the IdP first (for an erun-shipped Zitadel, the console and CLI client ids the `erun-zitadel` bootstrap publishes — the same values [`GET /v1/platform`](#platform-endpoint) serves as `consoleClientId`/`cliClientId`), confirm them against a real token's `aud`, then set the value.
 
 **First-identity bootstrap.** When the `tenants` table is empty, the first valid token bootstraps the system: it creates an `OPERATIONS` tenant, registers its `iss` in `issuers`, creates the first user, and grants it both `ReadAll` and `WriteAll`.
 
@@ -73,7 +106,7 @@ The runtime chart configures each edge with a set of trusted issuers mapping eac
 
 1. `Authorization: Bearer <jwt>` is present — missing → `401`.
 2. The token's `iss` is a trusted issuer for this edge — untrusted → `401`; the mapped value is the resolved tenant.
-3. The signature verifies against that issuer's key, and `exp` and the audience (`aud`) match — the per-env audience (`erun-mcp:<tenant>/<environment>`) means a token minted for one environment cannot be replayed against another, or against the REST API (whose `file://` path enforces its own `erun-api` audience — issue #674). The REST API's OIDC path does not yet enforce `aud` (see the [verification algorithm](#token-verification-algorithm) above).
+3. The signature verifies against that issuer's key, and `exp` and the audience (`aud`) match — the per-env audience (`erun-mcp:<tenant>/<environment>`) means a token minted for one environment cannot be replayed against another, or against the REST API (whose `file://` path enforces its own `erun-api` audience — issue #674). The REST API's OIDC path applies a configured allow-list instead of a fixed audience, since the audiences a hosted IdP mints are per-deployment — see [the audience allow-list](#oidc-audience-allow-list) above.
 4. The resolved tenant matches **this** environment's tenant (a per-env edge serves exactly one tenant) — a token resolving to another tenant → `401`. Tenant-scoped tools are likewise pinned to the edge's own environment: a `tenant`/`environment` argument that differs from the pod's identity is refused, so a caller can never drive one env's MCP to act on another (issue #657).
 
 An edge can trust **multiple issuers at once**, of two kinds, dispatched by the *configured* issuer's scheme (not the token's claimed `iss`, so the verification path can't be attacker-chosen):

--- a/erun-docs/docs/deployment/deploy-platform.md
+++ b/erun-docs/docs/deployment/deploy-platform.md
@@ -55,6 +55,8 @@ Name it to the component as `zitadel.masterkeySecretName` in the env's `<tenant>
 
 The API side needs nothing: a platform deploy already trusts its own auth host, threading `https://<auth-host>` into the API's `ERUN_OIDC_ALLOWED_ISSUERS` from the [`platform:` block](/reference/configuration#platform-block) alongside any cloud issuers. The first sign-in bootstraps the `OPERATIONS` tenant.
 
+Trusting an issuer trusts every client registered against it. To narrow that to named clients, set `api.oidcAllowedAudiences` on the `erun-backend-api` component to the client ids allowed to call the API. It is empty by default — every deployment's client ids differ, and a wrong list refuses every caller — so read the ids off the IdP and confirm them against a real token before setting it. The API's startup line says which state it is in (`oidc audience enforcement=on`/`=off`); see [the audience allow-list](/agent-reference/api-protocol#oidc-audience-allow-list) for the resolution rules and error behaviour.
+
 ### Error behaviour
 
 | Failure mode | What happens | Recovery |


### PR DESCRIPTION
Closes #1632

## The defect

`VerifyBearerToken` (`erun-backend/erun-backend-api/bearer_token_verifier.go`) branches on the token's issuer and discharged the audience policy on only one of the two branches:

- **desktop `file://` path** — `VerifyMCPToken(..., v.audience, ...)`; audience enforced.
- **OIDC path** — `v.verifier.Verify(...)` (the shared verifier skips `aud` by design and returns `OIDCClaims.Audience` for the caller to check), then straight to `oidcTokenClaimsFromRaw(verified.Raw)`. `verified.Audience` was never read.

`erun-common/mcp_auth.go` discharges the same delegation on both of *its* paths. This caller checked one branch and not its sibling, so any token a trusted issuer minted for any of its clients authenticated against the API — the issuer allow-list cannot distinguish audiences *within* one issuer.

## Where it is now enforced, and how it mirrors the issuer precedent

`checkOIDCAudience` runs immediately after `v.verifier.Verify` succeeds, before any claim is mapped. The allow-list is plumbed exactly the way `AllowedIssuers` already is, in the same files:

| `AllowedIssuers` | added alongside it |
|---|---|
| `BearerTokenVerifierOptions.AllowedIssuers []string` | `.AllowedAudiences []string` |
| `--oidc-allowed-issuers` / `ERUN_OIDC_ALLOWED_ISSUERS` / `splitCSV` (`cmd/eapi/main.go`) | `--oidc-allowed-audiences` / `ERUN_OIDC_ALLOWED_AUDIENCES` / `splitCSV` |
| `erun-devops/docker/erun-backend-api/entrypoint.sh` env→flag translation | same block, same shape |
| `api.oidcAllowedIssuers` → env (`k8s/erun-backend-api/templates/api.yaml`) | `api.oidcAllowedAudiences` → env |
| startup log `oidc allowed issuers=%d` | startup log, see below |
| empty means allow any | empty means allow any |

`APITokenAudience` (`"erun-api"`) is deliberately **not** enforced here. It is documented as the audience the desktop mints and the API enforces *on the `file:// path`*, appears in no OIDC minting path, and Zitadel puts the client id in `aud` — enforcing it on the OIDC branch would reject every hosted-IdP token. The desktop branch is untouched.

## Semantics

- **Configured** → a token whose `aud` intersects the allow-list passes (an OIDC `aud` may list several; any one match is enough). One that does not is rejected naming **both** the carried and the expected audiences — never any other token content.
- **Unconfigured (empty)** → accepted, matching `AllowedIssuers`.

## Startup log, verbatim

Unconfigured:

```
erun api listening on 0.0.0.0:17033; database=postgres audit=postgres oidc allowed issuers=1 oidc audience enforcement=off (any audience from an allowed issuer is accepted)
```

Configured:

```
erun api listening on 0.0.0.0:17033; database=postgres audit=postgres oidc allowed issuers=1 oidc audience enforcement=on (allowed: console-client, cli-client)
```

A count of zero would have been indistinguishable from enforcement that happens to be passing. The permissive default announces itself in words, so an operator can read the logs and know whether the boundary is up.

## The no-`aud` decision

**A token carrying no `aud` claim is rejected when the allow-list is configured**, and accepted when it is not. An explicit allow-list is a statement about which audiences may call; a token naming none cannot intersect it, and fail-closed is the entire point of configuring the boundary. It gets its own message (`oidc token carries no audience; expected one of [...]`) rather than `[] is not allowed`, which reads as a bug rather than a diagnosis. Pinned by test.

## Rollout — this PR does not flip production on

The chart default is **empty**. Which client ids the deployed Zitadel actually mints is an infrastructure fact that has not been established here, and enforcing a guess would lock every user out at once. **The rollout is a config change (`api.oidcAllowedAudiences` per env), made verifiable by this PR rather than performed by it** — the mechanism, the observable startup state, and the named-audience rejection all ship here; turning it on is a separate, deliberate act once the ids are read off the IdP and confirmed against a real token.

## Tests

`erun-backend/erun-backend-api/bearer_token_verifier_test.go` — `TestVerifyBearerTokenOIDCAudience` (against the existing mock OIDC provider, real JWKS + RS256 signatures):

1. configured allow-list, `aud` matches → accepted on the OIDC path
2. multi-valued `aud` intersecting the list on one entry → accepted
3. same trusted issuer, different `aud` → rejected, error names the carried **and** both expected audiences
4. no `aud` claim + configured list → rejected, naming the expectation (pins the decision above)
5. unconfigured → any audience accepted, including a token with no `aud`

Plus, in `TestVerifyBearerTokenFileIssuer`: an OIDC audience allow-list leaves the desktop path alone — a wrong-audience desktop token (its MCP audience, and the OIDC allow-list's own entry) is still rejected while an `erun-api` one is still accepted.

`cmd/eapi/main_test.go` pins both startup-log strings and that the flag/env reach config (the flag name is the entrypoint's contract). `erun-devops/k8s/erun-backend-api-chart_test.sh` § 19 pins that the env var always renders, defaults empty, and carries a configured value.

## Docs

- `agent-reference/api-protocol.md` — step 3 of the verification algorithm no longer says `aud` is unenforced/`(Planned.)`; new `#oidc-audience-allow-list` spec section (settings table, 3-case resolution, both log lines, error-behaviour table, the rollout note). The MCP-edge section's cross-reference updated to match.
- `deployment/deploy-platform.md` — Operator-facing companion: trusting an issuer trusts all its clients, how to narrow it, why the default is empty, link to the spec.

`cd erun-docs && yarn build` clean.

## Validation

- `make check` — **exit 0**. golangci-lint `0 issues.` across erun-common, erun-cli, erun-mcp, erun-integration, erun-backend/erun-backend-api, erun-ui; erun-ui Go `ok` (20.671s / 1.022s); issue-reference gate 6/6 pass; erun-kit + erun-console gates green (126 tests, 21 files); all 8 helm chart tests PASS; integration `ok github.com/sophium/erun/erun-integration 95.489s`; `ok coverage 76.0% (>= 75.8%)`.
- `go test ./...` in `erun-backend/erun-backend-api` (not covered by `check-gate`, which lints but does not test this module): all packages `ok`.
- The API image entrypoint's env→flag translation verified against a stub `eapi`: set → `--oidc-allowed-audiences console-client,cli-client` in argv; unset → absent.

Not verified: this is not deployed to a live control plane, so the enforcing path has not been exercised against a real Zitadel-minted token. That is the same act as the rollout above and is deliberately not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)