### PR TITLE
Widen exec_job_status's output schema to accept any job result shape

### DIFF
--- a/erun-mcp/capabilities.go
+++ b/erun-mcp/capabilities.go
@@ -2,11 +2,14 @@ package erunmcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"sync"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	eruncommon "github.com/sophium/erun/erun-common"
 )
@@ -64,7 +67,43 @@ func addTool[In, Out any](reg toolRegistrar, tool *mcp.Tool, handler mcp.ToolHan
 		return
 	}
 	describeTool(tool)
+	if tool.OutputSchema == nil {
+		if schema := outputSchemaFor[Out](); schema != nil {
+			tool.OutputSchema = schema
+		}
+	}
 	mcp.AddTool(reg.server, tool, guardTool(reg.identity, tool.Name, reg.metrics, handler))
+}
+
+// rawJSONSchemaOverrides widens json.RawMessage fields to accept any JSON
+// value. The SDK's reflector otherwise reads json.RawMessage by its
+// underlying Go kind — a []byte — and renders the wire representation of "an
+// arbitrary JSON value captured verbatim" (e.g. EnvironmentJob.Result) as an
+// array of bytes, which the value it actually carries (an object, a string, a
+// number...) can never satisfy.
+var rawJSONSchemaOverrides = &jsonschema.ForOptions{
+	TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+		reflect.TypeFor[json.RawMessage](): {},
+	},
+}
+
+// outputSchemaFor computes the schema for a tool's Out type the same way the
+// SDK's own AddTool does when no explicit schema is given, except routed
+// through rawJSONSchemaOverrides. It returns nil for Out == any, matching the
+// SDK's own choice to omit the output schema entirely in that case.
+func outputSchemaFor[Out any]() *jsonschema.Schema {
+	rt := reflect.TypeFor[Out]()
+	if rt == reflect.TypeFor[any]() {
+		return nil
+	}
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	schema, err := jsonschema.ForType(rt, rawJSONSchemaOverrides)
+	if err != nil {
+		panic(fmt.Sprintf("erun-mcp: computing output schema for %s: %v", rt, err))
+	}
+	return schema
 }
 
 // describeTool attaches the tool's family, CLI path, title and annotations from

--- a/erun-mcp/go.mod
+++ b/erun-mcp/go.mod
@@ -5,8 +5,11 @@ go 1.26.0
 require (
 	github.com/adrg/xdg v0.5.3
 	github.com/go-jose/go-jose/v4 v4.1.4
+	github.com/google/jsonschema-go v0.4.2
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.70.1
 	github.com/sophium/erun/erun-common v0.0.0
 )
 
@@ -14,10 +17,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.18.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/erun-mcp/job_result_schema_test.go
+++ b/erun-mcp/job_result_schema_test.go
@@ -1,0 +1,205 @@
+package erunmcp
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// A task job's Result is "whatever the task returned, captured verbatim as
+// JSON" -- an object for release, an array or scalar for others, absent for a
+// job still running or with no typed result. exec_job_status's own output
+// schema must accept every one of those shapes, not just the empty case: the
+// SDK derives that schema from EnvironmentJob.Result's Go type
+// (json.RawMessage, i.e. []byte), which the reflector renders as "array of
+// bytes" -- a shape no task's actual result value can ever satisfy.
+
+// execJobStatusOutputSchema fetches the schema the server actually publishes
+// for exec_job_status over the wire (via tools/list) and resolves it, so the
+// assertions below exercise the schema the tool really emits rather than a
+// hand-written expectation of what it should be.
+func execJobStatusOutputSchema(t *testing.T) *jsonschema.Resolved {
+	t.Helper()
+	session := connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead))
+	tools, err := session.ListTools(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	for _, tool := range tools.Tools {
+		if tool.Name != "exec_job_status" {
+			continue
+		}
+		if tool.OutputSchema == nil {
+			t.Fatal("exec_job_status has no output schema")
+		}
+		raw, err := json.Marshal(tool.OutputSchema)
+		if err != nil {
+			t.Fatalf("marshal published output schema: %v", err)
+		}
+		var schema jsonschema.Schema
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("unmarshal published output schema: %v", err)
+		}
+		resolved, err := schema.Resolve(nil)
+		if err != nil {
+			t.Fatalf("resolve published output schema: %v", err)
+		}
+		return resolved
+	}
+	t.Fatal("exec_job_status is not in tools/list")
+	return nil
+}
+
+// jobInstanceWithResult marshals a real EnvironmentJob carrying result, then
+// decodes it back into a plain any so it can be embedded in a hand-assembled
+// JobStatusResult instance -- the job shape itself comes from the production
+// type, only its result varies per case.
+func jobInstanceWithResult(t *testing.T, result json.RawMessage) any {
+	t.Helper()
+	job := finishedJobFixture("release", []string{"release"})
+	job.Result = result
+	data, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("marshal job fixture: %v", err)
+	}
+	var instance any
+	if err := json.Unmarshal(data, &instance); err != nil {
+		t.Fatalf("unmarshal job fixture: %v", err)
+	}
+	return instance
+}
+
+func TestExecJobStatusOutputSchemaAcceptsAnyResultShape(t *testing.T) {
+	resolved := execJobStatusOutputSchema(t)
+
+	cases := map[string]json.RawMessage{
+		"object result": json.RawMessage(`{"executed":true,"spec":{"images":3}}`),
+		"array result":  json.RawMessage(`[1,2,3]`),
+		"string result": json.RawMessage(`"done"`),
+		"number result": json.RawMessage(`42`),
+		"bool result":   json.RawMessage(`true`),
+		"null result":   json.RawMessage(`null`),
+	}
+
+	for name, result := range cases {
+		t.Run(name, func(t *testing.T) {
+			instance := map[string]any{
+				"tenant":      "tenant-a",
+				"environment": "dev",
+				"jobs":        []any{},
+				"job":         jobInstanceWithResult(t, result),
+			}
+			if err := resolved.Validate(instance); err != nil {
+				t.Fatalf("emitted output schema rejects a %s: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestExecJobStatusOutputSchemaAcceptsAJobWithNoResult(t *testing.T) {
+	resolved := execJobStatusOutputSchema(t)
+
+	job := finishedJobFixture("release", []string{"release"})
+	data, err := json.Marshal(job)
+	if err != nil {
+		t.Fatalf("marshal job fixture: %v", err)
+	}
+	var jobInstance any
+	if err := json.Unmarshal(data, &jobInstance); err != nil {
+		t.Fatalf("unmarshal job fixture: %v", err)
+	}
+
+	instance := map[string]any{
+		"tenant":      "tenant-a",
+		"environment": "dev",
+		"jobs":        []any{},
+		"job":         jobInstance,
+	}
+	if err := resolved.Validate(instance); err != nil {
+		t.Fatalf("emitted output schema rejects a job with no result: %v", err)
+	}
+}
+
+// execJobStatus calls the real tool through a real MCP session, so it
+// exercises the SDK's own output-schema validation on the way out -- the
+// exact step that failed for a finished release job.
+func execJobStatus(t *testing.T, session *mcp.ClientSession, id string) JobStatusResult {
+	t.Helper()
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "exec_job_status",
+		Arguments: map[string]any{"tenant": "tenant-a", "environment": "dev", "id": id},
+	})
+	if err != nil {
+		t.Fatalf("exec_job_status: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("exec_job_status reported a tool error: %+v", res.Content)
+	}
+	structured, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured content: %v", err)
+	}
+	var out JobStatusResult
+	if err := json.Unmarshal(structured, &out); err != nil {
+		t.Fatalf("unmarshal structured content: %v", err)
+	}
+	if out.Job == nil {
+		t.Fatalf("no job returned for id %q", id)
+	}
+	return out
+}
+
+func assertResultRoundTrips(t *testing.T, out JobStatusResult, want json.RawMessage) {
+	t.Helper()
+	var wantAny, gotAny any
+	if err := json.Unmarshal(want, &wantAny); err != nil {
+		t.Fatalf("unmarshal expected result: %v", err)
+	}
+	if err := json.Unmarshal(out.Job.Result, &gotAny); err != nil {
+		t.Fatalf("unmarshal returned result: %v", err)
+	}
+	if !reflect.DeepEqual(wantAny, gotAny) {
+		t.Fatalf("result did not round-trip: got %#v, want %#v", gotAny, wantAny)
+	}
+}
+
+func TestExecJobStatusRoundTripsAJobResult(t *testing.T) {
+	isolateLeaseCache(t)
+	session := connectWithCapabilities(t, string(eruncommon.MCPCapabilityRead))
+
+	cases := []struct {
+		name   string
+		id     string
+		result json.RawMessage
+	}{
+		{"object result", "release-object", json.RawMessage(`{"executed":true,"spec":{"images":3}}`)},
+		{"array result", "release-array", json.RawMessage(`[1,2,3]`)},
+		{"scalar result", "release-scalar", json.RawMessage(`"done"`)},
+	}
+
+	for _, tc := range cases {
+		job := finishedJobFixture(tc.id, []string{"release"})
+		job.Result = tc.result
+		writeJobFixture(t, "tenant-a", "dev", job)
+	}
+	writeJobFixture(t, "tenant-a", "dev", finishedJobFixture("no-result", []string{"raw", "echo", "hi"}))
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := execJobStatus(t, session, tc.id)
+			assertResultRoundTrips(t, out, tc.result)
+		})
+	}
+
+	t.Run("no result", func(t *testing.T) {
+		out := execJobStatus(t, session, "no-result")
+		if len(out.Job.Result) != 0 {
+			t.Fatalf("expected no result, got %s", out.Job.Result)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`exec_job_status` (and every other job tool returning an `EnvironmentJob`) failed its own MCP output-schema validation for any task job whose `Result` was non-empty and not an array — e.g. a finished `release` job, whose result is an object. The state and exit code an orchestrator polls for were unreachable at exactly the moment a long job finished.

## Root cause

`EnvironmentJob.Result` is `json.RawMessage` (an alias for `[]byte`). The `go-sdk`'s schema reflector (`jsonschema-go`) has no concept of "arbitrary JSON value" for a byte slice — it reads the Go kind and emits `{"type": ["null", "array"], "items": {"type": "integer", ...}}`, i.e. "an array of bytes". A `release` job's `Result` is a JSON object, so the value the tool actually produces can never satisfy the schema the same tool publishes. Verified directly against the reflector (`jsonschema.ForType`) before writing the fix — the emitted schema for `job.properties.result` is exactly that byte-array shape, matching the reported error message byte for byte.

## Fix

1. **Schema mechanism**: `jsonschema-go`'s `ForOptions.TypeSchemas` lets a caller override the schema for an exact Go type wherever it appears in the reflected tree — the same mechanism the library uses internally for `time.Time`, `big.Int`, etc. (`initialSchemaMap` in `jsonschema-go`). `erun-mcp/capabilities.go`'s `addTool` is the single choke point every tool registration passes through (`erun-mcp/capabilities.go:62`), so that's where the override now applies: `reflect.TypeFor[json.RawMessage]()` → a zero-value `*jsonschema.Schema{}`, which this same library already treats as "unrestricted" (its own `reflect.Interface` case uses the identical zero value, and `Schema.MarshalJSON` renders an empty schema as the JSON Schema boolean `true`). The computed schema is set explicitly on `tool.OutputSchema` before calling `mcp.AddTool`, mirroring exactly what the SDK's own default derivation does (same pointer-unwrap, same `Out == any` omission) except routed through the override.

   Emitted schema for `job.properties.result` **before**: `{"type": ["null", "array"], "items": {"type": "integer", "minimum": 0, "maximum": 255}}`.
   **After**: `true` (any JSON value).

2. **Terminal state surviving a surprising result**: no separate guard was added. `Result` was the only `json.RawMessage`-typed field anywhere in `EnvironmentJob`/`AwaitEnvironmentJobResult` — every other field is a plain string/int/bool/time/nested-struct that the reflector already renders correctly. With (1) making `result` unconditionally permissive, there is no longer any way for a real (already-valid, since it's "captured verbatim as JSON") `Result` payload to fail schema validation, so `state`/`exitCode` can no longer be held hostage by it. Adding a second guard on top would have no case to catch.

Nothing about what a job stores or returns changed — this is a schema-description fix only.

## Tests

`erun-mcp/job_result_schema_test.go`:
- `TestExecJobStatusOutputSchemaAcceptsAnyResultShape` — fetches the *actual* schema `exec_job_status` publishes over the wire (via `tools/list`), resolves it, and validates object/array/string/number/bool/null result shapes against it directly. This targets the real emitted schema rather than a hand-written expectation, so it would have caught the original bug.
- `TestExecJobStatusOutputSchemaAcceptsAJobWithNoResult` — same, for the absent-result case.
- `TestExecJobStatusRoundTripsAJobResult` — calls the tool through a real MCP client/server session (so it goes through the SDK's own output-schema validation, the exact step that errored in the field) with object, array, and scalar results, plus a job with no result, and asserts each round-trips correctly.

Confirmed all of the above fail against the pre-fix code (reproducing the reported error verbatim for object/string/number/bool; array happened to coincidentally satisfy the old schema) and pass with the fix.

## Validation

- `go test ./...` and `golangci-lint run ./...` green in `erun-mcp` (0 issues).
- `go build ./...` / `go test ./...` green in `erun-common` and `erun-cli` (unaffected, checked per repo convention).
- `make check` green end to end (lint across all modules, all module test suites, integration suite at 75.8% coverage, chart tests).

Closes #1635