### PR TITLE
Let enrollment target a tenant's own org, so a new tenant is not inert

### DIFF
--- a/erun-backend/erun-backend-api/internal/routes/identity.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity.go
@@ -169,6 +169,12 @@ type enrollIdentityUserRequest struct {
 	Email     string `json:"email"`
 	FirstName string `json:"firstName,omitempty"`
 	LastName  string `json:"lastName,omitempty"`
+	// OrgID enrolls into another organization rather than the platform's own
+	// -- the identity boundary another tenant resolves by, and the only way a
+	// newly created tenant can receive its first user. No erun user row is
+	// written in that case; the target tenant's own first-user bootstrap
+	// enrols them, with full access, on their first sign-in.
+	OrgID string `json:"orgId"`
 }
 
 // enrollIdentityUserResponse always carries IdPUser once the IdP half
@@ -232,6 +238,7 @@ func (r IdentityRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 		FirstName: strings.TrimSpace(body.FirstName),
 		LastName:  strings.TrimSpace(body.LastName),
 		Issuer:    securityContext.ExternalIssuer,
+		OrgID:     strings.TrimSpace(body.OrgID),
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrIdentityMappingFailed) {

--- a/erun-backend/erun-backend-api/internal/service/identity.go
+++ b/erun-backend/erun-backend-api/internal/service/identity.go
@@ -5,6 +5,7 @@ import (
 	cryptorand "crypto/rand"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
@@ -57,6 +58,19 @@ type EnrollIdentityParams struct {
 	FirstName string
 	LastName  string
 	Issuer    string
+	// OrgID enrolls into another organization: the identity boundary a
+	// different tenant resolves by. It is what makes a freshly created
+	// tenant reachable at all — without it every enrollment lands in the
+	// platform's own org, so a new tenant can never receive a token that
+	// resolves to it, never gets a first user, and can never own an
+	// environment.
+	//
+	// No erun-side user row is written in that case, and that is not a
+	// failure: the caller's tenant is not the new user's, and row-level
+	// security would file them under the wrong one. The target tenant's own
+	// first-user bootstrap enrolls them, with full access, on their first
+	// sign-in.
+	OrgID string
 }
 
 // EnrollIdentityResult reports what actually landed. ErunUser is the zero
@@ -77,6 +91,10 @@ type EnrollIdentityResult struct {
 	ErunUser               model.User
 	MailDeliveryConfigured bool
 	TemporaryPassword      string
+	// MappingDeferred reports that no erun user row was written because the
+	// identity was enrolled into another tenant's org, so a zero ErunUser
+	// here means "by design", not "the mapping failed".
+	MappingDeferred bool
 }
 
 // Enroll creates the IdP identity first — the erun mapping needs the
@@ -103,6 +121,7 @@ func (s *IdentityService) Enroll(ctx context.Context, params EnrollIdentityParam
 		Email:     params.Email,
 		FirstName: params.FirstName,
 		LastName:  params.LastName,
+		OrgID:     params.OrgID,
 	}
 	if !mailStatus.Configured {
 		temporaryPassword, err := generateTemporaryPassword()
@@ -115,6 +134,18 @@ func (s *IdentityService) Enroll(ctx context.Context, params EnrollIdentityParam
 	idpUser, err := s.admin.CreateHumanUser(ctx, createParams)
 	if err != nil {
 		return EnrollIdentityResult{}, fmt.Errorf("create identity provider user: %w", err)
+	}
+
+	// Enrolled into another tenant's org: stop at the IdP half. See
+	// EnrollIdentityParams.OrgID for why writing an erun user here would file
+	// them under the caller's tenant instead of their own.
+	if strings.TrimSpace(params.OrgID) != "" {
+		return EnrollIdentityResult{
+			IdPUser:                idpUser,
+			MailDeliveryConfigured: mailStatus.Configured,
+			TemporaryPassword:      createParams.InitialPassword,
+			MappingDeferred:        true,
+		}, nil
 	}
 
 	erunUser, err := s.users.Create(ctx, repository.CreateUserParams{

--- a/erun-backend/erun-backend-api/internal/service/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/service/identity_test.go
@@ -153,3 +153,63 @@ func TestIdentityServiceEnrollReportsOrphanedIdPUserOnMappingFailure(t *testing.
 		t.Fatalf("result.ErunUser = %+v, want the zero value on a mapping failure", result.ErunUser)
 	}
 }
+
+// Enrolling into another tenant's org is what makes a freshly created tenant
+// reachable: without it every identity lands in the platform's own org, so
+// the new tenant never receives a token that resolves to it, never gets a
+// first user, and can never own an environment.
+func TestIdentityServiceEnrollTargetsAnotherOrg(t *testing.T) {
+	admin := &stubIdentityAdmin{
+		created:    zitadel.User{ID: "idp-9", Username: "bob", Email: "bob@example.com"},
+		smtpStatus: zitadel.SMTPStatus{Configured: true},
+	}
+	users := &stubIdentityUserCreator{}
+	svc := NewIdentityService(admin, users)
+
+	result, err := svc.Enroll(context.Background(), EnrollIdentityParams{
+		Username: "bob", Email: "bob@example.com", Issuer: "https://auth.example.com",
+		OrgID: "388520359030161586",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if admin.gotParams.OrgID != "388520359030161586" {
+		t.Fatalf("OrgID reached the IdP as %q", admin.gotParams.OrgID)
+	}
+	// The erun row would land under the caller's tenant, not the new user's,
+	// so it is deliberately not written — the target tenant's own first-user
+	// bootstrap enrols them on first sign-in.
+	if users.createCalls != 0 {
+		t.Fatalf("createCalls = %d, want no erun user written for a cross-org enrollment", users.createCalls)
+	}
+	if !result.MappingDeferred {
+		t.Fatal("MappingDeferred must say the zero ErunUser is by design, not a failure")
+	}
+	if result.IdPUser.ID != "idp-9" {
+		t.Fatalf("IdPUser = %+v", result.IdPUser)
+	}
+}
+
+// The default path is unchanged: no org means the platform's own, and the
+// erun mapping is still written.
+func TestIdentityServiceEnrollWithoutOrgStillWritesTheMapping(t *testing.T) {
+	admin := &stubIdentityAdmin{
+		created:    zitadel.User{ID: "idp-10", Username: "carol"},
+		smtpStatus: zitadel.SMTPStatus{Configured: true},
+	}
+	users := &stubIdentityUserCreator{created: model.User{UserID: "erun-10", Username: "carol"}}
+	svc := NewIdentityService(admin, users)
+
+	result, err := svc.Enroll(context.Background(), EnrollIdentityParams{
+		Username: "carol", Email: "carol@example.com", Issuer: "https://auth.example.com",
+	})
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if admin.gotParams.OrgID != "" {
+		t.Fatalf("OrgID = %q, want the credential's own org", admin.gotParams.OrgID)
+	}
+	if users.createCalls != 1 || result.MappingDeferred {
+		t.Fatalf("createCalls = %d deferred = %v, want the mapping written", users.createCalls, result.MappingDeferred)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/zitadel/client.go
+++ b/erun-backend/erun-backend-api/internal/zitadel/client.go
@@ -112,7 +112,28 @@ func (e *APIError) NotFound() bool {
 
 const errorBodyTruncateLimit = 500
 
+// callInOrg is call, addressed at one organization instead of the
+// credential's own. Zitadel scopes a Management API call by the
+// x-zitadel-orgid header, so the same org-owner credential can act in an org
+// it did not create — which is what lets a tenant's first user be created in
+// the org that tenant resolves by. An empty orgID is exactly call.
+func (c *Client) callInOrg(ctx context.Context, orgID string, method string, path string, body any, out any) error {
+	return c.callWithHeaders(ctx, method, path, body, out, orgHeaders(orgID))
+}
+
+func orgHeaders(orgID string) map[string]string {
+	orgID = strings.TrimSpace(orgID)
+	if orgID == "" {
+		return nil
+	}
+	return map[string]string{"x-zitadel-orgid": orgID}
+}
+
 func (c *Client) call(ctx context.Context, method string, path string, body any, out any) error {
+	return c.callWithHeaders(ctx, method, path, body, out, nil)
+}
+
+func (c *Client) callWithHeaders(ctx context.Context, method string, path string, body any, out any, headers map[string]string) error {
 	var reader io.Reader
 	if body != nil {
 		encoded, err := json.Marshal(body)
@@ -132,6 +153,9 @@ func (c *Client) call(ctx context.Context, method string, path string, body any,
 	req.Host = c.externalDomain
 	req.Header.Set("Authorization", "Bearer "+c.pat)
 	req.Header.Set("Content-Type", "application/json")
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("call zitadel management api %s %s: %w", method, path, err)
@@ -247,6 +271,9 @@ type CreateHumanUserParams struct {
 	FirstName       string
 	LastName        string
 	InitialPassword string
+	// OrgID creates the user in that organization rather than the
+	// credential's own. Empty keeps today's behaviour.
+	OrgID string
 }
 
 // CreateHumanUser creates a new human user in Zitadel. See
@@ -284,7 +311,7 @@ func (c *Client) CreateHumanUser(ctx context.Context, params CreateHumanUserPara
 	var resp struct {
 		UserID string `json:"userId"`
 	}
-	if err := c.call(ctx, http.MethodPost, "/management/v1/users/human", body, &resp); err != nil {
+	if err := c.callInOrg(ctx, params.OrgID, http.MethodPost, "/management/v1/users/human", body, &resp); err != nil {
 		return User{}, err
 	}
 	state := "USER_STATE_INITIAL"

--- a/erun-docs/docs/agent-reference/identity-administration.md
+++ b/erun-docs/docs/agent-reference/identity-administration.md
@@ -20,6 +20,21 @@ Every operation is a named endpoint below, mapped to one specific Zitadel Manage
 
 Zitadel's built-in `ORG_USER_MANAGER` role would scope user create/list/deactivate/reactivate more narrowly than org-owner. Org policy management (login policy, password complexity) has no built-in role short of org-owner, though. Minting a second, narrower machine-user credential for only the user-CRUD half was considered and rejected for this increment: it would shrink the blast radius for half the surface while adding a second bootstrap-managed credential to operate, and the compensating control — an enumerated, non-proxying endpoint surface (previous section) — already applies uniformly. The single org-owner credential is used for the whole surface; this is a recorded decision, not a default.
 
+## Enrolling into another organization
+
+`POST /v1/identity/users` takes an optional `orgId`. Without it the identity is created in the platform's own organization, as before. With it, the identity is created in **that** organization — the identity boundary another tenant resolves by.
+
+```jsonc
+// POST /v1/identity/users
+{ "username": "alice", "email": "alice@example.com", "orgId": "388520359030161586" }
+```
+
+This is what makes a newly created tenant usable at all. A tenant's first admin arrives through the [per-tenant first-user bootstrap](/agent-reference/api-protocol#tenant-issuers) — the first valid token that resolves to it — and a token resolves to it only when its org claim is that tenant's org. Without `orgId` every enrollment lands in the platform's own org, so a fresh tenant can never receive such a token, never gets a first user, and can never own an environment: created, and inert.
+
+**No erun user row is written for a cross-org enrollment, and that is not a failure.** The caller's tenant is not the new user's, and row-level security would file them under the wrong one. The response reports `mappingDeferred`, so a zero erun user there means "by design" rather than "the mapping failed" — the target tenant's own first-user bootstrap enrolls them, with full access, on their first sign-in.
+
+Zitadel scopes a Management API call by an `x-zitadel-orgid` header, so the same org-owner credential acts in an org it did not create; no additional IdP privilege is involved.
+
 ## `POST /v1/identity/orgs`
 
 Creates a Zitadel **organization** — the per-tenant identity boundary an org-scoped issuer resolves tenants by.


### PR DESCRIPTION
Closes the gap that made everything #1605 built stop one step short: a tenant that can be created and then never used.

## The problem

A tenant's first admin arrives through the per-tenant first-user bootstrap — the first valid token that resolves to it — and a token resolves to it only when its org claim is that tenant's org. Every enrollment landed in the platform's **own** org: `EnrollIdentityParams` had no org field, and the Zitadel client never sent an org header (`grep -n 'x-zitadel-orgid\|OrgID' internal/zitadel/client.go` → nothing).

Nor could an operations caller route around it: `POST /v1/environments` resolves the tenant from the token and *never* from the body, by design. So a freshly created tenant could not receive a token that resolved to it, could not get a first user, and could not own an environment.

Found by doing it. Against the live platform today, all of this worked:

```
POST /v1/identity/orgs   {"name":"validationagent"}  -> 201 {"id":"388520359030161586"}
PATCH /v1/tenant-issuers {orgFieldKey,orgFieldValue} -> 200  issuer org-scoped, frs backfilled
platform tenant create --org-field-value 388…586     -> tenant 01a05169-…
```

…and then there was no way to put a user in `388520359030161586`.

## The change

`POST /v1/identity/users` takes an optional `orgId`. Zitadel scopes a Management API call by `x-zitadel-orgid`, so the same org-owner credential acts in an org it did not create — a client parameter, not new IdP privilege. Omitted, behaviour is byte-for-byte as before.

A cross-org enrollment **deliberately stops at the IdP half**. Writing the erun user row would file the new user under the *caller's* tenant, which row-level security scopes it to and which is not theirs. The result reports `mappingDeferred`, so a zero `ErunUser` reads as "by design" rather than "the mapping failed" — the target tenant's own first-user bootstrap enrols them, with full access, on their first sign-in.

## Tests

Cross-org enrollment reaches the IdP with the org and writes **no** erun row, reporting `MappingDeferred`; the default path still targets the credential's own org and still writes the mapping. `internal/service`, `internal/routes` and `internal/zitadel` suites pass; `go build` and `gofmt` clean.

## What this completes

The full onboarding sequence is now API-driven end to end:

1. `POST /v1/identity/orgs` — create the org *(1.0.213)*
2. `PATCH /v1/tenant-issuers` — convert a single-tenant issuer *(1.0.211)*
3. `POST /v1/tenants` — register the tenant against that org
4. `POST /v1/identity/users` with `orgId` — its first user *(this PR)*
5. that user signs in → first-user bootstrap makes them admin → they register environments

Closes #1675