### PR TITLE
Key IsInRuntimeEnvironment on ERUN_ENV_TYPE, not worktree storage

### DIFF
--- a/erun-common/doctor_remote_init.go
+++ b/erun-common/doctor_remote_init.go
@@ -73,10 +73,19 @@ func (r RemoteInitInspection) MissingItems() []RemoteInitInspectionItem {
 }
 
 // IsInRuntimeEnvironment reports whether the current process is running
-// inside an erun runtime pod.
+// inside an erun runtime pod. The chart sets ERUN_ENV_TYPE on every pod it
+// renders to local-agent, remote-agent, or runtime — never to host, the one
+// EnvironmentType with no pod — so a valid, non-host value is true for any
+// pod regardless of how its worktree is stored. ERUN_REPO_REMOTE records
+// worktree storage, not pod-ness, and stays false for a local-agent pod
+// (hostPath-mounted worktree) even though it runs in a pod; it is kept only
+// as a fallback for a pod deployed by a chart that predates ERUN_ENV_TYPE.
 func IsInRuntimeEnvironment(env func(string) string) bool {
 	if env == nil {
 		env = os.Getenv
+	}
+	if envType := EnvironmentType(strings.TrimSpace(env("ERUN_ENV_TYPE"))); envType.IsValid() {
+		return envType != EnvironmentTypeHost
 	}
 	return strings.EqualFold(strings.TrimSpace(env("ERUN_REPO_REMOTE")), "true")
 }

--- a/erun-common/doctor_remote_init_test.go
+++ b/erun-common/doctor_remote_init_test.go
@@ -1,0 +1,73 @@
+package eruncommon
+
+import "testing"
+
+// TestIsInRuntimeEnvironment pins the fix for the bug where a local-agent
+// pod's hostPath-mounted worktree (ERUN_REPO_REMOTE=false) made this function
+// report "not in a runtime pod" while running inside one. ERUN_ENV_TYPE is
+// the signal now: set by the chart on every pod it renders, to a value other
+// than host only for a pod.
+func TestIsInRuntimeEnvironment(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "local-agent pod",
+			env: map[string]string{
+				"ERUN_ENV_TYPE":    "local-agent",
+				"ERUN_REPO_REMOTE": "false",
+				"ERUN_TENANT":      "frs",
+				"ERUN_ENVIRONMENT": "local",
+			},
+			want: true,
+		},
+		{
+			name: "remote-agent pod",
+			env: map[string]string{
+				"ERUN_ENV_TYPE":    "remote-agent",
+				"ERUN_REPO_REMOTE": "true",
+				"ERUN_TENANT":      "erun",
+				"ERUN_ENVIRONMENT": "build",
+			},
+			want: true,
+		},
+		{
+			name: "runtime pod",
+			env: map[string]string{
+				"ERUN_ENV_TYPE":    "runtime",
+				"ERUN_REPO_REMOTE": "true",
+			},
+			want: true,
+		},
+		{
+			name: "host laptop",
+			env:  map[string]string{},
+			want: false,
+		},
+		{
+			name: "legacy chart predating ERUN_ENV_TYPE, remote-agent",
+			env: map[string]string{
+				"ERUN_REPO_REMOTE": "true",
+			},
+			want: true,
+		},
+		{
+			name: "legacy chart predating ERUN_ENV_TYPE, local-agent",
+			env: map[string]string{
+				"ERUN_REPO_REMOTE": "false",
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lookup := func(key string) string { return tc.env[key] }
+			if got := IsInRuntimeEnvironment(lookup); got != tc.want {
+				t.Errorf("IsInRuntimeEnvironment() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`IsInRuntimeEnvironment` (`erun-common/doctor_remote_init.go`) claims to answer "am I inside an erun runtime pod?" but was keyed on `ERUN_REPO_REMOTE`, which answers a different question: how the worktree is stored (PVC vs. hostPath mount). A `local-agent` environment hostPath-mounts the operator's own checkout, so its pod renders `ERUN_REPO_REMOTE=false` and the function reported "not in a runtime pod" while running inside one.

Measured live across three runtime pods before this change:

```
frs/local   (local-agent)   ERUN_REPO_REMOTE='false'   -> IsInRuntimeEnvironment() = false  (WRONG)
erun/build  (remote-agent)  ERUN_REPO_REMOTE='true'    -> IsInRuntimeEnvironment() = true
erun/ux     (remote-agent)  ERUN_REPO_REMOTE='true'    -> IsInRuntimeEnvironment() = true
```

This gated three real behaviors incorrectly for `local-agent` pods: `activity_lease.go`'s take/release/list (via `environmentTargetsItself()` in `erun-cli/cmd/environment_call.go`) took the off-environment branch instead of writing the pod's own lease store the in-pod `emcp` server reads — meaning an in-pod agent taking a lease before a long gate did nothing the environment's own idle monitor would see, risking auto-stop mid-run — plus `doctor.go`'s in-pod doctor behavior and `doctor_sync_config.go`'s in-pod-only sync path.

## The fix

Key the check on `ERUN_ENV_TYPE` instead. The runtime chart (`erun-devops/k8s/erun-devops/templates/service.yaml`) sets `ERUN_ENV_TYPE` unconditionally on every pod it renders, to one of `local-agent`, `remote-agent`, or `runtime` — the same three types `EnvironmentType` already models in `erun-common/config.go`, alongside `host`, the one type with **no** pod at all (see that type's own doc comment). So a valid, non-host value is true for any pod regardless of worktree storage, and is never set on an operator's own machine — grepping the whole repo, `ERUN_ENV_TYPE` is set only by that chart template and read only by `doctor_sync_config.go` (for the same "in-pod" question) and `scripts/agent-gate.sh`, which already uses exactly this variable to detect "am I in an agent pod" for the long-gate-detaching wrapper documented in the root `AGENTS.md` — so this fix reuses an already-established, already-trusted signal rather than inventing a new one.

Verified live in this pod (`erun/ux`, a `remote-agent` pod, itself checked out at `1.0.216`/`1.0.217`): `ERUN_ENV_TYPE=remote-agent` is already set, confirming the chart currently deployed sends it. I could not verify in-pod behavior for a `local-agent` environment directly (I'm running in a `remote-agent` pod and cannot reach one), so that case is verified only via the table test below plus the issue's own measured `ERUN_REPO_REMOTE='false'` value for that pod.

`ERUN_REPO_REMOTE` is kept as a fallback only for a pod deployed by a chart old enough to predate `ERUN_ENV_TYPE` — it resolves `true` for a legacy remote-agent/runtime pod (preserving old behavior exactly) and stays `false`/undetected for a legacy local-agent pod, which is no worse than before this fix for that already-broken case.

### Other readers of `ERUN_REPO_REMOTE` (left untouched — it is correct as a worktree-storage flag)

- `erun-devops/docker/erun-devops/entrypoint.sh` — decides whether the worktree needs remote-init recovery based on storage, which is exactly what the flag means.
- `erun-common/doctor_sync_config.go:95` — legacy fallback deriving `EnvironmentType` from the old remote+snapshot pair when `ERUN_ENV_TYPE` is absent (pre-existing pattern this PR's own legacy fallback mirrors).
- `erun-common/doctor_sync_config.go:154` (`injectedManagedCloud`) — uses it as one input to whether an env is a managed-cloud environment, a separate semantic from pod detection.

None of these read `ERUN_REPO_REMOTE` as "am I in a pod" — all are genuinely about worktree storage or its historical encoding, so they're unaffected.

## Tests

New `erun-common/doctor_remote_init_test.go`, table-driven against the existing `env func(string) string` seam (no fixtures needed):
- local-agent pod (`ERUN_ENV_TYPE=local-agent`, `ERUN_REPO_REMOTE=false`) → `true` (the bug this PR fixes)
- remote-agent pod → `true`
- runtime pod → `true`
- host/laptop (no env vars) → `false`
- legacy chart predating `ERUN_ENV_TYPE`, remote-agent (`ERUN_REPO_REMOTE=true` only) → `true` (existing behavior unchanged)
- legacy chart predating `ERUN_ENV_TYPE`, local-agent (`ERUN_REPO_REMOTE=false` only) → `false` (pre-existing blind spot, not a new regression)

## Validation

`make check` — green, detached via `erun exec job start`/`await` per this pod's own agent-gate wrapper:

```
job started: make check (id check-6eb665068bca7e0b)
exited 0: make check, 6854 bytes of output
...
ok  coverage 75.8% (>= 75.8%)
```

All lint, unit, chart, and integration suites passed with no changes needed elsewhere.

Closes #1644