### PR TITLE
Report an unreadable helm release as unreadable, not confirmed absent

### DIFF
--- a/erun-common/observe_drift.go
+++ b/erun-common/observe_drift.go
@@ -30,36 +30,52 @@ func computeObserveDrift(req ShellLaunchParams, release *ObservedHelmRelease, po
 	// they can.
 	switch {
 	case !release.Found && release.Error != "":
-		if recordedVersion != "" {
-			findings = append(findings, fmt.Sprintf(
-				"env config records runtimeversion %s but the runtime helm release %q in namespace %q could not be read: %s",
-				recordedVersion, release.Name, req.Namespace, release.Error))
-		}
+		findings = append(findings, unreadableReleaseDrift(req, release, recordedVersion)...)
 	case !release.Found:
-		if recordedVersion != "" {
-			findings = append(findings, fmt.Sprintf(
-				"env config records runtimeversion %s but no runtime helm release %q was found in namespace %q",
-				recordedVersion, release.Name, req.Namespace))
-		}
+		findings = append(findings, missingReleaseDrift(req, release, recordedVersion)...)
 	default:
-		if recordedVersion != "" && release.AppVersion != "" && recordedVersion != release.AppVersion {
-			findings = append(findings, fmt.Sprintf(
-				"env config runtimeversion (%s) does not match the release's app version (%s)",
-				recordedVersion, release.AppVersion))
-		}
-
-		if runtimeImage := strings.TrimSpace(req.RuntimeImage); runtimeImage != "" {
-			if recorded, ok := release.ImageOverrides[DevopsComponentName]; ok && recorded != runtimeImage {
-				findings = append(findings, fmt.Sprintf(
-					"env config runtimeimage (%s) does not match the release's imageOverrides.%s (%s)",
-					runtimeImage, DevopsComponentName, recorded))
-			}
-		}
+		findings = append(findings, foundReleaseDrift(req, release, recordedVersion)...)
 	}
 
 	findings = append(findings, runningImageDrift(release, pods)...)
 	findings = append(findings, runtimePodDrift(req, release)...)
 
+	return findings
+}
+
+func unreadableReleaseDrift(req ShellLaunchParams, release *ObservedHelmRelease, recordedVersion string) []string {
+	if recordedVersion == "" {
+		return nil
+	}
+	return []string{fmt.Sprintf(
+		"env config records runtimeversion %s but the runtime helm release %q in namespace %q could not be read: %s",
+		recordedVersion, release.Name, req.Namespace, release.Error)}
+}
+
+func missingReleaseDrift(req ShellLaunchParams, release *ObservedHelmRelease, recordedVersion string) []string {
+	if recordedVersion == "" {
+		return nil
+	}
+	return []string{fmt.Sprintf(
+		"env config records runtimeversion %s but no runtime helm release %q was found in namespace %q",
+		recordedVersion, release.Name, req.Namespace)}
+}
+
+func foundReleaseDrift(req ShellLaunchParams, release *ObservedHelmRelease, recordedVersion string) []string {
+	var findings []string
+	if recordedVersion != "" && release.AppVersion != "" && recordedVersion != release.AppVersion {
+		findings = append(findings, fmt.Sprintf(
+			"env config runtimeversion (%s) does not match the release's app version (%s)",
+			recordedVersion, release.AppVersion))
+	}
+
+	if runtimeImage := strings.TrimSpace(req.RuntimeImage); runtimeImage != "" {
+		if recorded, ok := release.ImageOverrides[DevopsComponentName]; ok && recorded != runtimeImage {
+			findings = append(findings, fmt.Sprintf(
+				"env config runtimeimage (%s) does not match the release's imageOverrides.%s (%s)",
+				runtimeImage, DevopsComponentName, recorded))
+		}
+	}
 	return findings
 }
 

--- a/erun-common/observe_drift.go
+++ b/erun-common/observe_drift.go
@@ -20,26 +20,40 @@ func computeObserveDrift(req ShellLaunchParams, release *ObservedHelmRelease, po
 	var findings []string
 	recordedVersion := strings.TrimSpace(req.RuntimeVersion)
 
-	if !release.Found {
+	// release.Found is only false when the helm read itself failed (see
+	// ObservedHelmRelease's doc comment); release.Error then distinguishes a
+	// confirmed absence from a read that could not tell — a caller must never
+	// see the same "not found" line for both. Either way, runningImageDrift
+	// and runtimePodDrift below still run: their own inputs (release fields
+	// populated only on a successful read) make them no-ops here today, but
+	// nothing about this branch should stop them from evaluating whatever
+	// they can.
+	switch {
+	case !release.Found && release.Error != "":
+		if recordedVersion != "" {
+			findings = append(findings, fmt.Sprintf(
+				"env config records runtimeversion %s but the runtime helm release %q in namespace %q could not be read: %s",
+				recordedVersion, release.Name, req.Namespace, release.Error))
+		}
+	case !release.Found:
 		if recordedVersion != "" {
 			findings = append(findings, fmt.Sprintf(
 				"env config records runtimeversion %s but no runtime helm release %q was found in namespace %q",
 				recordedVersion, release.Name, req.Namespace))
 		}
-		return findings
-	}
-
-	if recordedVersion != "" && release.AppVersion != "" && recordedVersion != release.AppVersion {
-		findings = append(findings, fmt.Sprintf(
-			"env config runtimeversion (%s) does not match the release's app version (%s)",
-			recordedVersion, release.AppVersion))
-	}
-
-	if runtimeImage := strings.TrimSpace(req.RuntimeImage); runtimeImage != "" {
-		if recorded, ok := release.ImageOverrides[DevopsComponentName]; ok && recorded != runtimeImage {
+	default:
+		if recordedVersion != "" && release.AppVersion != "" && recordedVersion != release.AppVersion {
 			findings = append(findings, fmt.Sprintf(
-				"env config runtimeimage (%s) does not match the release's imageOverrides.%s (%s)",
-				runtimeImage, DevopsComponentName, recorded))
+				"env config runtimeversion (%s) does not match the release's app version (%s)",
+				recordedVersion, release.AppVersion))
+		}
+
+		if runtimeImage := strings.TrimSpace(req.RuntimeImage); runtimeImage != "" {
+			if recorded, ok := release.ImageOverrides[DevopsComponentName]; ok && recorded != runtimeImage {
+				findings = append(findings, fmt.Sprintf(
+					"env config runtimeimage (%s) does not match the release's imageOverrides.%s (%s)",
+					runtimeImage, DevopsComponentName, recorded))
+			}
 		}
 	}
 

--- a/erun-common/observe_drift_test.go
+++ b/erun-common/observe_drift_test.go
@@ -1,0 +1,135 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// computeObserveDrift is pure (no subprocess, no filesystem), the same shape
+// as fetchObservedHelmRelease's parse layer in observe_helm_release_test.go —
+// so it gets a focused unit test here rather than relying only on the
+// integration goldens, which can only lock the couple of shapes the observe
+// command's own fixtures happen to produce. The branch matrix this function
+// needs (found / genuinely absent / unreadable, each crossed with image and
+// pod drift) is cheaper and more exhaustive to hit directly than by threading
+// distinct helm/kubectl stub output through a real `erun observe` subprocess
+// for each case.
+
+func TestComputeObserveDriftNilReleaseReturnsNil(t *testing.T) {
+	if got := computeObserveDrift(ShellLaunchParams{RuntimeVersion: "1.0.0"}, nil, nil); got != nil {
+		t.Fatalf("drift = %v, want nil", got)
+	}
+}
+
+func TestComputeObserveDriftGenuinelyAbsentReleaseReportsNotFound(t *testing.T) {
+	req := ShellLaunchParams{RuntimeVersion: "1.0.0", Namespace: "team-dev"}
+	release := &ObservedHelmRelease{Name: "team-devops"}
+
+	got := computeObserveDrift(req, release, nil)
+
+	want := []string{`env config records runtimeversion 1.0.0 but no runtime helm release "team-devops" was found in namespace "team-dev"`}
+	if len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("drift = %v, want %v", got, want)
+	}
+}
+
+func TestComputeObserveDriftUnreadableReleaseNamesTheReasonNotFoundPhrasing(t *testing.T) {
+	req := ShellLaunchParams{RuntimeVersion: "1.0.0", Namespace: "team-dev"}
+	release := &ObservedHelmRelease{Name: "team-devops", Error: "observe: not authorized to read helm release \"team-devops\""}
+
+	got := computeObserveDrift(req, release, nil)
+
+	if len(got) != 1 {
+		t.Fatalf("drift = %v, want exactly one finding", got)
+	}
+	finding := got[0]
+	if !strings.Contains(finding, "could not be read") || !strings.Contains(finding, release.Error) {
+		t.Fatalf("finding %q does not name the read failure", finding)
+	}
+	if strings.Contains(finding, "was found") || strings.Contains(finding, "not found") {
+		t.Fatalf("finding %q reuses confirmed-absence phrasing for an unreadable release", finding)
+	}
+}
+
+func TestComputeObserveDriftUnreadableReleaseWithNoRecordedVersionReportsNothing(t *testing.T) {
+	req := ShellLaunchParams{Namespace: "team-dev"}
+	release := &ObservedHelmRelease{Name: "team-devops", Error: "observe: helm is not installed or not on PATH"}
+
+	if got := computeObserveDrift(req, release, nil); got != nil {
+		t.Fatalf("drift = %v, want nil when the env config never recorded a runtimeversion", got)
+	}
+}
+
+func TestComputeObserveDriftEvaluatesImageDriftWhenReleaseUnreadableButPodsAvailable(t *testing.T) {
+	// release.Found is false with Error set (an unreadable release), yet
+	// ImageOverrides still carries an entry — a shape fetchObservedHelmRelease
+	// cannot produce today (a failed `helm status` returns before any config
+	// is parsed) but the drift computation must not assume that of its input;
+	// it evaluates whatever runningImageDrift's own inputs allow.
+	req := ShellLaunchParams{Namespace: "team-dev"}
+	release := &ObservedHelmRelease{
+		Name:           "team-devops",
+		Error:          "observe: not authorized to read helm release",
+		ImageOverrides: map[string]string{"erun-devops": "registry.example/erun-devops:1.0.0"},
+	}
+	pods := []ObservedPod{{
+		Name: "team-devops-abc123",
+		Containers: []ObservedContainer{{
+			Name:  "erun-devops",
+			Image: "registry.example/erun-devops:1.0.1-hotfix",
+		}},
+	}}
+
+	got := computeObserveDrift(req, release, pods)
+
+	found := false
+	for _, finding := range got {
+		if strings.Contains(finding, "imageOverrides.erun-devops") && strings.Contains(finding, "1.0.1-hotfix") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("drift = %v, want an image drift finding even though the release read failed", got)
+	}
+}
+
+func TestComputeObserveDriftEvaluatesPodDriftWhenReleaseUnreadableButRuntimePodAvailable(t *testing.T) {
+	req := ShellLaunchParams{Namespace: "team-dev", RuntimePod: RuntimePodResources{CPU: "4", Memory: "8916Mi"}}
+	release := &ObservedHelmRelease{
+		Name:       "team-devops",
+		Error:      "observe: not authorized to read helm release",
+		RuntimePod: RuntimePodResources{CPU: "2", Memory: "4096Mi"},
+	}
+
+	got := computeObserveDrift(req, release, nil)
+
+	found := false
+	for _, finding := range got {
+		if strings.Contains(finding, "runtime.resources.limits.cpu") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("drift = %v, want a runtimepod drift finding even though the release read failed", got)
+	}
+}
+
+func TestComputeObserveDriftFoundReleaseKeepsExistingChecks(t *testing.T) {
+	req := ShellLaunchParams{RuntimeVersion: "1.0.0", RuntimeImage: "registry.example/erun-devops:1.0.0", Namespace: "team-dev"}
+	release := &ObservedHelmRelease{
+		Name:           "team-devops",
+		Found:          true,
+		AppVersion:     "1.0.1",
+		ImageOverrides: map[string]string{"erun-devops": "registry.example/erun-devops:1.0.1"},
+	}
+
+	got := computeObserveDrift(req, release, nil)
+
+	joined := strings.Join(got, "\n")
+	if !strings.Contains(joined, "does not match the release's app version") {
+		t.Fatalf("drift = %v, want the recordedVersion/AppVersion mismatch finding", got)
+	}
+	if !strings.Contains(joined, "does not match the release's imageOverrides.erun-devops") {
+		t.Fatalf("drift = %v, want the runtimeimage/imageOverrides mismatch finding", got)
+	}
+}

--- a/erun-integration/observe_test.go
+++ b/erun-integration/observe_test.go
@@ -288,7 +288,9 @@ func TestObserve(t *testing.T) {
 
 	// real_run_helm_release_read_forbidden confirms an RBAC-denied read names
 	// the cause and the remedy instead of leaving the release section empty in
-	// a way indistinguishable from "nothing deployed here".
+	// a way indistinguishable from "nothing deployed here" — and that the
+	// drift array says the same thing, instead of collapsing to the identical
+	// "not found" line real_run_helm_release_not_found's golden carries.
 	t.Run("real_run_helm_release_read_forbidden", func(t *testing.T) {
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")

--- a/erun-integration/testdata/observe/real_run_helm_release_read_forbidden.txt
+++ b/erun-integration/testdata/observe/real_run_helm_release_read_forbidden.txt
@@ -97,7 +97,7 @@
     "error": "observe: not authorized to read helm release \"team-devops\" in namespace \"team-dev\" (Error: query: failed to query with labels: secrets is forbidden: User \"system:serviceaccount:team-dev:erun\" cannot list resource \"secrets\" in API group \"\" in the namespace \"team-dev\") — helm release state is stored as Secrets, so the caller's kubeconfig needs read access to Secrets in this namespace"
   },
   "drift": [
-    "env config records runtimeversion <VERSION> but no runtime helm release \"team-devops\" was found in namespace \"team-dev\""
+    "env config records runtimeversion <VERSION> but the runtime helm release \"team-devops\" in namespace \"team-dev\" could not be read: observe: not authorized to read helm release \"team-devops\" in namespace \"team-dev\" (Error: query: failed to query with labels: secrets is forbidden: User \"system:serviceaccount:team-dev:erun\" cannot list resource \"secrets\" in API group \"\" in the namespace \"team-dev\") — helm release state is stored as Secrets, so the caller's kubeconfig needs read access to Secrets in this namespace"
   ]
 }
 audit: erun observe --output json


### PR DESCRIPTION
## Summary

`computeObserveDrift` (`erun-common/observe_drift.go`) branched only on `release.Found` and never read `release.Error`, so a helm read that failed (RBAC denial, missing `helm`, an API-server timeout) produced the identical "no runtime helm release ... was found" drift line as a genuinely absent release — the exact conflation `ObservedHelmRelease`'s own doc comment forbids, and the exact bug `real_run_helm_release_read_forbidden.txt`'s doc comment said the goldens exist to catch. Its early `return` also skipped `runningImageDrift`/`runtimePodDrift` entirely on that path.

- An unreadable release now reports `"env config records runtimeversion %s but the runtime helm release %q in namespace %q could not be read: %s"`, naming the reason from `release.Error` — never "found"/"not found" phrasing.
- A genuinely absent release keeps its exact prior drift message.
- `runningImageDrift`/`runtimePodDrift` now run regardless of which of the three release states (found / absent / unreadable) applies, evaluating whatever inputs are actually available.
- Split the three branches into small helpers (`unreadableReleaseDrift`/`missingReleaseDrift`/`foundReleaseDrift`) to bring `computeObserveDrift` back under golangci-lint's `cyclop` limit.

## Before/after — the two integration goldens

`real_run_helm_release_not_found.txt` (release genuinely absent) is byte-identical, as required:
```
"env config records runtimeversion <VERSION> but no runtime helm release \"team-devops\" was found in namespace \"team-dev\""
```

`real_run_helm_release_read_forbidden.txt` (release unreadable, RBAC-denied) — before:
```
"env config records runtimeversion <VERSION> but no runtime helm release \"team-devops\" was found in namespace \"team-dev\""
```
after:
```
"env config records runtimeversion <VERSION> but the runtime helm release \"team-devops\" in namespace \"team-dev\" could not be read: observe: not authorized to read helm release \"team-devops\" in namespace \"team-dev\" (Error: query: failed to query with labels: secrets is forbidden: User \"system:serviceaccount:team-dev:erun\" cannot list resource \"secrets\" in API group \"\" in the namespace \"team-dev\") — helm release state is stored as Secrets, so the caller's kubeconfig needs read access to Secrets in this namespace"
```
The two goldens' drift arrays are no longer identical.

## Tests

Added `erun-common/observe_drift_test.go`: `computeObserveDrift` is a pure function (no subprocess, no filesystem) with a branch matrix — found / genuinely absent / unreadable, each crossed with image and pod drift — that's cheaper and more exhaustive to exercise directly than by threading distinct helm/kubectl stub output through a real `erun observe` subprocess for every combination. This mirrors the existing precedent in `observe_helm_release_test.go`, which already unit-tests `fetchObservedHelmRelease` (a similarly pure/stubbed parse layer) alongside the integration goldens rather than instead of them.

## Test plan

- [x] `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`
- [x] `erun-integration`'s `TestObserve` regenerated via `UPDATE_GOLDEN=1`; only `real_run_helm_release_read_forbidden.txt` changed, `real_run_helm_release_not_found.txt` is untouched
- [x] `make check` green (lint 0 issues across all modules, all test suites pass, integration coverage 75.8% ≥ 75.8% threshold)

Closes #1640