### PR TITLE
Report a refused namespace delete as a refusal, not a 20-minute termination timeout

### DIFF
--- a/erun-common/kubernetes_namespace.go
+++ b/erun-common/kubernetes_namespace.go
@@ -29,6 +29,26 @@ func (e *NamespaceTerminationBlockedError) Error() string {
 	return fmt.Sprintf("namespace %q did not finish terminating within %s:\n%s", e.Namespace, NamespaceDeleteTimeout, e.Detail)
 }
 
+// NamespaceDeleteRefusedError names a namespace delete the cluster never
+// accepted -- RBAC, an admission webhook, an API server that answered the
+// request with anything but "accepted". It is a distinct type from
+// NamespaceTerminationBlockedError because the two are different situations
+// with different remedies, and reporting the first as the second is
+// confidently wrong twice over: no wait happened, and the namespace's own
+// termination conditions describe a teardown that never started, sending an
+// operator to investigate finalizers when the fault is a missing grant.
+type NamespaceDeleteRefusedError struct {
+	Namespace string
+	Detail    string
+}
+
+func (e *NamespaceDeleteRefusedError) Error() string {
+	if e.Detail == "" {
+		return fmt.Sprintf("namespace %q was not deleted: the cluster refused the request", e.Namespace)
+	}
+	return fmt.Sprintf("namespace %q was not deleted: the cluster refused the request:\n%s", e.Namespace, e.Detail)
+}
+
 // TraceEnsureKubernetesNamespace traces the namespace check EnsureKubernetesNamespace
 // performs and, only when the create that would follow is actually going to run,
 // traces that too. A dry run cannot read the cluster to know which way the check
@@ -133,9 +153,11 @@ func traceRetractACMEChallenges(ctx Context, contextName, namespace string) {
 // namespace still present after the timeout returns
 // *NamespaceTerminationBlockedError naming its own conditions, so a caller can
 // tell "still terminating, here is why" apart from every other kubectl
-// failure. A namespace that has actually disappeared by the time the timeout
-// is checked (a benign race between the wait and the finalizer clearing)
-// still reports success.
+// failure; a delete the cluster never accepted returns
+// *NamespaceDeleteRefusedError carrying kubectl's refusal, because that one is
+// not a termination problem at all. A namespace that has actually disappeared
+// by the time the timeout is checked (a benign race between the wait and the
+// finalizer clearing) still reports success.
 func DeleteKubernetesNamespace(contextName, namespace string) error {
 	contextName = strings.TrimSpace(contextName)
 	namespace = strings.TrimSpace(namespace)
@@ -171,6 +193,15 @@ func DeleteKubernetesNamespace(contextName, namespace string) error {
 		if !exists {
 			return nil
 		}
+		if namespaceDeleteWasRefused(message) {
+			// Neither the namespace's conditions nor the retraction note belong
+			// here: both describe a teardown in progress, and this one never
+			// started. kubectl's own refusal is the only fact that explains it.
+			return &NamespaceDeleteRefusedError{
+				Namespace: namespace,
+				Detail:    namespaceDeleteRefusalDetail(message),
+			}
+		}
 		return &NamespaceTerminationBlockedError{
 			Namespace: namespace,
 			// The retraction note rides along here rather than being logged: if
@@ -184,6 +215,41 @@ func DeleteKubernetesNamespace(contextName, namespace string) error {
 		return fmt.Errorf("failed to delete kubernetes namespace %q in context %q: %w", namespace, contextName, err)
 	}
 	return fmt.Errorf("failed to delete kubernetes namespace %q in context %q: %w: %s", namespace, contextName, err, message)
+}
+
+// namespaceDeleteWasRefused reports whether kubectl's failure means the delete
+// was never accepted, as opposed to accepted and then not finishing. The wait
+// expiring is the one failure that genuinely is a termination problem, and
+// kubectl names it; everything else it reports ended the request before the
+// namespace could enter Terminating. An empty message says nothing either way
+// and keeps the termination reading, where the namespace's own conditions are
+// the only evidence left to go on.
+func namespaceDeleteWasRefused(message string) bool {
+	if strings.TrimSpace(message) == "" {
+		return false
+	}
+	lowered := strings.ToLower(message)
+	return !strings.Contains(lowered, "timed out") && !strings.Contains(lowered, "deadline exceeded")
+}
+
+// namespaceDeleteRefusalDetail carries kubectl's own refusal and, when that
+// refusal is a permission problem, names the grant that resolves it. An
+// operator handed only "forbidden" still has to work out that the fix is an
+// RBAC rule -- and that the finalizers a termination message would have sent
+// them to are not involved at all.
+func namespaceDeleteRefusalDetail(message string) string {
+	if !kubernetesRequestForbidden(message) {
+		return message
+	}
+	return message + "\nthis kubeconfig's user is not permitted to delete this namespace; grant it delete on namespaces (RBAC) and retry. The namespace is not terminating, so its finalizers are not the cause."
+}
+
+// kubernetesRequestForbidden matches kubectl's own wording for a request the
+// cluster refused on credentials or permissions, so a refusal can name its
+// remedy instead of only quoting the server.
+func kubernetesRequestForbidden(message string) bool {
+	lowered := strings.ToLower(message)
+	return strings.Contains(lowered, "forbidden") || strings.Contains(lowered, "unauthorized")
 }
 
 // acmeRetractTimeout bounds the pre-teardown challenge retraction. Short on

--- a/erun-integration/delete_test.go
+++ b/erun-integration/delete_test.go
@@ -376,6 +376,111 @@ exit 0
 		golden.Equal(t, "delete/real_run_with_output_json_reports_namespace_delete_failure", normalize.Apply(result.Combined))
 	})
 
+	t.Run("real_run_refused_namespace_delete_reports_the_refusal_not_a_timeout", func(t *testing.T) {
+		// A delete the cluster refuses outright -- here RBAC, in milliseconds --
+		// used to be reported as a twenty-minute termination timeout carrying the
+		// namespace's termination conditions, sending an operator to investigate
+		// finalizers when the real fault was a missing grant. It must instead
+		// report kubectl's own refusal and name the permission problem. The
+		// challenge read is refused by the same kubeconfig, which is what proves
+		// the retraction note is left out too: it warns about holding up a delete
+		// that here was never in flight.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "kubectl",
+			`case "$*" in
+  *"get challenges"*)
+    printf '%s\n' 'Error from server (Forbidden): challenges.acme.cert-manager.io is forbidden: User "jane" cannot list resource "challenges"' >&2
+    exit 1
+    ;;
+  *"delete namespace"*)
+    printf '%s\n' 'Error from server (Forbidden): namespaces "team-dev" is forbidden: User "jane" cannot delete resource "namespaces" in API group "" at the cluster scope' >&2
+    exit 1
+    ;;
+  *"get namespace"*)
+    # The delete never took effect, so the namespace is still Active -- the
+    # exact state that used to be misread as wedged in Terminating.
+    printf '%s\n' 'namespace/team-dev'
+    ;;
+esac
+exit 0
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "delete/real_run_refused_namespace_delete_reports_the_refusal_not_a_timeout", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_wedged_namespace_delete_still_reports_the_termination_timeout", func(t *testing.T) {
+		// The counterpart to the refusal scenario above, and the one that stops
+		// the two cases being flattened into one: a delete the cluster accepted
+		// and then could not finish must still read as a termination timeout,
+		// carrying the namespace's own conditions and the retraction note in the
+		// single string an operator reads off the environment row.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "kubectl",
+			`case "$*" in
+  *"get challenges"*)
+    printf '%s\n' 'Error from server (Forbidden): challenges.acme.cert-manager.io is forbidden: User "jane" cannot list resource "challenges"' >&2
+    exit 1
+    ;;
+  *"-o jsonpath"*)
+    printf '%s\t%s\n' 'NamespaceContentRemaining=True' 'challenges.acme.cert-manager.io has 1 resource instances'
+    printf '%s\t%s\n' 'NamespaceFinalizersRemaining=True' 'acme.cert-manager.io/finalizer in 1 resource instances'
+    ;;
+  *"delete namespace"*)
+    printf '%s\n' 'error: timed out waiting for the condition on namespaces/team-dev' >&2
+    exit 1
+    ;;
+  *"get namespace"*)
+    printf '%s\n' 'namespace/team-dev'
+    ;;
+esac
+exit 0
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "delete/real_run_wedged_namespace_delete_still_reports_the_termination_timeout", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_namespace_already_gone_after_a_failed_delete_reports_success", func(t *testing.T) {
+		// The benign race the delete is built to tolerate: kubectl's wait fails,
+		// but by the time erun looks the namespace has actually gone. That is a
+		// success, so it must report no warning at all -- neither a refusal nor a
+		// termination timeout. (A delete that simply succeeds is covered by
+		// real_run_with_yes_flag_skips_confirmation_and_removes_config below.)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryWithScript(t, stubs, "kubectl",
+			`case "$*" in
+  *"delete namespace"*)
+    printf '%s\n' 'error: An error occurred while waiting for the object to be deleted: unable to decode an event from the watch stream' >&2
+    exit 1
+    ;;
+  *"get namespace"*)
+    printf '%s\n' 'Error from server (NotFound): namespaces "team-dev" not found' >&2
+    exit 1
+    ;;
+esac
+exit 0
+`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl")...)
+		result := erun.Run(t, []string{"delete", "team", "dev", "--yes"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "delete/real_run_namespace_already_gone_after_a_failed_delete_reports_success", normalize.Apply(result.Combined))
+	})
+
 	t.Run("real_run_with_yes_flag_skips_confirmation_and_removes_config", func(t *testing.T) {
 		// --yes bypasses the confirmation prompt and really removes the env
 		// config tree.

--- a/erun-integration/testdata/delete/real_run_namespace_already_gone_after_a_failed_delete_reports_success.txt
+++ b/erun-integration/testdata/delete/real_run_namespace_already_gone_after_a_failed_delete_reports_success.txt
@@ -1,0 +1,2 @@
+deleted environment: team/dev
+audit: erun delete --yes team dev

--- a/erun-integration/testdata/delete/real_run_refused_namespace_delete_reports_the_refusal_not_a_timeout.txt
+++ b/erun-integration/testdata/delete/real_run_refused_namespace_delete_reports_the_refusal_not_a_timeout.txt
@@ -1,0 +1,5 @@
+deleted environment: team/dev
+audit: erun delete --yes team dev
+warning: failed to delete namespace "team-dev" in context "test-context": namespace "team-dev" was not deleted: the cluster refused the request:
+Error from server (Forbidden): namespaces "team-dev" is forbidden: User "jane" cannot delete resource "namespaces" in API group "" at the cluster scope
+this kubeconfig's user is not permitted to delete this namespace; grant it delete on namespaces (RBAC) and retry. The namespace is not terminating, so its finalizers are not the cause.

--- a/erun-integration/testdata/delete/real_run_wedged_namespace_delete_still_reports_the_termination_timeout.txt
+++ b/erun-integration/testdata/delete/real_run_wedged_namespace_delete_still_reports_the_termination_timeout.txt
@@ -1,0 +1,6 @@
+deleted environment: team/dev
+audit: erun delete --yes team dev
+warning: failed to delete namespace "team-dev" in context "test-context": namespace "team-dev" did not finish terminating within 20m0s:
+NamespaceContentRemaining=True     challenges.acme.cert-manager.io has 1 resource instances
+NamespaceFinalizersRemaining=True  acme.cert-manager.io/finalizer in 1 resource instances
+the pre-teardown ACME challenge retraction could not run (exit status 1: Error from server (Forbidden): challenges.acme.cert-manager.io is forbidden: User "jane" cannot list resource "challenges"); if a challenge is still finalizing it will hold this namespace until the namespace delete times out


### PR DESCRIPTION
Closes #1665

## The defect

`deleteKubernetesNamespace` captured kubectl's output into `message` and then dropped it on the path that actually fires. When the delete was **refused** — RBAC, an admission webhook, anything making `kubectl delete namespace` exit non-zero immediately — the namespace was still present, so the existence check succeeded, and the code returned `NamespaceTerminationBlockedError`. That renders as `namespace "x" did not finish terminating within 20m0s`, with a `Detail` of the namespace's *termination conditions*.

Confidently wrong twice: it asserts a wait that never happened (the command failed in milliseconds), and it carries conditions that, for a namespace never accepted for deletion, say nothing about the refusal. An operator missing a delete grant was sent to investigate finalizers — the one place the answer is not.

`message` was used only in the two fallback branches below, reached when the existence check itself failed.

## How refused is distinguished from wedged

On kubectl's own failure text, with no extra cluster round trip. The `--timeout` expiry is the *one* failure that genuinely means "accepted, then not finished"; everything else kubectl reports ended the request before the namespace could enter `Terminating`. `namespaceDeleteWasRefused` therefore detects the timeout positively (`timed out` / `deadline exceeded`) and treats the rest as a refusal.

An **empty** message keeps today's termination reading rather than becoming a refusal that carries nothing: with no output, the namespace's own conditions are the only evidence left to go on. Unknown → current behaviour, deliberately.

## New type, not `Detail`

A new `NamespaceDeleteRefusedError`, because `NamespaceTerminationBlockedError`'s message *hardcodes* the claim being corrected (`did not finish terminating within %s`). Reusing its `Detail` would have forced the refusal into a sentence that still asserts a twenty-minute timeout — the exact defect. The two are different situations with different remedies, so they are different types.

The refusal deliberately carries **neither** the termination conditions nor the ACME retraction note. That note's comment explains it belongs beside a *wedge* ("if a challenge is still finalizing it will hold this namespace until the delete times out"); on a delete that was never in flight it describes a hazard that cannot occur. Both facts describe a teardown in progress, and this one never started. The wedge case's `Detail` — conditions plus the retraction note joined by `joinTerminationDetail` — is untouched.

## What the callers do with it

Checked before deciding: **nothing does `errors.As`/`errors.Is` on `NamespaceTerminationBlockedError`.** Every consumer flattens the error to a string, so widening the returned set is safe:

- `erun-common/delete.go` `deleteRemoteEnvironmentNamespace` → `result.NamespaceDeleteError = err.Error()`, and the delete is non-fatal (local config cleanup still runs, exit 0).
- `erun-cli/cmd/delete.go` and `erun-mcp/delete.go` → print it as `warning: failed to delete namespace ...` on stderr.
- `erun-ui` (`terminal_sessions.go` → `manageDeleteThunks.ts`) → renders `Namespace deletion failed: <string>`.
- `erun-backend-api` `NamespaceDeleteFailureFromOutput` → decodes the same `namespaceDeleteError` string out of the delete Job's JSON to mark the row `deletion-blocked`.

So every surface gets a better string with no code change, and the type is exported (like its sibling) because it is returned from an exported function of a module that is a standalone library — a third-party caller distinguishing the two is the point of the fix.

## Tests

Integration scenarios in `erun-integration/delete_test.go`, per `erun-integration/AGENTS.md` (the suite is the only coverage signal the gate honours for `erun-common`; no overlapping unit tests added):

1. `real_run_refused_namespace_delete_reports_the_refusal_not_a_timeout` — RBAC refuses the delete, `get namespace` shows it still present. The golden reports the refusal, quotes kubectl's `Forbidden`, names the RBAC grant as the remedy, and never mentions a twenty-minute timeout. The same kubeconfig also refuses the challenge read, which is what proves the retraction note is left out of this path.
2. `real_run_wedged_namespace_delete_still_reports_the_termination_timeout` — **the test that stops the two cases being flattened.** kubectl times out, the namespace is still present, its conditions read back, the retraction note is produced. Golden is the unchanged `did not finish terminating within 20m0s` + conditions + note.
3. `real_run_namespace_already_gone_after_a_failed_delete_reports_success` — the benign race: kubectl's wait fails but the namespace has actually gone. No warning at all. (A delete that plainly succeeds stays covered by `real_run_with_yes_flag_skips_confirmation_and_removes_config`.)
4. The existence-check-failed fallbacks — `real_run_namespace_delete_failure_warns_and_continues` and `real_run_with_output_json_reports_namespace_delete_failure` — still carry kubectl's message. **Both goldens are unmodified in this PR.**

Verified the split is real, not asserted: with the production file stashed back to `main`, scenario 1 fails with exactly the reported bug (`did not finish terminating within 20m0s`, `Detail` of `namespace/team-dev`), while 2, 3 and both fallback goldens pass — so the wedge path is unchanged by construction *and* by test.

## Docs

No `erun-docs` change: this is a bug fix to an error message with no documented surface (`grep` over `erun-docs/docs` finds no reference to the namespace-termination wording), and no behaviour, flag, or output contract changes for a delete that succeeds. Exempt under root `AGENTS.md` § "Working Rules".

🤖 Generated with [Claude Code](https://claude.com/claude-code)