### PR TITLE
Give hosted-env stop a per-attempt Job id

### DIFF
--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job.go
@@ -15,6 +15,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/jobexec"
 )
@@ -33,6 +34,11 @@ type StopJobParams struct {
 	Namespace      string
 	Image          string
 	ServiceAccount string
+	// StopID identifies one explicit stop attempt, mirroring DeployID/DeleteID:
+	// it is what lets StopJobName give a fresh stop a fresh Job rather than
+	// watching a prior attempt's terminal one. Empty keeps the bare
+	// tenant+environment name.
+	StopID string
 	// Placement names the cluster this stop targets (#1112); see
 	// DeployJobParams.Placement.
 	Placement PlacementParams
@@ -62,10 +68,15 @@ type DeleteJobParams struct {
 	ExposePlatformNamespace string
 }
 
-// StopJobName is deterministic in its inputs, so a retried stop watches the
-// Job it already created rather than starting a second one.
-func StopJobName(tenant, environment string) string {
-	return lifecycleJobName(stopJobNamePrefix, tenant, environment, "")
+// StopJobName appends a per-attempt suffix, mirroring DeployJobName/
+// DeleteJobName: a name keyed only on tenant+environment would make a fresh
+// stop watch a prior attempt's already-terminal Job and replay its cached
+// outcome instead of actually running again — the bug this exists to prevent.
+// stopID empty keeps the bare tenant+environment name. A stop still in flight
+// is found and re-watched by Launcher.RunStop before a new attempt is ever
+// built, so this alone does not decide whether a fresh Job gets created.
+func StopJobName(tenant, environment, stopID string) string {
+	return lifecycleJobName(stopJobNamePrefix, tenant, environment, stopID)
 }
 
 // DeleteJobName appends a per-attempt suffix, mirroring DeployJobName: a
@@ -131,7 +142,7 @@ func buildLifecycleCommand(tenant, environment string, placement PlacementParams
 func buildStopJob(params StopJobParams) *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      StopJobName(params.Tenant, params.Environment),
+			Name:      StopJobName(params.Tenant, params.Environment, params.StopID),
 			Namespace: params.Namespace,
 			Labels:    lifecycleJobLabels(params.Tenant, params.Environment),
 		},
@@ -240,12 +251,52 @@ func NamespaceDeleteFailureFromOutput(output string) string {
 
 // RunStop creates the stop Job and blocks until it reaches a terminal state.
 // When params.Placement targets a remote cluster (#1112), it first upserts
-// the Secret the Job's container reads its admin token from.
+// the Secret the Job's container reads its admin token from. Unlike deploy
+// and delete, an explicit stop carries no durable workflow and no DB-level
+// claim guarding it, so the in-flight dedup a resumed workflow gets for free
+// (reusing its own attempt id) has to be reconstructed here: before minting a
+// fresh attempt, look for an existing stop Job for this tenant+environment
+// that has not yet reached a terminal state, and watch that one instead of
+// starting a second. Only once none is found (none exists, or every one
+// found is already terminal) does a fresh StopID-keyed Job get created,
+// which is what stops a lingering terminal Job's cached outcome from being
+// replayed for a new request (the defect this whole path exists to fix).
 func (l *Launcher) RunStop(ctx context.Context, params StopJobParams) (Result, error) {
 	if err := ensurePlacementSecret(ctx, l.kube, params.Namespace, params.Placement); err != nil {
 		return Result{}, fmt.Errorf("provision placement credential: %w", err)
 	}
+	activeName, err := l.activeStopJobName(ctx, params)
+	if err != nil {
+		return Result{}, err
+	}
+	if activeName != "" {
+		return l.stopRunner.Watch(ctx, params.Namespace, activeName)
+	}
 	return l.stopRunner.Run(ctx, buildStopJob(params))
+}
+
+// activeStopJobName looks for a not-yet-terminal stop Job for params'
+// tenant+environment, returning its name, or "" when none is found. It lists
+// by the same tenant+environment labels every lifecycle Job carries (deploy,
+// stop, and delete Jobs all share them) and filters to stopJobNamePrefix
+// client-side, since a shared label set alone cannot tell a stop Job apart
+// from a deploy or delete Job for the same environment.
+func (l *Launcher) activeStopJobName(ctx context.Context, params StopJobParams) (string, error) {
+	selector := labels.SelectorFromSet(lifecycleJobLabels(params.Tenant, params.Environment)).String()
+	jobs, err := l.kube.BatchV1().Jobs(params.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return "", fmt.Errorf("list stop jobs: %w", err)
+	}
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if !strings.HasPrefix(job.Name, stopJobNamePrefix) {
+			continue
+		}
+		if !jobexec.IsTerminal(job) {
+			return job.Name, nil
+		}
+	}
+	return "", nil
 }
 
 // RunDelete creates the delete Job and blocks until it reaches a terminal

--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
@@ -9,7 +9,9 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func testStopParams() StopJobParams {
@@ -232,7 +234,7 @@ func TestLauncherRunsStopAndDelete(t *testing.T) {
 	deleteParams.DeleteID = "3f2a91cc-1111-2222-3333-444455556666"
 	kube := fake.NewSimpleClientset(
 		&batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{Name: StopJobName(stopParams.Tenant, stopParams.Environment), Namespace: stopParams.Namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: StopJobName(stopParams.Tenant, stopParams.Environment, stopParams.StopID), Namespace: stopParams.Namespace},
 			Status:     batchv1.JobStatus{Succeeded: 1},
 		},
 		&batchv1.Job{
@@ -358,12 +360,213 @@ func TestDeleteJobNameFitsKubernetesLimit(t *testing.T) {
 
 func TestLifecycleJobNameSanitizesAndTruncates(t *testing.T) {
 	long := "a-very-long-tenant-name-that-pushes-past-the-kubernetes-object-name-limit"
-	name := StopJobName(long, "prod")
+	name := StopJobName(long, "prod", "")
 	if len(name) > 63 {
 		t.Fatalf("job name length = %d, want <= 63", len(name))
 	}
 	deleteName := DeleteJobName(long, "prod", "3f2a91cc-1111-2222-3333-444455556666")
 	if len(deleteName) > 63 {
 		t.Fatalf("job name length = %d, want <= 63", len(deleteName))
+	}
+}
+
+// admitAndCompleteJobReactors installs the same pair of fake-clientset
+// reactors TestRunCreatesWhenAbsent uses: "create" admits the Job Active
+// (standing in for the cluster's own Job controller) and records what was
+// created, then "get" flips it to Succeeded once it has been observed
+// running at least once — driving the transition off the client calls
+// themselves keeps the test free of any timing assumption. Only reacts to
+// Jobs named watchName, so a pre-seeded, unrelated Job already in the fake
+// clientset is left alone.
+func admitAndCompleteJobReactors(t *testing.T, kube *fake.Clientset, watchName, namespace string) (created func() *batchv1.Job) {
+	t.Helper()
+	jobsResource := batchv1.SchemeGroupVersion.WithResource("jobs")
+	var createdJob *batchv1.Job
+	kube.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		obj := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job).DeepCopy()
+		if obj.Name != watchName {
+			return false, nil, nil
+		}
+		createdJob = obj
+		admitted := obj.DeepCopy()
+		admitted.Status.Active = 1
+		if err := kube.Tracker().Add(admitted); err != nil {
+			return true, nil, err
+		}
+		return true, admitted, nil
+	})
+	polls := 0
+	kube.PrependReactor("get", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getAction := action.(k8stesting.GetAction)
+		if getAction.GetNamespace() != namespace || getAction.GetName() != watchName {
+			return false, nil, nil
+		}
+		polls++
+		if polls > 1 && createdJob != nil {
+			completed := createdJob.DeepCopy()
+			completed.Status.Succeeded = 1
+			if err := kube.Tracker().Update(jobsResource, completed, namespace); err != nil {
+				return true, nil, err
+			}
+		}
+		return false, nil, nil
+	})
+	return func() *batchv1.Job { return createdJob }
+}
+
+// TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops is the
+// regression test for erun#1678: a stop issued after a previous stop Job already
+// went terminal must run a fresh Job to a fresh outcome, never replay the
+// old one's cached result. The old Job is seeded Failed specifically so a
+// wrongly-replayed outcome is caught by the outcome assertion, not just by
+// the job count.
+func TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops(t *testing.T) {
+	params := testStopParams()
+	oldID := "3f2a91cc-1111-2222-3333-444455556666"
+	newID := "9b7d40aa-1111-2222-3333-444455556666"
+	oldName := StopJobName(params.Tenant, params.Environment, oldID)
+	newName := StopJobName(params.Tenant, params.Environment, newID)
+	if oldName == newName {
+		t.Fatalf("old and new stop attempts share the job name %q", oldName)
+	}
+
+	kube := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: oldName, Namespace: params.Namespace, Labels: lifecycleJobLabels(params.Tenant, params.Environment)},
+		Status:     batchv1.JobStatus{Failed: 1},
+	})
+	created := admitAndCompleteJobReactors(t, kube, newName, params.Namespace)
+
+	launcher := NewLauncher(kube)
+	launcher.PollEvery(0)
+	params.StopID = newID
+	result, err := launcher.RunStop(context.Background(), params)
+	if err != nil {
+		t.Fatalf("run stop: %v", err)
+	}
+	if result.Outcome != OutcomeSucceeded {
+		t.Fatalf("stop outcome = %q, want succeeded — got the previous terminal attempt's cached outcome instead of running a new Job", result.Outcome)
+	}
+	if created() == nil {
+		t.Fatal("a fresh stop job was not created for the new attempt")
+	}
+
+	jobs, err := kube.BatchV1().Jobs(params.Namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) != 2 {
+		t.Fatalf("jobs in namespace = %d, want 2 (the old terminal attempt plus the new one)", len(jobs.Items))
+	}
+}
+
+// TestRunStopWhileStopJobStillRunningReWatchesIt is the dedup test erun#1678
+// asks to be preserved: a stop issued while a previous stop Job is still in
+// flight must re-watch that same Job rather than starting a second one. The
+// "create" reactor fails the test outright if a second Job is ever created,
+// so this catches the fix regressing into "always mint a fresh Job".
+func TestRunStopWhileStopJobStillRunningReWatchesIt(t *testing.T) {
+	params := testStopParams()
+	inFlightID := "3f2a91cc-1111-2222-3333-444455556666"
+	inFlightName := StopJobName(params.Tenant, params.Environment, inFlightID)
+
+	kube := fake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: inFlightName, Namespace: params.Namespace, Labels: lifecycleJobLabels(params.Tenant, params.Environment)},
+		Status:     batchv1.JobStatus{Active: 1},
+	})
+
+	jobsResource := batchv1.SchemeGroupVersion.WithResource("jobs")
+	polls := 0
+	kube.PrependReactor("get", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getAction := action.(k8stesting.GetAction)
+		if getAction.GetName() != inFlightName {
+			return false, nil, nil
+		}
+		polls++
+		if polls > 1 {
+			completed := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: inFlightName, Namespace: params.Namespace, Labels: lifecycleJobLabels(params.Tenant, params.Environment)},
+				Status:     batchv1.JobStatus{Succeeded: 1},
+			}
+			if err := kube.Tracker().Update(jobsResource, completed, params.Namespace); err != nil {
+				return true, nil, err
+			}
+		}
+		return false, nil, nil
+	})
+	kube.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		obj := action.(k8stesting.CreateAction).GetObject().(*batchv1.Job)
+		t.Fatalf("a second stop job %q was created while %q was still in flight", obj.Name, inFlightName)
+		return true, nil, nil
+	})
+
+	launcher := NewLauncher(kube)
+	launcher.PollEvery(0)
+	// A fresh explicit stop request still mints its own attempt id, exactly
+	// as routes.EnvironmentRoutes.stopEnvironment does — the point of this
+	// test is that RunStop finds the in-flight Job before that id is ever
+	// used to build a Job name.
+	params.StopID = "9b7d40aa-1111-2222-3333-444455556666"
+	result, err := launcher.RunStop(context.Background(), params)
+	if err != nil {
+		t.Fatalf("run stop: %v", err)
+	}
+	if result.Outcome != OutcomeSucceeded {
+		t.Fatalf("stop outcome = %q, want succeeded", result.Outcome)
+	}
+
+	jobs, err := kube.BatchV1().Jobs(params.Namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("jobs in namespace = %d, want 1 — the fresh attempt should have re-watched the in-flight job instead of starting a second", len(jobs.Items))
+	}
+	if jobs.Items[0].Name != inFlightName {
+		t.Fatalf("job name = %q, want the original in-flight job %q to have been re-watched, not replaced", jobs.Items[0].Name, inFlightName)
+	}
+}
+
+// TestStopAfterRedeploySequenceEndsStopped reproduces the exact sequence
+// erun#1678 reported: stop, redeploy, stop again. The redeploy's own Job shares
+// the identical tenant+environment labels every lifecycle Job carries (and
+// is left running, to prove it), so this also pins that activeStopJobName's
+// name-prefix filter tells a deploy Job apart from a stop Job rather than
+// mistaking one for an in-flight stop.
+func TestStopAfterRedeploySequenceEndsStopped(t *testing.T) {
+	stopParams := testStopParams()
+	firstStopID := "3f2a91cc-1111-2222-3333-444455556666"
+	secondStopID := "9b7d40aa-1111-2222-3333-444455556666"
+	firstStopName := StopJobName(stopParams.Tenant, stopParams.Environment, firstStopID)
+	secondStopName := StopJobName(stopParams.Tenant, stopParams.Environment, secondStopID)
+
+	deployParams := testParams()
+	deployName := DeployJobName(deployParams.Tenant, deployParams.Environment, deployParams.Version, "")
+
+	// The first stop already ran to completion; the environment was then
+	// redeployed and that Job is still active when the second stop runs.
+	kube := fake.NewSimpleClientset(
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: firstStopName, Namespace: stopParams.Namespace, Labels: lifecycleJobLabels(stopParams.Tenant, stopParams.Environment)},
+			Status:     batchv1.JobStatus{Succeeded: 1},
+		},
+		&batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: deployName, Namespace: deployParams.Namespace, Labels: lifecycleJobLabels(deployParams.Tenant, deployParams.Environment)},
+			Status:     batchv1.JobStatus{Active: 1},
+		},
+	)
+	created := admitAndCompleteJobReactors(t, kube, secondStopName, stopParams.Namespace)
+
+	launcher := NewLauncher(kube)
+	launcher.PollEvery(0)
+	stopParams.StopID = secondStopID
+	result, err := launcher.RunStop(context.Background(), stopParams)
+	if err != nil {
+		t.Fatalf("run second stop: %v", err)
+	}
+	if result.Outcome != OutcomeSucceeded {
+		t.Fatalf("second stop outcome = %q, want succeeded — the environment must end up stopped", result.Outcome)
+	}
+	if created() == nil {
+		t.Fatal("the second stop did not create its own fresh job — it was confused by, or replayed, an unrelated job")
 	}
 }

--- a/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
+++ b/erun-backend/erun-backend-api/internal/deployexec/lifecycle_job_test.go
@@ -543,11 +543,16 @@ func TestStopAfterRedeploySequenceEndsStopped(t *testing.T) {
 	deployName := DeployJobName(deployParams.Tenant, deployParams.Environment, deployParams.Version, "")
 
 	// The first stop already ran to completion; the environment was then
-	// redeployed and that Job is still active when the second stop runs.
+	// redeployed and that Job is still active when the second stop runs. The
+	// first stop is seeded Failed, not Succeeded: a genuine second stop must
+	// end up Succeeded, so if it instead replayed the first attempt's cached
+	// outcome, the outcome assertion below would catch it — seeding the first
+	// attempt Succeeded too would let a replay slip through undetected, since
+	// "succeeded" is what both the replay and a real run would report.
 	kube := fake.NewSimpleClientset(
 		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{Name: firstStopName, Namespace: stopParams.Namespace, Labels: lifecycleJobLabels(stopParams.Tenant, stopParams.Environment)},
-			Status:     batchv1.JobStatus{Succeeded: 1},
+			Status:     batchv1.JobStatus{Failed: 1},
 		},
 		&batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{Name: deployName, Namespace: deployParams.Namespace, Labels: lifecycleJobLabels(deployParams.Tenant, deployParams.Environment)},
@@ -564,9 +569,17 @@ func TestStopAfterRedeploySequenceEndsStopped(t *testing.T) {
 		t.Fatalf("run second stop: %v", err)
 	}
 	if result.Outcome != OutcomeSucceeded {
-		t.Fatalf("second stop outcome = %q, want succeeded — the environment must end up stopped", result.Outcome)
+		t.Fatalf("second stop outcome = %q, want succeeded — the environment must end up stopped, not replay the first attempt's failed outcome", result.Outcome)
 	}
 	if created() == nil {
 		t.Fatal("the second stop did not create its own fresh job — it was confused by, or replayed, an unrelated job")
+	}
+
+	jobs, err := kube.BatchV1().Jobs(stopParams.Namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(jobs.Items) != 3 {
+		t.Fatalf("jobs in namespace = %d, want 3 (the failed first stop, the active redeploy, and the new second stop)", len(jobs.Items))
 	}
 }

--- a/erun-backend/erun-backend-api/internal/jobexec/job.go
+++ b/erun-backend/erun-backend-api/internal/jobexec/job.go
@@ -70,6 +70,14 @@ func (r *Runner) Run(ctx context.Context, job *batchv1.Job) (Result, error) {
 	return r.watch(ctx, job.Namespace, job.Name)
 }
 
+// Watch blocks on an already-created Job by name until it reaches a terminal
+// state, without attempting to create it. Used when a caller has already
+// determined — by some means other than this Job's own name — that a Job for
+// its current attempt exists and is still in flight.
+func (r *Runner) Watch(ctx context.Context, namespace, name string) (Result, error) {
+	return r.watch(ctx, namespace, name)
+}
+
 func (r *Runner) watch(ctx context.Context, namespace, name string) (Result, error) {
 	for {
 		job, err := r.kube.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -113,4 +121,13 @@ func jobOutcome(job *batchv1.Job) (Outcome, bool) {
 		return OutcomeFailed, true
 	}
 	return "", false
+}
+
+// IsTerminal reports whether a Job has already reached a terminal outcome —
+// exported so a caller deciding whether an existing Job is still in flight
+// (rather than one this package created and is about to watch) can ask the
+// same question this package asks of its own Jobs.
+func IsTerminal(job *batchv1.Job) bool {
+	_, done := jobOutcome(job)
+	return done
 }

--- a/erun-backend/erun-backend-api/internal/provision/lifecycle.go
+++ b/erun-backend/erun-backend-api/internal/provision/lifecycle.go
@@ -55,10 +55,16 @@ type EnvLifecycleInput struct {
 	PlacementKubernetesContext string
 	PlacementServerURL         string
 	// DeleteID identifies one explicit delete attempt (see
-	// EnvDeleteInput.DeleteID) and is threaded only into the delete Job's
-	// name, never into stop's — a stop request carries no attempt id and
-	// stays keyed on tenant+environment.
+	// EnvDeleteInput.DeleteID) and is threaded into the delete Job's name.
 	DeleteID string
+	// StopID identifies one explicit stop attempt, mirroring DeleteID: it is
+	// threaded into the stop Job's name so a fresh stop gets a fresh Job
+	// rather than replaying a prior attempt's terminal outcome. Unlike
+	// delete, stop has no durable workflow of its own to carry it across a
+	// resume, so the caller (routes.EnvironmentRoutes) mints a fresh one on
+	// every explicit stop request; deployexec.Launcher.RunStop is what still
+	// re-watches a genuinely in-flight stop rather than starting a second.
+	StopID string
 }
 
 // EnvLifecycle runs a hosted env's stop/delete Job to a terminal outcome and
@@ -140,6 +146,7 @@ func (l *EnvLifecycle) Stop(ctx context.Context, input EnvLifecycleInput) error 
 		Namespace:      l.config.PlatformNamespace,
 		Image:          l.image(ctx, input.Tenant, input.RunningVersion),
 		ServiceAccount: l.config.DeployerServiceAccount,
+		StopID:         input.StopID,
 		Placement:      placement,
 	})
 	if err != nil {

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -157,6 +157,7 @@ func (r EnvironmentRoutes) stopEnvironment(w http.ResponseWriter, req *http.Requ
 		writeError(w, http.StatusInternalServerError, "failed to resolve environment placement")
 		return
 	}
+	input.StopID = uuid.NewString()
 	if err := r.lifecycle.Stop(ctx, input); err != nil {
 		writeError(w, http.StatusBadGateway, "failed to stop environment: "+err.Error())
 		return


### PR DESCRIPTION
## Summary

`StopJobName` had no per-attempt component, so `jobexec.Runner.Run`'s tolerance for `AlreadyExists` made a fresh stop watch a *previous, already-terminal* stop Job and replay its cached outcome instead of running again: stop → redeploy → stop again within the first Job's TTL reported success while the environment kept running. `DeployID`/`DeleteID` already carry a per-attempt id for exactly this reason; `StopID` now does too, threaded the same way (`routes.stopEnvironment` mints `uuid.NewString()` → `EnvLifecycleInput.StopID` → `provision.EnvLifecycle.Stop` → `deployexec.StopJobParams.StopID` → `StopJobName`).

In-flight dedup is preserved deliberately: unlike deploy/delete, an explicit stop has no durable workflow or DB-level claim to carry an attempt id across a resume, so `Launcher.RunStop` reconstructs that dedup itself — `activeStopJobName` lists Jobs by the shared tenant+environment labels, filters to the `erun-stop-` prefix, and re-watches (via the new `jobexec.Runner.Watch`) any Job that is not yet terminal. Only when none is found does it mint a fresh `StopID`-keyed Job, which is what stops a lingering terminal Job's outcome from being replayed.

## What I inherited and had to correct

Resuming this branch after a pod restart mid-run. Most of the inherited diff was sound (`StopJobParams.StopID`, `StopJobName`'s per-attempt suffix, `jobexec.Runner.Watch`/`IsTerminal`, `provision.EnvLifecycleInput.StopID` threading, `routes.stopEnvironment` minting the id, and all four new/updated tests) — but `RunStop` itself still had the previous agent's mid-flight experiment left active:

```go
params.StopID = "" // simulate pre-fix bug: StopID ignored
return l.stopRunner.Run(ctx, buildStopJob(params))
```

i.e. the fix was still reverted in the worktree, and the new `activeStopJobName` helper was defined but never called. I removed the revert line and wired `RunStop` to call `activeStopJobName` first, re-watching an in-flight Job via `Watch` or falling through to `Run` for a fresh attempt.

I also found and fixed a real gap in the inherited `TestStopAfterRedeploySequenceEndsStopped`: it seeded the *first* stop Job as already `Succeeded`, so a replayed cached outcome and a genuine fresh run both report "succeeded" — the test passed even against the reverted code. I re-seeded that Job `Failed` (mirroring `TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops`'s same choice) and added a job-count assertion, so a replay is now observably wrong.

Traced every production caller of `StopJobName`/`RunStop`/`Stop`: `routes.stopEnvironment` is the only caller of `provision.EnvLifecycle.Stop`, and it mints a fresh `StopID` on every call — no unthreaded caller exists. `EnvDeleteInput.lifecycleInput()` (used only for delete) leaves `StopID` empty, which is fine since it never reaches `RunStop`.

## Verification

**Failure before the fix** (reverted in a scratch `git worktree`, never in this worktree — both the `StopID`-ignoring `StopJobName` and the `activeStopJobName`-free `RunStop` from before this fix):
```
=== RUN   TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops
    lifecycle_job_test.go:430: old and new stop attempts share the job name "erun-stop-acme-prod"
--- FAIL: TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops (0.00s)
=== RUN   TestRunStopWhileStopJobStillRunningReWatchesIt
    lifecycle_job_test.go:498: a second stop job "erun-stop-acme-prod" was created while "erun-stop-acme-prod" was still in flight
--- FAIL: TestRunStopWhileStopJobStillRunningReWatchesIt (0.00s)
=== RUN   TestStopAfterRedeploySequenceEndsStopped
    lifecycle_job_test.go:572: second stop outcome = "failed", want succeeded — the environment must end up stopped, not replay the first attempt's failed outcome
--- FAIL: TestStopAfterRedeploySequenceEndsStopped (0.00s)
FAIL
```

**Passing after restoring the fix** (this branch):
```
=== RUN   TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops
--- PASS: TestRunStopAfterPreviousTerminalJobCreatesANewJobAndStops (0.00s)
=== RUN   TestRunStopWhileStopJobStillRunningReWatchesIt
--- PASS: TestRunStopWhileStopJobStillRunningReWatchesIt (0.00s)
=== RUN   TestStopAfterRedeploySequenceEndsStopped
--- PASS: TestStopAfterRedeploySequenceEndsStopped (0.00s)
PASS
ok  	github.com/sophium/erun/erun-backend/erun-backend-api/internal/deployexec	0.013s
```

**`make check`**: `exited 0: make check, 6855 bytes of output` ... `ok  coverage 75.8% (>= 75.8%)`.

**`erun-backend-api` module `go test ./...`** (per its AGENTS.md, not otherwise covered by `make check`): all packages `ok`.

No real environment was stopped, deployed, or deleted — all verification is against the fake Kubernetes clientset in this package's own unit tests.

Closes #1678