### PR TITLE
Guard component-named deploys against in-pod local-agent runtime redeploy

### DIFF
--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -1091,14 +1091,11 @@ func ResolveDeploySpec(ctx Context, store DeployStore, findProjectRoot ProjectFi
 		}
 		spec.Deploy.NamespaceQuota = target.NamespaceQuotaOverride
 	}
-	applyRuntimeChartOverride(ctx, target, &spec)
-	if err := applyMCPAuthToRuntimeSpec(ctx, target, &spec); err != nil {
+	specs := []DeploySpec{spec}
+	if err := finalizeRuntimeChartSpecs(ctx, target, resolvedTarget, specs); err != nil {
 		return DeploySpec{}, err
 	}
-	if err := guardMCPAuthDowngrade(ctx, target, spec.Deploy); err != nil {
-		return DeploySpec{}, err
-	}
-	return spec, nil
+	return specs[0], nil
 }
 
 // ResolveCurrentDeploySpecs resolves specs for `erun deploy` — the pure deploy
@@ -1173,23 +1170,32 @@ func resolveCurrentDeploySpecs(ctx Context, store DeployStore, findProjectRoot P
 	if err != nil {
 		return nil, err
 	}
-	if err := guardInPodLocalAgentRuntimeDeploy(os.Getenv, resolvedTarget, specs); err != nil {
+	if err := finalizeRuntimeChartSpecs(ctx, target, resolvedTarget, specs); err != nil {
 		return nil, err
 	}
-	// Applied here rather than in the exported entrypoints so every deploy of the
-	// runtime chart — `erun deploy`, `erun upgrade`, `open --deploy`,
-	// `build --deploy` — carries the env's MCP-auth state. A path that skips this
-	// silently downgrades the edge to unauthenticated.
+	return specs, nil
+}
+
+// finalizeRuntimeChartSpecs applies every guard and override that only fires
+// when a resolved spec targets the runtime chart — the operator's chart
+// override, the env's MCP-auth state, the MCP-auth downgrade refusal, and the
+// in-pod local-agent redeploy refusal — in place, over whatever specs a path
+// resolved. It is the single seam both `ResolveDeploySpec` (the
+// component-named path) and `resolveCurrentDeploySpecs` (the current-deploy
+// set) funnel through after resolving specs and before returning them, so a
+// future path that resolves a spec able to name the runtime chart inherits
+// these guards for free instead of needing to remember them.
+func finalizeRuntimeChartSpecs(ctx Context, target DeployTarget, resolvedTarget OpenResult, specs []DeploySpec) error {
 	for i := range specs {
 		applyRuntimeChartOverride(ctx, target, &specs[i])
 		if err := applyMCPAuthToRuntimeSpec(ctx, target, &specs[i]); err != nil {
-			return nil, err
+			return err
 		}
 		if err := guardMCPAuthDowngrade(ctx, target, specs[i].Deploy); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return specs, nil
+	return guardInPodLocalAgentRuntimeDeploy(os.Getenv, resolvedTarget, specs)
 }
 
 func resolveDeploySpecsForResolvedTarget(ctx Context, store DeployStore, findProjectRoot ProjectFinderFunc, resolveDockerBuildContext BuildContextResolverFunc, resolveKubernetesDeployContext DeployContextResolverFunc, now NowFunc, resolvedTarget OpenResult, target DeployTarget, buildOrchestration bool, runtimeImageOverride string) ([]DeploySpec, error) {

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -2996,7 +2996,7 @@ esac
 	})
 
 	t.Run("devops_k8s_deploy_component_in_pod_local_agent_runtime_refused", func(t *testing.T) {
-		// Regression #1673: ResolveDeploySpec (the component-named path behind
+		// Regression: ResolveDeploySpec (the component-named path behind
 		// `devops k8s deploy` and the MCP deploy tool's component branch) already
 		// applied the runtime chart's other guards — the chart override and the
 		// MCP-auth downgrade refusal — but not this one, so naming the runtime

--- a/erun-integration/deploy_test.go
+++ b/erun-integration/deploy_test.go
@@ -2995,6 +2995,57 @@ esac
 		golden.Equal(t, "deploy/devops_k8s_deploy_component_dry_run", normalize.Apply(result.Combined))
 	})
 
+	t.Run("devops_k8s_deploy_component_in_pod_local_agent_runtime_refused", func(t *testing.T) {
+		// Regression #1673: ResolveDeploySpec (the component-named path behind
+		// `devops k8s deploy` and the MCP deploy tool's component branch) already
+		// applied the runtime chart's other guards — the chart override and the
+		// MCP-auth downgrade refusal — but not this one, so naming the runtime
+		// release as a component reached exactly the in-pod local-agent redeploy
+		// this guard exists to refuse. team-devops is RuntimeReleaseName("team").
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		envVars := append(setup.Env(), "ERUN_TENANT=team", "ERUN_ENVIRONMENT=dev")
+		result := erun.Run(t, []string{"devops", "k8s", "deploy", "team-devops", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a non-zero exit for an in-pod local-agent component-named runtime deploy:\n%s", result.Combined)
+		}
+		golden.Equal(t, "deploy/devops_k8s_deploy_component_in_pod_local_agent_runtime_refused", normalize.Apply(result.Combined))
+	})
+
+	t.Run("devops_k8s_deploy_component_in_pod_local_agent_non_runtime_allowed", func(t *testing.T) {
+		// The guard must stay scoped to the runtime chart alone: naming a
+		// non-runtime component from inside the pod carries no environment shape,
+		// so it must keep working even in-pod on a local-agent env.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		fixture.SeedDevopsRepo(t, setup, "team", "dev")
+		fixture.SeedDevopsBackendCharts(t, setup, "team", "dev")
+		envVars := append(setup.Env(), "ERUN_TENANT=team", "ERUN_ENVIRONMENT=dev")
+		result := erun.Run(t, []string{"devops", "k8s", "deploy", "erun-backend-api", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/devops_k8s_deploy_component_in_pod_local_agent_non_runtime_allowed", normalize.Apply(result.Combined))
+	})
+
+	t.Run("devops_k8s_deploy_component_in_pod_non_local_agent_runtime_allowed", func(t *testing.T) {
+		// The guard is scoped to local-agent envs: a remote-agent env owns its
+		// worktree inside the pod, so naming its runtime chart as the component
+		// from inside the pod stays supported — mirrors
+		// in_pod_remote_agent_runtime_deploy_allowed for the component-named path.
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnv(t, setup, "team", "dev")
+		repoPath := filepath.Join(setup.Home, "git", "team")
+		fixture.SeedDevopsRepoAt(t, repoPath, "team", "dev")
+		envVars := append(setup.Env(), "ERUN_TENANT=team", "ERUN_ENVIRONMENT=dev")
+		result := erun.Run(t, []string{"devops", "k8s", "deploy", "team-devops", "--version", "1.0.0", "--dry-run"}, erun.RunOptions{Cwd: setup.Home, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "deploy/devops_k8s_deploy_component_in_pod_non_local_agent_runtime_allowed", normalize.Apply(result.Combined))
+	})
+
 	t.Run("real_run_parallel_step_deploys_charts_concurrently", func(t *testing.T) {
 		// Exercises runDeployStep's real-run parallel branch (the goroutine
 		// fan-out + errors.Join), which dry-run never takes because dry-run

--- a/erun-integration/testdata/deploy/devops_k8s_deploy_component_in_pod_local_agent_non_runtime_allowed.txt
+++ b/erun-integration/testdata/deploy/devops_k8s_deploy_component_in_pod_local_agent_non_runtime_allowed.txt
@@ -1,0 +1,8 @@
+audit: erun devops k8s deploy --dry-run --version <VERSION> erun-backend-api
+deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
+kubectl --context test-context get namespace team-dev -o name
+deploy: namespace team-dev is created if the check above reports it missing
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=host --set-string worktreeRepoName=cwd --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set api.postgres.reset=false --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 erun-backend-api <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release erun-backend-api)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-erun-backend-api, hash=<HASH>)

--- a/erun-integration/testdata/deploy/devops_k8s_deploy_component_in_pod_local_agent_runtime_refused.txt
+++ b/erun-integration/testdata/deploy/devops_k8s_deploy_component_in_pod_local_agent_runtime_refused.txt
@@ -1,0 +1,3 @@
+audit: erun devops k8s deploy --dry-run --version <VERSION> team-devops
+deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
+deploy team/dev: refusing to deploy the runtime chart from inside this environment's own pod — team/dev is a local-agent environment, whose ports, worktree host path, runtime resources, and chart registry are defined by the host config store, not by the in-pod projection this process reads. Run `erun deploy --tenant team --environment dev --version <VERSION>` from the host CLI instead

--- a/erun-integration/testdata/deploy/devops_k8s_deploy_component_in_pod_non_local_agent_runtime_allowed.txt
+++ b/erun-integration/testdata/deploy/devops_k8s_deploy_component_in_pod_non_local_agent_runtime_allowed.txt
@@ -1,0 +1,10 @@
+audit: erun devops k8s deploy --dry-run --version <VERSION> team-devops
+deploy: version <VERSION> pinned; installing the published image by reference (deploy never builds)
+kubectl --context test-context get namespace team-dev -o name
+deploy: namespace team-dev is created if the check above reports it missing
+kubectl --context test-context --namespace team-dev get pvc team-devops-worktree -o name
+deploy: worktree <HOME>/git/team is served by the team-devops-worktree volume; a deploy that creates that volume adopts an existing tree from the team-devops-home volume before the pod starts
+cd <TMP> && helm upgrade --install --wait --wait-for-jobs --server-side true --force-conflicts --timeout 5m0s --namespace team-dev --debug --kube-context test-context -f <TMP> --set-string tenant=team --set-string environment=dev --set-string worktreeStorage=pvc --set-string worktreeRepoName=team --set-string worktreeHostPath=<TMP> --set sshdEnabled=false --set mcpPort=17000 --set apiPort=17033 --set sshPort=17022 --set managedCloud=false --set-string cloudContext.name= --set-string cloudContext.provider= --set-string cloudContext.providerAlias= --set-string cloudContext.instanceId= --set cloudContext.useHostCredentials=false --set api.postgres.reset=false --set-json 'containerRegistries=[{"registry":"registry.example/test","roles":["build","deploy"]}]' --set disableBuildScript=false --set-string idle.timeout=5m0s --set-string idle.workingHours=08:00-20:00 --set-string idle.timezone= --set idle.trafficBytes=0 --set-string runtime.resources.limits.cpu=4 --set-string runtime.resources.limits.memory=8916Mi --set-string claude.useMantle=0 --set-string claude.useBedrock=0 team-devops <TMP>
+deploy: watching pods in team-dev on context test-context for early container failure (release team-devops)
+kubectl --context test-context --namespace team-dev get pods -o json
+dedup: ready (release=test-context-team-dev-team-devops, hash=<HASH>)


### PR DESCRIPTION
## Summary

`ResolveDeploySpec` — the component-named deploy path behind `devops k8s deploy <component>` and the MCP `deploy` tool's `component` branch — already applied the runtime chart's other two guards (`applyRuntimeChartOverride`, `applyMCPAuthToRuntimeSpec` + `guardMCPAuthDowngrade`) but never `guardInPodLocalAgentRuntimeDeploy`. Naming the runtime release (`RuntimeReleaseName(tenant)`, e.g. `team-devops`) as the component therefore reached exactly the in-pod local-agent redeploy that guard exists to refuse, silently reshaping the environment (ports, worktree host path, pod resources, chart registry) and cutting the MCP channel that issued the call.

## The seam

Extracted `finalizeRuntimeChartSpecs(ctx, target, resolvedTarget, specs)` in `erun-common/deploy.go` as the single point both `ResolveDeploySpec` and `resolveCurrentDeploySpecs` funnel their resolved specs through, right before returning them. It bundles all three runtime-chart-only guards/overrides — the chart override, the MCP-auth application, the MCP-auth downgrade refusal, and now the in-pod local-agent refusal — in one place.

This is the seam a future caller cannot bypass: any deploy-spec-resolution path that needs the chart override or the MCP-auth guards (which every runtime-chart-capable path already needs, since a runtime chart with no auth threading would silently ship an unauthenticated MCP edge) is already required to call this function to get correct behavior at all. The in-pod guard now travels with them for free instead of needing to be remembered separately by each new entry point — the exact omission this issue reports.

## Unit vs integration coverage

No new unit tests. `erun-common/AGENTS.md` § "Validation" is explicit that `erun-common` behavior is gated end-to-end by the integration suite, not unit tests, and that a unit test overlapping an integration scenario should be deleted rather than kept. `ResolveDeploySpec`/`resolveCurrentDeploySpecs` have no existing unit tests for the same reason — every other deploy-resolution behavior in this file is pinned by `erun-integration`'s `--dry-run` goldens, and the new guard call is fully reachable that way, so a unit test would only duplicate the integration scenarios below.

## Tests (erun-integration/deploy_test.go)

- `devops_k8s_deploy_component_in_pod_local_agent_runtime_refused` — `devops k8s deploy team-devops` (a component name equal to the runtime release name) from inside that env's own local-agent pod is refused with the same message the default `erun deploy` path gives.
- `devops_k8s_deploy_component_dry_run` (pre-existing, unchanged) — the same component-named runtime-chart deploy from the host (no in-pod markers) still succeeds.
- `devops_k8s_deploy_component_in_pod_local_agent_non_runtime_allowed` — naming a non-runtime component (`erun-backend-api`) from inside the pod still works, proving the guard didn't widen.
- `devops_k8s_deploy_component_in_pod_non_local_agent_runtime_allowed` — the same runtime-named component deploy from inside a **remote-agent** env's pod still works, since the guard is scoped to local-agent only.
- `deploy/in_pod_local_agent_runtime_deploy_refused` (the existing default-path golden) is unchanged.

## Test plan

- [x] `make check` green (lint, erun-ui/erun-kit/erun-console suites, devops chart tests, full integration suite with coverage gate)
- [x] New and existing goldens inspected by hand
- [x] No real deploy run against any environment