### PR TITLE
Distinguish an unread memory.peak from a genuine zero in erun usage

### DIFF
--- a/erun-cli/cmd/usage_render.go
+++ b/erun-cli/cmd/usage_render.go
@@ -34,15 +34,36 @@ func writeUsageMemory(ctx common.Context, memory common.RuntimeMemoryUsage) erro
 		_, err := fmt.Fprintf(ctx.Stdout, "Memory: unavailable (%s)\n", memory.Unavailable)
 		return err
 	}
+	peak := formatUsagePeak(memory)
+	oomKills := formatUsageOOMKills(memory)
 	if memory.Unlimited {
-		_, err := fmt.Fprintf(ctx.Stdout, "Memory: %s used, no limit set, peak %s, OOM kills %d\n",
-			formatUsageBytes(memory.CurrentBytes), formatUsageBytes(memory.PeakBytes), memory.OOMKills)
+		_, err := fmt.Fprintf(ctx.Stdout, "Memory: %s used, no limit set, peak %s, OOM kills %s\n",
+			formatUsageBytes(memory.CurrentBytes), peak, oomKills)
 		return err
 	}
-	_, err := fmt.Fprintf(ctx.Stdout, "Memory: %s / %s (%.1f%%), peak %s, OOM kills %d\n",
+	_, err := fmt.Fprintf(ctx.Stdout, "Memory: %s / %s (%.1f%%), peak %s, OOM kills %s\n",
 		formatUsageBytes(memory.CurrentBytes), formatUsageBytes(memory.LimitBytes), memory.PercentOfLimit,
-		formatUsageBytes(memory.PeakBytes), memory.OOMKills)
+		peak, oomKills)
 	return err
+}
+
+// formatUsagePeak and formatUsageOOMKills report "unavailable" rather than a
+// fabricated zero when memory.peak / memory.events' oom_kill counter could
+// not be read -- the same distinction the reader itself carries via
+// PeakObserved/OOMKillsObserved, so the two never collapse into a confident
+// zero here either.
+func formatUsagePeak(memory common.RuntimeMemoryUsage) string {
+	if !memory.PeakObserved {
+		return "unavailable"
+	}
+	return formatUsageBytes(memory.PeakBytes)
+}
+
+func formatUsageOOMKills(memory common.RuntimeMemoryUsage) string {
+	if !memory.OOMKillsObserved {
+		return "unavailable"
+	}
+	return fmt.Sprintf("%d", memory.OOMKills)
 }
 
 func writeUsageDisk(ctx common.Context, disks []common.RuntimeDiskUsage) error {

--- a/erun-common/runtime_usage.go
+++ b/erun-common/runtime_usage.go
@@ -154,13 +154,25 @@ type RuntimeCPUUsage struct {
 // message would like to have had beforehand: current usage, the high-water
 // mark, and a real OOM-kill counter instead of "likely out of memory".
 type RuntimeMemoryUsage struct {
-	CurrentBytes   int64   `json:"currentBytes,omitempty"`
-	PeakBytes      int64   `json:"peakBytes,omitempty"`
+	CurrentBytes int64 `json:"currentBytes,omitempty"`
+	PeakBytes    int64 `json:"peakBytes,omitempty"`
+	// PeakObserved is true only when memory.peak was actually read. memory.peak
+	// is cgroup v2 and reasonably recent -- cgroup v1 exposes
+	// memory.max_usage_in_bytes instead, and older v2 kernels lack it entirely
+	// -- so a missing or unparseable memory.peak must not collapse into a
+	// reported zero indistinguishable from a genuine idle peak, and must not
+	// let a percent-of-limit warning compute against a reading that was never
+	// taken.
+	PeakObserved   bool    `json:"peakObserved,omitempty"`
 	LimitBytes     int64   `json:"limitBytes,omitempty"`
 	Unlimited      bool    `json:"unlimited,omitempty"`
 	PercentOfLimit float64 `json:"percentOfLimit,omitempty"`
 	OOMKills       int64   `json:"oomKills,omitempty"`
-	Unavailable    string  `json:"unavailable,omitempty"`
+	// OOMKillsObserved mirrors PeakObserved: memory.events' oom_kill counter
+	// can be as unreadable as memory.peak, and a caller must not read a silent
+	// zero as "no kills" when it actually means "could not tell".
+	OOMKillsObserved bool   `json:"oomKillsObserved,omitempty"`
+	Unavailable      string `json:"unavailable,omitempty"`
 }
 
 // RuntimeDiskUsage reports usage for one watched mount (the workspace path,
@@ -278,9 +290,11 @@ func runtimeMemoryUsageFromValues(v map[string]string) RuntimeMemoryUsage {
 	m.CurrentBytes = current
 	if peak, ok := parseRuntimeInt64(v["memory_peak"]); ok {
 		m.PeakBytes = peak
+		m.PeakObserved = true
 	}
 	if killed, ok := parseRuntimeInt64(v["memory_oom_kill"]); ok {
 		m.OOMKills = killed
+		m.OOMKillsObserved = true
 	}
 	maxRaw := v["memory_max"]
 	if maxRaw == "max" {
@@ -431,28 +445,35 @@ func parseRuntimeDFUsage(line string) (totalBytes, usedBytes int64, ok bool) {
 }
 
 func runtimeUsageWarnings(u RuntimeUsage) []string {
-	var warnings []string
-	if u.Memory.Unavailable == "" && !u.Memory.Unlimited && u.Memory.LimitBytes > 0 {
-		if u.Memory.PercentOfLimit >= RuntimeUsageMemoryWarnPercent {
-			warnings = append(warnings, fmt.Sprintf(
-				"memory is at %.0f%% of its %s limit (warns at %.0f%%)",
-				u.Memory.PercentOfLimit, formatMebibytes(u.Memory.LimitBytes), RuntimeUsageMemoryWarnPercent))
-		}
-		peakPercent := 100 * float64(u.Memory.PeakBytes) / float64(u.Memory.LimitBytes)
-		if peakPercent >= RuntimeUsageMemoryPeakWarnPercent {
-			warnings = append(warnings, fmt.Sprintf(
-				"memory.peak reached %.0f%% of the limit (warns at %.0f%%) -- this environment came close to an OOM kill",
-				peakPercent, RuntimeUsageMemoryPeakWarnPercent))
-		}
-	}
-	if u.Memory.OOMKills > 0 {
-		warnings = append(warnings, fmt.Sprintf("the cgroup recorded %d OOM kill(s)", u.Memory.OOMKills))
-	}
+	warnings := runtimeMemoryUsageWarnings(u.Memory)
 	for _, d := range u.Disk {
 		if d.Unavailable == "" && d.PercentUsed >= RuntimeUsageDiskWarnPercent {
 			warnings = append(warnings, fmt.Sprintf(
 				"%s is at %.0f%% disk usage (warns at %.0f%%)", d.Mount, d.PercentUsed, RuntimeUsageDiskWarnPercent))
 		}
+	}
+	return warnings
+}
+
+func runtimeMemoryUsageWarnings(memory RuntimeMemoryUsage) []string {
+	var warnings []string
+	if memory.Unavailable == "" && !memory.Unlimited && memory.LimitBytes > 0 {
+		if memory.PercentOfLimit >= RuntimeUsageMemoryWarnPercent {
+			warnings = append(warnings, fmt.Sprintf(
+				"memory is at %.0f%% of its %s limit (warns at %.0f%%)",
+				memory.PercentOfLimit, formatMebibytes(memory.LimitBytes), RuntimeUsageMemoryWarnPercent))
+		}
+		if memory.PeakObserved {
+			peakPercent := 100 * float64(memory.PeakBytes) / float64(memory.LimitBytes)
+			if peakPercent >= RuntimeUsageMemoryPeakWarnPercent {
+				warnings = append(warnings, fmt.Sprintf(
+					"memory.peak reached %.0f%% of the limit (warns at %.0f%%) -- this environment came close to an OOM kill",
+					peakPercent, RuntimeUsageMemoryPeakWarnPercent))
+			}
+		}
+	}
+	if memory.OOMKillsObserved && memory.OOMKills > 0 {
+		warnings = append(warnings, fmt.Sprintf("the cgroup recorded %d OOM kill(s)", memory.OOMKills))
 	}
 	return warnings
 }

--- a/erun-common/runtime_usage_test.go
+++ b/erun-common/runtime_usage_test.go
@@ -1,6 +1,7 @@
 package eruncommon
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 	"testing"
@@ -48,6 +49,11 @@ type runtimeUsageReadingCase struct {
 }
 
 func runtimeUsageReadingCases() []runtimeUsageReadingCase {
+	cases := runtimeUsageBaseReadingCases()
+	return append(cases, runtimeUsageMemoryObservationReadingCases()...)
+}
+
+func runtimeUsageBaseReadingCases() []runtimeUsageReadingCase {
 	return []runtimeUsageReadingCase{
 		{
 			name: "cgroup v2 present reports quota, usage, and disk",
@@ -65,9 +71,13 @@ func runtimeUsageReadingCases() []runtimeUsageReadingCase {
 				"disk_workspace=/dev/sda1        198234112  99117056   89006592  53% /home/erun",
 			}, "\n"),
 			// 100000 usec of CPU burned over 1 elapsed second, against a 1-core quota.
-			wantCPU:    RuntimeCPUUsage{QuotaCores: 1, UtilizationPercent: 10, IntervalSeconds: 1},
-			wantMemory: RuntimeMemoryUsage{CurrentBytes: 413589504, PeakBytes: 1027301376, LimitBytes: 2147483648, PercentOfLimit: 100 * float64(413589504) / float64(2147483648)},
-			wantDisk:   RuntimeDiskUsage{Mount: runtimeUsageWatchedMount, TotalBytes: 198234112 * 1024, UsedBytes: 99117056 * 1024, PercentUsed: 100 * float64(99117056) / float64(198234112)},
+			wantCPU: RuntimeCPUUsage{QuotaCores: 1, UtilizationPercent: 10, IntervalSeconds: 1},
+			wantMemory: RuntimeMemoryUsage{
+				CurrentBytes: 413589504, PeakBytes: 1027301376, PeakObserved: true,
+				LimitBytes: 2147483648, PercentOfLimit: 100 * float64(413589504) / float64(2147483648),
+				OOMKillsObserved: true,
+			},
+			wantDisk: RuntimeDiskUsage{Mount: runtimeUsageWatchedMount, TotalBytes: 198234112 * 1024, UsedBytes: 99117056 * 1024, PercentUsed: 100 * float64(99117056) / float64(198234112)},
 		},
 		{
 			name: "unlimited memory.max reports Unlimited, not a fabricated percentage",
@@ -84,9 +94,11 @@ func runtimeUsageReadingCases() []runtimeUsageReadingCase {
 				"cpu_time_after_ns=2000000000",
 				"disk_workspace=",
 			}, "\n"),
-			wantCPU:    RuntimeCPUUsage{IntervalSeconds: 1, Unavailable: "an unlimited cpu.max quota should report unavailable"},
-			wantMemory: RuntimeMemoryUsage{CurrentBytes: 52428800, PeakBytes: 104857600, Unlimited: true},
-			wantDisk:   RuntimeDiskUsage{Mount: runtimeUsageWatchedMount, Unavailable: "an empty df line should report unavailable"},
+			wantCPU: RuntimeCPUUsage{IntervalSeconds: 1, Unavailable: "an unlimited cpu.max quota should report unavailable"},
+			wantMemory: RuntimeMemoryUsage{
+				CurrentBytes: 52428800, PeakBytes: 104857600, PeakObserved: true, Unlimited: true, OOMKillsObserved: true,
+			},
+			wantDisk: RuntimeDiskUsage{Mount: runtimeUsageWatchedMount, Unavailable: "an empty df line should report unavailable"},
 		},
 		{
 			name: "cgroup v1 (or no cgroup fs) reports memory and CPU unavailable, not an error",
@@ -134,6 +146,51 @@ func runtimeUsageReadingCases() []runtimeUsageReadingCase {
 	}
 }
 
+// runtimeUsageMemoryObservationReadingCases covers memory.peak and
+// memory.events' oom_kill going missing independently of the rest of the
+// memory reading -- each must stay unobserved rather than reporting a
+// fabricated zero, without the struct-level Unavailable firing, since the
+// rest of the reading is genuinely available.
+func runtimeUsageMemoryObservationReadingCases() []runtimeUsageReadingCase {
+	return []runtimeUsageReadingCase{
+		{
+			name: "memory.peak missing reports unobserved, not a fabricated zero",
+			output: strings.Join([]string{
+				"cgroup_type=cgroup2fs",
+				"memory_current=413589504",
+				"memory_max=2147483648",
+				"memory_peak=",
+				"memory_oom_kill=0",
+			}, "\n"),
+			wantCPU: RuntimeCPUUsage{IntervalSeconds: 1, Unavailable: "cpu.max missing should report unavailable"},
+			wantMemory: RuntimeMemoryUsage{
+				CurrentBytes: 413589504, LimitBytes: 2147483648,
+				PercentOfLimit: 100 * float64(413589504) / float64(2147483648), OOMKillsObserved: true,
+			},
+			wantDisk: RuntimeDiskUsage{Mount: runtimeUsageWatchedMount, Unavailable: "missing df line should report unavailable"},
+		},
+		{
+			// memory.events' oom_kill counter can be as unreadable as
+			// memory.peak; OOMKillsObserved must stay false rather than
+			// reporting a confident "no kills".
+			name: "memory.events oom_kill missing reports unobserved, not a fabricated zero",
+			output: strings.Join([]string{
+				"cgroup_type=cgroup2fs",
+				"memory_current=413589504",
+				"memory_max=2147483648",
+				"memory_peak=1027301376",
+				"memory_oom_kill=",
+			}, "\n"),
+			wantCPU: RuntimeCPUUsage{IntervalSeconds: 1, Unavailable: "cpu.max missing should report unavailable"},
+			wantMemory: RuntimeMemoryUsage{
+				CurrentBytes: 413589504, PeakBytes: 1027301376, PeakObserved: true,
+				LimitBytes: 2147483648, PercentOfLimit: 100 * float64(413589504) / float64(2147483648),
+			},
+			wantDisk: RuntimeDiskUsage{Mount: runtimeUsageWatchedMount, Unavailable: "missing df line should report unavailable"},
+		},
+	}
+}
+
 // assertRuntimeCPU compares an availability marker (want.Unavailable's
 // presence, not its exact text -- the fixture table above uses the field to
 // document *why* a case is unavailable) and, only when available, the
@@ -164,12 +221,7 @@ func assertRuntimeMemory(t *testing.T, got, want RuntimeMemoryUsage) {
 	if want.Unavailable != "" {
 		return
 	}
-	if got.CurrentBytes != want.CurrentBytes {
-		t.Errorf("Memory.CurrentBytes = %d, want %d", got.CurrentBytes, want.CurrentBytes)
-	}
-	if got.PeakBytes != want.PeakBytes {
-		t.Errorf("Memory.PeakBytes = %d, want %d", got.PeakBytes, want.PeakBytes)
-	}
+	assertRuntimeMemoryPeakAndOOM(t, got, want)
 	if got.Unlimited != want.Unlimited {
 		t.Errorf("Memory.Unlimited = %t, want %t", got.Unlimited, want.Unlimited)
 	}
@@ -178,6 +230,25 @@ func assertRuntimeMemory(t *testing.T, got, want RuntimeMemoryUsage) {
 	}
 	if !want.Unlimited && got.PercentOfLimit != want.PercentOfLimit {
 		t.Errorf("Memory.PercentOfLimit = %v, want %v", got.PercentOfLimit, want.PercentOfLimit)
+	}
+}
+
+// assertRuntimeMemoryPeakAndOOM checks CurrentBytes/PeakBytes/OOMKills
+// alongside their own Observed bit: a value alone is never enough to say
+// whether it means anything.
+func assertRuntimeMemoryPeakAndOOM(t *testing.T, got, want RuntimeMemoryUsage) {
+	t.Helper()
+	if got.CurrentBytes != want.CurrentBytes {
+		t.Errorf("Memory.CurrentBytes = %d, want %d", got.CurrentBytes, want.CurrentBytes)
+	}
+	if got.PeakBytes != want.PeakBytes {
+		t.Errorf("Memory.PeakBytes = %d, want %d", got.PeakBytes, want.PeakBytes)
+	}
+	if got.PeakObserved != want.PeakObserved {
+		t.Errorf("Memory.PeakObserved = %t, want %t", got.PeakObserved, want.PeakObserved)
+	}
+	if got.OOMKillsObserved != want.OOMKillsObserved {
+		t.Errorf("Memory.OOMKillsObserved = %t, want %t", got.OOMKillsObserved, want.OOMKillsObserved)
 	}
 }
 
@@ -230,6 +301,42 @@ func TestParseRuntimeUsageWarnings(t *testing.T) {
 		}
 	})
 
+	t.Run("memory.peak warning does not fire when the peak could not be read", func(t *testing.T) {
+		output := strings.Join([]string{
+			"cgroup_type=cgroup2fs",
+			"memory_current=52428800",
+			"memory_max=2147483648",
+			"memory_peak=",
+			"memory_oom_kill=0",
+		}, "\n")
+
+		usage := parseRuntimeUsage(req, output, interval)
+		if usage.Memory.PeakObserved {
+			t.Fatalf("expected PeakObserved=false when memory.peak is unreadable, got %+v", usage.Memory)
+		}
+		if hasWarningContaining(usage.Warnings, "memory.peak reached") {
+			t.Errorf("an unread peak must not compute a percentage to warn on, got %v", usage.Warnings)
+		}
+	})
+
+	t.Run("OOM kill warning does not fire when oom_kill could not be read", func(t *testing.T) {
+		output := strings.Join([]string{
+			"cgroup_type=cgroup2fs",
+			"memory_current=52428800",
+			"memory_max=2147483648",
+			"memory_peak=52428800",
+			"memory_oom_kill=",
+		}, "\n")
+
+		usage := parseRuntimeUsage(req, output, interval)
+		if usage.Memory.OOMKillsObserved {
+			t.Fatalf("expected OOMKillsObserved=false when memory.events is unreadable, got %+v", usage.Memory)
+		}
+		if hasWarningContaining(usage.Warnings, "OOM kill") {
+			t.Errorf("an unread oom_kill counter must not report a confident zero, got %v", usage.Warnings)
+		}
+	})
+
 	t.Run("OOM kills always warn", func(t *testing.T) {
 		output := strings.Join([]string{
 			"cgroup_type=cgroup2fs",
@@ -274,6 +381,39 @@ func hasWarningContaining(warnings []string, substr string) bool {
 		}
 	}
 	return false
+}
+
+// TestRuntimeMemoryUsageJSONDistinguishesUnreadableFromZero pins the wire
+// contract: PeakBytes/OOMKills are already omitempty, so a genuine zero and
+// an unread value marshal identically unless their own Observed bit is
+// carried alongside them.
+func TestRuntimeMemoryUsageJSONDistinguishesUnreadableFromZero(t *testing.T) {
+	unread, err := json.Marshal(RuntimeMemoryUsage{CurrentBytes: 100})
+	if err != nil {
+		t.Fatalf("marshal unread: %v", err)
+	}
+	if strings.Contains(string(unread), "peakObserved") || strings.Contains(string(unread), "peakBytes") {
+		t.Errorf("an unread peak must omit both peakBytes and peakObserved, got %s", unread)
+	}
+
+	genuineZero, err := json.Marshal(RuntimeMemoryUsage{CurrentBytes: 100, PeakObserved: true})
+	if err != nil {
+		t.Fatalf("marshal genuine zero: %v", err)
+	}
+	if !strings.Contains(string(genuineZero), `"peakObserved":true`) {
+		t.Errorf("a genuinely-zero, observed peak must carry peakObserved:true, got %s", genuineZero)
+	}
+	if strings.Contains(string(genuineZero), "peakBytes") {
+		t.Errorf("a genuine zero peak still omits the zero-valued peakBytes key, got %s", genuineZero)
+	}
+
+	var roundTripped RuntimeMemoryUsage
+	if err := json.Unmarshal(genuineZero, &roundTripped); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !roundTripped.PeakObserved || roundTripped.PeakBytes != 0 {
+		t.Errorf("round trip = %+v, want PeakObserved=true, PeakBytes=0", roundTripped)
+	}
 }
 
 func TestClampRuntimeUsageInterval(t *testing.T) {

--- a/erun-integration/testdata/usage/real_run_genuine_zero_peak_renders_unchanged.txt
+++ b/erun-integration/testdata/usage/real_run_genuine_zero_peak_renders_unchanged.txt
@@ -1,0 +1,4 @@
+CPU: 0.0% of a 1.00-core quota (sampled over 1.0s)
+Memory: 0B / 2.0GiB (0.0%), peak 0B, OOM kills 0
+Disk <HOME> 84.9GiB / 189.1GiB (44.9%)
+audit: erun usage

--- a/erun-integration/testdata/usage/real_run_unreadable_peak_json_omits_peak_fields.txt
+++ b/erun-integration/testdata/usage/real_run_unreadable_peak_json_omits_peak_fields.txt
@@ -3,16 +3,10 @@
   "environment": "dev",
   "cpu": {
     "quotaCores": 1,
-    "utilizationPercent": 10,
-    "intervalSeconds": 1,
-    "usageUsec": 581611501,
-    "periods": 376556,
-    "throttledPeriods": 425
+    "intervalSeconds": 1
   },
   "memory": {
     "currentBytes": 413589504,
-    "peakBytes": 1027301376,
-    "peakObserved": true,
     "limitBytes": 2147483648,
     "percentOfLimit": 19.259262084960938,
     "oomKillsObserved": true

--- a/erun-integration/testdata/usage/real_run_unreadable_peak_renders_unavailable_not_zero.txt
+++ b/erun-integration/testdata/usage/real_run_unreadable_peak_renders_unavailable_not_zero.txt
@@ -1,0 +1,4 @@
+CPU: 0.0% of a 1.00-core quota (sampled over 1.0s)
+Memory: 394.4MiB / 2.0GiB (19.3%), peak unavailable, OOM kills 0
+Disk <HOME> 84.9GiB / 189.1GiB (44.9%)
+audit: erun usage

--- a/erun-integration/testdata/usage/real_run_warns_near_the_memory_limit.txt
+++ b/erun-integration/testdata/usage/real_run_warns_near_the_memory_limit.txt
@@ -8,9 +8,11 @@
   "memory": {
     "currentBytes": 1932735283,
     "peakBytes": 2100000000,
+    "peakObserved": true,
     "limitBytes": 2147483648,
     "percentOfLimit": 89.99999999068677,
-    "oomKills": 1
+    "oomKills": 1,
+    "oomKillsObserved": true
   },
   "disk": [
     {

--- a/erun-integration/usage_test.go
+++ b/erun-integration/usage_test.go
@@ -156,6 +156,107 @@ func TestUsage(t *testing.T) {
 			t.Fatalf("expected a warnings field in the JSON output, got:\n%s", result.Combined)
 		}
 	})
+
+	// real_run_unreadable_peak_renders_unavailable_not_zero: an unreadable
+	// memory.peak (an older cgroup v2 kernel, or cgroup v1) must render as
+	// unavailable, not as a measured "peak 0B" -- the reassuring wrong answer
+	// for the least known state.
+	t.Run("real_run_unreadable_peak_renders_unavailable_not_zero", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		stubUsageKubectlExec(t, stubs, []string{
+			"cgroup_type=cgroup2fs",
+			"memory_current=413589504",
+			"memory_max=2147483648",
+			"memory_peak=",
+			"memory_oom_kill=0",
+			"cpu_max=100000 100000",
+			"cpu_usage_before=0",
+			"cpu_usage_after=0",
+			"cpu_time_before_ns=1000000000",
+			"cpu_time_after_ns=2000000000",
+			"disk_workspace=overlay 198234112 89006592 99117056 45% /home/erun",
+		})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"usage"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if strings.Contains(result.Combined, "peak 0B") {
+			t.Fatalf("an unreadable peak must never render as a measured 0B, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "usage/real_run_unreadable_peak_renders_unavailable_not_zero", normalize.Apply(result.Combined))
+	})
+
+	// real_run_unreadable_peak_json_omits_peak_fields is the JSON-mode sibling
+	// of the scenario above: the wire shape must let a consumer tell "peak not
+	// readable here" from "peak is zero" (peakObserved's presence), and the
+	// close-to-OOM warning must not compute a percentage from a reading it
+	// never took, even though current usage alone is nowhere near either
+	// threshold in this fixture.
+	t.Run("real_run_unreadable_peak_json_omits_peak_fields", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		stubUsageKubectlExec(t, stubs, []string{
+			"cgroup_type=cgroup2fs",
+			"memory_current=413589504",
+			"memory_max=2147483648",
+			"memory_peak=",
+			"memory_oom_kill=0",
+			"cpu_max=100000 100000",
+			"cpu_usage_before=0",
+			"cpu_usage_after=0",
+			"cpu_time_before_ns=1000000000",
+			"cpu_time_after_ns=2000000000",
+			"disk_workspace=overlay 198234112 89006592 99117056 45% /home/erun",
+		})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"usage", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if strings.Contains(result.Combined, "peakBytes") || strings.Contains(result.Combined, "peakObserved") {
+			t.Fatalf("an unreadable peak must omit both peakBytes and peakObserved, got:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "memory.peak reached") {
+			t.Fatalf("an unreadable peak must not warn from a percentage it never computed, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "usage/real_run_unreadable_peak_json_omits_peak_fields", normalize.Apply(result.Combined))
+	})
+
+	// real_run_genuine_zero_peak_renders_unchanged is the regression guard for
+	// the sibling of the two scenarios above: a memory.peak that was actually
+	// read as zero must keep rendering exactly as before this fix, since a
+	// real zero is not the unknown state the two scenarios above cover.
+	t.Run("real_run_genuine_zero_peak_renders_unchanged", func(t *testing.T) {
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		stubUsageKubectlExec(t, stubs, []string{
+			"cgroup_type=cgroup2fs",
+			"memory_current=0",
+			"memory_max=2147483648",
+			"memory_peak=0",
+			"memory_oom_kill=0",
+			"cpu_max=100000 100000",
+			"cpu_usage_before=0",
+			"cpu_usage_after=0",
+			"cpu_time_before_ns=1000000000",
+			"cpu_time_after_ns=2000000000",
+			"disk_workspace=overlay 198234112 89006592 99117056 45% /home/erun",
+		})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"usage"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		if !strings.Contains(result.Combined, "peak 0B") {
+			t.Fatalf("a genuinely-zero, observed peak must still render as peak 0B, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "usage/real_run_genuine_zero_peak_renders_unchanged", normalize.Apply(result.Combined))
+	})
 }
 
 // stubUsageKubectlExec stubs `kubectl exec` to answer the usage reading


### PR DESCRIPTION
## What

`erun usage`'s memory reader kept the zero value when `memory.peak` couldn't
be read, so an unreadable peak rendered as a measured `peak 0B` and silently
disabled the close-to-OOM warning (it computed `0%` and never crossed the
95% threshold). `memory.events`' `oom_kill` counter had the identical
one-line `if ok { assign }` shape and the identical defect against its own
"OOM kill(s) recorded" warning.

Both now carry an explicit `Observed` bit alongside the value:

- `RuntimeMemoryUsage.PeakObserved` / `.OOMKillsObserved` (`erun-common/runtime_usage.go`)
- `runtimeMemoryUsageFromValues` sets the bit only when the cgroup value actually parsed
- `runtimeUsageWarnings`/`runtimeMemoryUsageWarnings` gate both warnings on their Observed bit — a warning never computes a percentage from a reading it never took
- `erun-cli/cmd/usage_render.go`'s `writeUsageMemory` renders `peak unavailable` / `OOM kills unavailable` instead of a fabricated `0B`/`0` when the bit is false

**Precedent followed:** the environment read model's `<Signal>Observed bool`
pattern (`erun-common/environment_read_model.go`'s `CloudContextObserved` /
`DeployHealthObserved` / `IdleStatusObserved`) — every fallible signal there
carries its own explicit observed bit so an unknown can never collapse into
a confident value. The wire-facing precedent for the same idea is
`erun-ui/ui_model.go`'s `Observed bool` fields on activity/usage payloads.

## Sibling cgroup readings — enumerated

The same value-map parser (`runtime_usage.go`) reads several cgroup counters
with the identical `if peak, ok := parseRuntimeInt64(...); ok { assign }`
shape, which silently leaves the field at its zero value on a failed parse.
Checked every one:

| Reading | Field | Same defect? | Action |
|---|---|---|---|
| `memory_peak` | `RuntimeMemoryUsage.PeakBytes` | Yes — this issue | **Fixed**: `PeakObserved` |
| `memory_oom_kill` | `RuntimeMemoryUsage.OOMKills` | Yes — same function, gates its own warning | **Fixed**: `OOMKillsObserved` |
| `memory_current` | `RuntimeMemoryUsage.CurrentBytes` | No | Already loud: an unparseable value sets the whole struct's `Unavailable` and returns early |
| `memory_max` | `RuntimeMemoryUsage.LimitBytes`/`Unlimited` | No | Already loud, same as above |
| `cpu_max` | `RuntimeCPUUsage.QuotaCores` | No | Already loud via `parseRuntimeCPUMax`'s `ok=false` → `Unavailable` |
| `cpu_usage_before`/`cpu_usage_after`/`cpu_time_*_ns` (rate calc) | `RuntimeCPUUsage.UtilizationPercent` | No | Already loud: any parse failure sets `Unavailable` and returns before the rate is used |
| `cpu_usage_after` (cumulative counter) | `RuntimeCPUUsage.UsageUsec` | Same one-line shape, but not a live defect | The value is re-parsed by the rate-calc check above with the same key, so a failed parse there already sets the whole-struct `Unavailable` before this field is ever rendered or read |
| `cpu_periods` | `RuntimeCPUUsage.Periods` | Same one-line shape | **Left as a named, bigger gap** — see below |
| `cpu_throttled_periods` | `RuntimeCPUUsage.ThrottledPeriods` | Same one-line shape | **Left as a named, bigger gap** — see below |

`cpu_periods`/`cpu_throttled_periods` are not gated by anything else today,
so an unread value would render as a confident `0`. Nothing currently
renders or warns on them directly (`writeUsageCPU` doesn't print them), so
today the only consumer is `RuntimeUsageHistory`'s cross-restart
accumulation (`runtimeUsageCountersReset`'s restart heuristic and
`runtimeUsageCounterDelta`'s cumulative-delta math), which already assumes
these counters are always populated when comparing two readings. Adding an
Observed bit to the leaf struct without teaching `RuntimeUsageHistory` about
a missing observation would just move the ambiguity one layer down (an
unobserved 0 vs. a real 0 in a restart-detection heuristic that currently
can't tell the difference either way) — a materially bigger, separate change
to history semantics rather than the same-size fix `PeakObserved`/
`OOMKillsObserved` are. Naming it here rather than fixing it, per the ask.

## JSON shape

`peakBytes`/`oomKills` were already `omitempty`, so a genuine zero and an
unread value marshaled identically. `peakObserved`/`oomKillsObserved` are
also `omitempty` bools (consistent with every other field on this struct):
absent means false/never-read, `true` means the value (even if 0) is real.

```json
// unread:   {"currentBytes": 100}
// genuine zero, observed: {"currentBytes": 100, "peakObserved": true}
```

Two existing `erun usage --output json` goldens gained the new fields (both regenerated, reviewed by hand):

`real_run_reports_cgroup_v2_usage.txt`:
```diff
     "currentBytes": 413589504,
     "peakBytes": 1027301376,
+    "peakObserved": true,
     "limitBytes": 2147483648,
-    "percentOfLimit": 19.259262084960938
+    "percentOfLimit": 19.259262084960938,
+    "oomKillsObserved": true
```

`real_run_warns_near_the_memory_limit.txt`:
```diff
     "currentBytes": 1932735283,
     "peakBytes": 2100000000,
+    "peakObserved": true,
     "limitBytes": 2147483648,
     "percentOfLimit": 89.99999999068677,
-    "oomKills": 1
+    "oomKills": 1,
+    "oomKillsObserved": true
```

Three new goldens (`real_run_unreadable_peak_renders_unavailable_not_zero`,
`real_run_unreadable_peak_json_omits_peak_fields`,
`real_run_genuine_zero_peak_renders_unchanged`) cover the new scenarios.

## Tests

- `memory.peak` absent → `PeakObserved=false`, renderer prints `peak
  unavailable`, JSON omits both `peakBytes`/`peakObserved`, close-to-OOM
  warning does not fire (unit tests in `runtime_usage_test.go` +
  integration scenarios `real_run_unreadable_peak_renders_unavailable_not_zero`
  / `real_run_unreadable_peak_json_omits_peak_fields`).
- `memory.peak` present and genuinely `0` → `PeakObserved=true`, renders
  `peak 0B` exactly as before (integration scenario
  `real_run_genuine_zero_peak_renders_unchanged`).
- A peak at/above the warn threshold → existing warning fires unchanged
  (regression-covered by the untouched-behavior part of the updated
  `real_run_warns_near_the_memory_limit` golden, plus the pre-existing unit
  test `memory.peak warning fires independently of current usage`).
- JSON distinguishes unreadable from zero →
  `TestRuntimeMemoryUsageJSONDistinguishesUnreadableFromZero` marshals both
  shapes and round-trips the genuine-zero case.
- Same coverage added for `memory.events`' `oom_kill` counter (identical
  shape, identical fix).

## Gate

`make check`: **green**. golangci-lint clean across `erun-common`,
`erun-cli`, `erun-mcp`, `erun-integration`, `erun-backend/erun-backend-api`,
`erun-ui`; all Go/frontend suites pass; integration coverage **75.9%** (≥
75.8% threshold).

Closes #1650