### PR TITLE
Fix org-scoped issuer bootstrap gaps: migration path, login scope, 409 advice

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
@@ -124,6 +124,79 @@ func assertHasReadAllAndWriteAll(t *testing.T, db *sql.DB, userID string) {
 	}
 }
 
+// TestBootstrapFirstIdentityRegistersSharedIssuerOrgScopedWithCallersOrgAsFirstMapping
+// proves the fix for erun#1605's first defect: bootstrapping against a token
+// that carries the shipped Zitadel org claim must register the issuer
+// org-scoped (issuers.org_field_key set), with the bootstrap caller's own org
+// as the first tenant_issuers mapping's org_field_value — not single-tenant,
+// which would permanently block every later tenant on that issuer.
+func TestBootstrapFirstIdentityRegistersSharedIssuerOrgScopedWithCallersOrgAsFirstMapping(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+
+	const issuer = "https://auth.erunpaas.example/shared"
+	const orgClaimKey = "urn:zitadel:iam:user:resourceowner:id"
+	const callerOrg = "386994597030592700"
+
+	tenant, _, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  issuer,
+		Subject: "operator-subject",
+		Raw:     map[string]any{orgClaimKey: callerOrg},
+	})
+	mustNoErr(t, err, "bootstrap with a shared-issuer org claim")
+
+	var orgFieldKey sql.NullString
+	mustNoErr(t, db.QueryRow(`SELECT org_field_key FROM issuers WHERE issuer = $1`, issuer).Scan(&orgFieldKey), "read issuers row")
+	if !orgFieldKey.Valid || orgFieldKey.String != orgClaimKey {
+		t.Fatalf("issuers.org_field_key = %+v, want %q (org-scoped, not single-tenant)", orgFieldKey, orgClaimKey)
+	}
+
+	var orgFieldValue sql.NullString
+	mustNoErr(t, db.QueryRow(
+		`SELECT org_field_value FROM tenant_issuers WHERE tenant_id = $1 AND issuer = $2`,
+		tenant.TenantID, issuer,
+	).Scan(&orgFieldValue), "read tenant_issuers row")
+	if !orgFieldValue.Valid || orgFieldValue.String != callerOrg {
+		t.Fatalf("tenant_issuers.org_field_value = %+v, want the bootstrap caller's own org %q as the first mapping", orgFieldValue, callerOrg)
+	}
+}
+
+// TestSecondTenantOnSharedIssuerWithDifferentOrgIsAcceptedNotConflict proves
+// the fix for erun#1605's compounding case: once bootstrap has registered a
+// shared issuer org-scoped (previous test), a second tenant created on that
+// same issuer with a different org value must succeed — the 409 the issue
+// reported no longer fires for this legitimate case.
+func TestSecondTenantOnSharedIssuerWithDifferentOrgIsAcceptedNotConflict(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+
+	const issuer = "https://auth.erunpaas.example/shared-second"
+	const orgClaimKey = "urn:zitadel:iam:user:resourceowner:id"
+
+	_, _, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  issuer,
+		Subject: "first-operator-subject",
+		Raw:     map[string]any{orgClaimKey: "111111111111111111"},
+	})
+	mustNoErr(t, err, "bootstrap the first (platform) tenant on the shared issuer")
+
+	tenants := NewTenantRepository(NewTxManager(db, DialectPostgres))
+	ctx := security.WithContext(context.Background(), security.Context{TenantType: string(model.TenantTypeOperations)})
+	second, err := tenants.Create(ctx, CreateTenantParams{
+		Name:          "second-org-tenant",
+		Type:          model.TenantTypeCompany,
+		Issuer:        issuer,
+		OrgFieldKey:   orgClaimKey,
+		OrgFieldValue: "222222222222222222",
+	})
+	mustNoErr(t, err, "create a second tenant on the shared issuer with a different org value")
+	if second.TenantID == "" {
+		t.Fatal("expected the second tenant to be created")
+	}
+}
+
 func TestBootstrapFirstIdentityFallsBackWhenERUNTenantAbsent(t *testing.T) {
 	db := identityBootstrapDatabase(t)
 	repo := NewIdentityRepository(db, DialectPostgres, "")

--- a/erun-backend/erun-backend-api/internal/repository/tenant_issuers_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenant_issuers_e2e_test.go
@@ -1,0 +1,93 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// UpdateOrgScope's whole point is a two-table write (issuers.org_field_key
+// plus the existing tenant's tenant_issuers.org_field_value) that must commit
+// or fail together, which only means something proven against a real
+// migrated PostgreSQL — a fake repository would just agree with itself about
+// what it decided to persist.
+func tenantIssuersDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+	databaseURL := os.Getenv("ERUN_E2E_TENANT_ISSUERS_DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("opt-in: set ERUN_E2E_TENANT_ISSUERS_DATABASE_URL to a migrated PostgreSQL")
+	}
+	db, err := sql.Open("pgx", databaseURL)
+	mustNoErr(t, err, "open db")
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestTenantIssuerRepositoryUpdateOrgScopeConvertsAndBackfills proves the
+// migration path for erun#1605's second defect: an issuer already registered
+// single-tenant (org_field_key NULL, the state first-identity bootstrap
+// leaves an already-deployed platform in) can be converted to org-scoped, and
+// the existing tenant's own mapping is backfilled with an org value in the
+// same operation — not left NULL, which would stop that tenant resolving as
+// soon as the issuer stops being single-tenant.
+func TestTenantIssuerRepositoryUpdateOrgScopeConvertsAndBackfills(t *testing.T) {
+	db := tenantIssuersDatabase(t)
+	const issuer = "https://auth.erunpaas.example/migrate-e2e"
+	const orgFieldKey = "urn:zitadel:iam:user:resourceowner:id"
+	const orgFieldValue = "platform-org-999"
+
+	var tenantID string
+	mustNoErr(t, db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, 'OPERATIONS') RETURNING tenant_id`,
+		"migrate-e2e-tenant",
+	).Scan(&tenantID), "seed tenant")
+	t.Cleanup(func() {
+		for _, table := range []string{"tenant_issuers", "tenants"} {
+			if _, err := db.Exec(`DELETE FROM `+table+` WHERE tenant_id = $1`, tenantID); err != nil {
+				t.Logf("clearing %s for tenant %s: %v", table, tenantID, err)
+			}
+		}
+		if _, err := db.Exec(`DELETE FROM issuers WHERE issuer = $1`, issuer); err != nil {
+			t.Logf("clearing issuers %s: %v", issuer, err)
+		}
+	})
+
+	// Seed the single-tenant registration first-identity bootstrap would have
+	// left behind: org_field_key NULL on issuers, org_field_value NULL on the
+	// existing tenant's own mapping.
+	_, err := db.Exec(`INSERT INTO issuers (issuer) VALUES ($1)`, issuer)
+	mustNoErr(t, err, "seed single-tenant issuer")
+	_, err = db.Exec(
+		`INSERT INTO tenant_issuers (tenant_id, issuer, name) VALUES ($1, $2, $3)`,
+		tenantID, issuer, "migrate-e2e issuer",
+	)
+	mustNoErr(t, err, "seed existing single-tenant mapping")
+
+	repo := NewTenantIssuerRepository(NewTxManager(db, DialectPostgres))
+	ctx := security.WithContext(context.Background(), security.Context{TenantID: tenantID, TenantType: "OPERATIONS"})
+	updated, err := repo.UpdateOrgScope(ctx, issuer, orgFieldKey, orgFieldValue)
+	mustNoErr(t, err, "UpdateOrgScope")
+	if updated.OrgFieldKey != orgFieldKey || updated.OrgFieldValue != orgFieldValue {
+		t.Fatalf("returned tenant_issuer = %+v, want key=%q value=%q", updated, orgFieldKey, orgFieldValue)
+	}
+
+	var storedKey sql.NullString
+	mustNoErr(t, db.QueryRow(`SELECT org_field_key FROM issuers WHERE issuer = $1`, issuer).Scan(&storedKey), "read issuers row")
+	if !storedKey.Valid || storedKey.String != orgFieldKey {
+		t.Fatalf("issuers.org_field_key = %+v, want %q", storedKey, orgFieldKey)
+	}
+
+	var storedValue sql.NullString
+	mustNoErr(t, db.QueryRow(
+		`SELECT org_field_value FROM tenant_issuers WHERE tenant_id = $1 AND issuer = $2`,
+		tenantID, issuer,
+	).Scan(&storedValue), "read tenant_issuers row")
+	if !storedValue.Valid || storedValue.String != orgFieldValue {
+		t.Fatalf("tenant_issuers.org_field_value = %+v, want the existing tenant's mapping backfilled to %q, not left NULL", storedValue, orgFieldValue)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/tenants.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants.go
@@ -146,10 +146,14 @@ func parseCreateTenantParams(req *http.Request) (repository.CreateTenantParams, 
 // duplicateIssuerMessage names the (issuer, org) mapping a create collided
 // with, since a caller re-registering an already-mapped issuer needs to know
 // whether to pick a different org discriminator or that the issuer is simply
-// taken.
+// taken. A single-tenant issuer cannot be scoped to a different org by
+// retrying this same create call: the issuer row's org-scoping mode is fixed
+// at first registration and this route's ON CONFLICT DO NOTHING leaves it
+// untouched, so the message points at the operations-only conversion route
+// that actually rewrites it and backfills the existing mapping.
 func duplicateIssuerMessage(issuer, orgFieldValue string) string {
 	if orgFieldValue == "" {
-		return fmt.Sprintf("issuer %q is already mapped to a tenant with no org discriminator; pass --org-field-key/--org-field-value to scope a shared issuer to a different org", issuer)
+		return fmt.Sprintf("issuer %q is already mapped to a tenant with no org discriminator; an operations caller must first convert it to org-scoped via PATCH /v1/tenant-issuers (orgFieldKey/orgFieldValue), which backfills the existing tenant's mapping, before a second tenant can be created on it with --org-field-key/--org-field-value", issuer)
 	}
 	return fmt.Sprintf("issuer %q is already mapped for org value %q", issuer, orgFieldValue)
 }

--- a/erun-backend/erun-backend-api/internal/routes/tenants_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants_test.go
@@ -132,6 +132,13 @@ func TestCreateTenantOperationsCallerPersists(t *testing.T) {
 	}
 }
 
+// TestCreateTenantDuplicateIssuerReturnsConflict proves the erun#1605 fix for
+// the 409's remedy text: retrying this same create call with
+// --org-field-key/--org-field-value can never work (ON CONFLICT DO NOTHING
+// leaves the existing issuer row's org_field_key untouched), so the message
+// must instead point at the operations-only PATCH /v1/tenant-issuers
+// conversion that actually rewrites it and backfills the existing mapping —
+// not repeat the advice the issue reported as a dead end.
 func TestCreateTenantDuplicateIssuerReturnsConflict(t *testing.T) {
 	tenants := &stubTenantRepository{err: repository.ErrConflict}
 	rec := postCreateTenant(t, tenants, string(model.TenantTypeOperations), `{
@@ -145,6 +152,9 @@ func TestCreateTenantDuplicateIssuerReturnsConflict(t *testing.T) {
 	}
 	if !bytes.Contains(rec.Body.Bytes(), []byte("https://idp.example")) {
 		t.Fatalf("expected the conflict message to name the issuer, got %s", rec.Body.String())
+	}
+	if !bytes.Contains(rec.Body.Bytes(), []byte("PATCH /v1/tenant-issuers")) {
+		t.Fatalf("expected the conflict message to name the conversion endpoint that actually works, got %s", rec.Body.String())
 	}
 }
 

--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -553,7 +553,7 @@ func newCloudLoginCmd(store common.CloudStore, promptRunner PromptRunner, select
 	}
 	cmd.Flags().StringVar(&alias, "alias", "", "Cloud provider alias to login")
 	cmd.Flags().StringVar(&flow, "flow", "", "OIDC grant for an erun-hosted alias: \"device\", \"authcode\", or \"auto\" (default) which prefers the device grant and falls back to authorization code + PKCE when it cannot complete. Use \"authcode\" when the device page's authentication method fails — its loopback redirect reuses a browser session you already hold")
-	cmd.Flags().StringArrayVar(&scopes, "scope", nil, "Extra OAuth scope to request on top of \"openid offline_access\" (repeatable). A provider's reserved scopes are often absent from its discovery document, so they can only be asked for by name — e.g. urn:zitadel:iam:user:resourceowner, which makes a Zitadel token carry the org claim an org-scoped issuer resolves tenants by")
+	cmd.Flags().StringArrayVar(&scopes, "scope", nil, "Extra OAuth scope to request on top of \"openid offline_access\" and the org-claim scope requested by default (repeatable). A provider's reserved scopes are often absent from its discovery document, so they can only be asked for by name")
 	cmd.Flags().BoolVar(&force, "force", false, "Re-authenticate even when the stored session is still active. Needed to change the requested scopes or flow on an alias that is already signed in, since an active session otherwise short-circuits the login")
 	addDryRunFlag(cmd)
 	return cmd

--- a/erun-common/cloud_erun.go
+++ b/erun-common/cloud_erun.go
@@ -138,12 +138,20 @@ func erunCloudProviderLogin(ctx Context, store CloudStore, provider CloudProvide
 		return CloudProviderStatus{}, err
 	}
 	hasDeviceEndpoint := strings.TrimSpace(discovery.DeviceAuthorizationEndpoint) != ""
-	scope := erunLoginScope(extraScopes)
+	// The org-claim scope is requested by default so a shared, org-scoped
+	// issuer's tokens carry the discriminator erun's tenant resolution reads.
+	// fallbackScope is what acquireERunLoginTokens retries with when an
+	// issuer that has never heard of it (a dedicated/BYO IdP, the common
+	// case) refuses the request — login still succeeds exactly as it did
+	// before this default was added, instead of breaking on an unrecognized
+	// scope.
+	scope := erunLoginScope(append([]string{erunOrgClaimScope}, extraScopes...))
+	fallbackScope := erunLoginScope(extraScopes)
 	if scope != erunOAuthScope {
 		ctx.Trace("cloud login erun: requesting scope " + scope)
 	}
 
-	tokens, err := acquireERunLoginTokens(ctx, discovery, provider.ERun.ClientID, scope, flow, hasDeviceEndpoint, deps)
+	tokens, err := acquireERunLoginTokens(ctx, discovery, provider.ERun.ClientID, scope, fallbackScope, flow, hasDeviceEndpoint, deps)
 	if err != nil {
 		return CloudProviderStatus{}, err
 	}
@@ -162,27 +170,46 @@ func erunCloudProviderLogin(ctx Context, store CloudStore, provider CloudProvide
 // redirect reuses the browser session that same operator may already hold.
 //
 // Split out of erunCloudProviderLogin to keep that function under the cyclop
-// threshold; the selection and its ordering are unchanged.
-func acquireERunLoginTokens(ctx Context, discovery OIDCDiscovery, clientID, scope, flow string, hasDeviceEndpoint bool, deps CloudDependencies) (ERunTokens, error) {
+// threshold; the selection and its ordering are unchanged. Each flow attempt
+// is wrapped by runERunLoginAttempt so a scope the issuer refuses is retried
+// once, on the same flow, with fallbackScope — before falling back to a
+// different flow at all, since a different flow against the same issuer would
+// likely refuse the same scope for the same reason.
+func acquireERunLoginTokens(ctx Context, discovery OIDCDiscovery, clientID, scope, fallbackScope, flow string, hasDeviceEndpoint bool, deps CloudDependencies) (ERunTokens, error) {
+	device := func(s string) (ERunTokens, error) { return erunDeviceFlowLogin(ctx, discovery, clientID, s, deps) }
+	authCode := func(s string) (ERunTokens, error) { return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, s) }
+
 	switch {
 	case flow == ERunLoginFlowAuthCode:
 		ctx.Trace("cloud login erun: authorization code + PKCE requested explicitly")
-		return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, scope)
+		return runERunLoginAttempt(ctx, scope, fallbackScope, authCode)
 	case flow == ERunLoginFlowDevice:
 		if !hasDeviceEndpoint {
 			return ERunTokens{}, fmt.Errorf("issuer %s does not advertise a device authorization endpoint; retry with --flow %s", discovery.Issuer, ERunLoginFlowAuthCode)
 		}
-		return erunDeviceFlowLogin(ctx, discovery, clientID, scope, deps)
+		return runERunLoginAttempt(ctx, scope, fallbackScope, device)
 	case hasDeviceEndpoint:
-		tokens, err := erunDeviceFlowLogin(ctx, discovery, clientID, scope, deps)
+		tokens, err := runERunLoginAttempt(ctx, scope, fallbackScope, device)
 		if err == nil {
 			return tokens, nil
 		}
 		ctx.Trace("cloud login erun: device flow did not complete (" + err.Error() + "); falling back to authorization code + PKCE")
-		return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, scope)
+		return runERunLoginAttempt(ctx, scope, fallbackScope, authCode)
 	default:
-		return deps.RunERunAuthCodeLogin(ctx, discovery, clientID, scope)
+		return runERunLoginAttempt(ctx, scope, fallbackScope, authCode)
 	}
+}
+
+// runERunLoginAttempt runs run(scope), retrying once with fallbackScope when
+// the issuer's refusal is specifically an invalid_scope response — never for
+// any other failure, which is returned to the caller unchanged.
+func runERunLoginAttempt(ctx Context, scope, fallbackScope string, run func(string) (ERunTokens, error)) (ERunTokens, error) {
+	tokens, err := run(scope)
+	if err == nil || scope == fallbackScope || !isERunInvalidScopeError(err) {
+		return tokens, err
+	}
+	ctx.Trace("cloud login erun: issuer rejected scope " + scope + "; retrying with " + fallbackScope)
+	return run(fallbackScope)
 }
 
 // persistERunLoginTokens saves a fresh refresh token (when the grant returned

--- a/erun-common/cloud_erun_oidc.go
+++ b/erun-common/cloud_erun_oidc.go
@@ -48,6 +48,16 @@ type ERunTokens struct {
 // CLI/agent session needs to outlive one access token's short lifetime.
 const erunOAuthScope = "openid offline_access"
 
+// erunOrgClaimScope asks the shipped Zitadel IdP to include the org
+// (resourceowner) claim erun's tenant resolution reads for a shared,
+// org-scoped issuer. Requested by default on every erun login so a token
+// actually carries the discriminator, rather than requiring an operator to
+// know to pass --scope by hand. A dedicated/BYO issuer (the common case) has
+// never heard of this scope; erunCloudProviderLogin retries once without it
+// when the issuer refuses the request, so login still succeeds exactly as it
+// did before this default was added.
+const erunOrgClaimScope = "urn:zitadel:iam:user:resourceowner"
+
 // erunLoginScope appends any operator-requested scopes to the baseline. A
 // provider's reserved scopes are frequently absent from its discovery
 // document's scopes_supported (Zitadel's urn:zitadel:* family is), so there is
@@ -76,7 +86,18 @@ var (
 	errERunSlowDown             = errors.New("slow_down")
 	errERunExpiredToken         = errors.New("expired_token")
 	errERunAccessDenied         = errors.New("access_denied")
+	errERunInvalidScope         = errors.New("invalid_scope")
 )
+
+// isERunInvalidScopeError reports whether a login attempt failed because the
+// issuer rejected a requested scope. The device/token-endpoint path surfaces
+// this through oauthTokenError's errERunInvalidScope sentinel; the
+// Authorization Code + PKCE path instead learns it from the redirect's own
+// error query parameter (erunCallbackHandler), which is a plain wrapped
+// string rather than that sentinel.
+func isERunInvalidScopeError(err error) bool {
+	return err != nil && (errors.Is(err, errERunInvalidScope) || strings.Contains(err.Error(), "invalid_scope"))
+}
 
 // defaultFetchPlatformInfo delegates to PlatformClient — the same
 // unauthenticated GET /v1/platform call a caller makes once it has a
@@ -425,6 +446,8 @@ func oauthTokenError(status int, body []byte) error {
 		return errERunExpiredToken
 	case "access_denied":
 		return errERunAccessDenied
+	case "invalid_scope":
+		return errERunInvalidScope
 	}
 	message := strings.TrimSpace(payload.ErrorDescription)
 	if message == "" {

--- a/erun-common/cloud_erun_test.go
+++ b/erun-common/cloud_erun_test.go
@@ -211,6 +211,18 @@ func TestERunCloudProviderLoginDegradesWhenIssuerRejectsOrgClaimScope(t *testing
 	if status.Status != CloudTokenStatusActive {
 		t.Fatalf("Status = %q, want active", status.Status)
 	}
+	assertDegradedScopeAttempts(t, gotScopes)
+	if cached, ok := loadCachedERunAccessToken(secrets, provider.Alias); !ok || cached != "access-degrade" {
+		t.Fatalf("cached = %q (ok=%v), want the fallback attempt's token persisted", cached, ok)
+	}
+}
+
+// assertDegradedScopeAttempts checks the two device-authorization attempts a
+// graceful scope degradation must produce: the first requests the org-claim
+// scope by default, the second (after the issuer's refusal) drops it while
+// keeping the baseline scopes.
+func assertDegradedScopeAttempts(t *testing.T, gotScopes []string) {
+	t.Helper()
 	if len(gotScopes) != 2 {
 		t.Fatalf("expected exactly 2 device-authorization attempts (with, then without, the org-claim scope), got %v", gotScopes)
 	}
@@ -224,9 +236,6 @@ func TestERunCloudProviderLoginDegradesWhenIssuerRejectsOrgClaimScope(t *testing
 		if !strings.Contains(gotScopes[1], baseline) {
 			t.Fatalf("fallback scope = %q, want the %q baseline kept", gotScopes[1], baseline)
 		}
-	}
-	if cached, ok := loadCachedERunAccessToken(secrets, provider.Alias); !ok || cached != "access-degrade" {
-		t.Fatalf("cached = %q (ok=%v), want the fallback attempt's token persisted", cached, ok)
 	}
 }
 

--- a/erun-common/cloud_erun_test.go
+++ b/erun-common/cloud_erun_test.go
@@ -175,6 +175,61 @@ func TestERunCloudProviderLoginDeviceFlowPersistsTokensAndCache(t *testing.T) {
 	}
 }
 
+// TestERunCloudProviderLoginDegradesWhenIssuerRejectsOrgClaimScope proves
+// erun#1605's third item degrades gracefully: the org-claim scope is
+// requested by default, but an issuer that has never heard of it (a
+// dedicated/BYO IdP, the common case, not the shipped Zitadel) must still let
+// the login through — exactly as it did before this default was added —
+// rather than breaking on an invalid_scope refusal.
+func TestERunCloudProviderLoginDegradesWhenIssuerRejectsOrgClaimScope(t *testing.T) {
+	store := erunTestCloudStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{erunTestProvider()}}}
+	secrets := NewFileCloudSecretStore(t.TempDir())
+	provider := erunTestProvider()
+
+	var gotScopes []string
+	deps := CloudDependencies{
+		CloudSecretStore: secrets,
+		FetchOIDCDiscovery: func(Context, string) (OIDCDiscovery, error) {
+			return OIDCDiscovery{Issuer: provider.OIDCIssuerURL, DeviceAuthorizationEndpoint: "https://auth.example.test/device", TokenEndpoint: "https://auth.example.test/token"}, nil
+		},
+		StartERunDeviceAuthorization: func(_ Context, _ OIDCDiscovery, _ string, scope string) (ERunDeviceAuthorization, error) {
+			gotScopes = append(gotScopes, scope)
+			if strings.Contains(scope, erunOrgClaimScope) {
+				return ERunDeviceAuthorization{}, errERunInvalidScope
+			}
+			return ERunDeviceAuthorization{DeviceCode: "device-code-degrade", UserCode: "DGRD-1234"}, nil
+		},
+		PollERunDeviceToken: func(Context, OIDCDiscovery, string, ERunDeviceAuthorization) (ERunTokens, error) {
+			return ERunTokens{AccessToken: "access-degrade", RefreshToken: "refresh-degrade", ExpiresIn: time.Hour}, nil
+		},
+	}
+
+	status, err := LoginCloudProviderAlias(Context{}, &store, CloudLoginParams{Alias: provider.Alias}, deps)
+	if err != nil {
+		t.Fatalf("LoginCloudProviderAlias: %v", err)
+	}
+	if status.Status != CloudTokenStatusActive {
+		t.Fatalf("Status = %q, want active", status.Status)
+	}
+	if len(gotScopes) != 2 {
+		t.Fatalf("expected exactly 2 device-authorization attempts (with, then without, the org-claim scope), got %v", gotScopes)
+	}
+	if !strings.Contains(gotScopes[0], erunOrgClaimScope) {
+		t.Fatalf("first attempt scope = %q, want the org-claim scope requested by default", gotScopes[0])
+	}
+	if strings.Contains(gotScopes[1], erunOrgClaimScope) {
+		t.Fatalf("fallback attempt scope = %q, must not repeat the scope the issuer just rejected", gotScopes[1])
+	}
+	for _, baseline := range []string{"openid", "offline_access"} {
+		if !strings.Contains(gotScopes[1], baseline) {
+			t.Fatalf("fallback scope = %q, want the %q baseline kept", gotScopes[1], baseline)
+		}
+	}
+	if cached, ok := loadCachedERunAccessToken(secrets, provider.Alias); !ok || cached != "access-degrade" {
+		t.Fatalf("cached = %q (ok=%v), want the fallback attempt's token persisted", cached, ok)
+	}
+}
+
 func TestERunCloudProviderLoginFallsBackToAuthCodeWithoutDeviceEndpoint(t *testing.T) {
 	store := erunTestCloudStore{config: ERunConfig{CloudProviders: []CloudProviderConfig{erunTestProvider()}}}
 	secrets := NewFileCloudSecretStore(t.TempDir())

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -775,7 +775,8 @@ The three identity rows — the `tenants` row, the `issuers` registry row (the g
 |---|---|---|
 | `400` | `name` is empty or contains anything other than lowercase letters and digits (no hyphens — so the `<tenant>-<env>` namespace stays injective), `issuer` is empty/missing, `type` is not one of `COMPANY`/`OPERATIONS`, or the body is not valid JSON. | Send a hyphen-free lowercase-alphanumeric `name`, a non-empty `issuer`, and a valid `type`. |
 | `403` | The caller's resolved tenant is not an `OPERATIONS` tenant (the explicit operations gate, beyond the standard auth failures in [Errors](#errors)). | Call from an operations-tenant token whose roles permit the write. |
-| `500` | Persistence failed — e.g. the tenant `name` or the `(issuer, org_field_value)` mapping already exists (a uniqueness violation), or the request-scoped security context is missing (an internal wiring error). | Use a unique tenant name and issuer mapping; if it persists with unique inputs, it is a server bug. |
+| `409` | The `(issuer, org_field_value)` mapping already exists — either the issuer is already registered single-tenant (no org discriminator) and `orgFieldValue` was left empty, or this exact org value on that issuer is already taken; the body names which. | For the no-discriminator case, an operations caller converts the issuer to org-scoped via [`PATCH /v1/tenant-issuers`](#patch-v1tenant-issuers) (which backfills the existing tenant's mapping) before retrying this call with `orgFieldKey`/`orgFieldValue`; for the taken-org-value case, pick a different `orgFieldValue`. |
+| `500` | Persistence failed — e.g. the tenant `name` already exists (a uniqueness violation), or the request-scoped security context is missing (an internal wiring error). | Use a unique tenant name; if it persists, it is a server bug. |
 
 ### `GET /v1/tenants/reachable` {#get-v1tenantsreachable}
 

--- a/erun-integration/testdata/cloud/login_help.txt
+++ b/erun-integration/testdata/cloud/login_help.txt
@@ -9,7 +9,7 @@ Flags:
       --flow string         OIDC grant for an erun-hosted alias: "device", "authcode", or "auto" (default) which prefers the device grant and falls back to authorization code + PKCE when it cannot complete. Use "authcode" when the device page's authentication method fails — its loopback redirect reuses a browser session you already hold
       --force               Re-authenticate even when the stored session is still active. Needed to change the requested scopes or flow on an alias that is already signed in, since an active session otherwise short-circuits the login
   -h, --help                help for login
-      --scope stringArray   Extra OAuth scope to request on top of "openid offline_access" (repeatable). A provider's reserved scopes are often absent from its discovery document, so they can only be asked for by name — e.g. urn:zitadel:iam:user:resourceowner, which makes a Zitadel token carry the org claim an org-scoped issuer resolves tenants by
+      --scope stringArray   Extra OAuth scope to request on top of "openid offline_access" and the org-claim scope requested by default (repeatable). A provider's reserved scopes are often absent from its discovery document, so they can only be asked for by name
 
 Global Flags:
       --output string   Result format: text (default, human stream) or json (structured result on stdout for orchestrators). (default "text")

--- a/erun-mcp/cloud.go
+++ b/erun-mcp/cloud.go
@@ -40,7 +40,7 @@ type CloudInitERunInput struct {
 
 type CloudLoginInput struct {
 	Alias     string   `json:"alias" jsonschema:"configured cloud provider alias to login"`
-	Scopes    []string `json:"scopes,omitempty" jsonschema:"extra OAuth scopes to request on top of openid offline_access; a provider\u0027s reserved scopes are often unadvertised and can only be asked for by name (e.g. urn:zitadel:iam:user:resourceowner, which makes a Zitadel token carry the org claim an org-scoped issuer resolves tenants by)"`
+	Scopes    []string `json:"scopes,omitempty" jsonschema:"extra OAuth scopes to request on top of openid offline_access and the org-claim scope requested by default; a provider\u0027s reserved scopes are often unadvertised and can only be asked for by name"`
 	Flow      string   `json:"flow,omitempty" jsonschema:"OIDC grant for an erun-hosted alias: device, authcode, or auto (the default) which prefers the device grant and falls back to authorization code + PKCE when it cannot complete"`
 	Preview   bool     `json:"preview,omitempty" jsonschema:"when true, return the planned operation without executing login"`
 	Verbosity int      `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`


### PR DESCRIPTION
## Summary

Issue #1605 describes two compounding defects around org-scoped issuer bootstrap on a shared IdP (e.g. the platform's own Zitadel), plus a 409 message that recommended a remedy neither of the fixes made possible. Verifying against current `main` (the issue was written against 1.0.203; this branch is based on `main` at 1.0.218) showed **items 1 and 2 were already fixed** by PR #1588 (merged the day before this work started). This PR adds the missing test coverage for those two, and implements the two items that were genuinely still open (3 and 4).

### How each of the four items is addressed

1. **Bootstrap registers a shared IdP org-scoped** — already fixed on `main` (`insertFirstIdentity`/`bootstrapOrgScope` in `erun-backend-api/internal/repository/identity.go`, from PR #1588). This PR adds `TestBootstrapFirstIdentityRegistersSharedIssuerOrgScopedWithCallersOrgAsFirstMapping` and `TestSecondTenantOnSharedIssuerWithDifferentOrgIsAcceptedNotConflict`, run against a real migrated PostgreSQL, proving the issuer is registered with `org_field_key` set and the bootstrap caller's own org as the first `tenant_issuers.org_field_value`, and that a second tenant on the same issuer with a different org value succeeds (no more 409 for the legitimate case).
2. **Migration path** — already fixed on `main` (`TenantIssuerRepository.UpdateOrgScope` + `PATCH /v1/tenant-issuers`'s org-scope branch, also from PR #1588), already operations-gated and already covered by route-level unit tests. This PR adds `TestTenantIssuerRepositoryUpdateOrgScopeConvertsAndBackfills`, a real-Postgres test proving the two-table write (issuers.org_field_key + the existing tenant's tenant_issuers.org_field_value) actually commits together.
3. **`cloud login` requests the org-carrying scope** — genuinely new in this PR. `erunCloudProviderLogin` (`erun-common/cloud_erun.go`) now requests `urn:zitadel:iam:user:resourceowner` by default alongside the existing `openid offline_access` baseline.
4. **409 message fixed** — genuinely new in this PR. `duplicateIssuerMessage` (`erun-backend-api/internal/routes/tenants.go`) now names `PATCH /v1/tenant-issuers` (the item-2 migration route) as the actual remedy, instead of recommending a retry of `POST /v1/tenants` with `--org-field-key`/`--org-field-value` — which can never work, since that route's `ON CONFLICT DO NOTHING` leaves the existing issuer row's `org_field_key` untouched.

### How item 3 degrades gracefully

The org-claim scope is appended to every erun-type login's scope request by default. `acquireERunLoginTokens` wraps each flow attempt (device grant, Authorization Code + PKCE) in `runERunLoginAttempt`, which retries the *same* flow once with the reduced (no-org-claim) scope specifically when the issuer refuses with `invalid_scope` — mapped from the device/token-endpoint's `error=invalid_scope` response, or the Authorization Code redirect's own `error` query parameter. Any other failure (timeout, network error, `access_denied`, etc.) is returned unchanged — no scope-retry masks a real failure. `TestERunCloudProviderLoginDegradesWhenIssuerRejectsOrgClaimScope` proves a login against an issuer that has never heard of the scope still authenticates, on the fallback scope, with the existing baseline (`openid offline_access`) intact.

### What authorises the migration endpoint

`PATCH /v1/tenant-issuers`'s org-scope branch (`updateTenantIssuerOrgScope` in `erun-backend-api/internal/routes/tenant_issuers.go`) gates on `security.Context.TenantType == model.TenantTypeOperations` — the same explicit operations-tenant check `POST /v1/tenants` already applies to writing the other root resolution tables (`tenants`, `issuers`). A non-operations (`COMPANY`) caller gets `403` before the repository is ever called; `TestTenantIssuerRoutesOrgScopeRequiresOperationsTenant` (pre-existing, unmodified) locks this. A tenant cannot re-scope an issuer through this path — only an operations-tenant token can.

### Whether item 1 can affect an existing platform

No. Bootstrap (`insertFirstIdentity`) only ever runs when `SELECT COUNT(*) FROM tenants` is zero; once any tenant row exists, this code path is never reached again (confirmed by the pre-existing `TestBootstrapFirstIdentityLeavesAlreadyBootstrappedDatabaseAlone`). An already-deployed platform that bootstrapped before PR #1588 is single-tenant already and stays exactly as it is; item 1 only changes the *first* sign-in against a brand-new, empty-tenants database.

### Tests (all five mandatory scenarios)

1. `TestBootstrapFirstIdentityRegistersSharedIssuerOrgScopedWithCallersOrgAsFirstMapping` (`erun-backend-api/internal/repository/identity_e2e_test.go`) — bootstrap against an empty tenants table with a resourceowner claim registers the issuer org-scoped with the caller's org as the first mapping.
2. `TestSecondTenantOnSharedIssuerWithDifferentOrgIsAcceptedNotConflict` (same file) — a second tenant on the same issuer with a different org value is accepted, no 409.
3. `TestTenantIssuerRepositoryUpdateOrgScopeConvertsAndBackfills` (new `tenant_issuers_e2e_test.go`) — the migration converts a single-tenant issuer row and backfills the existing mapping; non-operations refusal is covered by the pre-existing `TestTenantIssuerRoutesOrgScopeRequiresOperationsTenant`.
4. `TestERunCloudProviderLoginDegradesWhenIssuerRejectsOrgClaimScope` (`erun-common/cloud_erun_test.go`) — a login against an IdP that rejects the org-claim scope still authenticates, on the reduced scope.
5. `TestCreateTenantDuplicateIssuerReturnsConflict` (updated, `erun-backend-api/internal/routes/tenants_test.go`) — the 409 now names `PATCH /v1/tenant-issuers` as the working remedy.

### Verification performed

- Spun up a real `postgres:18` container locally, applied every Atlas migration in `erun-backend-db/migrations/default` with the pinned `atlas` CLI, and ran tests 1–3 above against it directly (not just against stub repositories) — all pass, confirming the actual SQL writes (issuers.org_field_key, tenant_issuers.org_field_value) land as expected. This container was local-only, torn down after the run; nothing was deployed and no live platform was touched.
- `go build`/`go vet`/`go test ./...` clean in `erun-common`, `erun-backend-api`, `erun-cli`, `erun-mcp`.
- `cd erun-docs && yarn build` clean (also corrected the pre-existing `POST /v1/tenants` error table, which mis-described the issuer-conflict case as `500` when it is actually `409` — a stale entry from before PR #1588 added the `ErrConflict` mapping).
- Full `make check` green (verbatim totals below).
- **Not verified**: the actual behavior of a real Zitadel instance's `device_authorization_endpoint`/authorize-endpoint on receiving an unrecognized `urn:zitadel:iam:user:resourceowner` scope, or any other real external IdP's response shape for `invalid_scope` — no live IdP or live platform was available to test against. The graceful-degradation logic is verified against the `invalid_scope` OAuth error code per RFC 6749 §5.2, via injected stub dependencies exercising both the device flow's token-endpoint-style error and the design's handling of it.

### Out of scope

Per the issue, tenant provisioning still has no way to create the Zitadel **org** a new tenant's mapping would point at — `/v1/identity/*` is scoped to the platform's own org and exposes user CRUD only. This PR does not touch that; it remains a manual step in Zitadel's console.

### Gate totals (verbatim)

```
>> golangci-lint erun-common
0 issues.
>> golangci-lint erun-cli
0 issues.
>> golangci-lint erun-mcp
0 issues.
>> golangci-lint erun-integration
0 issues.
>> golangci-lint erun-backend/erun-backend-api
0 issues.
>> golangci-lint erun-ui
0 issues.
>> go test erun-ui
ok  	github.com/sophium/erun/erun-ui	20.317s
ok  	github.com/sophium/erun/erun-ui/headlessserver	1.019s
>> erun-kit gates ... Done
>> erun-console gates ... Test Files  21 passed (21) / Tests  126 passed (126)
>> erun-devops/k8s/*_test.sh — all PASS/OK
>> running integration suite
ok  	github.com/sophium/erun/erun-integration	86.742s
ok  	github.com/sophium/erun/erun-integration/internal/desktopsurface	0.002s
ok  	github.com/sophium/erun/erun-integration/internal/normalize	0.002s
ok  coverage 75.9% (>= 75.8%)
```

`make check` exited 0.

Closes #1605