### PR TITLE
Preserve StartedAt across release repo claim renewals

### DIFF
--- a/erun-common/release_repo_claim.go
+++ b/erun-common/release_repo_claim.go
@@ -59,17 +59,35 @@ type releaseRepoClaimRecord struct {
 // ReleaseRepoClaimConflictError names the still-live holder of the
 // repository-global claim, in the same wording the local lease's refusal
 // uses, so a second orchestrator sees one consistent message regardless of
-// which of the two claims refused it.
+// which of the two claims refused it. Now is carried alongside StartedAt
+// (rather than computing a duration with time.Now() inside Error) so the
+// message is a pure function of the refusal's own fields and stays testable
+// against a fixed clock.
 type ReleaseRepoClaimConflictError struct {
 	Version     string
 	Holder      EnvironmentActivityLeaseHolder
 	Environment string
+	StartedAt   time.Time
 	ExpiresAt   time.Time
+	Now         time.Time
 }
 
 func (e *ReleaseRepoClaimConflictError) Error() string {
-	return fmt.Sprintf("%s is already being released by %s — wait for it to finish; a holder that crashes or whose pod is replaced is reclaimed automatically on the next attempt",
-		strings.TrimSpace(e.Version), releaseClaimHolderDescription(e.Holder, e.Environment))
+	return fmt.Sprintf("%s is already being released by %s (running for %s) — wait for it to finish; a holder that crashes or whose pod is replaced is reclaimed automatically on the next attempt",
+		strings.TrimSpace(e.Version), releaseClaimHolderDescription(e.Holder, e.Environment), releaseClaimRunningFor(e.StartedAt, e.Now))
+}
+
+// releaseClaimRunningFor reports how long the holder has been running,
+// rounded to the second for a stable, readable duration. StartedAt can be
+// zero for a claim record predating this field, or a previous format that
+// only ever carried ExpiresAt; a zero value is reported as "an unknown
+// duration" rather than the enormous, misleading span time.Since(zero) would
+// compute.
+func releaseClaimRunningFor(startedAt, now time.Time) string {
+	if startedAt.IsZero() {
+		return "an unknown duration"
+	}
+	return now.Sub(startedAt).Round(time.Second).String()
 }
 
 // releaseClaimHolderDescription renders a holder together with the
@@ -116,7 +134,9 @@ func takeReleaseRepoClaim(ctx Context, projectRoot, environment, version string,
 		}
 
 		if !exists {
-			newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now)
+			// A fresh claim: nobody held this version before, so now is a
+			// genuine StartedAt.
+			newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now, now)
 			if err != nil {
 				return "", err
 			}
@@ -131,10 +151,12 @@ func takeReleaseRepoClaim(ctx Context, projectRoot, environment, version string,
 			return "", fmt.Errorf("release: %s exists on %s but its content could not be read: %w", ref, releaseRepoClaimRemote, err)
 		}
 		if releaseRepoClaimHeld(record, now) {
-			return "", &ReleaseRepoClaimConflictError{Version: version, Holder: record.Holder, Environment: record.Environment, ExpiresAt: record.ExpiresAt}
+			return "", &ReleaseRepoClaimConflictError{Version: version, Holder: record.Holder, Environment: record.Environment, StartedAt: record.StartedAt, ExpiresAt: record.ExpiresAt, Now: now}
 		}
 
-		newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now)
+		// A reclaim of an expired holder: this is a new holder, so it gets
+		// its own StartedAt rather than inheriting the dead holder's.
+		newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now, now)
 		if err != nil {
 			return "", err
 		}
@@ -151,8 +173,20 @@ func takeReleaseRepoClaim(ctx Context, projectRoot, environment, version string,
 // it (its own renewal having lapsed past the TTL) is never silently
 // overwritten. A failure here is best-effort, matching the local lease's
 // renewal: the caller keeps its last-known sha and tries again next tick.
+//
+// A renewal is the same holder extending the same claim, so it must carry
+// the original StartedAt forward rather than resetting it to now: currentSHA
+// names the blob this process itself wrote (originally or on a prior
+// renewal), and that object already exists locally — reading it is a plain
+// local git object lookup, not a network call, and it happens before the
+// push below, so it neither reads nor writes the ref and cannot weaken the
+// force-with-lease compare-and-swap that follows.
 func renewReleaseRepoClaim(ctx Context, projectRoot, environment, version string, holder EnvironmentActivityLeaseHolder, now time.Time, currentSHA string) (string, error) {
-	newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, now)
+	existing, err := readReleaseRepoClaimBlob(ctx, projectRoot, currentSHA)
+	if err != nil {
+		return "", err
+	}
+	newSHA, err := writeReleaseRepoClaimBlob(ctx, projectRoot, environment, holder, existing.StartedAt, now)
 	if err != nil {
 		return "", err
 	}
@@ -179,11 +213,11 @@ func releaseRepoClaimHeld(record releaseRepoClaimRecord, now time.Time) bool {
 	return !record.ExpiresAt.IsZero() && now.Before(record.ExpiresAt)
 }
 
-func writeReleaseRepoClaimBlob(ctx Context, projectRoot, environment string, holder EnvironmentActivityLeaseHolder, now time.Time) (string, error) {
+func writeReleaseRepoClaimBlob(ctx Context, projectRoot, environment string, holder EnvironmentActivityLeaseHolder, startedAt, now time.Time) (string, error) {
 	record := releaseRepoClaimRecord{
 		Holder:      holder,
 		Environment: environment,
-		StartedAt:   now,
+		StartedAt:   startedAt,
 		ExpiresAt:   now.Add(releaseVersionClaimTTL),
 	}
 	data, err := json.Marshal(record)
@@ -198,6 +232,24 @@ func writeReleaseRepoClaimBlob(ctx Context, projectRoot, environment string, hol
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// readReleaseRepoClaimBlob reads a claim record blob this process itself
+// wrote earlier via writeReleaseRepoClaimBlob, by its git object sha. The
+// object is already present in the local object database — no fetch, no ref
+// read — which is what lets the renewal path recover the original StartedAt
+// without touching the CAS in takeReleaseRepoClaim/renewReleaseRepoClaim.
+func readReleaseRepoClaimBlob(ctx Context, projectRoot, sha string) (releaseRepoClaimRecord, error) {
+	ctx.TraceCommand(projectRoot, "git", "cat-file", "-p", sha)
+	output, err := Command("git", "-C", projectRoot, "cat-file", "-p", sha).Output()
+	if err != nil {
+		return releaseRepoClaimRecord{}, err
+	}
+	var record releaseRepoClaimRecord
+	if err := json.Unmarshal(output, &record); err != nil {
+		return releaseRepoClaimRecord{}, err
+	}
+	return record, nil
 }
 
 // gitLsRemoteRef reads a single ref's current sha directly from the remote,

--- a/erun-common/release_repo_claim_test.go
+++ b/erun-common/release_repo_claim_test.go
@@ -167,6 +167,133 @@ func TestReleaseRepoClaimReclaimsAnAbandonedReleaseFromADifferentCheckout(t *tes
 	}
 }
 
+// TestReleaseRepoClaimFreshClaimSetsStartedAtToNow guards the baseline a
+// renewal must not disturb: a brand-new claim has nothing to inherit, so its
+// StartedAt is the moment it was taken.
+func TestReleaseRepoClaimFreshClaimSetsStartedAtToNow(t *testing.T) {
+	env := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, env)
+	runGitForTest(t, env, "push", "-q", "-u", "origin", "main")
+
+	now := time.Date(2026, 8, 29, 4, 0, 5, 0, time.UTC)
+	ctx := newTestClaimContext()
+	holder := EnvironmentActivityLeaseHolder{Tenant: "erun"}
+
+	sha, err := takeReleaseRepoClaim(ctx, env, "build", "1.0.220", holder, now)
+	if err != nil {
+		t.Fatalf("fresh claim: %v", err)
+	}
+	record, err := readReleaseRepoClaimBlob(ctx, env, sha)
+	if err != nil {
+		t.Fatalf("reading back the claim blob: %v", err)
+	}
+	if !record.StartedAt.Equal(now) {
+		t.Errorf("fresh claim StartedAt = %v, want %v", record.StartedAt, now)
+	}
+}
+
+// TestReleaseRepoClaimRenewalPreservesStartedAtAndAdvancesOnlyExpiresAt is the
+// regression test for erun#1668: a renewal used to rewrite StartedAt to the
+// renewal time, so a release running for an hour with periodic renewals
+// always looked a couple of minutes old in the claim blob.
+func TestReleaseRepoClaimRenewalPreservesStartedAtAndAdvancesOnlyExpiresAt(t *testing.T) {
+	env := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, env)
+	runGitForTest(t, env, "push", "-q", "-u", "origin", "main")
+
+	started := time.Date(2026, 8, 29, 4, 0, 5, 0, time.UTC)
+	ctx := newTestClaimContext()
+	holder := EnvironmentActivityLeaseHolder{Tenant: "erun"}
+
+	sha, err := takeReleaseRepoClaim(ctx, env, "ux", "1.0.220", holder, started)
+	if err != nil {
+		t.Fatalf("initial claim: %v", err)
+	}
+
+	renewedAt := started.Add(13 * time.Minute)
+	newSHA, err := renewReleaseRepoClaim(ctx, env, "ux", "1.0.220", holder, renewedAt, sha)
+	if err != nil {
+		t.Fatalf("renewal: %v", err)
+	}
+
+	record, err := readReleaseRepoClaimBlob(ctx, env, newSHA)
+	if err != nil {
+		t.Fatalf("reading back the renewed claim blob: %v", err)
+	}
+	if !record.StartedAt.Equal(started) {
+		t.Errorf("renewal StartedAt = %v, want the original %v preserved", record.StartedAt, started)
+	}
+	wantExpiresAt := renewedAt.Add(releaseVersionClaimTTL)
+	if !record.ExpiresAt.Equal(wantExpiresAt) {
+		t.Errorf("renewal ExpiresAt = %v, want %v", record.ExpiresAt, wantExpiresAt)
+	}
+}
+
+// TestReleaseRepoClaimReclaimOfAnExpiredHolderSetsANewStartedAt is the test
+// that stops the fix above from over-correcting: a reclaim takes over from a
+// dead holder, so it must NOT carry that holder's StartedAt forward — it is
+// a different holder, and preserving the old value would make a genuinely
+// wedged-looking claim (the thing StartedAt exists to reveal) look however
+// old the abandoned holder happened to be.
+func TestReleaseRepoClaimReclaimOfAnExpiredHolderSetsANewStartedAt(t *testing.T) {
+	envA := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, envA)
+	runGitForTest(t, envA, "push", "-q", "-u", "origin", "main")
+	envB := cloneRepoForTest(t, remote)
+
+	start := time.Date(2026, 8, 29, 17, 0, 53, 0, time.UTC)
+	ctx := newTestClaimContext()
+
+	holderA := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a", Tenant: "erun"}
+	if _, err := takeReleaseRepoClaim(ctx, envA, "build-a", "1.0.220", holderA, start); err != nil {
+		t.Fatalf("first environment's claim: %v", err)
+	}
+
+	afterLapse := start.Add(releaseVersionClaimTTL + time.Minute)
+	holderB := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b", Tenant: "erun"}
+	sha, err := takeReleaseRepoClaim(ctx, envB, "build-b", "1.0.220", holderB, afterLapse)
+	if err != nil {
+		t.Fatalf("expected the abandoned claim to be reclaimed automatically, got refused: %v", err)
+	}
+
+	record, err := readReleaseRepoClaimBlob(ctx, envB, sha)
+	if err != nil {
+		t.Fatalf("reading back the reclaiming holder's blob: %v", err)
+	}
+	if !record.StartedAt.Equal(afterLapse) {
+		t.Errorf("reclaim StartedAt = %v, want the new holder's own claim time %v, not the abandoned holder's %v", record.StartedAt, afterLapse, start)
+	}
+}
+
+// TestReleaseRepoClaimRefusalReportsHowLongTheHolderHasBeenRunning guards the
+// refusal message added alongside the StartedAt fix: once the field means
+// what its name says, the refusal can tell an operator how long the holder
+// has actually been running, which is the number that says whether to wait
+// or go investigate.
+func TestReleaseRepoClaimRefusalReportsHowLongTheHolderHasBeenRunning(t *testing.T) {
+	envA := newAgentJobTestRepo(t)
+	remote := newBareRemoteForTest(t, envA)
+	runGitForTest(t, envA, "push", "-q", "-u", "origin", "main")
+	envB := cloneRepoForTest(t, remote)
+
+	start := time.Date(2026, 8, 29, 4, 0, 5, 0, time.UTC)
+	ctx := newTestClaimContext()
+
+	holderA := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-a", Tenant: "erun"}
+	if _, err := takeReleaseRepoClaim(ctx, envA, "build-a", "1.0.220", holderA, start); err != nil {
+		t.Fatalf("first environment's claim: %v", err)
+	}
+
+	holderB := EnvironmentActivityLeaseHolder{Orchestrator: "orchestrator-b", Tenant: "erun"}
+	_, err := takeReleaseRepoClaim(ctx, envB, "build-b", "1.0.220", holderB, start.Add(15*time.Minute))
+	if err == nil {
+		t.Fatal("expected the second claim to be refused")
+	}
+	if !strings.Contains(err.Error(), "running for 15m0s") {
+		t.Errorf("refusal must report how long the holder has been running, got: %v", err)
+	}
+}
+
 // TestReleaseBranchPushRebaseKeepsTheReleaseTagOnTheTargetBranch reproduces
 // the second defect from the same run: the branch push absorbs a moved base
 // branch by rebasing and retrying, but the release tag was already published


### PR DESCRIPTION
## Summary

Every renewal of the repository-global release claim (`renewReleaseRepoClaim`) rewrote `StartedAt` from the renewal's own clock via `writeReleaseRepoClaimBlob`, so a release running for an hour with periodic renewals always looked a couple of minutes old in the claim blob — the one field an operator or a second orchestrator reads to tell "still running" from "wedged". Observed live during a real release: same claim, read twice 15 minutes apart, `startedAt` had moved forward with each renewal.

- `renewReleaseRepoClaim` now reads its own previously-written blob by sha (`readReleaseRepoClaimBlob`, a plain `git cat-file -p <sha>` against a local object this process itself wrote via `hash-object -w`) and carries its `StartedAt` forward, resetting only `ExpiresAt`.
- A **fresh claim** and a **reclaim of an expired holder** still set a brand-new `StartedAt` — both are legitimately new holders, and preserving a dead holder's start time would defeat the exact signal `StartedAt` exists to give.
- **How the read avoids weakening the CAS:** the read is a local object lookup keyed by the sha `renewReleaseRepoClaim` already carries as `currentSHA` — no fetch, no ref read. It happens entirely before the write, and the subsequent `git push --force-with-lease=<ref>:<currentSHA>` is completely unchanged: it still compares against the exact same `currentSHA` it always did, so a claim reclaimed out from under a stale renewer is still never silently overwritten.
- Since `StartedAt` now means what its name says, `ReleaseRepoClaimConflictError`'s refusal message reports how long the holder has been running (e.g. `running for 15m0s`) alongside the existing holder/environment naming — the number that tells an operator whether to wait or go investigate. The duration is computed from fields carried on the error (`StartedAt`, `Now`) rather than `time.Now()` inside `Error()`, so the message stays a pure, testable function of the refusal.

## Tests

Added to `erun-common/release_repo_claim_test.go`, exercised against real git remotes the same way the existing suite in that file does:
- `TestReleaseRepoClaimRenewalPreservesStartedAtAndAdvancesOnlyExpiresAt` — the regression test: a renewal preserves the original `StartedAt` and advances only `ExpiresAt`.
- `TestReleaseRepoClaimFreshClaimSetsStartedAtToNow` — a fresh claim sets `StartedAt` to now.
- `TestReleaseRepoClaimReclaimOfAnExpiredHolderSetsANewStartedAt` — a reclaim of an expired holder sets a *new* `StartedAt`, not the abandoned holder's — the test that stops the fix from over-correcting.
- `TestReleaseRepoClaimRefusalReportsHowLongTheHolderHasBeenRunning` — the new refusal wording.

Existing claim/reclaim/refusal tests in the file are unchanged and still pass.

## Validation

- `make check` — green (lint, all module test suites, chart tests, integration suite at 75.8% coverage).

Closes #1668