### PR TITLE
Parallelise the lint and helm-chart-tests gate recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,44 @@ LINT_TIMEOUT ?= 15m
 
 LINT_MODULES := erun-common erun-cli erun-mcp erun-integration erun-backend/erun-backend-api erun-ui
 
-# Run golangci-lint across the gated modules, each against its own
-# .golangci.yml (erun-integration has none, so it uses the default linters).
-# Runs every module even when an earlier one has findings, then fails once at
-# the end, so one red module never hides the rest -- reporting a subset of
-# findings as if it were the whole answer is worse than reporting nothing.
-# golangci-lint must be on PATH (the image test stage installs it; locally,
-# install the version pinned in the repo-root GOLANGCI_LINT_VERSION file), and
-# it must actually be that pinned version: a newer install's vendored
-# analyzers can flag things the pinned one does not (and vice versa), so
-# `make lint` and the image build would otherwise silently disagree.
+# Bound on how many golangci-lint invocations run at once. Each invocation is
+# itself internally parallel (cgroup-aware GOMAXPROCS), so running every
+# LINT_MODULES entry at once already oversubscribes the machine -- measured on
+# a 12-core pod (warm cache, one file touched per module to force real
+# analysis rather than a full cache hit) to still win on wall-clock, because a
+# single module's own analysis has serial phases that leave cores idle: p1
+# (serial) 13.5s, p2 10.3s, p3 9.3s, p4 9.6s, p6 (all modules at once) 8.7s
+# wall, peak memory climbing from 2.5GiB at p1 to 4.1GiB at p6 (see erun#1690).
+# Scaled off `nproc` rather than a flat constant so a small pod runs fewer
+# concurrent golangci-lint processes -- each wants the full core count, and a
+# flat width sized for a 12-core pod would oversubscribe a 4-core one far
+# harder and multiply its peak memory for no wall-clock benefit it has the
+# cores to use anyway. Capped at the module count: more workers than modules
+# cannot help.
+LINT_PARALLELISM ?= $(shell n=$$(nproc 2>/dev/null || echo 4); m=$(words $(LINT_MODULES)); if [ "$$n" -lt "$$m" ]; then echo "$$n"; else echo "$$m"; fi)
+
+# Run golangci-lint across the gated modules concurrently (bounded by
+# LINT_PARALLELISM), each against its own .golangci.yml (erun-integration has
+# none, so it uses the default linters). Every module's combined stdout/stderr
+# is buffered by scripts/parallel-gate.sh and emitted atomically under its
+# ">> golangci-lint <module>" marker, in LINT_MODULES order, so concurrent
+# runs never shred each other's diagnostics. Runs every module even when an
+# earlier one has findings, then fails once at the end (with every failing
+# module named on the "lint failed in:" line), so one red module never hides
+# the rest -- reporting a subset of findings as if it were the whole answer is
+# worse than reporting nothing. golangci-lint must be on PATH (the image test
+# stage installs it; locally, install the version pinned in the repo-root
+# GOLANGCI_LINT_VERSION file), and it must actually be that pinned version: a
+# newer install's vendored analyzers can flag things the pinned one does not
+# (and vice versa), so `make lint` and the image build would otherwise
+# silently disagree. That version check runs once, up front, outside the
+# fan-out, so a missing/mismatched tool fails the whole target before any
+# golangci-lint process starts. `--allow-parallel-runners` is required here:
+# golangci-lint acquires a file lock around its (shared, ~/.cache/golangci-lint)
+# result cache by default and refuses a second concurrent instance ("parallel
+# golangci-lint is running"); the flag opts into golangci-lint's own supported
+# concurrent-runner mode, which is safe against the shared cache because cache
+# entries are keyed by file content hash, not writer identity.
 lint:
 	@pin=$$(tr -d '\n' < GOLANGCI_LINT_VERSION); \
 	pin_num=$${pin#v}; \
@@ -64,17 +92,9 @@ lint:
 		   echo "install the pinned version: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$$pin" >&2; \
 		   exit 1 ;; \
 	esac
-	@failed=""; \
-	for m in $(LINT_MODULES); do \
-		echo ">> golangci-lint $$m"; \
-		if ! (cd $$m && golangci-lint run --timeout $(LINT_TIMEOUT) ./...); then \
-			failed="$$failed $$m"; \
-		fi; \
-	done; \
-	if [ -n "$$failed" ]; then \
-		echo "lint failed in:$$failed" >&2; \
-		exit 1; \
-	fi
+	@for m in $(LINT_MODULES); do \
+		printf '%s\t%s\t%s\n' "$$m" "golangci-lint $$m" "cd $$m && golangci-lint run --allow-parallel-runners --timeout $(LINT_TIMEOUT) ./..."; \
+	done | ./scripts/parallel-gate.sh $(LINT_PARALLELISM) lint
 
 # erun-ui's own Go tests. See the LINT_MODULES comment above for why this is
 # a separate step rather than folded into integration-test or a contributor's
@@ -132,6 +152,16 @@ test-frontend:
 	@echo ">> erun-console gates"
 	@(cd erun-console && yarn typecheck && yarn lint && yarn format:check && yarn build && yarn test)
 
+# Bound on how many chart-test scripts run at once. Each is a single `helm
+# template` render (no cluster, no docker), so unlike lint this scales cleanly
+# with width and memory stays flat: measured on a 12-core pod at p1 2.7s, p2
+# 2.4s, p4 1.9s, p8 (every current script at once) 1.1s wall, ~1.25-1.3GiB
+# peak memory across all widths (see erun#1690). Scaled off `nproc` like
+# LINT_PARALLELISM anyway, capped at the actual script count, so a small pod
+# doesn't launch more `helm template` processes than it has cores for and a
+# growing k8s/ directory can't launch unboundedly many at once.
+HELM_CHART_TEST_PARALLELISM ?= $(shell n=$$(nproc 2>/dev/null || echo 4); m=$(words $(wildcard erun-devops/k8s/*_test.sh)); if [ "$$n" -lt "$$m" ]; then echo "$$n"; else echo "$$m"; fi)
+
 # Helm-render assertions for the erun-devops/k8s charts (erun-devops,
 # erun-backend-postgres, erun-backend-db, erun-backend-api, erun-oci-registry,
 # erun-zitadel, erun-console, erun-docs): each *_test.sh renders its chart with
@@ -139,12 +169,19 @@ test-frontend:
 # rendering -- so a pinned `helm` binary is all the image test stage needs to
 # run these (see the Dockerfile's test stage). Iterates the directory rather
 # than naming each script so a new chart's *_test.sh is picked up with no
-# Makefile edit.
+# Makefile edit. Scripts run concurrently (bounded by
+# HELM_CHART_TEST_PARALLELISM) via scripts/parallel-gate.sh, which buffers
+# each script's output and emits it atomically under its ">> <script>"
+# marker, then runs every script and reports every failing one on a single
+# "helm-chart-tests failed in:" line -- deliberately aggregate rather than
+# the prior fail-fast `|| exit 1`: once the scripts run in parallel, a
+# fail-fast exit has already paid for every other script's `helm template`
+# work, so discarding those results on the first failure buys nothing (see
+# erun#1690).
 helm-chart-tests:
 	@for t in erun-devops/k8s/*_test.sh; do \
-		echo ">> $$t"; \
-		sh "$$t" || exit 1; \
-	done
+		printf '%s\t%s\t%s\n' "$$t" "$$t" "sh $$t"; \
+	done | ./scripts/parallel-gate.sh $(HELM_CHART_TEST_PARALLELISM) helm-chart-tests
 
 # End-to-end proof that a postgres restart cannot destroy committed data,
 # against a real postgres and the real atlas migrations. Deliberately NOT part

--- a/scripts/parallel-gate.sh
+++ b/scripts/parallel-gate.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+# Runs a list of independent shell commands with bounded concurrency,
+# buffering each command's combined stdout/stderr so concurrent output never
+# interleaves, then emits every buffered block in input order under its own
+# marker line and aggregates every failure into one final report -- the same
+# contract the serial `for m in ...; do ...; done` loops it replaces had:
+# run everything, name every failure, exit non-zero iff anything failed.
+#
+# Each job is one line on stdin, tab-separated:
+#   <short-name>\t<marker-text>\t<command>
+# - short-name: bare identifier used in the aggregated failure line
+# - marker-text: text printed after ">> " (kept identical to the prior
+#   serial recipes' markers so log-grepping and tooling keep working)
+# - command: run via `sh -c`
+#
+# Usage: parallel-gate.sh <max-parallel> <failure-message-prefix>
+#
+# Exit status is 0 iff every job exits 0. On any failure, prints
+# "<failure-message-prefix> failed in:<space-separated short-names>" to
+# stderr (matching the exact "lint failed in:..." text the lint recipe
+# already produced) and exits 1.
+set -eu
+
+max_parallel=$1
+prefix=$2
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+tab=$(printf '\t')
+i=0
+running=0
+while IFS="$tab" read -r short_name marker cmd; do
+	i=$((i + 1))
+	printf '%s' "$short_name" > "$tmp/$i.name"
+	printf '%s' "$marker" > "$tmp/$i.marker"
+	(
+		if sh -c "$cmd" > "$tmp/$i.out" 2>&1; then
+			echo 0 > "$tmp/$i.rc"
+		else
+			echo 1 > "$tmp/$i.rc"
+		fi
+	) &
+	running=$((running + 1))
+	if [ "$running" -ge "$max_parallel" ]; then
+		wait
+		running=0
+	fi
+done
+wait
+
+total=$i
+failed=""
+j=1
+while [ "$j" -le "$total" ]; do
+	echo ">> $(cat "$tmp/$j.marker")"
+	cat "$tmp/$j.out"
+	if [ "$(cat "$tmp/$j.rc")" != "0" ]; then
+		failed="$failed $(cat "$tmp/$j.name")"
+	fi
+	j=$((j + 1))
+done
+
+if [ -n "$failed" ]; then
+	echo "$prefix failed in:$failed" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

`make check-gate` left ~67% of a 12-core build pod idle (issue-measured: peak 33% cgroup CPU). Two recipes serialised embarrassingly-parallel work: `lint`'s `for m in $(LINT_MODULES)` loop ran 6 independent golangci-lint invocations one at a time, and `helm-chart-tests`'s loop ran 7 (now 8) independent `helm template` scripts one at a time. This fans both out with a bounded worker pool while leaving `check-gate`'s five top-level phases untouched (no `-j`, no reordering) — per the issue, `test-erun-ui`/`integration-test-gate` size their own concurrency (Playwright) against the full core count and running another phase alongside them would oversubscribe the cores they sized against.

## What changed

- **`scripts/parallel-gate.sh`**: a small POSIX-sh helper that takes `<max-parallel> <failure-prefix>` plus a tab-separated job list on stdin (`short-name\tmarker\tcommand`), runs the jobs with bounded concurrency, buffers each job's combined stdout/stderr to a temp file, then emits every buffered block **in input order** under its `>> <marker>` line (never completion order, never interleaved), and finally reports every failing job on one `<prefix> failed in:<names>` line. Exit 0 iff every job exits 0.
- **`lint`**: now pipes its module list through `parallel-gate.sh`, bounded by `LINT_PARALLELISM` (defaults to `min(nproc, module count)`). Added `--allow-parallel-runners` to the golangci-lint invocation — golangci-lint file-locks its shared result cache by default and refuses a second concurrent instance; the flag opts into its own supported concurrent-runner mode (cache entries are keyed by content hash, not writer identity). The version-pin preflight is unchanged and still runs as its own recipe line before any fan-out, so a missing/mismatched tool still fails the whole target before a single golangci-lint process starts.
- **`helm-chart-tests`**: same treatment, bounded by `HELM_CHART_TEST_PARALLELISM` (`min(nproc, script count)`).

## Failure-semantics decision (explicit, not incidental)

**Both loops now aggregate all failures** rather than stopping at the first:

- `lint` already aggregated (`failed="$failed $m"`, report all at the end) — unchanged in spirit, still runs every module and names every failure.
- `helm-chart-tests` previously **fail-fast** (`sh "$t" || exit 1`). Changed to aggregate. Reasoning: once the scripts run in parallel, a fail-fast exit has *already paid for* every other script's `helm template` work by the time the first failure is observed — discarding those results buys nothing. Aggregating gives strictly more information (every broken chart named in one gate run) for no extra wall-clock cost.

## Width justification (measured, not guessed)

Warm-cache, 12-core pod, one file touched per lint module to force real per-module analysis rather than a degenerate full-cache-hit (see Methodology below):

| LINT_PARALLELISM | wall (s) | peak mem (MiB) |
|---|---|---|
| 1 (serial) | 13.5 | 2510 |
| 2 | 10.3 | 2952 |
| 3 | 9.3 | 2518 |
| 4 | 9.6 | 3043 |
| 6 (all modules) | 8.7 | 4074 |

| HELM_CHART_TEST_PARALLELISM | wall (s) | peak mem (MiB) |
|---|---|---|
| 1 | 2.73 | 1250 |
| 2 | 2.39 | 1257 |
| 4 | 1.85 | 1268 |
| 8 (all scripts) | 1.11 | 1299 |

Chart tests scale cleanly to full width with flat memory (pure `helm template`, no cluster/docker). Lint shows diminishing but still-positive returns to full width; memory grows with width (each golangci-lint wants the full core count) but stays well inside a 12-core pod's typical memory budget. Both `LINT_PARALLELISM` and `HELM_CHART_TEST_PARALLELISM` default to `min(nproc, job-count)` rather than a flat constant, so a small (e.g. 4-core) pod runs fewer concurrent processes automatically instead of inheriting a width sized for a 12-core pod and multiplying its peak memory for no wall-clock benefit it lacks the cores to realize anyway.

## Measurement methodology

Per the issue's own warning, a **cold-cache before/after would overstate the win**: cold lint is dominated by compiling dependencies from scratch, which is already embarrassingly parallel and close to linear regardless of Makefile structure. So:

- **Primary (warm cache), 3 interleaved samples each (main, branch, main, branch, main, branch)**, cache left warm between samples:

  `lint` (one file touched per module before each sample, to force real analysis instead of a degenerate full-cache-hit no-op):
  | round | main wall (s) | branch wall (s) | main peak CPU% | branch peak CPU% | main peak mem (MiB) | branch peak mem (MiB) |
  |---|---|---|---|---|---|---|
  | 1 | 13.43 | 9.32 | 77.8% | 92.5% | 2076 | 4100 |
  | 2 | 13.74 | 8.66 | 75.2% | 90.1% | 2409 | 4285 |
  | 3 | 13.89 | 8.23 | 74.5% | 90.7% | 2456 | 4260 |

  `helm-chart-tests` (no touch needed — pure stateless `helm template`, no cache dependency):
  | round | main wall (s) | branch wall (s) | main peak CPU% | branch peak CPU% | main peak mem (MiB) | branch peak mem (MiB) |
  |---|---|---|---|---|---|---|
  | 1 | 2.79 | 1.14 | 14.5% | 51.5% | 1838 | 1861 |
  | 2 | 2.81 | 1.11 | 9.8% | 50.2% | 1838 | 1865 |
  | 3 | 2.90 | 1.17 | 10.0% | 48.7% | 1839 | 1879 |

  ~35-40% wall-clock reduction for lint, ~59% for chart tests, peak memory well inside a 12-core pod's typical budget (23 GiB mentioned in the issue).

- **Supplementary: one cold sample per arm** (`go clean -cache` + `golangci-lint cache clean`, two cleans total for the whole exercise, labeled as standing in for the erun-devops image-build path — the only place a genuinely cold cache is realistic): main 67.4s, branch 69.1s. Essentially a wash (branch marginally slower), confirming the issue's own prediction that a cold-cache comparison would not show — and must not be used to advertise — the parallel win. Rewarmed with one `make lint` afterward per instructions.

  Chart tests have no cache dependency at all (pure `helm template`), so their "cold" numbers (main 2.82s, branch 1.16s) are indistinguishable from warm.

## Correctness proof

- **Two simultaneous lint violations** (unused import in `erun-cli` and `erun-mcp`, chosen as independent leaf modules with no interdependency): both modules failed independently, the other four still ran and reported `0 issues.`, output was not interleaved, and the final line read `lint failed in: erun-cli erun-mcp` with exit code 2. Ran 3x to confirm no flakiness. Reverted; `git status` clean, `make lint` green again.
- **Two simultaneous broken chart tests** (`erun-oci-registry-chart_test.sh`, `erun-devops-chart_test.sh`): both failed independently, the other six still ran and passed, final line read `helm-chart-tests failed in: erun-devops/k8s/erun-devops-chart_test.sh erun-devops/k8s/erun-oci-registry-chart_test.sh` with exit code 2. Reverted; `git status` clean, `make helm-chart-tests` green again.
- **`make check`** run as a detached job (`erun exec job start`/`await` via `scripts/agent-gate.sh`, per this repo's agent-pod convention) and completed green end-to-end in one round: all 6 lint modules `0 issues.`, `erun-ui` Go tests pass, frontend kit/console gates pass, all 8 chart tests pass, integration suite `ok`, coverage `75.8% (>= 75.8%)`.

## Files

- `scripts/parallel-gate.sh` (new)
- `Makefile` (lint, helm-chart-tests recipes + new `LINT_PARALLELISM`/`HELM_CHART_TEST_PARALLELISM` variables)

No Dockerfile change needed — the erun-devops test stage already does `COPY scripts /src/scripts`, which picks up the new script automatically.

Closes #1690