### PR TITLE
Validate diff selectedCommit before it reaches git argv

### DIFF
--- a/erun-common/diff.go
+++ b/erun-common/diff.go
@@ -158,6 +158,14 @@ func ResolveGitDiffWithOptions(projectRoot string, options DiffOptions, runGit G
 		runGit = GitCommandRunner
 	}
 
+	scope := normalizeDiffScope(options.Scope)
+	selectedCommit := strings.TrimSpace(options.SelectedCommit)
+	if scope == "commit" && selectedCommit != "" {
+		if err := rejectOptionShapedRevision(selectedCommit); err != nil {
+			return DiffResult{}, err
+		}
+	}
+
 	base, baseFound, err := resolveGitDiffReviewBase(projectRoot, runGit)
 	if err != nil {
 		return DiffResult{}, err
@@ -167,8 +175,13 @@ func ResolveGitDiffWithOptions(projectRoot string, options DiffOptions, runGit G
 		return DiffResult{}, err
 	}
 
-	scope := normalizeDiffScope(options.Scope)
-	selectedCommit := strings.TrimSpace(options.SelectedCommit)
+	if scope == "commit" && selectedCommit != "" {
+		selectedCommit, err = resolveDiffCommitRevision(projectRoot, selectedCommit, runGit)
+		if err != nil {
+			return DiffResult{}, err
+		}
+	}
+
 	stdout := new(bytes.Buffer)
 	diffArgs := gitDiffReviewArgs(base.Commit, baseFound, scope, selectedCommit)
 	stderr := new(bytes.Buffer)
@@ -196,6 +209,28 @@ func normalizeDiffScope(scope string) string {
 	default:
 		return "current"
 	}
+}
+
+// rejectOptionShapedRevision refuses a value that git would parse as an
+// option rather than a revision, before any git command runs with it. exec_diff
+// is a read-scoped MCP tool, so a caller-supplied revision must never be able
+// to steer git's own flags.
+func rejectOptionShapedRevision(revision string) error {
+	if strings.HasPrefix(revision, "-") {
+		return fmt.Errorf("selectedCommit must be a commit revision, not %q", revision)
+	}
+	return nil
+}
+
+// resolveDiffCommitRevision resolves the caller-supplied revision to a commit
+// sha via git itself, so only a value git already agreed is a commit reaches
+// the diff argv.
+func resolveDiffCommitRevision(projectRoot, revision string, runGit GitCommandRunnerFunc) (string, error) {
+	resolved, err := gitOutput(projectRoot, runGit, "rev-parse", "--verify", revision+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("selectedCommit %q is not a valid commit: %w", revision, err)
+	}
+	return resolved, nil
 }
 
 func gitDiffReviewArgs(baseCommit string, baseFound bool, scope, selectedCommit string) []string {

--- a/erun-common/diff.go
+++ b/erun-common/diff.go
@@ -160,10 +160,8 @@ func ResolveGitDiffWithOptions(projectRoot string, options DiffOptions, runGit G
 
 	scope := normalizeDiffScope(options.Scope)
 	selectedCommit := strings.TrimSpace(options.SelectedCommit)
-	if scope == "commit" && selectedCommit != "" {
-		if err := rejectOptionShapedRevision(selectedCommit); err != nil {
-			return DiffResult{}, err
-		}
+	if err := rejectOptionShapedSelectedCommit(scope, selectedCommit); err != nil {
+		return DiffResult{}, err
 	}
 
 	base, baseFound, err := resolveGitDiffReviewBase(projectRoot, runGit)
@@ -175,11 +173,9 @@ func ResolveGitDiffWithOptions(projectRoot string, options DiffOptions, runGit G
 		return DiffResult{}, err
 	}
 
-	if scope == "commit" && selectedCommit != "" {
-		selectedCommit, err = resolveDiffCommitRevision(projectRoot, selectedCommit, runGit)
-		if err != nil {
-			return DiffResult{}, err
-		}
+	selectedCommit, err = resolveDiffSelectedCommit(projectRoot, scope, selectedCommit, runGit)
+	if err != nil {
+		return DiffResult{}, err
 	}
 
 	stdout := new(bytes.Buffer)
@@ -211,24 +207,32 @@ func normalizeDiffScope(scope string) string {
 	}
 }
 
-// rejectOptionShapedRevision refuses a value that git would parse as an
-// option rather than a revision, before any git command runs with it. exec_diff
-// is a read-scoped MCP tool, so a caller-supplied revision must never be able
-// to steer git's own flags.
-func rejectOptionShapedRevision(revision string) error {
-	if strings.HasPrefix(revision, "-") {
-		return fmt.Errorf("selectedCommit must be a commit revision, not %q", revision)
+// rejectOptionShapedSelectedCommit refuses a selectedCommit that git would
+// parse as an option rather than a revision, before any git command runs with
+// it. exec_diff is a read-scoped MCP tool, so a caller-supplied revision must
+// never be able to steer git's own flags. Only the "commit" scope ever passes
+// selectedCommit into argv, so other scopes have nothing to validate.
+func rejectOptionShapedSelectedCommit(scope, selectedCommit string) error {
+	if scope != "commit" || selectedCommit == "" {
+		return nil
+	}
+	if strings.HasPrefix(selectedCommit, "-") {
+		return fmt.Errorf("selectedCommit must be a commit revision, not %q", selectedCommit)
 	}
 	return nil
 }
 
-// resolveDiffCommitRevision resolves the caller-supplied revision to a commit
-// sha via git itself, so only a value git already agreed is a commit reaches
-// the diff argv.
-func resolveDiffCommitRevision(projectRoot, revision string, runGit GitCommandRunnerFunc) (string, error) {
-	resolved, err := gitOutput(projectRoot, runGit, "rev-parse", "--verify", revision+"^{commit}")
+// resolveDiffSelectedCommit resolves a "commit" scope's selectedCommit to a
+// commit sha via git itself, so only a value git already agreed is a commit
+// reaches the diff argv. Other scopes pass selectedCommit through unresolved
+// since it never reaches argv for them.
+func resolveDiffSelectedCommit(projectRoot, scope, selectedCommit string, runGit GitCommandRunnerFunc) (string, error) {
+	if scope != "commit" || selectedCommit == "" {
+		return selectedCommit, nil
+	}
+	resolved, err := gitOutput(projectRoot, runGit, "rev-parse", "--verify", selectedCommit+"^{commit}")
 	if err != nil {
-		return "", fmt.Errorf("selectedCommit %q is not a valid commit: %w", revision, err)
+		return "", fmt.Errorf("selectedCommit %q is not a valid commit: %w", selectedCommit, err)
 	}
 	return resolved, nil
 }

--- a/erun-integration/exec_test.go
+++ b/erun-integration/exec_test.go
@@ -360,6 +360,67 @@ func TestExec(t *testing.T) {
 		golden.Equal(t, "exec/diff_selected_commit_without_scope_errors", normalize.Apply(result.Combined))
 	})
 
+	t.Run("diff_selected_commit_option_shaped_refused", func(t *testing.T) {
+		// exec_diff is a read-scoped capability: git reads a value starting
+		// with "-" as an option rather than a revision, so a selectedCommit in
+		// that shape must be refused before it ever reaches git's argv. Stub
+		// git to fail loudly so the assertion proves the refusal happens
+		// before any git invocation, not just that the command errors.
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		stubs := setup.Cwd + "/stubs"
+		fixture.StubBinaryAdvanced(t, stubs, "git", fixture.StubBinarySpec{Stderr: "stub-git-must-not-run", ExitCode: 1})
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "git")...)
+		result := erun.Run(t, []string{"exec", "diff", "--scope=commit", "--selected-commit=--not-a-revision"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit, got 0:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "stub-git-must-not-run") {
+			t.Fatalf("git ran even though the option-shaped selectedCommit should have been refused first: %s", result.Combined)
+		}
+		golden.Equal(t, "exec/diff_selected_commit_option_shaped_refused", normalize.Apply(result.Combined))
+	})
+
+	t.Run("diff_selected_commit_malformed_revision_errors", func(t *testing.T) {
+		// A revision that is not option-shaped but does not resolve to any
+		// commit (typo, unknown ref) must fail with a clear message naming the
+		// value, not git's raw "fatal: ..." text.
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		result := erun.Run(t, []string{"exec", "diff", "--scope=commit", "--selected-commit=not-a-real-commit"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit, got 0:\n%s", result.Combined)
+		}
+		golden.Equal(t, "exec/diff_selected_commit_malformed_revision_errors", normalize.Apply(result.Combined))
+	})
+
+	t.Run("diff_scope_commit_resolves_abbreviated_commit", func(t *testing.T) {
+		// The fix resolves selectedCommit to a full sha via `git rev-parse
+		// --verify` before it reaches the diff argv, so an abbreviated hash
+		// must still produce the same diff and echo the resolved full sha.
+		setup := env.New(t)
+		fixture.SeedGitRepo(t, setup.Cwd)
+		mustWriteFile(t, filepath.Join(setup.Cwd, "second.txt"), "second\n")
+		fixture.RunGit(t, setup.Cwd, "add", "second.txt")
+		fixture.RunGit(t, setup.Cwd, "commit", "-q", "-m", "second commit")
+		fullHash := strings.TrimSpace(captureGit(t, setup.Cwd, "rev-parse", "HEAD"))
+		shortHash := strings.TrimSpace(captureGit(t, setup.Cwd, "rev-parse", "--short", "HEAD"))
+		result := erun.Run(t, []string{"exec", "diff", "--json", "--scope=commit", "--selected-commit=" + shortHash}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		var parsed common.DiffResult
+		if err := json.Unmarshal([]byte(result.Stdout), &parsed); err != nil {
+			t.Fatalf("decode --json output: %v\n%s", err, result.Stdout)
+		}
+		if parsed.SelectedCommit != fullHash {
+			t.Errorf("expected resolved SelectedCommit=%s, got %q", fullHash, parsed.SelectedCommit)
+		}
+		if parsed.Summary.FileCount == 0 {
+			t.Errorf("expected non-zero FileCount across selected commit, got 0")
+		}
+	})
+
 	t.Run("dry_run_with_time_flag_prints_elapsed_on_error", func(t *testing.T) {
 		setup := env.New(t)
 		result := erun.Run(t, []string{"exec", "diff", "--dry-run", "--time"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})

--- a/erun-integration/testdata/exec/diff_selected_commit_malformed_revision_errors.txt
+++ b/erun-integration/testdata/exec/diff_selected_commit_malformed_revision_errors.txt
@@ -1,0 +1,3 @@
+audit: erun exec diff --scope commit --selected-commit not-a-real-commit
+selectedCommit "not-a-real-commit" is not a valid commit: exit status 128
+fatal: Needed a single revision

--- a/erun-integration/testdata/exec/diff_selected_commit_option_shaped_refused.txt
+++ b/erun-integration/testdata/exec/diff_selected_commit_option_shaped_refused.txt
@@ -1,0 +1,2 @@
+audit: erun exec diff --scope commit --selected-commit --not-a-revision
+selectedCommit must be a commit revision, not "--not-a-revision"


### PR DESCRIPTION
## Summary
- `exec_diff` appended a caller-supplied `selectedCommit` straight into `git diff`'s argv without validating it was a revision. A value beginning with `-` is read by git as an *option*, not a revision, so a read-scoped MCP caller could steer `git diff`'s own flags — some of which write to the filesystem. This breaks the read-capability invariant documented in `erun-common/mcp_capabilities.go` and `erun-mcp/server.go` ("exec_diff only reads").
- Fix: resolve `selectedCommit` first, via `git rev-parse --verify <rev>^{commit}`, so only a value git already agreed is a commit reaches the diff argv (the stronger of the two options named in the issue — it also turns a malformed revision into a clear error instead of a raw git failure, and the resolved sha is what the diff should pin against anyway). An option-shaped value (`-`-prefixed) is refused before any git command runs at all, rather than being sent to `rev-parse`.
- Both checks are scoped to `scope == "commit"` (the only scope that ever puts `selectedCommit` into `git diff`'s argv); `all` and the default scope are untouched.

## Siblings checked
Searched `erun-common/diff.go` and its callers (`erun-mcp/diff.go`, `erun-cli/cmd/exec.go`) for any other caller-supplied scope/branch/ref reaching git argv: `selectedCommit` is the only one. `resolveGitDiffReviewBase`'s branch list (`origin/HEAD`, `origin/main`, etc.) is a fixed internal list, not caller input. I also scanned every other `erun-common` file that calls `GitCommandRunner`/`runGit` (`exec_merge.go`, `exec_gate_merge.go`, `exec_commit.go`, `exec_push.go`, `release.go`, `release_remote.go`, `contribute.go`, `build_run.go`) — every branch/tag/ref they pass to argv comes from internal repo config (`spec.Branch`, release tags), not from a read-scoped MCP caller. Nothing else needed a fix.

## Tests (erun-integration/exec_test.go)
- `diff_selected_commit_option_shaped_refused` — stubs `git` to fail loudly, asserts the stub never runs (i.e. the refusal happens before any git invocation) and the error names what was expected.
- `diff_selected_commit_malformed_revision_errors` — a non-option-shaped but unresolvable revision gets a clear error, not raw git failure text.
- `diff_scope_commit_uses_selected_commit_parent` (pre-existing, unmodified) — a valid full-sha revision still produces the same diff; golden untouched.
- `diff_scope_commit_resolves_abbreviated_commit` (new) — an abbreviated hash still resolves correctly and the result echoes the resolved full sha.
- `all`/default scope scenarios are unmodified and still pass, confirming they're unaffected.

## Validation
- `go test ./...` green in `erun-common`, `erun-cli`, `erun-mcp`.
- `make check` green end to end (lint, all module tests, chart tests, `erun-integration` suite, coverage 75.8% >= 75.8% threshold).

Closes #1676