### PR TITLE
Discharge the runtime namespace-quota floor in the provision preview

### DIFF
--- a/erun-backend/erun-backend-api/internal/routes/environments_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments_test.go
@@ -820,6 +820,76 @@ func TestCreateEnvironmentPreviewStillEnforcesPlacement(t *testing.T) {
 	}
 }
 
+// runtimeFloorQuotaCases are the exact quota shapes
+// TestCreateEnvironmentRejectsQuotaBelowRuntimeFloor and
+// TestCreateEnvironmentAllowsWithinAggregateBudget already exercise on the
+// executing path, reused here so both preview entry points are checked
+// against the same table rather than a freshly invented one.
+var runtimeFloorQuotaCases = map[string]struct {
+	quota   stubTenantQuotaRepository
+	floorOK bool
+}{
+	"below runtime floor": {
+		quota:   stubTenantQuotaRepository{maxEnvironments: 10, maxCPUMillicores: 500, maxMemoryMB: 9216, maxStorageGB: 80},
+		floorOK: false,
+	},
+	"meets runtime floor": {
+		quota: stubTenantQuotaRepository{
+			maxEnvironments: 10, maxCPUMillicores: 8000, maxMemoryMB: 17832, maxStorageGB: 72,
+			maxTotalCPUMillicores: 16000, maxTotalMemoryMB: 35664, maxTotalStorageGB: 144,
+		},
+		floorOK: true,
+	},
+}
+
+// TestProvisionPreviewAgreesWithCreateOnRuntimeQuotaFloor locks the fix for
+// the provision preview skipping validateNamespaceQuotaFloor: both preview
+// entry points (POST /v1/provision and POST /v1/environments?preview=true)
+// must discharge the same runtime namespace-quota floor the executing create
+// path enforces, across the same quota shapes, so a plan that previews as
+// fine can never then 409 on the real request.
+func TestProvisionPreviewAgreesWithCreateOnRuntimeQuotaFloor(t *testing.T) {
+	for label, tc := range runtimeFloorQuotaCases {
+		t.Run(label, func(t *testing.T) {
+			previewRec := postCreateEnvironmentPreview(t, &stubEnvironmentRepository{}, tc.quota, `{"name":"prod","type":"runtime","preview":true}`)
+			if previewRec.Code != http.StatusOK {
+				t.Fatalf("preview status = %d, want 200", previewRec.Code)
+			}
+			previewResponse := decodeProvisionResponse(t, previewRec)
+			if previewResponse.QuotaOk != tc.floorOK {
+				t.Fatalf("preview quotaOk = %v, want %v: %v", previewResponse.QuotaOk, tc.floorOK, previewResponse.Plan)
+			}
+
+			provisionRec := postProvision(t, acmeTenant, &stubEnvironmentRepository{}, tc.quota, `{"environment":{"name":"prod","type":"runtime"}}`)
+			if provisionRec.Code != http.StatusOK {
+				t.Fatalf("provision status = %d, want 200", provisionRec.Code)
+			}
+			provisionResponse := decodeProvisionResponse(t, provisionRec)
+			if provisionResponse.QuotaOk != tc.floorOK {
+				t.Fatalf("provision quotaOk = %v, want %v: %v", provisionResponse.QuotaOk, tc.floorOK, provisionResponse.Plan)
+			}
+
+			if !tc.floorOK {
+				mustPlanLine(t, previewResponse.Plan, "BELOW RUNTIME MINIMUM, provisioning blocked: tenant CPU quota", "preview plan must name the quota and the shortfall")
+				mustPlanLine(t, provisionResponse.Plan, "BELOW RUNTIME MINIMUM, provisioning blocked: tenant CPU quota", "provision plan must name the quota and the shortfall")
+			}
+
+			environments := &stubEnvironmentRepository{created: model.Environment{EnvironmentID: "env-1", Name: "prod", Type: model.EnvironmentTypeRuntime}}
+			createRec := postCreateEnvironment(t, environments, tc.quota, `{"name":"prod","type":"runtime"}`)
+			wantCreateStatus := http.StatusConflict
+			if tc.floorOK {
+				wantCreateStatus = http.StatusCreated
+			}
+			if createRec.Code != wantCreateStatus {
+				t.Fatalf("create status = %d (body %s), want %d", createRec.Code, createRec.Body.String(), wantCreateStatus)
+			}
+			if previewResponse.QuotaOk != (createRec.Code != http.StatusConflict) {
+				t.Fatalf("preview quotaOk (%v) disagrees with whether the real create actually succeeded (status %d)", previewResponse.QuotaOk, createRec.Code)
+			}
+		})
+	}
+}
+
 type stubEnvironmentLifecycle struct {
 	stopped []provision.EnvLifecycleInput
 	err     error

--- a/erun-backend/erun-backend-api/internal/routes/provision.go
+++ b/erun-backend/erun-backend-api/internal/routes/provision.go
@@ -213,8 +213,13 @@ func (in provisionPlanInput) quotaOk() bool {
 	if in.count >= in.quota.MaxEnvironments {
 		return false
 	}
-	if in.envType == model.EnvironmentTypeRuntime && validateAggregateResourceBudget(in.runtimeCount+1, in.quota) != nil {
-		return false
+	if in.envType == model.EnvironmentTypeRuntime {
+		if validateNamespaceQuotaFloor(in.quota) != nil {
+			return false
+		}
+		if validateAggregateResourceBudget(in.runtimeCount+1, in.quota) != nil {
+			return false
+		}
 	}
 	return true
 }
@@ -239,7 +244,13 @@ func provisionPlan(in provisionPlanInput) []string {
 	}
 	plan = append(plan, quotaLine)
 	if in.envType == model.EnvironmentTypeRuntime {
-		plan = append(plan, fmt.Sprintf("quota: namespace capped at %dm CPU / %dMi memory / %dGi storage", in.quota.MaxCPUMillicores, in.quota.MaxMemoryMB, in.quota.MaxStorageGB))
+		floorLine := fmt.Sprintf("quota: namespace capped at %dm CPU / %dMi memory / %dGi storage", in.quota.MaxCPUMillicores, in.quota.MaxMemoryMB, in.quota.MaxStorageGB)
+		if err := validateNamespaceQuotaFloor(in.quota); err != nil {
+			floorLine += fmt.Sprintf(" — BELOW RUNTIME MINIMUM, provisioning blocked: %s", err.Error())
+		} else {
+			floorLine += " — meets the runtime environment's minimum"
+		}
+		plan = append(plan, floorLine)
 		projected := in.runtimeCount + 1
 		budgetLine := fmt.Sprintf("quota: %d runtime environment(s) at that cap project to %dm CPU / %dMi memory / %dGi storage against a tenant budget of %dm / %dMi / %dGi",
 			projected, projected*in.quota.MaxCPUMillicores, projected*in.quota.MaxMemoryMB, projected*in.quota.MaxStorageGB,


### PR DESCRIPTION
## Summary

`validateNamespaceQuotaFloor` (`environments.go`) is enforced on both the create path (`environments.go:783`) and the deploy path (`environments.go:574`, `revalidateResourceQuota`), but the provision preview never called it. A tenant quota whose fields are all `> 0` (so it saves fine) but whose per-environment CPU/memory is below the runtime floor previewed as `quotaOk: true` and then 409'd on the real request.

Both preview entry points — `POST /v1/provision` and `POST /v1/environments?preview=true` — build the same `provisionPlanInput` and call its `quotaOk()`/`provisionPlan()`, so the fix is in one place (`provision.go`):
- `quotaOk()` now also returns `false` for a runtime environment whose quota fails `validateNamespaceQuotaFloor`, alongside the existing environment-count and aggregate-budget checks.
- `provisionPlan()`'s "namespace capped at ..." line now names the outcome — `— meets the runtime environment's minimum` or `— BELOW RUNTIME MINIMUM, provisioning blocked: <the same shortfall text validateNamespaceQuotaFloor's 409 uses>` — the same "describe, don't error" shape the existing quota-count and aggregate-budget lines already use.

The 409 itself is untouched; the preview simply agrees with it now.

## Executing-path validations vs. what the preview discharges

Enumerating every check `createEnvironment` performs, for the fields the provision preview can affect:

| Validation | Executing path | Preview (`POST /v1/provision` and `?preview=true`) |
|---|---|---|
| name/type shape (`validNamespaceLabel`, known type) | yes | yes (same/mirrored validation before the plan is built) |
| raw `kubernetesContext` refused for runtime | yes (`resolvePlacement`) | yes |
| explicit `contextId` capacity (`validatePlacementCapacity`) | yes | yes for `?preview=true` (runs the same `resolvePlacement`, before the preview branch); N/A for `POST /v1/provision`, which has no `contextId` field of its own (documented in `provision.go`) |
| environment-count quota | yes | yes (`quotaOk()`) |
| runtime namespace-quota floor (`validateNamespaceQuotaFloor`) | yes | **was missing — fixed here** |
| aggregate resource budget (`validateAggregateResourceBudget`) | yes | yes (`quotaOk()`) |

One asymmetry found but **not** fixed here, named per the issue's "if any is genuinely bigger, name it and leave it" instruction: `?preview=true`'s placement resolution (`resolvePlacement`) is discharged, but by *erroring* (400/409) rather than *describing* the way the count/floor/budget checks do — a placement failure short-circuits before `previewCreateEnvironment` ever builds a plan/quotaOk response. That's a different shape from this bug (preview enforcing too little); it's preview enforcing via hard error instead of via a describable field, and reworking it to describe rather than error is a bigger change (would need a plan-shaped capacity outcome threaded through placement resolution) than the one-line floor fix this issue asked for.

## Tests

Added `TestProvisionPreviewAgreesWithCreateOnRuntimeQuotaFloor` (`environments_test.go`), table-driven over `runtimeFloorQuotaCases` — the exact quota shapes `TestCreateEnvironmentRejectsQuotaBelowRuntimeFloor` and `TestCreateEnvironmentAllowsWithinAggregateBudget` already use, reused rather than invented fresh:
- **below runtime floor**: both preview entry points report `quotaOk: false` with the shortfall named in the plan, and the real create 409s.
- **meets runtime floor**: both preview entry points report `quotaOk: true`, and the real create succeeds (201).
- Both cases assert the preview's `quotaOk` agrees with whether the real create actually succeeded.

## Validation

`make check` — green (lint, unit tests across all Go modules, frontend gates for `erun-kit`/`erun-console`, devops chart tests, integration suite, coverage 75.8% ≥ 75.8% threshold).

Closes #1646