### PR TITLE
Distinguish a registry's refusal from a failure to reach it in the anonymous-pullability check

### DIFF
--- a/erun-common/release_anonymous_pullability.go
+++ b/erun-common/release_anonymous_pullability.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -133,8 +134,17 @@ func probeAnonymousManifestPullAt(ctx context.Context, client *http.Client, repo
 	tokenURL = normalizeGHCRBaseURL(tokenURL)
 	repoPath = strings.ToLower(repoPath)
 
+	// A 401/403 here is ghcr answering the anonymous token request with "no" --
+	// a conclusive refusal, not a failure to reach the registry -- so it
+	// resolves to pullable=false with no error and lets the baseline decide.
+	// Any other failure (DNS, connection refused, timeout, a non-2xx status
+	// registryStatusError doesn't recognize as an auth refusal) is genuinely
+	// inconclusive and must keep failing the release loudly.
 	token, err := fetchGHCRPullToken(ctx, client, repoPath, tokenURL, registryBasicAuth{}, false)
 	if err != nil {
+		if errors.Is(err, ErrRegistryAuthRequired) {
+			return false, nil
+		}
 		return false, err
 	}
 
@@ -151,7 +161,13 @@ func probeAnonymousManifestPullAt(ctx context.Context, client *http.Client, repo
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300, nil
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return false, nil
+	}
+	return false, registryStatusError("anonymous manifest pull", resp.Status, resp.StatusCode)
 }
 
 // verifyModuleReferencedImagesAnonymouslyPullable asserts that every erun
@@ -202,6 +218,16 @@ func verifyImageAnonymouslyPullable(ctx Context, name string, image DockerImageR
 	repoPath := DockerNamespaceFromTag(tag) + "/" + name
 	pullable, probeErr := probe(context.Background(), nil, repoPath, image.Version)
 	if probeErr != nil {
+		// A genuine failure to reach the registry (not a refusal -- those come
+		// back as pullable=false, no error) tells us nothing new about an
+		// image already recorded as known-not-anonymously-pullable, so it
+		// must not block a release over network flakiness alone. For any
+		// other image, whether the probe could even run is exactly what this
+		// check exists to answer, so the release still fails loudly.
+		if anonymousPullabilityBaseline[name] {
+			ctx.Info("==> Anonymous-pullability probe for " + tag + " could not run (" + probeErr.Error() + "), but it is already baselined as not anonymously pullable (see anonymousPullabilityBaseline) -- proceeding")
+			return nil
+		}
 		return fmt.Errorf("probe anonymous pull of %s: %w", tag, probeErr)
 	}
 	if pullable {

--- a/erun-common/release_anonymous_pullability_test.go
+++ b/erun-common/release_anonymous_pullability_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // writeModuleFixture lays down a single Terraform file referencing imageName
@@ -64,6 +65,7 @@ func TestDiscoverModuleReferencedImageNames(t *testing.T) {
 // genuinely credential-free rather than inferring it from a passing status.
 type anonymousManifestStub struct {
 	ManifestStatus int
+	TokenStatus    int
 
 	tokenRequestSawBasicAuth  bool
 	tokenRequestSawAnyAuthHdr bool
@@ -79,6 +81,10 @@ func (s *anonymousManifestStub) start(t *testing.T) *httptest.Server {
 		}
 		if r.Header.Get("Authorization") != "" {
 			s.tokenRequestSawAnyAuthHdr = true
+		}
+		if s.TokenStatus != 0 && s.TokenStatus != http.StatusOK {
+			w.WriteHeader(s.TokenStatus)
+			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]string{"token": "anon-token"})
 	})
@@ -119,6 +125,58 @@ func TestProbeAnonymousManifestPullAt(t *testing.T) {
 		}
 		if pullable {
 			t.Fatal("expected the manifest to report not pullable")
+		}
+	})
+
+	// This is the 1.0.219 regression: a private ghcr package refuses the
+	// anonymous token request itself with 401, before a manifest request is
+	// even made. That refusal is a conclusive answer -- "a stranger cannot
+	// pull this" -- not a failure to reach the registry, so it must resolve
+	// like any other denial: false, no error.
+	t.Run("401 on the token request reports false, not an error", func(t *testing.T) {
+		stub := &anonymousManifestStub{TokenStatus: http.StatusUnauthorized}
+		server := stub.start(t)
+
+		pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-dns01-webhook", "1.0.219", server.URL, server.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pullable {
+			t.Fatal("expected the token refusal to report not pullable")
+		}
+	})
+
+	t.Run("403 on the token request reports false, not an error", func(t *testing.T) {
+		stub := &anonymousManifestStub{TokenStatus: http.StatusForbidden}
+		server := stub.start(t)
+
+		pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pullable {
+			t.Fatal("expected the token refusal to report not pullable")
+		}
+	})
+
+	// A registry that cannot even be reached is genuinely inconclusive -- it
+	// must keep erroring rather than being folded into "not pullable", or a
+	// network blip during release would silently pass this check.
+	t.Run("a token request that cannot reach the registry is an error", func(t *testing.T) {
+		unreachable := "http://127.0.0.1:1"
+		_, err := probeAnonymousManifestPullAt(context.Background(), &http.Client{Timeout: time.Second}, "sophium/erun-example", "1.0.0", unreachable, unreachable)
+		if err == nil {
+			t.Fatal("expected an error: the probe could not reach the registry at all")
+		}
+	})
+
+	t.Run("a non-auth manifest failure is an error, not a conclusive denial", func(t *testing.T) {
+		stub := &anonymousManifestStub{ManifestStatus: http.StatusInternalServerError}
+		server := stub.start(t)
+
+		_, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
+		if err == nil {
+			t.Fatal("expected an error: a 500 is not a conclusive answer about pullability")
 		}
 	})
 
@@ -208,6 +266,118 @@ func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselined(t *t
 	}
 	if !strings.Contains(logBuf.String(), "Not anonymously pullable (baselined") {
 		t.Fatalf("expected the baselined gap to be reported, got log:\n%s", logBuf.String())
+	}
+}
+
+// realProbeAt closes over a stub server's URL so verifyModuleReferencedImagesAnonymouslyPullable
+// can be exercised through the real anonymousPullProbeFunc chain -- token
+// exchange, then manifest GET -- rather than a fake bool/error stand-in, so
+// these tests reproduce the 1.0.219 failure end to end instead of just at the
+// unit level.
+func realProbeAt(server *httptest.Server) anonymousPullProbeFunc {
+	return func(ctx context.Context, client *http.Client, repoPath, tag string) (bool, error) {
+		return probeAnonymousManifestPullAt(ctx, server.Client(), repoPath, tag, server.URL, server.URL)
+	}
+}
+
+// This is the 1.0.219 regression itself: ghcr refuses the anonymous token
+// request for the known-private erun-dns01-webhook package with 401. That
+// refusal must be reported and the release must proceed, because the
+// baseline already records this image as known not anonymously pullable.
+func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselinedTokenRequestRefused(t *testing.T) {
+	root := t.TempDir()
+	writeModuleFixture(t, root, "erun-dns01-webhook")
+	execution := fakeExecutionForImage("erun-dns01-webhook", "ghcr.io/sophium/erun-dns01-webhook:1.0.219", "1.0.219")
+	var logBuf strings.Builder
+	ctx := Context{Logger: NewLogger(0).WithTraceSink(&logBuf)}
+
+	stub := &anonymousManifestStub{TokenStatus: http.StatusUnauthorized}
+	server := stub.start(t)
+
+	if err := verifyModuleReferencedImagesAnonymouslyPullable(ctx, root, execution, realProbeAt(server)); err != nil {
+		t.Fatalf("a baselined image's token-request refusal must not fail the release: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "Not anonymously pullable (baselined") {
+		t.Fatalf("expected the baselined refusal to be reported, got log:\n%s", logBuf.String())
+	}
+}
+
+// A 401 on the token request for an image that is NOT baselined is a
+// conclusive "this is private", and a fresh, unrecorded private image must
+// still fail the release -- the baseline is an explicit opt-in, never
+// inferred from a single probe result.
+func TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselinedTokenRequestRefused(t *testing.T) {
+	root := t.TempDir()
+	writeModuleFixture(t, root, "erun-example-webhook")
+	execution := fakeExecutionForImage("erun-example-webhook", "ghcr.io/sophium/erun-example-webhook:1.2.3", "1.2.3")
+	ctx := Context{Logger: NewLogger(0)}
+
+	stub := &anonymousManifestStub{TokenStatus: http.StatusUnauthorized}
+	server := stub.start(t)
+
+	err := verifyModuleReferencedImagesAnonymouslyPullable(ctx, root, execution, realProbeAt(server))
+	if err == nil {
+		t.Fatal("expected an error: an unbaselined private image must fail the release")
+	}
+	if !strings.Contains(err.Error(), "ghcr.io/sophium/erun-example-webhook:1.2.3") {
+		t.Fatalf("error should name the offending image, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "make the ghcr.io/sophium/erun-example-webhook package public") {
+		t.Fatalf("error should offer the make-public remedy, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "anonymousPullabilityBaseline") {
+		t.Fatalf("error should offer the baseline remedy, got: %v", err)
+	}
+}
+
+// A probe that cannot reach the registry at all is genuinely inconclusive.
+// For an image with no recorded baseline entry, that must still fail the
+// release, and the message must say the probe could not run -- not repeat
+// the "this image is private" wording a conclusive refusal gets, since
+// nothing here established that.
+func TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselinedProbeUnreachable(t *testing.T) {
+	root := t.TempDir()
+	writeModuleFixture(t, root, "erun-example-webhook")
+	execution := fakeExecutionForImage("erun-example-webhook", "ghcr.io/sophium/erun-example-webhook:1.2.3", "1.2.3")
+	ctx := Context{Logger: NewLogger(0)}
+
+	unreachable := "http://127.0.0.1:1"
+	probe := func(ctx context.Context, _ *http.Client, repoPath, tag string) (bool, error) {
+		return probeAnonymousManifestPullAt(ctx, &http.Client{Timeout: time.Second}, repoPath, tag, unreachable, unreachable)
+	}
+
+	err := verifyModuleReferencedImagesAnonymouslyPullable(ctx, root, execution, probe)
+	if err == nil {
+		t.Fatal("expected an error: the probe could not run at all")
+	}
+	if !strings.Contains(err.Error(), "probe anonymous pull of") {
+		t.Fatalf("error should say the probe could not run, not that the image is private, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "resolves for the publishing credential but not anonymously") {
+		t.Fatalf("error must not claim the image is private when the probe never got an answer, got: %v", err)
+	}
+}
+
+// An unreachable probe for an already-baselined image adds no information --
+// the image's status is already recorded as known-not-anonymously-pullable --
+// so it must not fail the release either.
+func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselinedAndProbeUnreachable(t *testing.T) {
+	root := t.TempDir()
+	writeModuleFixture(t, root, "erun-dns01-webhook")
+	execution := fakeExecutionForImage("erun-dns01-webhook", "ghcr.io/sophium/erun-dns01-webhook:1.0.219", "1.0.219")
+	var logBuf strings.Builder
+	ctx := Context{Logger: NewLogger(0).WithTraceSink(&logBuf)}
+
+	unreachable := "http://127.0.0.1:1"
+	probe := func(ctx context.Context, _ *http.Client, repoPath, tag string) (bool, error) {
+		return probeAnonymousManifestPullAt(ctx, &http.Client{Timeout: time.Second}, repoPath, tag, unreachable, unreachable)
+	}
+
+	if err := verifyModuleReferencedImagesAnonymouslyPullable(ctx, root, execution, probe); err != nil {
+		t.Fatalf("a baselined image must not fail the release when the probe cannot even run: %v", err)
+	}
+	if !strings.Contains(logBuf.String(), "could not run") {
+		t.Fatalf("expected the unreachable probe to be reported, got log:\n%s", logBuf.String())
 	}
 }
 

--- a/erun-common/release_anonymous_pullability_test.go
+++ b/erun-common/release_anonymous_pullability_test.go
@@ -101,113 +101,94 @@ func (s *anonymousManifestStub) start(t *testing.T) *httptest.Server {
 	return server
 }
 
-func TestProbeAnonymousManifestPullAt(t *testing.T) {
-	t.Run("pullable manifest reports true", func(t *testing.T) {
-		stub := &anonymousManifestStub{ManifestStatus: http.StatusOK}
-		server := stub.start(t)
+// probeStatusCase is one status-handling scenario for probeAnonymousManifestPullAt:
+// a token-endpoint status, a manifest-endpoint status, and the answer the
+// probe must resolve to.
+type probeStatusCase struct {
+	name           string
+	tokenStatus    int
+	manifestStatus int
+	wantPullable   bool
+	wantErr        bool
+}
 
-		pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !pullable {
-			t.Fatal("expected the manifest to report pullable")
-		}
-	})
-
-	t.Run("denied manifest reports false, not an error", func(t *testing.T) {
-		stub := &anonymousManifestStub{ManifestStatus: http.StatusForbidden}
-		server := stub.start(t)
-
-		pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if pullable {
-			t.Fatal("expected the manifest to report not pullable")
-		}
-	})
-
+var probeStatusCases = []probeStatusCase{
+	{name: "pullable manifest reports true", manifestStatus: http.StatusOK, wantPullable: true},
+	{name: "denied manifest reports false, not an error", manifestStatus: http.StatusForbidden},
 	// This is the 1.0.219 regression: a private ghcr package refuses the
 	// anonymous token request itself with 401, before a manifest request is
 	// even made. That refusal is a conclusive answer -- "a stranger cannot
 	// pull this" -- not a failure to reach the registry, so it must resolve
 	// like any other denial: false, no error.
-	t.Run("401 on the token request reports false, not an error", func(t *testing.T) {
-		stub := &anonymousManifestStub{TokenStatus: http.StatusUnauthorized}
-		server := stub.start(t)
+	{name: "401 on the token request reports false, not an error", tokenStatus: http.StatusUnauthorized},
+	{name: "403 on the token request reports false, not an error", tokenStatus: http.StatusForbidden},
+	// A non-auth manifest status is not a conclusive answer about
+	// pullability, so it must keep erroring rather than being folded into
+	// "not pullable".
+	{name: "a non-auth manifest failure is an error, not a conclusive denial", manifestStatus: http.StatusInternalServerError, wantErr: true},
+}
 
-		pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-dns01-webhook", "1.0.219", server.URL, server.URL)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if pullable {
-			t.Fatal("expected the token refusal to report not pullable")
-		}
-	})
+func TestProbeAnonymousManifestPullAtStatusHandling(t *testing.T) {
+	for _, tc := range probeStatusCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &anonymousManifestStub{ManifestStatus: tc.manifestStatus, TokenStatus: tc.tokenStatus}
+			server := stub.start(t)
 
-	t.Run("403 on the token request reports false, not an error", func(t *testing.T) {
-		stub := &anonymousManifestStub{TokenStatus: http.StatusForbidden}
-		server := stub.start(t)
+			pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if pullable != tc.wantPullable {
+				t.Fatalf("pullable = %v, want %v", pullable, tc.wantPullable)
+			}
+		})
+	}
+}
 
-		pullable, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if pullable {
-			t.Fatal("expected the token refusal to report not pullable")
-		}
-	})
+// A registry that cannot even be reached is genuinely inconclusive -- it must
+// keep erroring rather than being folded into "not pullable", or a network
+// blip during release would silently pass this check.
+func TestProbeAnonymousManifestPullAtTokenRequestUnreachable(t *testing.T) {
+	unreachable := "http://127.0.0.1:1"
+	_, err := probeAnonymousManifestPullAt(context.Background(), &http.Client{Timeout: time.Second}, "sophium/erun-example", "1.0.0", unreachable, unreachable)
+	if err == nil {
+		t.Fatal("expected an error: the probe could not reach the registry at all")
+	}
+}
 
-	// A registry that cannot even be reached is genuinely inconclusive -- it
-	// must keep erroring rather than being folded into "not pullable", or a
-	// network blip during release would silently pass this check.
-	t.Run("a token request that cannot reach the registry is an error", func(t *testing.T) {
-		unreachable := "http://127.0.0.1:1"
-		_, err := probeAnonymousManifestPullAt(context.Background(), &http.Client{Timeout: time.Second}, "sophium/erun-example", "1.0.0", unreachable, unreachable)
-		if err == nil {
-			t.Fatal("expected an error: the probe could not reach the registry at all")
-		}
-	})
+// This is the regression for the defect release-time verification used to
+// have: verifyPublishedReleaseArtifacts re-resolves a manifest through
+// `docker manifest inspect`, which authenticates with whatever the local
+// daemon has stored, so it can never observe whether a stranger with no
+// credential at all could pull the same image. This probe must never send
+// one, in either direction: not on the token exchange, and not folded into
+// the manifest request's own Authorization header.
+func TestProbeAnonymousManifestPullAtSendsNoCredentials(t *testing.T) {
+	dir := writeDockerConfig(t, fmt.Sprintf(`{"auths":{"ghcr.io":{"auth":%q}}}`, b64Auth("sophium:tok")))
+	useDockerConfigDir(t, dir)
+	useGHToken(t, func(string) (string, bool) { return "leaked-gh-token", true })
 
-	t.Run("a non-auth manifest failure is an error, not a conclusive denial", func(t *testing.T) {
-		stub := &anonymousManifestStub{ManifestStatus: http.StatusInternalServerError}
-		server := stub.start(t)
+	stub := &anonymousManifestStub{ManifestStatus: http.StatusOK}
+	server := stub.start(t)
 
-		_, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL)
-		if err == nil {
-			t.Fatal("expected an error: a 500 is not a conclusive answer about pullability")
-		}
-	})
-
-	// This is the regression for the defect release-time verification used to
-	// have: verifyPublishedReleaseArtifacts re-resolves a manifest through
-	// `docker manifest inspect`, which authenticates with whatever the local
-	// daemon has stored, so it can never observe whether a stranger with no
-	// credential at all could pull the same image. This probe must never send
-	// one, in either direction: not on the token exchange, and not folded into
-	// the manifest request's own Authorization header.
-	t.Run("sends no credentials", func(t *testing.T) {
-		dir := writeDockerConfig(t, fmt.Sprintf(`{"auths":{"ghcr.io":{"auth":%q}}}`, b64Auth("sophium:tok")))
-		useDockerConfigDir(t, dir)
-		useGHToken(t, func(string) (string, bool) { return "leaked-gh-token", true })
-
-		stub := &anonymousManifestStub{ManifestStatus: http.StatusOK}
-		server := stub.start(t)
-
-		if _, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if stub.tokenRequestSawBasicAuth {
-			t.Fatal("the token exchange must never send Basic auth, even when a docker credential is configured on this machine")
-		}
-		if stub.tokenRequestSawAnyAuthHdr {
-			t.Fatal("the token exchange must carry no Authorization header at all")
-		}
-		if stub.manifestAuthHeader != "Bearer anon-token" {
-			t.Fatalf("manifest request Authorization = %q, want the anonymously-minted token, never a stored credential", stub.manifestAuthHeader)
-		}
-	})
+	if _, err := probeAnonymousManifestPullAt(context.Background(), server.Client(), "sophium/erun-example", "1.0.0", server.URL, server.URL); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.tokenRequestSawBasicAuth {
+		t.Fatal("the token exchange must never send Basic auth, even when a docker credential is configured on this machine")
+	}
+	if stub.tokenRequestSawAnyAuthHdr {
+		t.Fatal("the token exchange must carry no Authorization header at all")
+	}
+	if stub.manifestAuthHeader != "Bearer anon-token" {
+		t.Fatalf("manifest request Authorization = %q, want the anonymously-minted token, never a stored credential", stub.manifestAuthHeader)
+	}
 }
 
 func fakeExecutionForImage(imageName, tag, version string) BuildExecutionSpec {


### PR DESCRIPTION
## Summary

The anonymous-pullability check added in #1656 blocked release 1.0.219: ghcr refused the anonymous *token request* for the known-private `erun-dns01-webhook` package with `401`, and `verifyImageAnonymouslyPullable` treated any probe error as fatal — short-circuiting above the baseline the check exists to consult. Nothing was corrupted (the failure is inside `verify-publication`, after publish but before the tag push, per the documented ordering), but every release was blocked until this landed.

## Classification

- **Conclusive `pullable = false`, no error** — a `401`/`403` on the anonymous token request, or on the manifest GET. The registry answered, and its answer is "a stranger cannot pull this." The baseline then decides.
- **Error (probe could not run)** — everything else: DNS failure, connection refused, timeout, or any other non-2xx manifest status (e.g. `500`). A release must not silently pass a check it could not run.

Changes in `erun-common/release_anonymous_pullability.go`:
- `probeAnonymousManifestPullAt`: a token-request error wrapping `ErrRegistryAuthRequired` (ghcr's existing 401/403 sentinel, already used elsewhere in this file) now resolves to `(false, nil)` instead of propagating. The manifest GET now explicitly resolves 401/403 to `(false, nil)` and any other non-2xx status to an error via `registryStatusError`, instead of folding every non-2xx status into "not pullable."
- `verifyImageAnonymouslyPullable`: unchanged for the conclusive-false path (it already consults the baseline correctly) — the fix is upstream in the probe. Separately, a genuine probe error is no longer fatal when the image is already baselined.

## Inconclusive-plus-baselined decision

**Not fatal.** A baselined image's status is already recorded as known-not-anonymously-pullable; failing a release because the *probe itself* couldn't reach the registry (a transient network blip) adds no protection the baseline doesn't already provide, and reintroduces the same "known-safe image blocks every release" failure mode this issue reports, just triggered by a different symptom. A non-baselined image still fails hard on any probe error, since whether the probe could even run is exactly what this check exists to establish for an unrecorded image.

## Tests (`erun-common/release_anonymous_pullability_test.go`)

- `TestProbeAnonymousManifestPullAtStatusHandling` (table-driven): 401/403 on the token request → `(false, nil)`; 401/403 on the manifest → `(false, nil)`; a pullable manifest → `(true, nil)`; a non-auth manifest status (500) → error.
- `TestProbeAnonymousManifestPullAtTokenRequestUnreachable`: a token endpoint the client can't reach at all → error.
- `TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselinedTokenRequestRefused` — **the 1.0.219 regression itself**, reproduced end-to-end through the real probe chain against `erun-dns01-webhook`: 401 on the token request, baselined → reported, release proceeds.
- `TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselinedTokenRequestRefused`: same 401, but an unbaselined image → still fails, naming the image and both remedies (make-public / add to baseline).
- `TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselinedProbeUnreachable`: unreachable registry, unbaselined image → still fails, and the message says the probe couldn't run, not that the image is private.
- `TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselinedAndProbeUnreachable`: unreachable registry, baselined image → release proceeds (the inconclusive-plus-baselined decision above).
- `TestVerifyModuleReferencedImagesAnonymouslyPullablePasses` (pre-existing, unmodified): an anonymously pullable image still passes.

All against the existing stub-server seam (`probeAnonymousManifestPullAt`'s explicit endpoints) — no real ghcr traffic.

## Validation

`make check` (lint, `erun-common`/`erun-cli`/`erun-mcp`/`erun-ui` unit tests, frontend gates, chart tests, full integration suite): green.
```
ok  	github.com/sophium/erun/erun-integration	95.979s
ok  coverage 75.8% (>= 75.8%)
```

Did not run a real `erun release`; the 1.0.219 re-run is being driven separately.

Closes #1669