### PR TITLE
Bound the ERun settings dialog to the viewport and let its body scroll

### DIFF
--- a/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
+++ b/erun-ui/frontend/src/components/app/GlobalConfigDialogView.tsx
@@ -42,14 +42,18 @@ export function GlobalConfigDialogView(): React.ReactElement {
       }}
     >
       <DialogContent
-        className="sm:max-w-xl"
+        // Bound the panel to the viewport and let the body scroll, same shape as
+        // EnvironmentDialogView — cloud aliases and cloud contexts grow this
+        // dialog's content without limit, so a plain centered grid overflows off
+        // both edges with nothing scrollable.
+        className="flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
         onCloseAutoFocus={(event) => {
           event.preventDefault();
           controller.focusTerminalSoon();
         }}
       >
         <form
-          className="grid gap-4"
+          className="flex min-h-0 flex-1 flex-col"
           onSubmit={(event) => {
             event.preventDefault();
             void dispatch(submitGlobalConfig()).catch((error: unknown) => {
@@ -57,15 +61,21 @@ export function GlobalConfigDialogView(): React.ReactElement {
             });
           }}
         >
-          <DialogHeader>
-            <DialogTitle>ERun settings</DialogTitle>
-            <DialogDescription>
-              Default tenant, cloud aliases, and cloud contexts shared across the app.
-            </DialogDescription>
-          </DialogHeader>
-          <GlobalConfigBody />
-          <DialogError error={dialog.error} />
-          <GlobalConfigFooter dialog={dialog} />
+          <div className="shrink-0 px-6 pt-6 pb-4">
+            <DialogHeader>
+              <DialogTitle>ERun settings</DialogTitle>
+              <DialogDescription>
+                Default tenant, cloud aliases, and cloud contexts shared across the app.
+              </DialogDescription>
+            </DialogHeader>
+          </div>
+          <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto px-6 pb-1">
+            <GlobalConfigBody />
+            <DialogError error={dialog.error} />
+          </div>
+          <div className="shrink-0 border-t px-6 pt-4 pb-6">
+            <GlobalConfigFooter dialog={dialog} />
+          </div>
         </form>
       </DialogContent>
     </Dialog>

--- a/erun-ui/playwright/tests/env-init.spec.ts
+++ b/erun-ui/playwright/tests/env-init.spec.ts
@@ -487,10 +487,7 @@ test.describe('environment init dialog', () => {
     await app.envInitDialog.waitForClosed();
   });
 
-  test('offers the hosted registry only once it is confirmed reachable', async ({
-    app,
-    page,
-  }) => {
+  test('offers the hosted registry only once it is confirmed reachable', async ({ app, page }) => {
     // The reported defect: the hosted-registry option was offered
     // unconditionally, with no check that registry.erunpaas.com was actually
     // reachable, unlike the in-cluster registry which is already gated on

--- a/erun-ui/playwright/tests/global-config.spec.ts
+++ b/erun-ui/playwright/tests/global-config.spec.ts
@@ -4,6 +4,20 @@ import { boundingBoxOf } from '../fixtures/boundingBox.js';
 import { test, expect } from '../fixtures/erunApp.js';
 import { SEED_TENANT } from '../fixtures/seedRoot.js';
 
+function manyCloudContexts(count: number): Record<string, unknown>[] {
+  return Array.from({ length: count }, (_, index) => ({
+    name: `pw-ctx-${String(index)}`,
+    provider: 'aws',
+    cloudProviderAlias: 'me+aws@aws',
+    region: 'eu-west-2',
+    instanceType: 'c8gd.2xlarge',
+    diskType: 'gp3',
+    diskSizeGb: 100,
+    kubernetesContext: `pw-ctx-${String(index)}`,
+    status: 'running',
+  }));
+}
+
 interface StubbedResponse {
   data?: Record<string, unknown> | unknown[];
   error?: string;
@@ -195,5 +209,117 @@ test.describe('global config dialog — cloud aliases add actions and erun provi
 
     await app.globalConfigDialog.cancel();
     await app.globalConfigDialog.waitForClosed();
+  });
+});
+
+test.describe('global config dialog — bounded height and scroll', () => {
+  test('overflowing cloud contexts keep the title and footer reachable, and the body scrolls', async ({
+    app,
+    page,
+  }) => {
+    // 12 contexts is far more than fits in an 85vh frame at any viewport this
+    // suite uses, so the body region must be what scrolls, not the dialog
+    // growing past its cap -- the regression this guards.
+    stubRPC(page, {
+      LoadERunConfig: {
+        data: {
+          defaultTenant: SEED_TENANT,
+          cloudProviders: [
+            {
+              alias: 'me+aws@aws',
+              provider: 'aws',
+              status: 'active',
+              username: 'me',
+              accountId: '111111111111',
+            },
+            {
+              alias: 'me+cloudflare@cloudflare',
+              provider: 'cloudflare',
+              status: 'active',
+              username: 'me',
+            },
+            {
+              alias: 'erun+api.acme.test@erun',
+              provider: 'erun',
+              status: 'active',
+              username: 'erun',
+              accountId: 'api.acme.test',
+            },
+          ],
+          cloudContexts: manyCloudContexts(12),
+        },
+      },
+    });
+
+    await app.sidebar.openSettings();
+    await app.globalConfigDialog.waitForOpen();
+
+    // The dialog's own frame (DialogContent's max-h-[85vh]) caps the whole
+    // surface regardless of how much is configured. The suite's config
+    // viewport is 1440x1200 and this test never changes it.
+    const dialog = app.globalConfigDialog.locator();
+    const dialogBox = await boundingBoxOf(dialog, 'ERun settings dialog');
+    expect(dialogBox.height).toBeLessThanOrEqual(1200 * 0.85 + 2);
+
+    // The title and the footer buttons must both land inside that bounded
+    // frame -- cut off above and cut off below is exactly the failure mode
+    // being guarded against.
+    const titleBox = await boundingBoxOf(
+      dialog.getByText('ERun settings', { exact: true }),
+      'ERun settings title',
+    );
+    expect(titleBox.y).toBeGreaterThanOrEqual(dialogBox.y - 1);
+    const cancelBox = await boundingBoxOf(
+      dialog.getByRole('button', { name: 'Cancel', exact: true }),
+      'Cancel button',
+    );
+    expect(cancelBox.y + cancelBox.height).toBeLessThanOrEqual(dialogBox.y + dialogBox.height + 1);
+    const saveBox = await boundingBoxOf(
+      dialog.getByRole('button', { name: /Save settings|Saving/ }),
+      'Save settings button',
+    );
+    expect(saveBox.y + saveBox.height).toBeLessThanOrEqual(dialogBox.y + dialogBox.height + 1);
+
+    // The body region -- not the dialog itself -- is what scrolls.
+    const bodyScroll = dialog.locator('.overflow-y-auto').first();
+    const { scrollHeight, clientHeight } = await bodyScroll.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+
+    await app.globalConfigDialog.cancel();
+    await app.globalConfigDialog.waitForClosed();
+  });
+
+  test('a short window keeps the title and footer buttons reachable without resizing', async ({
+    app,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 500 });
+
+    await app.sidebar.openSettings();
+    await app.globalConfigDialog.waitForOpen();
+
+    const dialog = app.globalConfigDialog.locator();
+    const dialogBox = await boundingBoxOf(dialog, 'ERun settings dialog');
+    expect(dialogBox.height).toBeLessThanOrEqual(500 * 0.85 + 2);
+
+    const titleBox = await boundingBoxOf(
+      dialog.getByText('ERun settings', { exact: true }),
+      'ERun settings title',
+    );
+    expect(titleBox.y).toBeGreaterThanOrEqual(0);
+    const cancelBox = await boundingBoxOf(
+      dialog.getByRole('button', { name: 'Cancel', exact: true }),
+      'Cancel button',
+    );
+    expect(cancelBox.y + cancelBox.height).toBeLessThanOrEqual(500);
+
+    await app.globalConfigDialog.cancel();
+    await app.globalConfigDialog.waitForClosed();
+
+    // Restore the config default viewport for later specs in the singleton backend.
+    await page.setViewportSize({ width: 1440, height: 1200 });
   });
 });


### PR DESCRIPTION
## Summary
- `GlobalConfigDialogView`'s `DialogContent` grew unbounded with cloud aliases/contexts and had no scroll container, so it overflowed off both edges at once: the "ERun settings" title cut off above, the footer buttons cut off below, leaving the dialog unsubmittable/uncancellable from its own controls.
- Applies the same bounded-frame/scrolling-body shape already established by `EnvironmentDialogView` and `ReviewDetailDialog` (`flex max-h-[85vh] flex-col overflow-hidden`, header and footer fixed, body `min-h-0 flex-1 overflow-y-auto`). Width (`sm:max-w-xl`) is unchanged.
- Also fixes two pre-existing gate failures encountered while getting `make check` green in this PR, unrelated to the dialog fix itself:
  - Stale Prettier formatting in `erun-ui/playwright/tests/env-init.spec.ts` (module-wide gate, now touched by this PR).
  - A `cyclop` complexity violation in `erun-backend-api`'s `zitadel.Client.callWithHeaders`, split into `newRequest`/`doRequest`/`decodeResponse` with no behavior change.

## UX Impact Review Checklist
1. **Affected paths:** Sidebar → "Open ERun settings" → `GlobalConfigDialogView`.
2. **User-visible sequence:** Dialog opens centered, bounded to 85% of viewport height; header ("ERun settings" + description) and footer (Cancel / Save settings) stay fixed; only the middle field region (default tenant, cloud aliases, cloud contexts) scrolls.
3. **State-without-affordance:** none — pure layout change, no new state.
4/5. **Visibility of system status / success-failure feedback:** unaffected — Cancel/Save behavior unchanged, now simply always reachable.
6. **Consistency with comparable flows:** matches `EnvironmentDialogView` and `ReviewDetailDialog` exactly (same className shape).
7. **Heuristic pass:** Nielsen #1 (visibility of status) — title and footer no longer disappear off-screen; #3 (user control) — Cancel/Save always reachable regardless of how much is configured.
8. **Playwright coverage:** `erun-ui/playwright/tests/global-config.spec.ts` — new describe block "global config dialog — bounded height and scroll" with two specs: one stages 12 cloud contexts (far more than fits) and asserts the dialog's own frame stays ≤85% of the 1200px config viewport, the title and footer buttons both land inside that frame, and the body region (not the dialog) is what scrolls; the other repeats the title/footer-reachable assertions at a short 1440×500 window.

## Test plan
- [x] `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn test` — all green (wailsjs bindings regenerated locally to match already-merged Go changes; no source changes needed there).
- [x] `erun-ui/playwright`: full suite (`./run.sh`) — 420 passed, including the 2 new specs and all existing `global-config.spec.ts`/`dialog-content-overflow.spec.ts` coverage.
- [x] `make check` — green (job `check-70713d69a3d3c88b`, exit 0), including `erun-integration`'s `make integration-test` (coverage 75.8% ≥ 75.8% gate).
- [x] Manually drove the real dialog via a throwaway Playwright script (no Playwright MCP browser tool was actually connected in this session, despite being expected — substituted the existing test harness) at both the default 1440×1200 viewport and a short 1440×500 window, staging 4 cloud contexts + 3 cloud aliases: screenshots confirmed the title and footer buttons are simultaneously visible with the body scrolled/clipped in between at both sizes. The throwaway spec and screenshots were deleted after verification.
- [x] No `ui/dialog.tsx` edit.
- [x] No new issue-number comments; `TestNoIssueReferenceInCode` gate covers this.

Closes #1685