### PR TITLE
Name the signed-in identity and add sign-out on the console's not-enrolled screen

### DIFF
--- a/erun-console/src/App.test.tsx
+++ b/erun-console/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from './App';
@@ -162,5 +162,40 @@ describe('App tenant switch mismatch', () => {
 
     await screen.findByRole('heading', { level: 1, name: 'Overview' });
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+// erun#1680: a signed-in-but-unenrolled user was stuck on the not-enrolled
+// card with no way to sign in as a different account. Sign-out has to
+// actually return the whole app to the sign-in flow, not just fire a callback.
+describe('App not-enrolled route', () => {
+  it('returns to the sign-in flow when the operator signs out from the not-enrolled card', async () => {
+    vi.stubEnv('VITE_DEV_BEARER_TOKEN', 'dev-token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL) => {
+        const url = input instanceof URL ? input.href : input;
+        if (url.includes('/v1/platform')) {
+          return Promise.resolve(jsonResponse(PLATFORM));
+        }
+        if (url.includes('/v1/config')) {
+          return Promise.resolve({
+            ok: false,
+            status: 401,
+            json: () => Promise.resolve({}),
+          } as unknown as Response);
+        }
+        return Promise.resolve(jsonResponse([]));
+      }),
+    );
+
+    renderWithStore(<App />);
+
+    await screen.findByText('Not yet part of a tenant');
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign out' }));
+
+    expect(
+      await screen.findByRole('heading', { level: 2, name: 'What makes Acme different' }),
+    ).toBeInTheDocument();
   });
 });

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -174,7 +174,7 @@ function AppContent({
         />
       );
     case 'not-enrolled':
-      return <NotEnrolledScreen brand={brand} token={state.token} />;
+      return <NotEnrolledScreen brand={brand} token={state.token} onSignOut={onSignOut} />;
     case 'error':
       return <ErrorScreen brand={brand} message={state.message} />;
     case 'ready':

--- a/erun-console/src/shell/PreShellScreens.test.tsx
+++ b/erun-console/src/shell/PreShellScreens.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NotEnrolledScreen } from './PreShellScreens';
+
+// Builds a JWT-shaped string with the given payload — the same shape
+// src/auth/identity.test.ts uses, since NotEnrolledScreen decodes the token
+// the same way.
+function tokenWith(payload: Record<string, unknown>): string {
+  const encode = (value: string): string => {
+    const bytes = new TextEncoder().encode(value);
+    const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  };
+  return `${encode('{"alg":"RS256"}')}.${encode(JSON.stringify(payload))}.signature`;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('NotEnrolledScreen', () => {
+  it('names the user from the email claim and still shows the subject for the operator', () => {
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({
+          sub: '387534471668170904',
+          email: 'someone@example.com',
+          iss: 'https://auth.example.com',
+        })}
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    const identityLine = screen.getByText(/Give them this identity:/);
+    expect(identityLine).toHaveTextContent('someone@example.com');
+    expect(identityLine).toHaveTextContent('subject 387534471668170904');
+    expect(identityLine).toHaveTextContent('https://auth.example.com');
+  });
+
+  it('degrades to the subject alone, not a blank name, when the token carries no email claim', () => {
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904', iss: 'https://auth.example.com' })}
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    const identityLine = screen.getByText(/Give them this identity:/);
+    expect(identityLine).toHaveTextContent('387534471668170904');
+    expect(identityLine).not.toHaveTextContent('subject 387534471668170904');
+  });
+
+  it('offers a sign-out so a wrongly-signed-in user can sign in as someone else', () => {
+    const onSignOut = vi.fn();
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904' })}
+        onSignOut={onSignOut}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/erun-console/src/shell/PreShellScreens.tsx
+++ b/erun-console/src/shell/PreShellScreens.tsx
@@ -1,4 +1,5 @@
-import { LoaderCircle } from 'lucide-react';
+import { Button } from 'erun-kit';
+import { LoaderCircle, LogOut } from 'lucide-react';
 import type * as React from 'react';
 
 import { readTokenIdentity } from '../auth/identity';
@@ -18,14 +19,18 @@ export function LoadingScreen({ brand }: { brand: string | undefined }): React.R
 // NotEnrolledScreen is the dead end a self-signed-up user hits: OIDC
 // succeeded, so a token is held, but the API rejects the identity because it
 // is enrolled in no tenant. This says what actually has to happen (an
-// operator must enrol them) and names the identity an operator needs in order
-// to do it — signing in again just returns here (#1167).
+// operator must enrol them), names the identity an operator needs in order to
+// do it, and offers a sign-out — signing in again as the *same* identity just
+// returns here, but signing in as a different one is the actual escape, so
+// this screen must not be a true dead end for that case.
 export function NotEnrolledScreen({
   brand,
   token,
+  onSignOut,
 }: {
   brand: string | undefined;
   token: string;
+  onSignOut: () => void;
 }): React.ReactElement {
   const identity = readTokenIdentity(token);
   const named = identity.email ?? identity.subject;
@@ -35,8 +40,8 @@ export function NotEnrolledScreen({
         You are signed in, but your account is not yet part of a tenant on this platform.
       </p>
       <p className="text-sm text-muted-foreground">
-        An operator has to enrol you before you can see any environments. Signing in again will not
-        change this.
+        An operator has to enrol you before you can see any environments. Signing in again as this
+        same account will not change that — sign out below if you meant to use a different one.
       </p>
       {named !== undefined && (
         <p className="text-xs text-muted-foreground">
@@ -47,6 +52,16 @@ export function NotEnrolledScreen({
           {identity.issuer !== undefined ? ` from ${identity.issuer}` : ''}
         </p>
       )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="justify-self-start"
+        onClick={onSignOut}
+      >
+        <LogOut aria-hidden="true" />
+        Sign out
+      </Button>
     </CenteredCard>
   );
 }

--- a/scripts/check-issue-references.mjs
+++ b/scripts/check-issue-references.mjs
@@ -168,7 +168,6 @@ export const issueReferenceBaseline = {
   'erun-console/src/identity/controller.ts': 1,
   'erun-console/src/shell/AppShell.tsx': 2,
   'erun-console/src/shell/ConsoleSidebar.tsx': 1,
-  'erun-console/src/shell/PreShellScreens.tsx': 1,
   'erun-console/src/shell/landingContent.ts': 1,
   'erun-console/src/shell/sections.ts': 3,
   'erun-kit/src/models/platformConfig.ts': 1,


### PR DESCRIPTION
## Summary

An unenrolled user landed on the console's "Not yet part of a tenant" card with no way to sign in as a different account short of clearing cookies, and the card's copy read as a hard dead end even though signing in as someone else is exactly the escape a sign-out enables. Observed live by the operator on `console.erunpaas.com`.

## What I confirmed before fixing

- **Which token is actually used.** The issue's hypothesis was that `App.tsx` passes the *access* token (opaque) rather than the *ID* token (always a JWT) as the bearer/display token. That is not what the code does: `auth.ts`'s `completeLogin` only ever extracts and stores `id_token` — its own comment states this is deliberate because an issuer's access token may be opaque. `state.token` flowing into `NotEnrolledScreen` is the ID token.
- **Why the name was still missing.** Per the OIDC Core spec (confirmed against Zitadel's own docs/discussions), an ID token omits `profile`/`email`-scope claims whenever an access token is *also* issued in the same response — which the Authorization Code flow always does — unless the app has "User Info inside ID Token" enabled. The console currently has no way to reach those claims (the access token that could call `/oidc/v1/userinfo` for them is discarded), so a token that lacks them isn't a console bug so much as a Zitadel-app-config fact this PR can't reach from client code.
- Given that, `readTokenIdentity`'s existing `email ?? preferred_username ?? subject` fallback in `identity.ts` already degrades correctly — it just had no test coverage at the screen level, and the screen offered no way to sign out and try a different identity.

## Changes

- `NotEnrolledScreen` (`erun-console/src/shell/PreShellScreens.tsx`) now takes an `onSignOut` callback and renders a "Sign out" button (same `Button`/`LogOut` treatment `ConsoleHeader` uses for the authenticated shell), wired through from `App.tsx`'s existing `onSignOut` handler — no second sign-out path.
- Reworded "Signing in again will not change this" to "Signing in again as this same account will not change that — sign out below if you meant to use a different one," so the copy names the actual escape instead of reading as a dead end.
- Fixed a pre-existing issue-reference-in-comment violation this edit touched (`#1167` in the comment I rewrote) and lowered its now-stale baseline entry in `scripts/check-issue-references.mjs`.

## Test plan

- [x] `erun-console/src/shell/PreShellScreens.test.tsx` (new): a token with an email claim renders the email *and* still shows the subject; a token with neither degrades to subject-only (not blank); clicking "Sign out" invokes the callback.
- [x] `erun-console/src/App.test.tsx`: end-to-end, driving the app to the not-enrolled state via a 401 config response and asserting sign-out actually returns the app to the sign-in (`LandingScreen`) flow, not just firing a callback.
- [x] The identity decode stays display-only — no new code path added that uses `identity.subject`/`identity.email` for an authorization decision; `onSignOut` is a plain UI callback into the existing `signOut()` + `clearAuth()` path.
- [x] `erun-console`: `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn build`, `yarn test` (130 passed) all green.
- [x] `make test-frontend` green (erun-kit + erun-ui/frontend issue-reference gate + erun-console gates).
- [ ] `make check` — running now.
- Not independently verified: the actual live Zitadel token shape (I could not reach the live platform from this environment); the root-cause analysis above is grounded in the OIDC Core spec and Zitadel's own documentation/discussions, not a decoded token from this incident.

Closes #1680