### PR TITLE
Name the release claim holder's environment, not just its tenant

### DIFF
--- a/erun-common/release_claim.go
+++ b/erun-common/release_claim.go
@@ -111,7 +111,7 @@ func claimReleaseVersion(ctx Context, spec ReleaseSpec, env func(string) string)
 	holder := EnvironmentActivityLeaseHolder{Orchestrator: strings.TrimSpace(env("ERUN_ORCHESTRATOR_ID")), Tenant: tenant}
 	pid := os.Getpid()
 
-	repoSHA, err := takeReleaseRepoClaim(ctx, spec.ProjectRoot, spec.Version, holder, pid, time.Now())
+	repoSHA, err := takeReleaseRepoClaim(ctx, spec.ProjectRoot, environment, spec.Version, holder, time.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func renewReleaseClaims(ctx Context, spec ReleaseSpec, tenant, environment strin
 	if sha == "" {
 		return
 	}
-	if renewed, err := renewReleaseRepoClaim(ctx, spec.ProjectRoot, spec.Version, holder, pid, time.Now(), sha); err == nil {
+	if renewed, err := renewReleaseRepoClaim(ctx, spec.ProjectRoot, environment, spec.Version, holder, time.Now(), sha); err == nil {
 		repo.set(renewed)
 	}
 }

--- a/erun-common/release_repo_claim.go
+++ b/erun-common/release_repo_claim.go
@@ -43,12 +43,17 @@ const (
 	releaseRepoClaimMaxAttempts = 3
 )
 
-// releaseRepoClaimRecord is the JSON stored in the claim ref's blob.
+// releaseRepoClaimRecord is the JSON stored in the claim ref's blob. It
+// carries Environment rather than PID: every environment that can push to
+// the release's origin can race this claim, so the environment is what
+// actually identifies a losing caller's counterpart, while a pid only ever
+// named a process in a pod that may already be gone by the time anyone reads
+// it back.
 type releaseRepoClaimRecord struct {
-	Holder    EnvironmentActivityLeaseHolder `json:"holder"`
-	PID       int                            `json:"pid,omitempty"`
-	StartedAt time.Time                      `json:"startedAt"`
-	ExpiresAt time.Time                      `json:"expiresAt"`
+	Holder      EnvironmentActivityLeaseHolder `json:"holder"`
+	Environment string                         `json:"environment,omitempty"`
+	StartedAt   time.Time                      `json:"startedAt"`
+	ExpiresAt   time.Time                      `json:"expiresAt"`
 }
 
 // ReleaseRepoClaimConflictError names the still-live holder of the
@@ -56,14 +61,33 @@ type releaseRepoClaimRecord struct {
 // uses, so a second orchestrator sees one consistent message regardless of
 // which of the two claims refused it.
 type ReleaseRepoClaimConflictError struct {
-	Version   string
-	Holder    EnvironmentActivityLeaseHolder
-	ExpiresAt time.Time
+	Version     string
+	Holder      EnvironmentActivityLeaseHolder
+	Environment string
+	ExpiresAt   time.Time
 }
 
 func (e *ReleaseRepoClaimConflictError) Error() string {
 	return fmt.Sprintf("%s is already being released by %s — wait for it to finish; a holder that crashes or whose pod is replaced is reclaimed automatically on the next attempt",
-		strings.TrimSpace(e.Version), e.Holder.String())
+		strings.TrimSpace(e.Version), releaseClaimHolderDescription(e.Holder, e.Environment))
+}
+
+// releaseClaimHolderDescription renders a holder together with the
+// environment racing it, which is the pair that actually lets a losing
+// caller find their counterpart. Either half can be absent — an older
+// claim record predating this field, or a holder with no other identifying
+// fields set — so each is only appended when present, never leaving a
+// dangling separator or an empty fragment.
+func releaseClaimHolderDescription(holder EnvironmentActivityLeaseHolder, environment string) string {
+	desc := holder.String()
+	environment = strings.TrimSpace(environment)
+	if environment == "" {
+		return desc
+	}
+	if desc == "an unnamed holder" {
+		return "environment " + environment
+	}
+	return desc + ", environment " + environment
 }
 
 func releaseRepoClaimRef(version string) string {
@@ -81,7 +105,7 @@ func releaseRepoClaimProbeRef(version string) string {
 // from a solo caller with nothing to contend against, so it is treated the
 // same way: proceed without the repository-global claim rather than invent a
 // refusal nothing confirms.
-func takeReleaseRepoClaim(ctx Context, projectRoot, version string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time) (string, error) {
+func takeReleaseRepoClaim(ctx Context, projectRoot, environment, version string, holder EnvironmentActivityLeaseHolder, now time.Time) (string, error) {
 	ref := releaseRepoClaimRef(version)
 
 	for attempt := 0; attempt < releaseRepoClaimMaxAttempts; attempt++ {
@@ -92,7 +116,7 @@ func takeReleaseRepoClaim(ctx Context, projectRoot, version string, holder Envir
 		}
 
 		if !exists {
-			newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, holder, pid, now)
+			newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now)
 			if err != nil {
 				return "", err
 			}
@@ -107,10 +131,10 @@ func takeReleaseRepoClaim(ctx Context, projectRoot, version string, holder Envir
 			return "", fmt.Errorf("release: %s exists on %s but its content could not be read: %w", ref, releaseRepoClaimRemote, err)
 		}
 		if releaseRepoClaimHeld(record, now) {
-			return "", &ReleaseRepoClaimConflictError{Version: version, Holder: record.Holder, ExpiresAt: record.ExpiresAt}
+			return "", &ReleaseRepoClaimConflictError{Version: version, Holder: record.Holder, Environment: record.Environment, ExpiresAt: record.ExpiresAt}
 		}
 
-		newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, holder, pid, now)
+		newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now)
 		if err != nil {
 			return "", err
 		}
@@ -127,8 +151,8 @@ func takeReleaseRepoClaim(ctx Context, projectRoot, version string, holder Envir
 // it (its own renewal having lapsed past the TTL) is never silently
 // overwritten. A failure here is best-effort, matching the local lease's
 // renewal: the caller keeps its last-known sha and tries again next tick.
-func renewReleaseRepoClaim(ctx Context, projectRoot, version string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time, currentSHA string) (string, error) {
-	newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, holder, pid, now)
+func renewReleaseRepoClaim(ctx Context, projectRoot, environment, version string, holder EnvironmentActivityLeaseHolder, now time.Time, currentSHA string) (string, error) {
+	newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now)
 	if err != nil {
 		return "", err
 	}
@@ -155,12 +179,12 @@ func releaseRepoClaimHeld(record releaseRepoClaimRecord, now time.Time) bool {
 	return !record.ExpiresAt.IsZero() && now.Before(record.ExpiresAt)
 }
 
-func writeReleaseRepoClaimBlob(ctx Context, projectRoot string, holder EnvironmentActivityLeaseHolder, pid int, now time.Time) (string, error) {
+func writeReleaseRepoClaimBlob(ctx Context, projectRoot, environment string, holder EnvironmentActivityLeaseHolder, now time.Time) (string, error) {
 	record := releaseRepoClaimRecord{
-		Holder:    holder,
-		PID:       pid,
-		StartedAt: now,
-		ExpiresAt: now.Add(releaseVersionClaimTTL),
+		Holder:      holder,
+		Environment: environment,
+		StartedAt:   now,
+		ExpiresAt:   now.Add(releaseVersionClaimTTL),
 	}
 	data, err := json.Marshal(record)
 	if err != nil {

--- a/erun-common/release_repo_claim_test.go
+++ b/erun-common/release_repo_claim_test.go
@@ -45,7 +45,7 @@ func TestReleaseRepoClaimRefusesASecondReleaseFromADifferentCheckoutAndNamesTheH
 	ctx := newTestClaimContext()
 
 	holderA := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a", Tenant: "erun"}
-	sha, err := takeReleaseRepoClaim(ctx, envA, "1.0.213", holderA, os.Getpid(), now)
+	sha, err := takeReleaseRepoClaim(ctx, envA, "build-a", "1.0.213", holderA, now)
 	if err != nil {
 		t.Fatalf("first environment's claim: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestReleaseRepoClaimRefusesASecondReleaseFromADifferentCheckoutAndNamesTheH
 	}
 
 	holderB := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b", Tenant: "erun"}
-	_, err = takeReleaseRepoClaim(ctx, envB, "1.0.213", holderB, os.Getpid()+1, now.Add(time.Second))
+	_, err = takeReleaseRepoClaim(ctx, envB, "build-b", "1.0.213", holderB, now.Add(time.Second))
 	if err == nil {
 		t.Fatal("expected a second release of the same version from a different checkout to be refused")
 	}
@@ -64,11 +64,69 @@ func TestReleaseRepoClaimRefusesASecondReleaseFromADifferentCheckoutAndNamesTheH
 	if !strings.Contains(err.Error(), "orchestrator-a") {
 		t.Errorf("refusal must name the holder so the second environment knows who to wait on, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "build-a") {
+		t.Errorf("refusal must name the losing caller's counterpart environment, got: %v", err)
+	}
 
 	// A release of a different version must not be affected: the claim is
 	// scoped to the version's own ref, not the whole repository.
-	if _, err := takeReleaseRepoClaim(ctx, envB, "1.0.214", holderB, os.Getpid()+1, now.Add(time.Second)); err != nil {
+	if _, err := takeReleaseRepoClaim(ctx, envB, "build-b", "1.0.214", holderB, now.Add(time.Second)); err != nil {
 		t.Fatalf("a release of a different version must not collide with an unrelated one in flight: %v", err)
+	}
+}
+
+// TestReleaseRepoClaimRefusalNamesTheEnvironmentWhenTheOrchestratorIDIsUnset
+// reproduces the shape a real release actually writes (erun#1637):
+// ERUN_ORCHESTRATOR_ID is unset in every in-pod release, so the holder
+// carries only a tenant. Two environments of that same tenant racing the
+// same version must still be told apart in the refusal — "tenant erun"
+// alone does not say which environment to go look at.
+func TestReleaseRepoClaimRefusalNamesTheEnvironmentWhenTheOrchestratorIDIsUnset(t *testing.T) {
+	envA := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, envA)
+	runGitForTest(t, envA, "push", "-q", "-u", "origin", "main")
+	envB := cloneRepoForTest(t, remote)
+
+	now := time.Date(2026, 8, 29, 17, 0, 53, 0, time.UTC)
+	ctx := newTestClaimContext()
+
+	holder := EnvironmentActivityLeaseHolder{Tenant: "erun"}
+	if _, err := takeReleaseRepoClaim(ctx, envA, "build", "1.0.215", holder, now); err != nil {
+		t.Fatalf("first environment's claim: %v", err)
+	}
+
+	_, err := takeReleaseRepoClaim(ctx, envB, "release", "1.0.215", holder, now.Add(time.Second))
+	if err == nil {
+		t.Fatal("expected a second release of the same version from a different environment to be refused")
+	}
+	if !strings.Contains(err.Error(), "environment build") {
+		t.Errorf("refusal must name the losing caller's counterpart environment, not just its tenant, got: %v", err)
+	}
+}
+
+// TestReleaseClaimHolderDescriptionRendersSensiblyWithMissingFields guards the
+// rendering itself: either half of the holder/environment pair can be
+// missing (an older claim record predating the environment field, or a
+// holder with nothing else set), and the description must never leave an
+// empty fragment or a dangling separator.
+func TestReleaseClaimHolderDescriptionRendersSensiblyWithMissingFields(t *testing.T) {
+	cases := []struct {
+		name        string
+		holder      EnvironmentActivityLeaseHolder
+		environment string
+		want        string
+	}{
+		{"holder and environment", EnvironmentActivityLeaseHolder{Tenant: "erun"}, "build", "tenant erun, environment build"},
+		{"environment only, holder unnamed", EnvironmentActivityLeaseHolder{}, "build", "environment build"},
+		{"holder only, no environment", EnvironmentActivityLeaseHolder{Tenant: "erun"}, "", "tenant erun"},
+		{"neither", EnvironmentActivityLeaseHolder{}, "", "an unnamed holder"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := releaseClaimHolderDescription(tc.holder, tc.environment); got != tc.want {
+				t.Errorf("releaseClaimHolderDescription(%+v, %q) = %q, want %q", tc.holder, tc.environment, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -82,7 +140,7 @@ func TestReleaseRepoClaimReclaimsAnAbandonedReleaseFromADifferentCheckout(t *tes
 	ctx := newTestClaimContext()
 
 	holderA := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a", Tenant: "erun"}
-	if _, err := takeReleaseRepoClaim(ctx, envA, "1.0.213", holderA, os.Getpid(), start); err != nil {
+	if _, err := takeReleaseRepoClaim(ctx, envA, "build-a", "1.0.213", holderA, start); err != nil {
 		t.Fatalf("first environment's claim: %v", err)
 	}
 
@@ -92,7 +150,7 @@ func TestReleaseRepoClaimReclaimsAnAbandonedReleaseFromADifferentCheckout(t *tes
 	// lapses.
 	afterLapse := start.Add(releaseVersionClaimTTL + time.Minute)
 	holderB := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b", Tenant: "erun"}
-	sha, err := takeReleaseRepoClaim(ctx, envB, "1.0.213", holderB, os.Getpid()+1, afterLapse)
+	sha, err := takeReleaseRepoClaim(ctx, envB, "build-b", "1.0.213", holderB, afterLapse)
 	if err != nil {
 		t.Fatalf("expected the abandoned claim to be reclaimed automatically, got refused: %v", err)
 	}


### PR DESCRIPTION
Closes #1637.

## The defect

#1633 made the release claim repository-global and that works -- observed live: `refs/erun/release-claim/1.0.215` appeared on origin during a real release, with a TTL, and was released cleanly afterwards. Mutual exclusion is not in question. This is a follow-up to a correct fix.

But the refusal named nobody. The blob that real release wrote:

```json
{"holder":{"tenant":"erun"},"pid":420,"startedAt":"...","expiresAt":"..."}
```

so a refused second releaser was told `... is already being released by tenant erun`. Every environment that can race this claim is tenant `erun`, so that identifies no one.

Two causes:

1. `holder` was built with `Orchestrator: env("ERUN_ORCHESTRATOR_ID")` -- a **host-side** variable. The release runs in the environment's pod, where it is unset (verified directly), so `Orchestrator` is empty on every in-pod release and `String()` fell through to tenant alone. It cannot be populated there: the pod does not know which host orchestrator drove it.
2. `EnvironmentActivityLeaseHolder` has no environment field -- yet the environment was in hand one statement away at the call site.

The claim was correctly scoped repository-globally; the *description* of the holder had lost the very axis #1631 was about.

## The change

**Environment goes on the claim record, not on the shared holder type.** `EnvironmentActivityLeaseHolder` is shared with the activity-lease system, so widening it would have reached unrelated construction sites and `String()` consumers for the benefit of one caller. `releaseRepoClaimRecord` carries `Environment` instead, and `releaseClaimHolderDescription(holder, environment)` renders the pair.

**`PID` is replaced by `Environment` on the claim record.** A pid named a process in a pod that may already be gone by the time anyone reads the record back; the environment is what actually identifies a losing caller's counterpart. Checked that nothing read the claim record's pid -- the remaining `PID` references are the activity-lease system's own, untouched.

**Both halves are optional.** An older claim record predating the field, or a holder with no identifying fields set, still renders sensibly: no dangling separator, no empty fragment, and an otherwise-unnamed holder renders as `environment <env>` rather than `an unnamed holder, environment <env>`.

The TTL reclaim, the CAS on the ref, and the inconclusive-read no-op are unchanged.

## Refusal text

Before:

```
1.0.215 is already being released by tenant erun — wait for it to finish; ...
```

After:

```
1.0.215 is already being released by tenant erun, environment build — wait for it to finish; ...
```

## Tests

- `TestReleaseRepoClaimRefusalNamesTheEnvironmentWhenTheOrchestratorIDIsUnset` -- the exact observed case: orchestrator id unset in-pod, and the refusal must still name the environment. Asserts on the rendered message, not merely that a conflict error came back.
- `TestReleaseClaimHolderDescriptionRendersSensiblyWithMissingFields` -- table over holder/environment present and absent, pinning the rendered string in each combination.
- Existing claim, reclaim and tag-repoint tests pass unchanged.

The pre-existing cross-checkout refusal test passed *before* this change with a holder that named nobody, which is how the gap shipped; asserting on rendered text is what closes that.

## Test plan
- [x] `make check` green -- full run, exit 0, integration suite 95.984s, coverage 75.8% (>= 75.8%)
