### PR TITLE
Stop workspace sync from pruning artifacts on an inconclusive remote listing

### DIFF
--- a/erun-common/workspace_sync.go
+++ b/erun-common/workspace_sync.go
@@ -228,20 +228,31 @@ func localArtifactPaths(artifactsLocal string, paths []string) []string {
 	return resolved
 }
 
+// remoteOutputsDirAbsentExitCode is the sentinel the remote script in
+// remoteOutputsFiles exits with when `cd` into the outputs dir fails, so that
+// outcome can be told apart from every other way the listing can fail: ssh's
+// own exit 255 on a connection failure, or `find` itself failing (e.g. on a
+// permission error). Only this exact code means "confirmed absent"; nothing
+// else does.
+const remoteOutputsDirAbsentExitCode = 42
+
 // remoteOutputsFiles lists the regular files under the pod outputs dir, relative
 // to it. A not-yet-created dir yields no paths and no error, so the mirror is a
-// no-op until an agent writes a deliverable. GNU find's %P prints the path
-// without the leading "./" so entries pass SafeWorkspaceSyncPath.
+// no-op until an agent writes a deliverable. Any other failure — the ssh
+// connection itself (exit 255), or `find` failing once inside the dir — is
+// reported as an error rather than folded into an empty listing, so a caller
+// that prunes local artifacts against this result never mistakes "could not
+// tell" for "confirmed empty" (see ObservedHelmRelease for the same
+// distinction applied to a helm read). GNU find's %P prints the path without
+// the leading "./" so entries pass SafeWorkspaceSyncPath.
 func remoteOutputsFiles(ctx context.Context, hostAlias, outputsRemote string) ([]string, error) {
-	script := fmt.Sprintf("cd %s 2>/dev/null && find . -type f -printf '%%P\\0'", shellQuote(outputsRemote))
+	script := fmt.Sprintf("cd %s 2>/dev/null || exit %d; find . -type f -printf '%%P\\0'", shellQuote(outputsRemote), remoteOutputsDirAbsentExitCode)
 	cmd := CommandContext(ctx, "ssh", workspaceSyncSSHArgs(hostAlias, script)...)
 	HideConsoleWindow(cmd)
 	output, err := cmd.Output()
 	if err != nil {
-		// `cd` into a not-yet-created outputs dir exits non-zero; treat the whole
-		// "no deliverables yet" case as an empty, error-free listing.
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == remoteOutputsDirAbsentExitCode {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("list remote outputs: %w", err)

--- a/erun-common/workspace_sync_outputs_test.go
+++ b/erun-common/workspace_sync_outputs_test.go
@@ -1,0 +1,97 @@
+package eruncommon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests drive syncOutputsArtifacts against a stub `ssh` so the outputs
+// listing and the prune it feeds are exercised together — erun#1657: an
+// inconclusive listing (a dropped ssh connection, a `find` failure) must never
+// be read as "no deliverables" and must never reach the prune, while a
+// genuinely absent outputs dir and a genuinely empty one must still be
+// no-ops, and a listing that succeeds must still prune what the pod removed.
+
+// stubWorkspaceSyncSSHForOutputs points `ssh` at the TestMain stub with no
+// source-lane listings configured, since these tests only exercise the
+// outputs lane's own remote command.
+func stubWorkspaceSyncSSHForOutputs(t *testing.T) {
+	t.Helper()
+	stubWorkspaceSyncSSH(t, nil, nil)
+}
+
+func TestSyncOutputsArtifactsDoesNotPruneOnSSHConnectionFailure(t *testing.T) {
+	stubWorkspaceSyncSSHForOutputs(t)
+	t.Setenv(workspaceSyncStubOutputsExitEnv, "255")
+
+	artifactsLocal := t.TempDir()
+	seedWorkspaceMirror(t, artifactsLocal, "keep.exe")
+
+	_, _, err := syncOutputsArtifacts(context.Background(), "pod", "/home/agent/outputs", artifactsLocal)
+	if err == nil {
+		t.Fatal("expected an ssh connection failure (exit 255) to surface as an error")
+	}
+	if _, statErr := os.Stat(filepath.Join(artifactsLocal, "keep.exe")); statErr != nil {
+		t.Fatalf("an inconclusive listing must leave the artifact mirror alone, got: %v", statErr)
+	}
+}
+
+func TestSyncOutputsArtifactsTreatsAbsentOutputsDirAsEmptyNoop(t *testing.T) {
+	stubWorkspaceSyncSSHForOutputs(t)
+	// No workspaceSyncStubOutputsEnv and no exit override: the stub's `cd`
+	// branch behaves as it would on a pod that has never written a deliverable.
+
+	artifactsLocal := filepath.Join(t.TempDir(), "artifacts-not-yet-created")
+
+	copied, _, err := syncOutputsArtifacts(context.Background(), "pod", "/home/agent/outputs", artifactsLocal)
+	requireWorkspaceSyncNoError(t, err, "sync outputs artifacts")
+	if copied != 0 {
+		t.Fatalf("expected 0 artifacts copied for an absent outputs dir, got %d", copied)
+	}
+	if _, statErr := os.Stat(artifactsLocal); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no mirror directory to be created for an absent outputs dir, got: %v", statErr)
+	}
+}
+
+func TestSyncOutputsArtifactsStillPrunesRemovedArtifactOnSuccessfulListing(t *testing.T) {
+	archive := writeWorkspaceSyncArchive(t, map[string][]byte{"keep.exe": []byte("still built")})
+	stubWorkspaceSyncSSHForOutputs(t)
+	t.Setenv(workspaceSyncStubOutputsEnv, "keep.exe")
+	t.Setenv(workspaceSyncStubArchiveEnv, archive)
+
+	artifactsLocal := t.TempDir()
+	seedWorkspaceMirror(t, artifactsLocal, "gone.exe")
+
+	copied, _, err := syncOutputsArtifacts(context.Background(), "pod", "/home/agent/outputs", artifactsLocal)
+	requireWorkspaceSyncNoError(t, err, "sync outputs artifacts")
+	if copied != 1 {
+		t.Fatalf("expected 1 artifact copied, got %d", copied)
+	}
+	if _, statErr := os.Stat(filepath.Join(artifactsLocal, "gone.exe")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected the pod-removed artifact to still be pruned on a successful listing, got: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(artifactsLocal, "keep.exe")); statErr != nil {
+		t.Fatalf("expected the newly listed artifact to be present: %v", statErr)
+	}
+}
+
+func TestSyncOutputsArtifactsTreatsNonConnectionFindFailureAsInconclusive(t *testing.T) {
+	stubWorkspaceSyncSSHForOutputs(t)
+	// Exit 1 simulates `find` itself failing once inside the outputs dir (e.g. a
+	// permission error) -- a real failure distinct from both success (0) and the
+	// script's own "confirmed absent" sentinel (remoteOutputsDirAbsentExitCode).
+	t.Setenv(workspaceSyncStubOutputsExitEnv, "1")
+
+	artifactsLocal := t.TempDir()
+	seedWorkspaceMirror(t, artifactsLocal, "keep.exe")
+
+	_, _, err := syncOutputsArtifacts(context.Background(), "pod", "/home/agent/outputs", artifactsLocal)
+	if err == nil {
+		t.Fatal("expected a non-connection find failure to surface as an error, not an empty listing")
+	}
+	if _, statErr := os.Stat(filepath.Join(artifactsLocal, "keep.exe")); statErr != nil {
+		t.Fatalf("an inconclusive listing must leave the artifact mirror alone, got: %v", statErr)
+	}
+}

--- a/erun-common/workspace_sync_pass_test.go
+++ b/erun-common/workspace_sync_pass_test.go
@@ -22,6 +22,7 @@ const (
 	workspaceSyncStubMissingEnv     = "ERUN_COMMON_TEST_SSH_STUB_MISSING"
 	workspaceSyncStubStatEnv        = "ERUN_COMMON_TEST_SSH_STUB_STAT"
 	workspaceSyncStubOutputsEnv     = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS"
+	workspaceSyncStubOutputsExitEnv = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS_EXIT"
 	workspaceSyncStubArchiveEnv     = "ERUN_COMMON_TEST_SSH_STUB_ARCHIVE"
 	workspaceSyncStubGateEnv        = "ERUN_COMMON_TEST_SSH_STUB_GATE"
 	workspaceSyncStubTruncateEnv    = "ERUN_COMMON_TEST_SSH_STUB_TRUNCATE"
@@ -65,10 +66,18 @@ func runWorkspaceSyncSSHStub(args []string) int {
 	case strings.Contains(script, "git ls-files -sz"):
 		return 0
 	case strings.Contains(script, "find . -type f"):
+		if code := strings.TrimSpace(os.Getenv(workspaceSyncStubOutputsExitEnv)); code != "" {
+			n, convErr := strconv.Atoi(code)
+			if convErr != nil {
+				return 1
+			}
+			return n
+		}
 		outputs := os.Getenv(workspaceSyncStubOutputsEnv)
 		if outputs == "" {
-			// `cd` into a not-yet-created outputs dir exits non-zero.
-			return 1
+			// `cd` into a not-yet-created outputs dir: the script's own sentinel
+			// for "confirmed absent" (see remoteOutputsDirAbsentExitCode).
+			return remoteOutputsDirAbsentExitCode
 		}
 		writeNULList(outputs)
 		return 0

--- a/erun-common/workspace_sync_pass_test.go
+++ b/erun-common/workspace_sync_pass_test.go
@@ -66,25 +66,34 @@ func runWorkspaceSyncSSHStub(args []string) int {
 	case strings.Contains(script, "git ls-files -sz"):
 		return 0
 	case strings.Contains(script, "find . -type f"):
-		if code := strings.TrimSpace(os.Getenv(workspaceSyncStubOutputsExitEnv)); code != "" {
-			n, convErr := strconv.Atoi(code)
-			if convErr != nil {
-				return 1
-			}
-			return n
-		}
-		outputs := os.Getenv(workspaceSyncStubOutputsEnv)
-		if outputs == "" {
-			// `cd` into a not-yet-created outputs dir: the script's own sentinel
-			// for "confirmed absent" (see remoteOutputsDirAbsentExitCode).
-			return remoteOutputsDirAbsentExitCode
-		}
-		writeNULList(outputs)
-		return 0
+		return runWorkspaceSyncSSHStubOutputsListing()
 	case strings.Contains(script, "tar --null"):
 		return streamWorkspaceSyncStubArchive()
 	}
 	return 1
+}
+
+// runWorkspaceSyncSSHStubOutputsListing answers the outputs-dir `find`
+// listing. workspaceSyncStubOutputsExitEnv overrides the exit code outright,
+// letting a test simulate the ssh connection itself failing (255) or `find`
+// failing once inside the dir (any other non-zero, non-sentinel code) --
+// otherwise an empty workspaceSyncStubOutputsEnv reports the script's own
+// "confirmed absent" sentinel (remoteOutputsDirAbsentExitCode), matching a
+// `cd` into a not-yet-created outputs dir.
+func runWorkspaceSyncSSHStubOutputsListing() int {
+	if code := strings.TrimSpace(os.Getenv(workspaceSyncStubOutputsExitEnv)); code != "" {
+		n, convErr := strconv.Atoi(code)
+		if convErr != nil {
+			return 1
+		}
+		return n
+	}
+	outputs := os.Getenv(workspaceSyncStubOutputsEnv)
+	if outputs == "" {
+		return remoteOutputsDirAbsentExitCode
+	}
+	writeNULList(outputs)
+	return 0
 }
 
 // streamWorkspaceSyncStubArchive plays back a prepared archive so a pass reaches

--- a/erun-integration/internal/fixture/fixture.go
+++ b/erun-integration/internal/fixture/fixture.go
@@ -967,14 +967,19 @@ func StubWorkspaceSyncSSH(t testing.TB, dir string, spec WorkspaceSyncSSHStubSpe
 	if spec.ArchivePath != "" {
 		archiveBranch = "cat " + shellSingleQuote(filepath.ToSlash(spec.ArchivePath))
 	}
-	// The readiness probe runs a bare `true`; everything not answered here — the
-	// outputs listing in particular — is "nothing there yet", which is exit 1.
+	// The readiness probe runs a bare `true`. The outputs listing's own script
+	// exits 42 when its `cd` fails (erun-common's remoteOutputsDirAbsentExitCode)
+	// -- the sentinel that tells "the outputs dir does not exist yet" apart from
+	// every other listing failure, so "nothing there yet" must answer with that
+	// exact code rather than the bare non-zero exit a real connection failure
+	// would also produce.
 	StubBinaryWithScript(t, dir, "ssh", `case "$*" in
   *' true') : ;;
   *'stat -c'*) `+statBranch+` ;;
   *'git ls-files -coz'*) `+indexBranch+` ;;
   *'git ls-files -dz'*) : ;;
   *'git ls-files -sz'*) : ;;
+  *'find . -type f'*) exit 42 ;;
   *'tar --null'*) `+archiveBranch+` ;;
   *) exit 1 ;;
 esac


### PR DESCRIPTION
## Summary

`remoteOutputsFiles` (`erun-common/workspace_sync.go`) treated **any** non-zero exit from the remote `ssh` listing as "no deliverables yet" -- including ssh's own exit 255 on a dropped connection, a stale channel, a rejected key, or `find` itself failing on a permission error. That empty listing fed straight into `pruneLocalArtifacts`, which deletes every host artifact the (falsely) empty remote set doesn't contain -- so a transient failure (a pod restarting on every deploy is the ordinary case) deleted the entire host artifact mirror and reported success.

## Fix

The remote script now distinguishes the one case the old comment actually described from every other failure, by exit code rather than by "any `*exec.ExitError`":

```sh
cd <outputs> 2>/dev/null || exit 42; find . -type f -printf '%P\0'
```

- **Empty (safe, no prune, no error):** exit code exactly `42` (`remoteOutputsDirAbsentExitCode`) -- `cd` failed because no agent has written a deliverable yet. This is the one case the original comment justified, and it's now the only one that reaches it.
- **Inconclusive (error, never reaches the prune):** every other non-zero exit -- ssh's own 255 on a connection failure, or `find` itself failing (e.g. permission error) once inside the dir. `remoteOutputsFiles` returns an error, `syncOutputsArtifacts` returns before calling `pruneLocalArtifacts`, and `SyncWorkspaceOnce` reports the failure instead of success.

This mirrors the precedent in `ObservedHelmRelease` (`erun-common/observe_helm_release.go`): a confirmed absence and a read that could not tell are different outcomes, and a caller must never see the same "nothing here" answer for both.

## Worktree side

Checked `resolveWorkspaceSyncPaths` / `remoteWorkspaceGitVisibleFiles`, which feeds the same-shaped `deleteLocalWorkspaceFilesNotInRemote` prune for the *source* lane. It was already safe: it only treats the specific stderr substring `"not a git repository"` as the legitimate no-op sentinel (`errRemoteNotGitRepo`); every other failure -- including an ssh connection failure -- is wrapped and returned as a real error, which stops the pass before any delete runs. `remoteWorkspaceMissingFiles` and `remoteWorkspaceSymlinkSet` degrade best-effort on failure, but in the direction that keeps more files rather than deletes more, so they can't cause a wrongful deletion either. No change needed there.

## Tests

Added `erun-common/workspace_sync_outputs_test.go`, driving `syncOutputsArtifacts` against the stub `ssh`:
- `TestSyncOutputsArtifactsDoesNotPruneOnSSHConnectionFailure` -- exit 255 surfaces as an error; the existing artifact mirror is untouched.
- `TestSyncOutputsArtifactsTreatsAbsentOutputsDirAsEmptyNoop` -- no outputs configured (the stub's `cd`-fails branch) yields 0 artifacts, no error, no mirror directory created.
- `TestSyncOutputsArtifactsStillPrunesRemovedArtifactOnSuccessfulListing` -- regression guard: a successful listing still prunes an artifact the pod no longer has (this already existed for the full pass via `TestSyncOutputsArtifactsPublishesCompletelyAndKeepsItsMarkingAndPruning`; this one exercises it directly at the `syncOutputsArtifacts` level).
- `TestSyncOutputsArtifactsTreatsNonConnectionFindFailureAsInconclusive` -- exit 1 (simulating a `find` failure once inside the dir) surfaces as an error, not an empty listing.

Also updated `erun-integration/internal/fixture.StubWorkspaceSyncSSH`: its catch-all `exit 1` was standing in for "outputs dir absent" for the real-run `sshd sync` integration scenarios, which is exactly the conflation this PR removes from production. It now answers the outputs listing explicitly with the new sentinel exit code.

## Validation

`make check`: green (all lint 0 issues, all module test suites pass, integration suite green, coverage 75.8% >= 75.8% threshold).

Closes #1657