### PR TITLE
Normalize lease id and scope before comparing against a stored lease

### DIFF
--- a/erun-cli/cmd/activity_lease.go
+++ b/erun-cli/cmd/activity_lease.go
@@ -120,10 +120,7 @@ func takeLease(ctx context.Context, commandCtx common.Context, resolveOpen OpenR
 	}
 	if commandCtx.DryRun {
 		if params.Exclusive {
-			scope := params.Scope
-			if strings.TrimSpace(scope) == "" {
-				scope = "worktree"
-			}
+			scope := common.NormalizeExclusiveEnvironmentActivityLeaseScope(params.Scope)
 			commandCtx.TraceCommand("", "activity", "lease-take", params.Tenant, params.Environment, params.Name, "--exclusive", "--scope", scope)
 		} else {
 			commandCtx.TraceCommand("", "activity", "lease-take", params.Tenant, params.Environment, params.Name)
@@ -187,10 +184,7 @@ func releaseLease(ctx context.Context, commandCtx common.Context, resolveOpen Op
 	}
 	if commandCtx.DryRun {
 		if exclusive {
-			resolvedScope := scope
-			if strings.TrimSpace(resolvedScope) == "" {
-				resolvedScope = "worktree"
-			}
+			resolvedScope := common.NormalizeExclusiveEnvironmentActivityLeaseScope(scope)
 			commandCtx.TraceCommand("", "activity", "lease-release", tenant, environment, id, "--exclusive", "--scope", resolvedScope)
 		} else {
 			commandCtx.TraceCommand("", "activity", "lease-release", tenant, environment, id)

--- a/erun-common/activity_lease.go
+++ b/erun-common/activity_lease.go
@@ -142,14 +142,15 @@ func (p TakeEnvironmentActivityLeaseParams) normalize() (TakeEnvironmentActivity
 	if p.Name == "" {
 		return p, fmt.Errorf("lease name is required")
 	}
-	id, err := resolveEnvironmentActivityLeaseID(p.ID, p.Name)
+	id, err := ResolveEnvironmentActivityLeaseID(p.ID, p.Name)
 	if err != nil {
 		return p, err
 	}
 	p.ID = id
-	p.Scope = strings.TrimSpace(p.Scope)
-	if p.Exclusive && p.Scope == "" {
-		p.Scope = defaultEnvironmentActivityLeaseScope
+	if p.Exclusive {
+		p.Scope = NormalizeExclusiveEnvironmentActivityLeaseScope(p.Scope)
+	} else {
+		p.Scope = strings.TrimSpace(p.Scope)
 	}
 	if p.TTL == 0 {
 		if p.Exclusive {
@@ -398,7 +399,7 @@ func writeEnvironmentActivityLease(path string, lease EnvironmentActivityLease) 
 // success, so a wrapper's exit trap never fails a job that already finished
 // cleanly.
 func ReleaseEnvironmentActivityLease(tenant, environment, id string) error {
-	resolved, err := resolveEnvironmentActivityLeaseID(id, id)
+	resolved, err := ResolveEnvironmentActivityLeaseID(id, id)
 	if err != nil {
 		return err
 	}
@@ -423,7 +424,7 @@ func ReleaseExclusiveEnvironmentActivityLease(tenant, environment, scope, id str
 	if scope == "" {
 		scope = defaultEnvironmentActivityLeaseScope
 	}
-	resolvedID, err := resolveEnvironmentActivityLeaseID(id, id)
+	resolvedID, err := ResolveEnvironmentActivityLeaseID(id, id)
 	if err != nil {
 		return err
 	}
@@ -553,7 +554,12 @@ func capEnvironmentActivityLeaseExpiry(startedAt, expiresAt time.Time) time.Time
 	return expiresAt
 }
 
-func resolveEnvironmentActivityLeaseID(id, fallback string) (string, error) {
+// ResolveEnvironmentActivityLeaseID resolves a caller-supplied lease id (or
+// its fallback, typically the lease name) to the sanitized form the store
+// persists and keys files by. A caller that needs to compare a raw id against
+// a stored lease's ID must resolve it through here first — comparing the raw
+// value against the sanitized one is how erun#1652 happened.
+func ResolveEnvironmentActivityLeaseID(id, fallback string) (string, error) {
 	value := strings.TrimSpace(id)
 	if value == "" {
 		value = strings.TrimSpace(fallback)
@@ -566,6 +572,18 @@ func resolveEnvironmentActivityLeaseID(id, fallback string) (string, error) {
 		return "", fmt.Errorf("lease id %q has no usable characters", value)
 	}
 	return sanitized, nil
+}
+
+// NormalizeExclusiveEnvironmentActivityLeaseScope trims scope and defaults it
+// to "worktree" when empty, exactly as an exclusive take's own params
+// normalisation does before persisting — so a caller comparing against a
+// stored lease's Scope agrees with what will actually be written.
+func NormalizeExclusiveEnvironmentActivityLeaseScope(scope string) string {
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = defaultEnvironmentActivityLeaseScope
+	}
+	return scope
 }
 
 func environmentActivityLeaseDir(tenant, environment string) (string, error) {

--- a/erun-mcp/activity_lease.go
+++ b/erun-mcp/activity_lease.go
@@ -96,17 +96,26 @@ func activityLeaseTakeTool(runtime RuntimeConfig) func(context.Context, *mcp.Cal
 // would renew a claim the same holder id already has, in which case the
 // operator-presence gate does not apply. A best-effort read: if it cannot
 // tell, the take proceeds to the gate rather than skipping it.
+//
+// params.ID is still the caller's raw, unsanitized input at this point — the
+// store only sanitizes it inside TakeEnvironmentActivityLease, which has not
+// run yet — so it is resolved through the same normalisation the store uses
+// before comparing against the stored, already-sanitized lease.ID. Comparing
+// the raw value directly is how erun#1652 happened: a lease id needing
+// sanitisation (a space, a slash, a colon) never matched its stored form, so
+// every renewal misread as a fresh claim.
 func exclusiveEnvironmentActivityLeaseRenewsOwnClaim(tenant, environment string, params eruncommon.TakeEnvironmentActivityLeaseParams) bool {
-	scope := params.Scope
-	if strings.TrimSpace(scope) == "" {
-		scope = "worktree"
+	id, err := eruncommon.ResolveEnvironmentActivityLeaseID(params.ID, params.Name)
+	if err != nil {
+		return false
 	}
+	scope := eruncommon.NormalizeExclusiveEnvironmentActivityLeaseScope(params.Scope)
 	held, err := eruncommon.LoadEnvironmentActivityLeases(tenant, environment, time.Now())
 	if err != nil {
 		return false
 	}
 	for _, lease := range held {
-		if lease.Exclusive && lease.Scope == scope && lease.ID == params.ID {
+		if lease.Exclusive && lease.Scope == scope && lease.ID == id {
 			return true
 		}
 	}

--- a/erun-mcp/activity_lease_test.go
+++ b/erun-mcp/activity_lease_test.go
@@ -154,6 +154,104 @@ func TestExclusiveLeaseToolRefusesAFreshClaimWhileAnOperatorSSHSessionIsActive(t
 	}
 }
 
+// The lease id defaults to the name and is never sanitized by the caller,
+// but the store sanitizes it before persisting. A renewal must normalize the
+// raw id the same way before comparing against the stored lease, or a name
+// needing sanitization (a space, here) always misreads as a fresh claim.
+func TestExclusiveLeaseRenewalNormalizesASanitizedIDForTheSameCaller(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "erun", Environment: "ux"},
+		Store: listToolStore{
+			envConfigs: map[string]eruncommon.EnvConfig{"erun/ux": {Name: "ux"}},
+		},
+	}
+
+	_, first, err := activityLeaseTakeTool(runtime)(context.Background(), nil, ActivityLeaseTakeInput{
+		Name: "release 1.4.2", Exclusive: true,
+	})
+	if err != nil {
+		t.Fatalf("first take: %v", err)
+	}
+	if first.Lease == nil || first.Lease.ID != "release_1.4.2" {
+		t.Fatalf("expected the stored lease id to be sanitized, got %+v", first.Lease)
+	}
+
+	if err := eruncommon.RecordEnvironmentActivity(eruncommon.EnvironmentActivityParams{
+		Tenant: "erun", Environment: "ux", Kind: eruncommon.ActivityKindSSH,
+	}); err != nil {
+		t.Fatalf("seed ssh activity: %v", err)
+	}
+
+	if _, _, err := activityLeaseTakeTool(runtime)(context.Background(), nil, ActivityLeaseTakeInput{
+		Name: "release 1.4.2", Exclusive: true,
+	}); err != nil {
+		t.Fatalf("expected the same caller's renewal of a sanitized id to proceed despite ssh activity, got %v", err)
+	}
+}
+
+// The presence gate must still catch a genuinely fresh claim even when its id
+// happens to need sanitization - the fix must normalize both sides of the
+// comparison, not simply stop comparing.
+func TestExclusiveLeaseFreshClaimWithASanitizedIDStillRefusedWhileOperatorPresent(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "erun", Environment: "ux"},
+		Store: listToolStore{
+			envConfigs: map[string]eruncommon.EnvConfig{"erun/ux": {Name: "ux"}},
+		},
+	}
+	if err := eruncommon.RecordEnvironmentActivity(eruncommon.EnvironmentActivityParams{
+		Tenant: "erun", Environment: "ux", Kind: eruncommon.ActivityKindSSH,
+	}); err != nil {
+		t.Fatalf("seed ssh activity: %v", err)
+	}
+
+	_, _, err := activityLeaseTakeTool(runtime)(context.Background(), nil, ActivityLeaseTakeInput{
+		Name: "release 1.4.2", Exclusive: true,
+	})
+	var operatorPresent *eruncommon.EnvironmentOperatorPresentError
+	if !errors.As(err, &operatorPresent) {
+		t.Fatalf("expected a fresh exclusive claim with a sanitized id to still be refused while an ssh session is active, got %v", err)
+	}
+}
+
+// The lease's persisted Scope is only trimmed and defaulted, never run
+// through the id's filename sanitisation, so an untrimmed scope - not a
+// sanitized one - is the analogous mismatch on this field: the renewal check
+// must trim it the same way the store does before comparing.
+func TestExclusiveLeaseRenewalNormalizesAnUntrimmedScopeForTheSameCaller(t *testing.T) {
+	isolateLeaseCache(t)
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "erun", Environment: "ux"},
+		Store: listToolStore{
+			envConfigs: map[string]eruncommon.EnvConfig{"erun/ux": {Name: "ux"}},
+		},
+	}
+
+	_, first, err := activityLeaseTakeTool(runtime)(context.Background(), nil, ActivityLeaseTakeInput{
+		Name: "clone-a", Exclusive: true, Scope: " clone-a ",
+	})
+	if err != nil {
+		t.Fatalf("first take: %v", err)
+	}
+	if first.Lease == nil || first.Lease.Scope != "clone-a" {
+		t.Fatalf("expected the stored lease scope to be trimmed, got %+v", first.Lease)
+	}
+
+	if err := eruncommon.RecordEnvironmentActivity(eruncommon.EnvironmentActivityParams{
+		Tenant: "erun", Environment: "ux", Kind: eruncommon.ActivityKindSSH,
+	}); err != nil {
+		t.Fatalf("seed ssh activity: %v", err)
+	}
+
+	if _, _, err := activityLeaseTakeTool(runtime)(context.Background(), nil, ActivityLeaseTakeInput{
+		Name: "clone-a", Exclusive: true, Scope: " clone-a ",
+	}); err != nil {
+		t.Fatalf("expected the same caller's renewal of an untrimmed scope to proceed despite ssh activity, got %v", err)
+	}
+}
+
 func TestActivityLeaseToolsRejectIncompleteInput(t *testing.T) {
 	isolateLeaseCache(t)
 	// No server context and none supplied: an MCP path must fail clearly rather


### PR DESCRIPTION
## Problem

`activity_lease_take` defaults the lease id to the raw, unsanitized name and compares it directly against the store's sanitized, persisted `ID` when deciding whether a take renews the caller's own claim (`exclusiveEnvironmentActivityLeaseRenewsOwnClaim` in `erun-mcp/activity_lease.go`). A name needing sanitization (a space, a slash, a colon) never matches its stored form, so a renewal always misreads as a fresh claim. A fresh exclusive claim is gated on operator presence; a renewal deliberately is not. With the ids never matching, an operator opening an SSH session to watch a job's work sets the presence marker, and the job's next renewal is misclassified as fresh, refusing itself.

## Fix

- Exported `resolveEnvironmentActivityLeaseID` (the store's existing id normalization: trim, fall back to name, then `sanitizeForFilename`) as `eruncommon.ResolveEnvironmentActivityLeaseID`, and used it on both sides of the renewal comparison instead of re-implementing sanitization at the call site — a second copy is exactly how the comparison and the store drifted apart, so reusing the same function keeps them from drifting again.
- `exclusiveEnvironmentActivityLeaseRenewsOwnClaim` now resolves `params.ID` through that same normalization before comparing against the stored, already-sanitized `lease.ID`.

## Scope field — checked, genuinely a related but distinct gap

The persisted `EnvironmentActivityLease.Scope` field is **never** run through `sanitizeForFilename` — that sanitization only derives the on-disk file *path* (`exclusiveEnvironmentActivityLeasePath`); the JSON body stores the trimmed-and-defaulted raw scope. So a scope needing filename sanitization (e.g. containing `/`) is *not* actually affected by the id's defect, because the stored field never diverges from the trimmed raw value on that axis.

There is, however, a narrower analogous gap on the same field: the renewal comparison trimmed scope only when checking whether it was empty (to apply the `"worktree"` default), but never reassigned the trimmed value for a non-empty result — so a raw scope with incidental leading/trailing whitespace would fail to match its trimmed, stored form. Fixed by extracting the store's own trim-and-default logic (already duplicated at the take/normalize path) into an exported `eruncommon.NormalizeExclusiveEnvironmentActivityLeaseScope`, and using it on both sides of the comparison. Also reused it in `erun-cli/cmd/activity_lease.go`'s two dry-run trace call sites, which had their own inline copies of the same trim-and-default logic — removing those duplicates before they could drift the same way.

## Other raw-vs-stored comparisons checked

Searched every comparison against a persisted `EnvironmentActivityLease.ID`/`.Scope` across `erun-cli`, `erun-mcp`, and `erun-common`:
- `erun-common/activity_lease.go`'s `decideExclusiveEnvironmentActivityLeaseClaim` (`existing.ID == id`) and the two `Release*` functions — all resolve their id through `resolveEnvironmentActivityLeaseID`/normalization before comparing; unaffected.
- `erun-common/runtime_resize.go`'s release-on-defer uses the already-persisted `lease.Scope`/`lease.ID` from the take it just performed, not a fresh raw value; unaffected.
- `erun-cli/cmd/activity_lease.go` has no take-time comparison at all (no operator-presence gate on the CLI path); its only related logic was the display-only dry-run trace duplication called out above.

`exclusiveEnvironmentActivityLeaseRenewsOwnClaim` was the only real defect.

## Tests

Added to `erun-mcp/activity_lease_test.go` (all verified to fail against the pre-fix code, confirming they exercise the real bug):
- `TestExclusiveLeaseRenewalNormalizesASanitizedIDForTheSameCaller` — an exclusive lease taken with a name requiring sanitization (a space), renewed by the same caller while an operator is present, is recognized as a renewal and not refused.
- `TestExclusiveLeaseFreshClaimWithASanitizedIDStillRefusedWhileOperatorPresent` — the same lease taken fresh while an operator is present is still refused.
- `TestExclusiveLeaseRenewalNormalizesAnUntrimmedScopeForTheSameCaller` — a scope requiring normalization (whitespace) matches its stored, trimmed form on renewal.
- Pre-existing `TestExclusiveLeaseToolRenewalSkipsTheOperatorPresenceGate` / `TestExclusiveLeaseToolRefusesAFreshClaimWhileAnOperatorSSHSessionIsActive` continue to cover the id-needs-no-sanitization case unchanged.

## Validation

- `go test ./...` green in `erun-common`, `erun-mcp`, `erun-cli`.
- `make check` run (see follow-up comment / CI status for totals).

Closes #1652