### PR TITLE
Retire the erun-dns01-webhook pullability baseline entry

### DIFF
--- a/erun-common/release_anonymous_pullability.go
+++ b/erun-common/release_anonymous_pullability.go
@@ -75,18 +75,21 @@ func discoverModuleReferencedImageNames(root string) ([]string, error) {
 // anonymously pullable yet. It is a record of a known gap, not a design
 // decision: an entry here means the ghcr.io package is currently private, a
 // visibility setting on the sophium org this repository cannot flip on its
-// own, not that the image is meant to stay private. Once the package is made
-// public, TestAnonymousPullabilityBaselineIsCurrent fails until the stale
-// entry is removed -- the same shrink-only enforcement the two precedents
-// above use -- which is what proves the visibility fix actually landed rather
-// than being asserted in a PR description.
-var anonymousPullabilityBaseline = map[string]bool{
-	// ghcr.io/sophium/erun-dns01-webhook is private, so an anonymous pull
-	// fails; terraform-erun-cluster-edge's dns01_webhook_image references it
-	// directly, which is what makes a cluster following that module's
-	// documented powerdns-broker path end at ImagePullBackOff.
-	"erun-dns01-webhook": true,
-}
+// own, not that the image is meant to stay private.
+//
+// This baseline retires itself at release time, not at test time.
+// TestAnonymousPullabilityBaselineIsCurrent only checks that a baselined name
+// still corresponds to an image some module references -- it never touches
+// the network, so it cannot see whether the underlying package went public.
+// verifyImageAnonymouslyPullable does: when a baselined image's release-time
+// probe comes back pullable, the release fails and names the stale entry to
+// delete, instead of reporting success while a baseline that no longer
+// describes reality quietly disables the very check it exists to perform.
+//
+// Empty right now: ghcr.io/sophium/erun-dns01-webhook was the only entry and
+// the package has since been made public, so it was removed rather than left
+// as a stale example.
+var anonymousPullabilityBaseline = map[string]bool{}
 
 // anonymousManifestAcceptHeaders is every manifest media type a multi-arch
 // pull negotiates, mirroring what `docker manifest inspect` itself sends.
@@ -174,9 +177,10 @@ func probeAnonymousManifestPullAt(ctx context.Context, client *http.Client, repo
 // image a Terraform module references resolves with no credential at all, at
 // the version this release just published. A name absent from
 // anonymousPullabilityBaseline must resolve anonymously or the release fails;
-// a baselined name is reported and let through, so today's known-private
-// erun-dns01-webhook does not block every release until the sophium org's
-// package visibility changes.
+// a baselined name is reported and let through instead, so a known-private
+// image does not block every release until the sophium org's package
+// visibility changes -- unless it turns out to already be pullable, in which
+// case the baseline entry itself is the defect (see verifyImageAnonymouslyPullable).
 func verifyModuleReferencedImagesAnonymouslyPullable(ctx Context, projectRoot string, execution BuildExecutionSpec, probe anonymousPullProbeFunc) error {
 	names, err := discoverModuleReferencedImageNames(filepath.Join(strings.TrimSpace(projectRoot), "erun-devops", "terraform-erun"))
 	if err != nil {
@@ -206,6 +210,9 @@ func verifyModuleReferencedImagesAnonymouslyPullable(ctx Context, projectRoot st
 // verifyImageAnonymouslyPullable is the per-image half of
 // verifyModuleReferencedImagesAnonymouslyPullable: probe name's tag with no
 // credential at all, then apply anonymousPullabilityBaseline to the result.
+// A baselined name that probes as pullable fails the release rather than
+// passing silently -- see anonymousPullabilityBaseline's doc comment for why
+// this enforcement has to live here and not in a unit test.
 func verifyImageAnonymouslyPullable(ctx Context, name string, image DockerImageReference, probe anonymousPullProbeFunc) error {
 	tag := strings.TrimSpace(image.Tag)
 	if !isGHCRRegistry(dockerRegistryFromImageTag(tag)) {
@@ -231,6 +238,11 @@ func verifyImageAnonymouslyPullable(ctx Context, name string, image DockerImageR
 		return fmt.Errorf("probe anonymous pull of %s: %w", tag, probeErr)
 	}
 	if pullable {
+		if anonymousPullabilityBaseline[name] {
+			return fmt.Errorf(
+				"image %s is baselined in anonymousPullabilityBaseline as not anonymously pullable, but it just probed as pullable -- the entry is now stale and would silently disable this check every release from here on; remove %q from anonymousPullabilityBaseline in release_anonymous_pullability.go",
+				tag, name)
+		}
 		ctx.Info("==> Verified anonymously pullable: " + tag)
 		return nil
 	}

--- a/erun-common/release_anonymous_pullability_test.go
+++ b/erun-common/release_anonymous_pullability_test.go
@@ -231,13 +231,25 @@ func TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselined(t 
 	}
 }
 
+// withAnonymousPullabilityBaseline overrides the package-level baseline for
+// the duration of a test, restoring the original afterward. The real baseline
+// is expected to be empty most of the time (erun-common/AGENTS.md's
+// dependency-injection-over-globals preference doesn't apply cleanly to a
+// shrink-only map that production code also reads by name), so tests that
+// need a baselined entry inject their own fixture name instead of depending
+// on whatever the real map currently holds.
+func withAnonymousPullabilityBaseline(t *testing.T, baseline map[string]bool) {
+	t.Helper()
+	original := anonymousPullabilityBaseline
+	anonymousPullabilityBaseline = baseline
+	t.Cleanup(func() { anonymousPullabilityBaseline = original })
+}
+
 func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselined(t *testing.T) {
+	withAnonymousPullabilityBaseline(t, map[string]bool{"erun-baselined-webhook": true})
 	root := t.TempDir()
-	// erun-dns01-webhook is the real, current anonymousPullabilityBaseline
-	// entry, so this exercises the baseline as it stands today, not a
-	// fixture-only name.
-	writeModuleFixture(t, root, "erun-dns01-webhook")
-	execution := fakeExecutionForImage("erun-dns01-webhook", "ghcr.io/sophium/erun-dns01-webhook:1.0.217", "1.0.217")
+	writeModuleFixture(t, root, "erun-baselined-webhook")
+	execution := fakeExecutionForImage("erun-baselined-webhook", "ghcr.io/sophium/erun-baselined-webhook:1.0.217", "1.0.217")
 	var logBuf strings.Builder
 	ctx := Context{Logger: NewLogger(0).WithTraceSink(&logBuf)}
 
@@ -247,6 +259,31 @@ func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselined(t *t
 	}
 	if !strings.Contains(logBuf.String(), "Not anonymously pullable (baselined") {
 		t.Fatalf("expected the baselined gap to be reported, got log:\n%s", logBuf.String())
+	}
+}
+
+// This is the property erun#1587 found missing: a baselined image is a
+// record that the package is *currently* private, not a promise it will stay
+// that way. Once it probes as anonymously pullable, the entry is a lie that
+// would otherwise let this check silently no-op forever, so the release must
+// fail and name the stale entry to remove.
+func TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenBaselinedButNowPullable(t *testing.T) {
+	withAnonymousPullabilityBaseline(t, map[string]bool{"erun-baselined-webhook": true})
+	root := t.TempDir()
+	writeModuleFixture(t, root, "erun-baselined-webhook")
+	execution := fakeExecutionForImage("erun-baselined-webhook", "ghcr.io/sophium/erun-baselined-webhook:1.0.221", "1.0.221")
+	ctx := Context{Logger: NewLogger(0)}
+
+	probe := func(context.Context, *http.Client, string, string) (bool, error) { return true, nil }
+	err := verifyModuleReferencedImagesAnonymouslyPullable(ctx, root, execution, probe)
+	if err == nil {
+		t.Fatal("expected an error: a baselined image that now probes as pullable means the baseline entry is stale")
+	}
+	if !strings.Contains(err.Error(), "erun-baselined-webhook") {
+		t.Fatalf("error should name the stale entry, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "anonymousPullabilityBaseline") {
+		t.Fatalf("error should point at anonymousPullabilityBaseline, got: %v", err)
 	}
 }
 
@@ -262,13 +299,14 @@ func realProbeAt(server *httptest.Server) anonymousPullProbeFunc {
 }
 
 // This is the 1.0.219 regression itself: ghcr refuses the anonymous token
-// request for the known-private erun-dns01-webhook package with 401. That
-// refusal must be reported and the release must proceed, because the
-// baseline already records this image as known not anonymously pullable.
+// request for a known-private package with 401. That refusal must be
+// reported and the release must proceed, because the baseline already
+// records this image as known not anonymously pullable.
 func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselinedTokenRequestRefused(t *testing.T) {
+	withAnonymousPullabilityBaseline(t, map[string]bool{"erun-baselined-webhook": true})
 	root := t.TempDir()
-	writeModuleFixture(t, root, "erun-dns01-webhook")
-	execution := fakeExecutionForImage("erun-dns01-webhook", "ghcr.io/sophium/erun-dns01-webhook:1.0.219", "1.0.219")
+	writeModuleFixture(t, root, "erun-baselined-webhook")
+	execution := fakeExecutionForImage("erun-baselined-webhook", "ghcr.io/sophium/erun-baselined-webhook:1.0.219", "1.0.219")
 	var logBuf strings.Builder
 	ctx := Context{Logger: NewLogger(0).WithTraceSink(&logBuf)}
 
@@ -343,9 +381,10 @@ func TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselinedPro
 // the image's status is already recorded as known-not-anonymously-pullable --
 // so it must not fail the release either.
 func TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselinedAndProbeUnreachable(t *testing.T) {
+	withAnonymousPullabilityBaseline(t, map[string]bool{"erun-baselined-webhook": true})
 	root := t.TempDir()
-	writeModuleFixture(t, root, "erun-dns01-webhook")
-	execution := fakeExecutionForImage("erun-dns01-webhook", "ghcr.io/sophium/erun-dns01-webhook:1.0.219", "1.0.219")
+	writeModuleFixture(t, root, "erun-baselined-webhook")
+	execution := fakeExecutionForImage("erun-baselined-webhook", "ghcr.io/sophium/erun-baselined-webhook:1.0.219", "1.0.219")
 	var logBuf strings.Builder
 	ctx := Context{Logger: NewLogger(0).WithTraceSink(&logBuf)}
 


### PR DESCRIPTION
## Summary

- The ghcr.io/sophium/erun-dns01-webhook package is now public. Removed the `"erun-dns01-webhook": true` entry from `anonymousPullabilityBaseline` in `erun-common/release_anonymous_pullability.go` -- the release check now verifies it for real, anonymously, on every release. The map is now empty; kept the map and its doc comment for the next image that needs it.
- Made the shrink-only baseline self-retiring at release time, not just documentation. `TestAnonymousPullabilityBaselineIsCurrent` only checks that a baselined name still corresponds to an image some Terraform module references -- it never touches the network, so it cannot see whether the package behind it went public. That was a wrong claim in the original PR/issue (#1587): the test does *not* fail once a baselined package goes public.

## Where the enforcement lives, and why not a test

The enforcement is in `verifyImageAnonymouslyPullable` (`erun-common/release_anonymous_pullability.go`), the release-time function that already probes each image. When a **baselined** image's probe comes back pullable, the release now fails with an error naming the exact stale entry to remove, instead of logging "Verified anonymously pullable" and moving on.

This can't be a unit test because the property depends on a real network result (is the ghcr package actually public right now?), and root `AGENTS.md`/`erun-common/AGENTS.md` are explicit that a unit test must never reach a live registry. `verifyImageAnonymouslyPullable` already receives its probe result through the injectable `anonymousPullProbeFunc` seam, so the *logic* (baselined + pullable = fail) is fully unit-tested with a stub probe -- only the real ghcr call itself stays out of the test suite, exercised only at actual release time.

## Tests

All in `erun-common/release_anonymous_pullability_test.go`, using the existing stub-probe seam (no test reaches real ghcr):

- `TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenBaselinedButNowPullable` (new) -- a baselined image that probes as pullable fails the release and names the stale entry.
- `TestVerifyModuleReferencedImagesAnonymouslyPullablePassesWhenBaselined` -- a baselined image that probes as not pullable still reports and proceeds (unchanged; now uses an injected fixture baseline entry instead of depending on the real, now-empty map).
- `TestVerifyModuleReferencedImagesAnonymouslyPullableFailsWhenNotBaselined` -- a non-baselined image that is not pullable still fails, naming both remedies (unchanged).
- `TestVerifyModuleReferencedImagesAnonymouslyPullablePasses` -- a non-baselined pullable image still passes (unchanged).

Added `withAnonymousPullabilityBaseline` test helper to inject a temporary baseline for tests that need one, since the real baseline is expected to be empty most of the time now.

## Validation

- `go build ./...` / `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`.
- `make check` green (lint, unit, integration, coverage 75.8%).

Closes #1587