### PR TITLE
Mirror the max-age reclaim decision into deploy dry-run singleflight

### DIFF
--- a/erun-common/deploy_singleflight.go
+++ b/erun-common/deploy_singleflight.go
@@ -223,6 +223,47 @@ func removeInflightMarker(path string) error {
 	return nil
 }
 
+// inflightMarkerFate is the dedup decision for a marker that blocked a claim,
+// expressed once so the mutating and dry-run paths cannot drift apart the way
+// the max-age reclaim arm once did on this path alone.
+type inflightMarkerFate int
+
+const (
+	inflightMarkerFateReclaimDead inflightMarkerFate = iota
+	inflightMarkerFateReclaimAged
+	inflightMarkerFateSkipDuplicate
+	inflightMarkerFateConcurrent
+)
+
+// decideInflightMarkerFate is a pure function of the existing marker, the
+// candidate params hash, and deps.now/deps.isAlive; it holds no side effects
+// so both the mutating reconcile path and the dry-run preview can share it.
+func decideInflightMarkerFate(deps helmDeploySingleFlightDeps, existing deployInflightRecord, paramsHash string) inflightMarkerFate {
+	if !deps.isAlive(existing.PID) {
+		return inflightMarkerFateReclaimDead
+	}
+	if !existing.StartedAt.IsZero() && deps.now().Sub(existing.StartedAt) > helmDeploySingleFlightMaxAge {
+		return inflightMarkerFateReclaimAged
+	}
+	if existing.ParamsHash == paramsHash {
+		return inflightMarkerFateSkipDuplicate
+	}
+	return inflightMarkerFateConcurrent
+}
+
+func concurrentDeployError(deploy HelmDeploySpec, existing deployInflightRecord) *HelmReleaseConcurrentDeployError {
+	return &HelmReleaseConcurrentDeployError{
+		ReleaseName:       deploy.ReleaseName,
+		Namespace:         deploy.Namespace,
+		KubernetesContext: deploy.KubernetesContext,
+		OtherPID:          existing.PID,
+		OtherStartedAt:    existing.StartedAt,
+		OtherTenant:       existing.Tenant,
+		OtherEnvironment:  existing.Environment,
+		OtherVersion:      existing.Version,
+	}
+}
+
 // reconcileExistingInflightMarker decides how to handle the marker that blocked
 // our claim. A true first return means it reclaimed the marker and the caller
 // should retry the exclusive create.
@@ -235,33 +276,24 @@ func reconcileExistingInflightMarker(ctx Context, deps helmDeploySingleFlightDep
 		}
 		return true, HelmDeploySingleFlightProceed, nil
 	}
-	if !deps.isAlive(existing.PID) {
+	switch decideInflightMarkerFate(deps, existing, paramsHash) {
+	case inflightMarkerFateReclaimDead:
 		ctx.Trace(fmt.Sprintf("dedup: reclaim (release=%s, prior pid=%d is dead)", releaseKey, existing.PID))
 		if rmErr := removeInflightMarker(path); rmErr != nil {
 			return false, HelmDeploySingleFlightProceed, fmt.Errorf("remove stale in-flight marker: %w", rmErr)
 		}
 		return true, HelmDeploySingleFlightProceed, nil
-	}
-	if !existing.StartedAt.IsZero() && deps.now().Sub(existing.StartedAt) > helmDeploySingleFlightMaxAge {
+	case inflightMarkerFateReclaimAged:
 		ctx.Trace(fmt.Sprintf("dedup: reclaim (release=%s, marker age %s exceeds max %s)", releaseKey, deps.now().Sub(existing.StartedAt).Round(time.Second), helmDeploySingleFlightMaxAge))
 		if rmErr := removeInflightMarker(path); rmErr != nil {
 			return false, HelmDeploySingleFlightProceed, fmt.Errorf("remove aged-out in-flight marker: %w", rmErr)
 		}
 		return true, HelmDeploySingleFlightProceed, nil
-	}
-	if existing.ParamsHash == paramsHash {
+	case inflightMarkerFateSkipDuplicate:
 		ctx.Trace(fmt.Sprintf("dedup: skip (release=%s, hash=%s, pid=%d already running identical deploy)", releaseKey, paramsHash, existing.PID))
 		return false, HelmDeploySingleFlightSkipDuplicate, nil
-	}
-	return false, HelmDeploySingleFlightProceed, &HelmReleaseConcurrentDeployError{
-		ReleaseName:       deploy.ReleaseName,
-		Namespace:         deploy.Namespace,
-		KubernetesContext: deploy.KubernetesContext,
-		OtherPID:          existing.PID,
-		OtherStartedAt:    existing.StartedAt,
-		OtherTenant:       existing.Tenant,
-		OtherEnvironment:  existing.Environment,
-		OtherVersion:      existing.Version,
+	default:
+		return false, HelmDeploySingleFlightProceed, concurrentDeployError(deploy, existing)
 	}
 }
 
@@ -277,23 +309,18 @@ func reportHelmDeploySingleFlightDryRun(ctx Context, deploy HelmDeploySpec, deps
 		ctx.Trace("dedup: ready (release=" + releaseKey + ", hash=" + paramsHash + ", existing marker unreadable: " + readErr.Error() + ")")
 		return HelmDeploySingleFlightProceed, nil, nil
 	}
-	if !deps.isAlive(existing.PID) {
+	switch decideInflightMarkerFate(deps, existing, paramsHash) {
+	case inflightMarkerFateReclaimDead:
 		ctx.Trace(fmt.Sprintf("dedup: would reclaim (release=%s, prior pid=%d is dead)", releaseKey, existing.PID))
 		return HelmDeploySingleFlightProceed, nil, nil
-	}
-	if existing.ParamsHash == paramsHash {
+	case inflightMarkerFateReclaimAged:
+		ctx.Trace(fmt.Sprintf("dedup: would reclaim (release=%s, marker age %s exceeds max %s)", releaseKey, deps.now().Sub(existing.StartedAt).Round(time.Second), helmDeploySingleFlightMaxAge))
+		return HelmDeploySingleFlightProceed, nil, nil
+	case inflightMarkerFateSkipDuplicate:
 		ctx.Trace(fmt.Sprintf("dedup: would skip (release=%s, hash=%s, pid=%d already running identical deploy)", releaseKey, paramsHash, existing.PID))
 		return HelmDeploySingleFlightSkipDuplicate, nil, nil
-	}
-	return HelmDeploySingleFlightProceed, nil, &HelmReleaseConcurrentDeployError{
-		ReleaseName:       deploy.ReleaseName,
-		Namespace:         deploy.Namespace,
-		KubernetesContext: deploy.KubernetesContext,
-		OtherPID:          existing.PID,
-		OtherStartedAt:    existing.StartedAt,
-		OtherTenant:       existing.Tenant,
-		OtherEnvironment:  existing.Environment,
-		OtherVersion:      existing.Version,
+	default:
+		return HelmDeploySingleFlightProceed, nil, concurrentDeployError(deploy, existing)
 	}
 }
 

--- a/erun-common/deploy_singleflight_test.go
+++ b/erun-common/deploy_singleflight_test.go
@@ -1,0 +1,252 @@
+package eruncommon
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeInflightMarkerFile writes a marker JSON file to path with the same
+// encoding acquireHelmDeploySingleFlight itself uses, so tests can seed a
+// pre-existing marker without going through the acquire path.
+func writeInflightMarkerFile(t *testing.T, path string, record deployInflightRecord) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create marker file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := writeInflightRecord(f, record); err != nil {
+		t.Fatalf("write marker record: %v", err)
+	}
+}
+
+func testDeploySpec() HelmDeploySpec {
+	return HelmDeploySpec{
+		ReleaseName:       "acme-app",
+		Namespace:         "acme-ns",
+		KubernetesContext: "acme-ctx",
+		ChartPath:         "oci://ghcr.io/sophium/charts/erun-devops",
+	}
+}
+
+func markerPathFor(t *testing.T, configDir string, deploy HelmDeploySpec) string {
+	t.Helper()
+	deployDir := filepath.Join(configDir, deployInflightDirName)
+	if err := os.MkdirAll(deployDir, 0o755); err != nil {
+		t.Fatalf("mkdir deploy dir: %v", err)
+	}
+	return filepath.Join(deployDir, helmDeployReleaseKey(deploy)+".json")
+}
+
+// TestDryRunReclaimsAnAgedMarkerWithALivePIDLikeTheRealRun proves the dry-run
+// preview mirrors the real run's max-age reclaim arm: a marker older than
+// helmDeploySingleFlightMaxAge with a live PID and identical params must report
+// that it would proceed and reclaim, the same fate the real run reaches via
+// reconcileExistingInflightMarker.
+func TestDryRunReclaimsAnAgedMarkerWithALivePIDLikeTheRealRun(t *testing.T) {
+	configDir := t.TempDir()
+	deploy := testDeploySpec()
+	path := markerPathFor(t, configDir, deploy)
+	paramsHash := helmDeployParamsHash(deploy)
+
+	startedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	record := deployInflightRecord{
+		PID:        4242,
+		StartedAt:  startedAt,
+		ParamsHash: paramsHash,
+	}
+	writeInflightMarkerFile(t, path, record)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker before: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	ctx := Context{DryRun: true, Logger: NewLogger(0).WithTraceSink(&logBuf)}
+	deps := helmDeploySingleFlightDeps{
+		configDir: func() (string, error) { return configDir, nil },
+		now:       func() time.Time { return startedAt.Add(helmDeploySingleFlightMaxAge + time.Minute) },
+		isAlive:   func(int) bool { return true },
+	}
+
+	outcome, handle, err := acquireHelmDeploySingleFlight(ctx, deploy, deps)
+	if err != nil {
+		t.Fatalf("acquire: unexpected error: %v", err)
+	}
+	if handle != nil {
+		t.Fatalf("dry-run must never return a real handle")
+	}
+	if outcome != HelmDeploySingleFlightProceed {
+		t.Fatalf("outcome = %v, want Proceed (would reclaim)", outcome)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte("would reclaim")) {
+		t.Fatalf("trace = %q, want it to mention 'would reclaim'", logBuf.String())
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("dry-run mutated the on-disk marker: before=%q after=%q", before, after)
+	}
+}
+
+// TestDryRunReclaimsAnAgedMarkerInsteadOfRefusingAsConcurrent proves the
+// different-params case: without the max-age arm, dry-run refused with a
+// concurrent-deploy error for a marker the real run would reclaim and deploy
+// past. It must instead report Proceed with no error.
+func TestDryRunReclaimsAnAgedMarkerInsteadOfRefusingAsConcurrent(t *testing.T) {
+	configDir := t.TempDir()
+	deploy := testDeploySpec()
+	path := markerPathFor(t, configDir, deploy)
+
+	startedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	record := deployInflightRecord{
+		PID:        4242,
+		StartedAt:  startedAt,
+		ParamsHash: "some-other-hash",
+	}
+	writeInflightMarkerFile(t, path, record)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker before: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	ctx := Context{DryRun: true, Logger: NewLogger(0).WithTraceSink(&logBuf)}
+	deps := helmDeploySingleFlightDeps{
+		configDir: func() (string, error) { return configDir, nil },
+		now:       func() time.Time { return startedAt.Add(helmDeploySingleFlightMaxAge + time.Minute) },
+		isAlive:   func(int) bool { return true },
+	}
+
+	outcome, handle, err := acquireHelmDeploySingleFlight(ctx, deploy, deps)
+	if err != nil {
+		t.Fatalf("acquire: want Proceed with no error (would reclaim), got error: %v", err)
+	}
+	if handle != nil {
+		t.Fatalf("dry-run must never return a real handle")
+	}
+	if outcome != HelmDeploySingleFlightProceed {
+		t.Fatalf("outcome = %v, want Proceed (would reclaim), not a concurrent-deploy refusal", outcome)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte("would reclaim")) {
+		t.Fatalf("trace = %q, want it to mention 'would reclaim'", logBuf.String())
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("dry-run mutated the on-disk marker: before=%q after=%q", before, after)
+	}
+}
+
+// TestDryRunKeepsSkipBehaviorForAFreshMarkerWithIdenticalParams proves the fix
+// does not touch today's behavior for a marker within the max age: identical
+// params still report SkipDuplicate, and the marker is left untouched.
+func TestDryRunKeepsSkipBehaviorForAFreshMarkerWithIdenticalParams(t *testing.T) {
+	startedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fixedNow := startedAt.Add(time.Minute)
+
+	configDir := t.TempDir()
+	deploy := testDeploySpec()
+	path := markerPathFor(t, configDir, deploy)
+	paramsHash := helmDeployParamsHash(deploy)
+
+	writeInflightMarkerFile(t, path, deployInflightRecord{
+		PID:        4242,
+		StartedAt:  startedAt,
+		ParamsHash: paramsHash,
+	})
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker before: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	ctx := Context{DryRun: true, Logger: NewLogger(0).WithTraceSink(&logBuf)}
+	deps := helmDeploySingleFlightDeps{
+		configDir: func() (string, error) { return configDir, nil },
+		now:       func() time.Time { return fixedNow },
+		isAlive:   func(int) bool { return true },
+	}
+
+	outcome, handle, err := acquireHelmDeploySingleFlight(ctx, deploy, deps)
+	if err != nil {
+		t.Fatalf("acquire: unexpected error: %v", err)
+	}
+	if handle != nil {
+		t.Fatalf("dry-run must never return a real handle")
+	}
+	if outcome != HelmDeploySingleFlightSkipDuplicate {
+		t.Fatalf("outcome = %v, want SkipDuplicate", outcome)
+	}
+	if !bytes.Contains(logBuf.Bytes(), []byte("would skip")) {
+		t.Fatalf("trace = %q, want it to mention 'would skip'", logBuf.String())
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("dry-run mutated the on-disk marker: before=%q after=%q", before, after)
+	}
+}
+
+// TestDryRunKeepsRefuseBehaviorForAFreshMarkerWithDifferentParams proves the
+// fix does not touch today's behavior for a marker within the max age:
+// different params still refuse with a concurrent-deploy error, and the
+// marker is left untouched.
+func TestDryRunKeepsRefuseBehaviorForAFreshMarkerWithDifferentParams(t *testing.T) {
+	startedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fixedNow := startedAt.Add(time.Minute)
+
+	configDir := t.TempDir()
+	deploy := testDeploySpec()
+	path := markerPathFor(t, configDir, deploy)
+
+	writeInflightMarkerFile(t, path, deployInflightRecord{
+		PID:        4242,
+		StartedAt:  startedAt,
+		ParamsHash: "some-other-hash",
+	})
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker before: %v", err)
+	}
+
+	ctx := Context{DryRun: true, Logger: NewLogger(0)}
+	deps := helmDeploySingleFlightDeps{
+		configDir: func() (string, error) { return configDir, nil },
+		now:       func() time.Time { return fixedNow },
+		isAlive:   func(int) bool { return true },
+	}
+
+	outcome, handle, err := acquireHelmDeploySingleFlight(ctx, deploy, deps)
+	if err == nil {
+		t.Fatalf("acquire: want a concurrent-deploy error, got none (outcome=%v)", outcome)
+	}
+	var concurrentErr *HelmReleaseConcurrentDeployError
+	if !errors.As(err, &concurrentErr) {
+		t.Fatalf("acquire: want *HelmReleaseConcurrentDeployError, got %T: %v", err, err)
+	}
+	if handle != nil {
+		t.Fatalf("dry-run must never return a real handle")
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read marker after: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatalf("dry-run mutated the on-disk marker: before=%q after=%q", before, after)
+	}
+}

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -3203,7 +3203,10 @@ esac
 		// the same params hash, dry-run reports "would skip" and exits 0.
 		// We seed the marker with our own pid (always alive during this
 		// test) and the params hash erun --dry-run will compute on the
-		// first run. The second run sees the live identical marker.
+		// first run. The second run sees the live identical marker. The
+		// marker must also be recent or the max-age reclaim arm would fire
+		// first (the fixture's default StartedAt is fixed, so it ages past
+		// the 15-minute ceiling as real time passes).
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		fixture.SeedDevopsRepo(t, setup, "team", "dev")
@@ -3214,6 +3217,7 @@ esac
 		hash := extractDedupHash(t, first.Combined)
 		fixture.SeedDeployInflightMarker(t, setup, "test-context", "team-dev", "team-devops", fixture.DeployInflightRecord{
 			PID:         os.Getpid(),
+			StartedAt:   time.Now().UTC().Format(time.RFC3339),
 			ParamsHash:  hash,
 			Tenant:      "team",
 			Environment: "dev",
@@ -3236,12 +3240,16 @@ esac
 		// A live in-flight deploy with a different params hash should fail
 		// the second invocation with HelmReleaseConcurrentDeployError so two
 		// callers with conflicting intent surface the conflict instead of
-		// stomping on each other's helm release.
+		// stomping on each other's helm release. The marker must also be
+		// recent or the max-age reclaim arm would fire first (the fixture's
+		// default StartedAt is fixed, so it ages past the 15-minute ceiling
+		// as real time passes).
 		setup := env.New(t)
 		fixture.SeedTenantEnv(t, setup, "team", "dev")
 		fixture.SeedDevopsRepo(t, setup, "team", "dev")
 		fixture.SeedDeployInflightMarker(t, setup, "test-context", "team-dev", "team-devops", fixture.DeployInflightRecord{
 			PID:         os.Getpid(),
+			StartedAt:   time.Now().UTC().Format(time.RFC3339),
 			ParamsHash:  "0000000000000000",
 			Tenant:      "team",
 			Environment: "dev",


### PR DESCRIPTION
## Summary
- `reportHelmDeploySingleFlightDryRun` lacked the real run's max-age reclaim arm, so for a marker older than `helmDeploySingleFlightMaxAge` with a live PID (the documented case of a deploy CLI killed with its runtime pod, whose PID is coincidentally alive in a new pod's PID namespace), dry-run disagreed with what the real run would do: it reported "identical deploy already in progress" or refused with a concurrent-deploy error for a deploy the real run would reclaim and carry out.
- Extracted the dedup decision into a pure `decideInflightMarkerFate` (dead-PID reclaim / aged reclaim / identical skip / concurrent) consumed by both `reconcileExistingInflightMarker` (mutating) and `reportHelmDeploySingleFlightDryRun` (preview-only), so the two paths can no longer drift apart the way they did here — each path keeps its own trace wording ("reclaim" vs "would reclaim", "skip" vs "would skip") and its own side effects.
- Fixed two integration scenarios (`dry_run_dedup_skip_when_identical_marker_alive`, `dry_run_dedup_conflict_on_different_params`) that relied on the fixture's fixed default `StartedAt` (2026-05-10) to seed a "fresh" marker — with dry-run now applying the same max-age check, that fixed timestamp has aged past the 15-minute ceiling and the tests were hitting the new reclaim arm instead of the skip/conflict arm they meant to test. Gave them an explicit recent `StartedAt`, matching what the real-run siblings already do for the same reason.

## Test plan
- [x] New unit tests in `erun-common/deploy_singleflight_test.go`:
  - Aged marker (past `helmDeploySingleFlightMaxAge`), live PID, identical params: dry-run reports would-proceed/reclaim, matching the real run.
  - Same, different params: dry-run reports would-proceed/reclaim, not a concurrent-deploy refusal.
  - Fresh marker, live PID, identical params: dry-run still reports SkipDuplicate (unchanged).
  - Fresh marker, live PID, different params: dry-run still refuses with `*HelmReleaseConcurrentDeployError` (unchanged).
  - Every case asserts the on-disk marker file is byte-identical before/after via `os.ReadFile` comparison, not just "no error".
- [x] `go test ./...` and `golangci-lint run ./...` in `erun-common`.
- [x] `make check` green (lint across all modules, `erun-ui` tests, `erun-kit`/`erun-console` gates, devops chart tests, `erun-integration` suite including the two fixed dry-run dedup scenarios, coverage 75.8%).

Closes #1647