### PR TITLE
Fix two data races in the deploy path's shared output buffers

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -713,9 +713,65 @@ func projectDirReachable(path string) bool {
 	return err == nil && info.IsDir()
 }
 
+// parallelDeployCapture is one goroutine's private output destination for a
+// parallel deploy step. Context.Stdout/Stderr and a Logger's own stdout/stderr
+// are io.Writer values copied by value into every goroutine's Context, so
+// concurrent RunDeploySpec calls would otherwise write them from more than one
+// goroutine at once -- a data race when the underlying writer is a
+// *bytes.Buffer, as it is on the MCP edge (erun-mcp/runtime.go builds its
+// Context from plain bytes.Buffer values). Even where the destination
+// tolerates concurrent writers, unsynchronized parallel components interleave
+// mid-line into something unreadable. Each goroutine captures its own output
+// here; runDeployStep replays every capture back onto the real ctx, in spec
+// order, only after wg.Wait() has joined every goroutine.
+type parallelDeployCapture struct {
+	loggerStdout *bytes.Buffer
+	loggerStderr *bytes.Buffer
+	ctxStdout    *bytes.Buffer
+	ctxStderr    *bytes.Buffer
+}
+
+// isolateContextForParallelDeploy returns the Context one parallel-step
+// goroutine writes through in place of ctx, plus the buffers to replay
+// afterward. A writer left nil on ctx stays nil -- there is nothing to
+// isolate or replay for it.
+func isolateContextForParallelDeploy(ctx Context) (Context, *parallelDeployCapture) {
+	capture := &parallelDeployCapture{
+		loggerStdout: new(bytes.Buffer),
+		loggerStderr: new(bytes.Buffer),
+	}
+	ctx.Logger.stdout = capture.loggerStdout
+	ctx.Logger.stderr = capture.loggerStderr
+	if ctx.Stdout != nil {
+		capture.ctxStdout = new(bytes.Buffer)
+		ctx.Stdout = capture.ctxStdout
+	}
+	if ctx.Stderr != nil {
+		capture.ctxStderr = new(bytes.Buffer)
+		ctx.Stderr = capture.ctxStderr
+	}
+	return ctx, capture
+}
+
+// replayParallelDeployCapture writes one goroutine's captured output onto
+// ctx's real destinations. Called only after wg.Wait() has joined every
+// goroutine, so every capture buffer is done being written to and no
+// synchronization is needed for the replay itself.
+func replayParallelDeployCapture(ctx Context, capture *parallelDeployCapture) {
+	_, _ = io.Copy(ctx.Logger.stdoutWriter(), capture.loggerStdout)
+	_, _ = io.Copy(ctx.Logger.stderrWriter(), capture.loggerStderr)
+	if ctx.Stdout != nil && capture.ctxStdout != nil {
+		_, _ = io.Copy(ctx.Stdout, capture.ctxStdout)
+	}
+	if ctx.Stderr != nil && capture.ctxStderr != nil {
+		_, _ = io.Copy(ctx.Stderr, capture.ctxStderr)
+	}
+}
+
 // runDeployStep runs every spec in the group. Single-spec steps and dry-run
 // invocations execute serially so traces stay deterministic; a real multi-spec
-// step runs them in parallel and joins their errors.
+// step runs them in parallel, each against its own isolated Context, and joins
+// their errors and their output once every goroutine has finished.
 func runDeployStep(ctx Context, stepIndex int, specs []DeploySpec, deploy HelmChartDeployerFunc) error {
 	if len(specs) == 0 {
 		return nil
@@ -737,14 +793,20 @@ func runDeployStep(ctx Context, stepIndex int, specs []DeploySpec, deploy HelmCh
 	}
 	var wg sync.WaitGroup
 	errs := make([]error, len(specs))
+	captures := make([]*parallelDeployCapture, len(specs))
 	for i, spec := range specs {
 		wg.Add(1)
-		go func(i int, spec DeploySpec) {
+		specCtx, capture := isolateContextForParallelDeploy(ctx)
+		captures[i] = capture
+		go func(i int, spec DeploySpec, specCtx Context) {
 			defer wg.Done()
-			errs[i] = RunDeploySpec(ctx, spec, deploy)
-		}(i, spec)
+			errs[i] = RunDeploySpec(specCtx, spec, deploy)
+		}(i, spec, specCtx)
 	}
 	wg.Wait()
+	for _, capture := range captures {
+		replayParallelDeployCapture(ctx, capture)
+	}
 	return errors.Join(errs...)
 }
 
@@ -3191,26 +3253,45 @@ func helmDeployCommandSpec(params HelmDeployParams, chartPath string) commandSpe
 	return spec.command()
 }
 
+// helmOutputCapture holds helm's stdout and stderr on separate buffers. os/exec
+// runs one copier goroutine per stream it wires up, and Cmd.stderr() only reuses
+// the stdout descriptor (making the two safe to alias) when cmd.Stderr is the
+// same interface value as cmd.Stdout via interfaceEqual -- here cmd.Stdout is a
+// *bytes.Buffer (or a tee) and cmd.Stderr is an io.MultiWriter, so that check
+// never fires and a single combined buffer would be written by both copier
+// goroutines at once. combined() is read only from classifyHelmDeployResult,
+// which runs after runHelmDeployWithPodWatch has already waited out cmd.Wait()
+// -- the point os/exec guarantees both copier goroutines have finished -- so no
+// further synchronization is needed there.
+type helmOutputCapture struct {
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+}
+
+// combined joins the captured streams for the classify error text.
+func (c *helmOutputCapture) combined() string {
+	return c.stdout.String() + c.stderr.String()
+}
+
 // configureHelmDeployCmdOutput wires the command's stdout/stderr and returns
-// the capture buffers used for error classification. At VerbosityInfo helm
-// output is captured silently so a successful run is quiet; the buffer feeds
-// back into the returned error on failure. At VerbosityDebug or higher the
-// output is also teed to params.Stdout/Stderr so the user sees the live --debug
-// stream.
-func configureHelmDeployCmdOutput(cmd *exec.Cmd, params HelmDeployParams) (*bytes.Buffer, *strings.Builder) {
-	helmOutput := new(bytes.Buffer)
+// the capture used for error classification. At VerbosityInfo helm output is
+// captured silently so a successful run is quiet; the capture feeds back into
+// the returned error on failure. At VerbosityDebug or higher the output is
+// also teed to params.Stdout/Stderr so the user sees the live --debug stream.
+func configureHelmDeployCmdOutput(cmd *exec.Cmd, params HelmDeployParams) (*helmOutputCapture, *strings.Builder) {
+	capture := &helmOutputCapture{stdout: new(bytes.Buffer), stderr: new(bytes.Buffer)}
 	if params.Verbosity >= VerbosityDebug {
-		cmd.Stdout = teeWriter(params.Stdout, helmOutput)
+		cmd.Stdout = teeWriter(params.Stdout, capture.stdout)
 	} else {
-		cmd.Stdout = helmOutput
+		cmd.Stdout = capture.stdout
 	}
 	stderr := new(strings.Builder)
-	stderrWriters := []io.Writer{stderr, helmOutput}
+	stderrWriters := []io.Writer{stderr, capture.stderr}
 	if params.Verbosity >= VerbosityDebug && params.Stderr != nil {
 		stderrWriters = append(stderrWriters, params.Stderr)
 	}
 	cmd.Stderr = io.MultiWriter(stderrWriters...)
-	return helmOutput, stderr
+	return capture, stderr
 }
 
 // runHelmDeployWithPodWatch runs the already-started helm command alongside the
@@ -3289,7 +3370,7 @@ func DeployHelmChart(params HelmDeployParams) error {
 // pending-operation and published-chart-not-found stderr cases are recognized,
 // and otherwise the helm error is returned with its captured output appended
 // (at non-debug verbosity, where the stream was silenced).
-func classifyHelmDeployResult(params HelmDeployParams, watchOutcome podWatchOutcome, helmErr error, helmOutput *bytes.Buffer, stderr *strings.Builder) error {
+func classifyHelmDeployResult(params HelmDeployParams, watchOutcome podWatchOutcome, helmErr error, helmOutput *helmOutputCapture, stderr *strings.Builder) error {
 	if watchOutcome.Failure != nil {
 		failure := watchOutcome.Failure
 		failure.Err = helmErr
@@ -3299,8 +3380,9 @@ func classifyHelmDeployResult(params HelmDeployParams, watchOutcome podWatchOutc
 		return nil
 	}
 	// The string matches below read the dedicated stderr capture, not
-	// helmOutput: helm errors land on stderr, and helmOutput doubles as
-	// cmd.Stdout so a stderr-only failure can race to empty there.
+	// helmOutput: helm errors land on stderr, and the classification patterns
+	// below are stderr-specific messages that helmOutput's combined stdout
+	// content would never match.
 	if isHelmReleasePendingOperationMessage(stderr.String()) {
 		return &HelmReleasePendingOperationError{
 			ReleaseName:       params.ReleaseName,
@@ -3325,7 +3407,7 @@ func classifyHelmDeployResult(params HelmDeployParams, watchOutcome podWatchOutc
 		}
 	}
 	if params.Verbosity < VerbosityDebug {
-		if output := strings.TrimSpace(helmOutput.String()); output != "" {
+		if output := strings.TrimSpace(helmOutput.combined()); output != "" {
 			return fmt.Errorf("%w\n%s", helmErr, output)
 		}
 	}

--- a/erun-common/deploy_helm_output_race_test.go
+++ b/erun-common/deploy_helm_output_race_test.go
@@ -1,0 +1,51 @@
+package eruncommon
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestConfigureHelmDeployCmdOutputConcurrentStreams runs a real child process
+// that writes on both stdout and stderr at once through the exact wiring
+// configureHelmDeployCmdOutput builds. os/exec runs one copier goroutine per
+// stream; before the erun#1664 fix, helmOutput was reachable from both --
+// directly as cmd.Stdout and again through cmd.Stderr's io.MultiWriter -- so
+// the two goroutines wrote it concurrently with no synchronization. Run with
+// -race: it must report no race, and both streams must still be captured.
+func TestConfigureHelmDeployCmdOutputConcurrentStreams(t *testing.T) {
+	cmd := exec.Command("sh", "-c", `for i in $(seq 1 400); do echo "out-$i"; echo "err-$i" >&2; done`)
+	params := HelmDeployParams{}
+
+	helmOutput, stderr := configureHelmDeployCmdOutput(cmd, params)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	combined := helmOutput.combined()
+	if !strings.Contains(combined, "out-1") {
+		t.Errorf("combined helm output missing stdout content: %q", truncate(combined))
+	}
+	if !strings.Contains(combined, "err-1") {
+		t.Errorf("combined helm output missing stderr content: %q", truncate(combined))
+	}
+
+	stderrText := stderr.String()
+	if !strings.Contains(stderrText, "err-1") {
+		t.Errorf("separately-returned stderr missing its own content: %q", truncate(stderrText))
+	}
+	if strings.Contains(stderrText, "out-1") {
+		t.Errorf("separately-returned stderr must not carry stdout content, got: %q", truncate(stderrText))
+	}
+}
+
+func truncate(s string) string {
+	if len(s) <= 200 {
+		return s
+	}
+	return s[:200] + "…"
+}

--- a/erun-common/deploy_parallel_race_test.go
+++ b/erun-common/deploy_parallel_race_test.go
@@ -1,0 +1,126 @@
+package eruncommon
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// parallelRaceTestSpecCount is deliberately > 1 so runDeployStep takes its
+// real-parallel branch (len(specs) > 1 && !ctx.DryRun), and large enough that
+// the fanned-out goroutines are very likely to be writing to the shared
+// Context concurrently rather than by scheduling accident.
+const parallelRaceTestSpecCount = 8
+
+// parallelRaceTestSpecs builds specs whose KubernetesContext/Namespace are
+// unique per component -- fake names not present in any kubeconfig, so the
+// real (but fast-failing) kubectl invocation TraceEnsureKubernetesNamespace
+// makes before it hits the stubbed ensureDeployNamespace resolves in
+// milliseconds instead of touching a real cluster.
+func parallelRaceTestSpecs() []DeploySpec {
+	specs := make([]DeploySpec, parallelRaceTestSpecCount)
+	for i := range specs {
+		name := fmt.Sprintf("component-%d", i)
+		specs[i] = DeploySpec{
+			DeployContext: KubernetesDeployContext{ComponentName: name},
+			Deploy: HelmDeploySpec{
+				ReleaseName:       name,
+				Namespace:         "ns-" + name,
+				KubernetesContext: "ctx-" + name,
+				ChartPath:         "oci://ghcr.io/sophium/charts/erun-" + name,
+			},
+		}
+	}
+	return specs
+}
+
+// TestRunDeployStepParallelSpecsShareNoWriter runs runDeployStep's real
+// (non-dry-run) parallel branch against a Context shaped like the MCP edge's
+// (erun-mcp/runtime.go builds Logger and Stdout/Stderr from plain
+// bytes.Buffer values) and proves the fan-out never writes one buffer from
+// more than one goroutine. Before the erun#1664 fix, every goroutine's
+// RunDeploySpec call traced through the same Context, so ctx.Trace/ctx.Info
+// raced on the shared buffers. ensureDeployNamespace is stubbed to fail fast
+// so the test never reaches the real helm invocation or the on-disk
+// single-flight marker.
+func TestRunDeployStepParallelSpecsShareNoWriter(t *testing.T) {
+	sentinel := errors.New("namespace-ensure-refused")
+	original := ensureDeployNamespace
+	ensureDeployNamespace = func(_, _ string) error { return sentinel }
+	t.Cleanup(func() { ensureDeployNamespace = original })
+
+	var stdout, stderr bytes.Buffer
+	ctx := Context{
+		Logger:    NewLoggerWithWriters(VerbosityTrace, &stdout, &stderr),
+		Verbosity: VerbosityTrace,
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+	}
+
+	err := runDeployStep(ctx, 0, parallelRaceTestSpecs(), func(HelmDeployParams) error {
+		t.Error("the chart deployer must not run when the namespace ensure refuses")
+		return nil
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want every spec to fail with the namespace-ensure sentinel", err)
+	}
+}
+
+// TestRunDeployStepParallelOutputAttributableToComponent proves the merged
+// trace stays attributable per component instead of interleaving mid-line: each
+// component's own kubectl trace lines (naming its own namespace) must appear as
+// one contiguous block, in spec order, rather than mixed with another
+// component's lines.
+func TestRunDeployStepParallelOutputAttributableToComponent(t *testing.T) {
+	sentinel := errors.New("namespace-ensure-refused")
+	original := ensureDeployNamespace
+	ensureDeployNamespace = func(_, _ string) error { return sentinel }
+	t.Cleanup(func() { ensureDeployNamespace = original })
+
+	var stdout, stderr bytes.Buffer
+	ctx := Context{
+		Logger:    NewLoggerWithWriters(VerbosityTrace, &stdout, &stderr),
+		Verbosity: VerbosityTrace,
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+	}
+
+	specs := parallelRaceTestSpecs()
+	err := runDeployStep(ctx, 0, specs, func(HelmDeployParams) error { return nil })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want every spec to fail with the namespace-ensure sentinel", err)
+	}
+
+	combined := stdout.String() + stderr.String()
+	var lastEnd int
+	for i, spec := range specs {
+		marker := "namespace " + spec.Deploy.Namespace
+		start := strings.Index(combined, marker)
+		if start == -1 {
+			t.Fatalf("component %d: marker %q not found in merged output:\n%s", i, marker, combined)
+		}
+		if start < lastEnd {
+			t.Fatalf("component %d: marker %q appeared before the previous component's block (out of order merge)", i, marker)
+		}
+		block := combined[start:]
+		for j, other := range specs {
+			if j == i {
+				continue
+			}
+			otherMarker := "namespace " + other.Deploy.Namespace
+			// Only the immediate neighbourhood after this component's own
+			// marker should be scanned for foreign markers -- bound it to
+			// this component's own block by cutting at the next marker.
+			end := len(block)
+			if next := strings.Index(block[len(marker):], "namespace ns-"); next != -1 {
+				end = len(marker) + next
+			}
+			if strings.Contains(block[:end], otherMarker) {
+				t.Fatalf("component %d block contains component %d's marker %q -- output interleaved", i, j, otherMarker)
+			}
+		}
+		lastEnd = start + len(marker)
+	}
+}


### PR DESCRIPTION
## Summary
- `configureHelmDeployCmdOutput` reached one `bytes.Buffer` from both `cmd.Stdout` and `cmd.Stderr`'s `io.MultiWriter`. `os/exec`'s stdout/stderr dedupe (`interfaceEqual(c.Stderr, c.Stdout)`) never fires here because the two are different `io.Writer` values, so os/exec allocates a second pipe and its two copier goroutines wrote the shared buffer concurrently. Fixed by giving stdout and stderr their own buffers (`helmOutputCapture`) and joining them only in `classifyHelmDeployResult`, which runs after `runHelmDeployWithPodWatch` has already waited out `cmd.Wait()` — the point os/exec guarantees both copier goroutines are done.
- `runDeployStep`'s parallel fan-out ran every `DeploySpec` through the same `Context`, so concurrent `RunDeploySpec` calls raced on `Context.Stdout`/`Stderr` and the `Logger`'s own writers — plain `bytes.Buffer` values on the MCP edge (`erun-mcp/runtime.go`). Fixed by giving each goroutine an isolated `Context` (`isolateContextForParallelDeploy`) and replaying its captured output back onto the real `ctx` in spec order once `wg.Wait()` has joined every goroutine (`replayParallelDeployCapture`) — deterministic per-component blocks instead of interleaving mid-line, racy or not.
- The separately-returned `stderr *strings.Builder` in `classifyHelmDeployResult` is unchanged: it's still written by the stderr copier goroutine alone (never shared with stdout), so callers that read it independently (pending-operation / immutable-selector / chart-not-found message matching) get exactly what they did before.

## Test plan
- [x] `TestConfigureHelmDeployCmdOutputConcurrentStreams` — runs a real subprocess writing on both stdout and stderr through `configureHelmDeployCmdOutput`'s exact wiring, under `-race`. Confirmed failing (DATA RACE, `bytes.(*Buffer).Write` vs `bytes.growSlice`) on the pre-fix code; passes clean after.
- [x] `TestRunDeployStepParallelSpecsShareNoWriter` — runs `runDeployStep`'s real parallel branch (8 specs) against a `Context` built from plain `bytes.Buffer` writers (mirroring the MCP edge), under `-race`. Confirmed failing (DATA RACE in `Logger.Trace` via `TraceEnsureKubernetesNamespace`) on the pre-fix code; passes clean after.
- [x] Captured helm output still contains both streams, and the separately-returned stderr is unchanged (asserted in the first test).
- [x] `TestRunDeployStepParallelOutputAttributableToComponent` — proves the merged parallel-deploy output groups each component's own trace lines into one contiguous, in-order block instead of interleaving.
- [x] `go test -race ./...` and `go test ./...` clean in `erun-common`; `go test ./...` clean in `erun-cli` and `erun-mcp`; `golangci-lint run` clean in all three modules.
- [x] `make check` green, including `make integration-test` (coverage 75.8%, unchanged gate).

Closes #1664