### PR TITLE
Stop erun doctor recommending a rollback when the helm read failed

### DIFF
--- a/erun-common/doctor_deploy.go
+++ b/erun-common/doctor_deploy.go
@@ -6,10 +6,20 @@ import (
 	"strings"
 )
 
-// DeployDiagnosisResult holds the deploy-failure diagnosis for the caller to interpret.
+// DeployDiagnosisResult holds the deploy-failure diagnosis for the caller to
+// interpret. HelmStatus always carries the raw `helm status` output — including
+// stderr on a failed read, which is itself diagnostic — but a caller deciding
+// whether to recommend a mutating recovery must consult HelmReadError first:
+// it is non-empty exactly when the read itself could not be trusted (RBAC, no
+// helm on PATH, an API-server timeout), as opposed to a confirmed answer such
+// as "no release exists" or "release failed". A caller must never derive the
+// same "nothing to recover" answer for both a confirmed-healthy release and a
+// read that could not tell (mirrors ObservedHelmRelease's Found/Error contract
+// in observe_helm_release.go).
 type DeployDiagnosisResult struct {
-	HelmStatus string
-	Pods       string
+	HelmStatus    string
+	HelmReadError string
+	Pods          string
 }
 
 func helmStatusArgs(req ShellLaunchParams) []string {
@@ -39,22 +49,26 @@ func RunDeployDiagnosis(ctx Context, req ShellLaunchParams) DeployDiagnosisResul
 	if ctx.DryRun {
 		return DeployDiagnosisResult{}
 	}
-	return DeployDiagnosisResult{
-		HelmStatus: runDoctorDiagnosisCommand("helm", helmArgs),
-		Pods:       runDoctorDiagnosisCommand("kubectl", podArgs),
+	helmStatus, helmErr := runDoctorDiagnosisCommand("helm", helmArgs)
+	pods, _ := runDoctorDiagnosisCommand("kubectl", podArgs)
+	result := DeployDiagnosisResult{HelmStatus: helmStatus, Pods: pods}
+	if helmErr != nil && !isHelmReleaseNotFound(helmStatus) {
+		result.HelmReadError = observeHelmReadErrorMessage(RuntimeReleaseName(req.Tenant), req.Namespace, helmStatus, helmErr)
 	}
+	return result
 }
 
 // runDoctorDiagnosisCommand folds command errors into the returned output —
 // `helm status` stderr on a missing release is itself diagnostic — so the
-// caller always has something to show.
-func runDoctorDiagnosisCommand(name string, args []string) string {
+// caller always has something to show, while still returning the command's own
+// error so a caller that needs to know whether the read succeeded can tell.
+func runDoctorDiagnosisCommand(name string, args []string) (string, error) {
 	cmd := Command(name, args...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
-	_ = cmd.Run()
-	return strings.TrimSpace(out.String())
+	err := cmd.Run()
+	return strings.TrimSpace(out.String()), err
 }
 
 // DeployRecoveryAction names a mutating recovery `erun doctor` can run against a
@@ -78,9 +92,15 @@ const (
 // alternative fixes for different failure modes, not additive steps: clearing
 // pending leaves the release at its last deployed revision, so a rollback run
 // straight after would step back a further revision. The bool is false when no
-// helm-level recovery applies — a healthy release, or no release to act on (a
-// missing release is recovered by `erun deploy --force`, not by helm).
+// helm-level recovery applies — a healthy release, no release to act on (a
+// missing release is recovered by `erun deploy --force`, not by helm), or a
+// release the read could not confirm one way or the other: recommending the
+// destructive rollback for a read failure would act on a guess, not a
+// diagnosis, so HelmReadError is checked before any HelmStatus text.
 func RecommendedDeployRecovery(diagnosis DeployDiagnosisResult) (DeployRecoveryAction, bool) {
+	if strings.TrimSpace(diagnosis.HelmReadError) != "" {
+		return "", false
+	}
 	status := strings.ToLower(strings.TrimSpace(diagnosis.HelmStatus))
 	switch {
 	case status == "":

--- a/erun-common/doctor_deploy_test.go
+++ b/erun-common/doctor_deploy_test.go
@@ -1,6 +1,11 @@
 package eruncommon
 
-import "testing"
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
 
 // TestRecommendedDeployRecovery locks the diagnosis → single-recovery mapping.
 // The classifier only runs on a real `erun doctor` (dry-run produces an empty
@@ -8,10 +13,11 @@ import "testing"
 // unreachable from the dry-run integration subprocess and is covered here.
 func TestRecommendedDeployRecovery(t *testing.T) {
 	cases := []struct {
-		name       string
-		helmStatus string
-		wantAction DeployRecoveryAction
-		wantOK     bool
+		name          string
+		helmStatus    string
+		helmReadError string
+		wantAction    DeployRecoveryAction
+		wantOK        bool
 	}{
 		{
 			name:       "empty status offers nothing",
@@ -46,10 +52,20 @@ func TestRecommendedDeployRecovery(t *testing.T) {
 			wantAction: DeployRecoveryRollback,
 			wantOK:     true,
 		},
+		{
+			// This is the defect erun#1659 exists to fix: a status string
+			// that would otherwise fall into the "failed" default arm must
+			// not recommend a rollback when the read itself is the thing
+			// that failed, not the release.
+			name:          "unreadable release offers nothing even though the status text looks like a failure",
+			helmStatus:    "Error from server (Forbidden): secrets is forbidden: User \"jane\" cannot list resource \"secrets\"",
+			helmReadError: `observe: not authorized to read helm release "team-devops" in namespace "team-dev"`,
+			wantOK:        false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			action, ok := RecommendedDeployRecovery(DeployDiagnosisResult{HelmStatus: tc.helmStatus})
+			action, ok := RecommendedDeployRecovery(DeployDiagnosisResult{HelmStatus: tc.helmStatus, HelmReadError: tc.helmReadError})
 			if ok != tc.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
 			}
@@ -57,5 +73,86 @@ func TestRecommendedDeployRecovery(t *testing.T) {
 				t.Fatalf("action = %q, want %q", action, tc.wantAction)
 			}
 		})
+	}
+}
+
+// writeDoctorHelmStub points ERUN_HELM_BIN at a script that prints stdout and
+// stderr and exits with the given code, so a test can drive RunDeployDiagnosis
+// against the real, distinct shapes a live `helm status` invocation returns
+// (plain text, not the `-o json` shape observe reads) without a live cluster.
+func writeDoctorHelmStub(t *testing.T, stdout, stderr string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/helm-stub"
+	script := "#!/bin/sh\n"
+	if stdout != "" {
+		script += "cat <<'ERUN_TEST_HELM_STDOUT'\n" + stdout + "\nERUN_TEST_HELM_STDOUT\n"
+	}
+	if stderr != "" {
+		script += "cat <<'ERUN_TEST_HELM_STDERR' >&2\n" + stderr + "\nERUN_TEST_HELM_STDERR\n"
+	}
+	script += "exit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helm stub: %v", err)
+	}
+	t.Setenv("ERUN_HELM_BIN", path)
+}
+
+// TestRunDeployDiagnosisRecordsHelmReadError is the end-to-end half of
+// erun#1659's fix: a failed helm read (here, an RBAC denial reading the
+// release Secrets) must populate HelmReadError, and that alone must be enough
+// for RecommendedDeployRecovery to refuse a destructive recovery -- without
+// this repo adding another strings.Contains arm for the RBAC wording.
+func TestRunDeployDiagnosisRecordsHelmReadError(t *testing.T) {
+	writeDoctorHelmStub(t, "", `Error from server (Forbidden): secrets is forbidden: User "jane" cannot list resource "secrets"`, 1)
+	writeKubectlStub(t, "", 0)
+
+	diagnosis := RunDeployDiagnosis(testTraceContext(false), ShellLaunchParams{Tenant: "team", Environment: "dev", Namespace: "team-dev"})
+
+	if diagnosis.HelmReadError == "" {
+		t.Fatalf("expected a non-empty HelmReadError for a failed RBAC read")
+	}
+	if !strings.Contains(diagnosis.HelmReadError, "not authorized") {
+		t.Fatalf("HelmReadError must explain the RBAC cause, got %q", diagnosis.HelmReadError)
+	}
+	if action, ok := RecommendedDeployRecovery(diagnosis); ok {
+		t.Fatalf("recommended action = %q, ok = true; want no recovery recommended for an unreadable release", action)
+	}
+}
+
+// TestRunDeployDiagnosisMissingReleaseHasNoReadError locks the unchanged
+// side: `helm status` also exits non-zero for a genuinely missing release,
+// but that is a confirmed answer, not a failed read, so HelmReadError must
+// stay empty.
+func TestRunDeployDiagnosisMissingReleaseHasNoReadError(t *testing.T) {
+	writeDoctorHelmStub(t, "", "Error: release: not found", 1)
+	writeKubectlStub(t, "", 0)
+
+	diagnosis := RunDeployDiagnosis(testTraceContext(false), ShellLaunchParams{Tenant: "team", Environment: "dev", Namespace: "team-dev"})
+
+	if diagnosis.HelmReadError != "" {
+		t.Fatalf("expected no HelmReadError for a confirmed-missing release, got %q", diagnosis.HelmReadError)
+	}
+	if action, ok := RecommendedDeployRecovery(diagnosis); ok {
+		t.Fatalf("recommended action = %q, ok = true; want no recovery recommended for a missing release", action)
+	}
+}
+
+// TestRunDeployDiagnosisFailedReleaseStillRecommendsRollback is the test that
+// stops erun#1659's fix from regressing into "never recommend anything":
+// `helm status` exits 0 for a release that exists but genuinely failed, so
+// HelmReadError must stay empty and the rollback recommendation must survive.
+func TestRunDeployDiagnosisFailedReleaseStillRecommendsRollback(t *testing.T) {
+	writeDoctorHelmStub(t, "NAME: team-devops\nSTATUS: failed\nREVISION: 5", "", 0)
+	writeKubectlStub(t, "", 0)
+
+	diagnosis := RunDeployDiagnosis(testTraceContext(false), ShellLaunchParams{Tenant: "team", Environment: "dev", Namespace: "team-dev"})
+
+	if diagnosis.HelmReadError != "" {
+		t.Fatalf("expected no HelmReadError for a genuinely failed release, got %q", diagnosis.HelmReadError)
+	}
+	action, ok := RecommendedDeployRecovery(diagnosis)
+	if !ok || action != DeployRecoveryRollback {
+		t.Fatalf("action = %q, ok = %v; want (%q, true) for a genuinely failed release", action, ok, DeployRecoveryRollback)
 	}
 }


### PR DESCRIPTION
## Summary

`erun doctor` recommended a destructive **rollback** whenever `helm status` itself failed to read — an RBAC denial reading the release Secrets, `helm` missing from PATH, an API-server timeout — because `runDoctorDiagnosisCommand` folded command errors into `HelmStatus`'s raw text, and `RecommendedDeployRecovery` only special-cased the "release not found" wording; every other error string fell through to the `default` arm and recommended `DeployRecoveryRollback`.

If the read failure is persistent, the rollback fails the same way and nothing is destroyed — the operator is merely misled. The harmful case is a *transient* failure (API-server hiccup, restarting control plane): the read fails, doctor misclassifies a healthy release as broken, and the rollback that then succeeds steps a running environment back a revision.

## Fix

`DeployDiagnosisResult` now carries a new `HelmReadError` field, populated only when the helm status read itself could not be trusted — distinct from a confirmed "release not found" or a confirmed "release failed". `RunDeployDiagnosis` classifies this by capturing the command's own exit error and checking `isHelmReleaseNotFound` on the folded output before deciding the read failed. `RecommendedDeployRecovery` now checks `HelmReadError` first and returns no recovery when it is set, before ever looking at `HelmStatus` text. No new `strings.Contains` arms were added for specific error wording — the distinction is now carried in the data, not inferred from stderr phrasing.

This reuses the pattern established by the recent `observe` drift fix: `ObservedHelmRelease`'s `Found`/`Error` contract (`erun-common/observe_helm_release.go`) already distinguishes "confirmed missing" from "could not tell," with the rule that a caller must never see the same answer for both. `isHelmReleaseNotFound` and `observeHelmReadErrorMessage` (both already in `observe_helm_release.go`) are reused directly rather than re-implemented.

## Other consumer with the same conflation (named, not fixed here)

`AssembleEnvironmentReadModel` (`erun-common/environment_read_model.go`) computes `DeployHealthy = !needsRecovery` from `RecommendedDeployRecovery`'s result. With this fix, an unreadable release now yields `needsRecovery = false`, so it reads as `DeployHealthy = true` — i.e. an environment whose deploy health genuinely could not be read now resolves to the `Running`/healthy lifecycle state rather than a distinct "unknown" state. This is a real gap (the boolean can't distinguish "confirmed healthy" from "could not tell" either), but fixing it means widening `EnvironmentLifecycleState`, which is a separate, larger change than this issue's scope (stopping a destructive recommendation). Flagging it here per the issue's request rather than folding it into this PR.

## Tests

Added to `erun-common/doctor_deploy_test.go`:
- `TestRecommendedDeployRecovery`'s table gained an "unreadable release offers nothing even though the status text looks like a failure" case, proving the `HelmReadError` gate overrides the text-based `default` arm.
- `TestRunDeployDiagnosisRecordsHelmReadError` — a failed helm read (RBAC stub) populates `HelmReadError` and `RecommendedDeployRecovery` returns no action.
- `TestRunDeployDiagnosisMissingReleaseHasNoReadError` — a genuinely missing release (helm exits non-zero with "release: not found") leaves `HelmReadError` empty and still recommends nothing — unchanged.
- Existing pending-install/upgrade/rollback table cases — unchanged, still recommend clearing the pending lock.
- `TestRunDeployDiagnosisFailedReleaseStillRecommendsRollback` — a release that genuinely failed (helm exits 0, `STATUS: failed`) still recommends the rollback — the test that stops this fix from regressing into "never recommend anything."
- Existing "deployed offers nothing" table case — unchanged.

## Validation

- `make check` green: golangci-lint (0 issues, all Go modules), `erun-ui` Go tests, frontend gates (erun-kit, erun-console), devops chart tests, `erun-integration` suite (coverage 75.8% ≥ 75.8% threshold).

Closes #1659