### PR TITLE
Fix guardTool writing the live caller into shared closure state

### DIFF
--- a/erun-mcp/capabilities.go
+++ b/erun-mcp/capabilities.go
@@ -165,17 +165,23 @@ func guardTool[In, Out any](identity authIdentity, name string, metrics *metrics
 		// registration is whichever caller first produced that set. Its
 		// capabilities are right by construction; its user is not. Prefer the
 		// live caller so the audit line names who actually called.
+		//
+		// caller is a per-call local: this closure is built once at
+		// registration and reused for every call to this tool, so the
+		// captured identity parameter is shared across concurrent callers and
+		// must stay read-only.
+		caller := identity
 		if live, ok := ctx.Value(authContextKey{}).(authIdentity); ok {
-			identity = live
+			caller = live
 		}
 		action := "mcp." + name
-		if !identity.Capabilities.AllowsTool(name) {
+		if !caller.Capabilities.AllowsTool(name) {
 			var zero Out
-			auditToolDecision(identity, name, false)
+			auditToolDecision(caller, name, false)
 			metrics.recordAuditEvent(action, "agent", "error")
 			return nil, zero, fmt.Errorf("tool %q requires the %s capability", name, eruncommon.MCPToolCapability(name))
 		}
-		auditToolDecision(identity, name, true)
+		auditToolDecision(caller, name, true)
 		result, out, err := handler(ctx, req, input)
 		label := mcpCallResultLabel(out, err)
 		metrics.recordMCPCall(name, label)

--- a/erun-mcp/capabilities_test.go
+++ b/erun-mcp/capabilities_test.go
@@ -2,10 +2,13 @@ package erunmcp
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -165,5 +168,107 @@ func TestGuardRefusesEvenWhenAHandlerIsReachedDirectly(t *testing.T) {
 	}
 	if called {
 		t.Fatal("a refused tool must not run its handler")
+	}
+}
+
+// captureAuditLog redirects the standard logger, which auditToolDecision
+// writes to, into a buffer for the duration of the test. log.SetOutput is
+// process-global, so the previous writer is restored on cleanup (see
+// erun-ui's restoreLogOutputAfter for the same pattern); the standard
+// logger serializes concurrent writers internally, so concurrent callers may
+// safely log through it while the test holds no lock of its own.
+func captureAuditLog(t *testing.T) *strings.Builder {
+	t.Helper()
+	var out strings.Builder
+	prev := log.Writer()
+	log.SetOutput(&out)
+	t.Cleanup(func() { log.SetOutput(prev) })
+	return &out
+}
+
+// The closure guardTool returns is built once per tool registration and
+// reused for every call to that tool, so the captured identity must not
+// become shared mutable state across concurrent callers. Each of many
+// concurrent callers, released at the same instant, must see its own audit
+// line -- not another caller's, and not a mix.
+func TestGuardToolAttributesEachConcurrentCallToItsOwnCaller(t *testing.T) {
+	out := captureAuditLog(t)
+
+	capabilities := eruncommon.NewMCPCapabilitySet([]string{string(eruncommon.MCPCapabilityRead)})
+	handler := func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, struct{}, error) {
+		return nil, struct{}{}, nil
+	}
+	guarded := guardTool(authIdentity{Tenant: "acme", User: "registration-time", Capabilities: capabilities}, "list", nil, handler)
+
+	const callers = 200
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(callers)
+	for i := 0; i < callers; i++ {
+		go func(i int) {
+			defer wg.Done()
+			ctx := withAuthIdentity(context.Background(), authIdentity{
+				Tenant:       "acme",
+				User:         fmt.Sprintf("user-%d", i),
+				Capabilities: capabilities,
+			})
+			<-start
+			if _, _, err := guarded(ctx, nil, struct{}{}); err != nil {
+				t.Errorf("call %d: unexpected refusal: %v", i, err)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	seen := make(map[string]int, callers)
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		idx := strings.Index(line, "user=")
+		if idx < 0 {
+			t.Fatalf("audit line has no user field: %q", line)
+		}
+		field := line[idx+len("user="):]
+		if sp := strings.IndexByte(field, ' '); sp >= 0 {
+			field = field[:sp]
+		}
+		seen[field]++
+	}
+	for i := 0; i < callers; i++ {
+		want := fmt.Sprintf("user-%d", i)
+		if seen[want] != 1 {
+			t.Fatalf("caller %q was audited %d times, want exactly 1 (audit log: %s)", want, seen[want], out.String())
+		}
+	}
+}
+
+// A call with no live auth context in it (the loopback-only edge, or a
+// misrouted request) must not be audited as whoever called previously. The
+// captured parameter starts at "registration-time" and is never touched by a
+// call that carries no identity, so it must still read that way after a
+// live caller has been through the same closure.
+func TestGuardToolWithNoAuthContextDoesNotInheritThePreviousCaller(t *testing.T) {
+	out := captureAuditLog(t)
+
+	capabilities := eruncommon.NewMCPCapabilitySet([]string{string(eruncommon.MCPCapabilityRead)})
+	handler := func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, struct{}, error) {
+		return nil, struct{}{}, nil
+	}
+	guarded := guardTool(authIdentity{Tenant: "acme", User: "registration-time", Capabilities: capabilities}, "list", nil, handler)
+
+	liveCtx := withAuthIdentity(context.Background(), authIdentity{Tenant: "acme", User: "live-caller", Capabilities: capabilities})
+	if _, _, err := guarded(liveCtx, nil, struct{}{}); err != nil {
+		t.Fatalf("live caller: unexpected refusal: %v", err)
+	}
+
+	if _, _, err := guarded(context.Background(), nil, struct{}{}); err != nil {
+		t.Fatalf("no-auth-context caller: unexpected refusal: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 audit lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[1], "user=registration-time") {
+		t.Fatalf("a call with no auth context must be audited as the registered identity, not the previous live caller: %q", lines[1])
 	}
 }


### PR DESCRIPTION
## Summary

`guardTool` in `erun-mcp/capabilities.go` writes the live caller into its closure-captured `identity` parameter. That closure is built once per tool registration and reused for every call, so `identity` was shared mutable state across concurrent callers: a data race in the Go memory-model sense, and it let `auditToolDecision` and the metrics events attribute a call to the wrong user — including a call arriving with no auth context, which took neither branch and got audited as whoever ran previously.

This is **not** a privilege escalation or auth bypass. `capabilityServerCache.serverFor` keys the cache on `identity.Capabilities.Key()`, so a caller is always routed to the server built for its own capability set; a stale `identity` still carries that same capability set, so `AllowsTool` decides correctly regardless. The damage is audit integrity and correctness under concurrency.

## Fix

Shadow the captured parameter with a per-call local (`caller`) instead of writing through it. `identity` (the registration-time parameter) is now read-only; `caller` holds the live value for this call only. No other change to `guardTool`'s structure or the capability check's semantics.

## Tests

- `TestGuardToolAttributesEachConcurrentCallToItsOwnCaller` — 200 goroutines call one `guardTool`-wrapped handler concurrently, each with a distinct identity; asserts every caller's own audit line appears exactly once. Fails before the fix (misattributed/duplicated/dropped users) and trips the race detector; passes and is race-silent after.
- `TestGuardToolWithNoAuthContextDoesNotInheritThePreviousCaller` — a live caller followed by a call with no auth context; the second call must audit as the registered identity, not the previous live caller.
- Existing capability allow/deny tests (`TestReadCapabilitySeesOnlyTheReadTools`, `TestAdminCapabilitySeesEveryTool`, `TestCallingAToolOutsideTheCapabilityFails`, `TestGuardRefusesEvenWhenAHandlerIsReachedDirectly`, etc.) are unchanged and pass under `-race`.

## Validation

- `go test ./... -race` in `erun-mcp`: green.
- `make check`: green (lint, unit, chart, and integration gates, integration coverage 75.8%).

Closes #1639