### PR TITLE
Derive parallel-gate widths from CPU quota and memory, not nproc alone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,14 @@ after touching it — like `erun-devops/docker/erun-devops/entrypoint_test.sh`,
 it asserts process/argv behavior against a stubbed `erun` and is not wired
 into `make check`.
 
+`scripts/parallel-gate.sh`'s `width` mode is the single place that derives
+how wide a parallel fan-out (`LINT_PARALLELISM`, `HELM_CHART_TEST_PARALLELISM`)
+may run on this environment, from the real CPU quota and a memory ceiling
+rather than `nproc` alone — see its own header comment for why `nproc` (which
+reads the CPU affinity mask, not the CFS quota) isn't sufficient on its own.
+Run `scripts/parallel-gate_test.sh` directly after touching it, same
+not-wired-into-`make check` reasoning as `agent-gate_test.sh` above.
+
 The criterion for wrapping a command this way is "long enough that a harness
 will background it", never the target's name — `make check` was simply the
 first one found this way. `erun-ui/playwright/run.sh` (longer than `make

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,18 @@ LINT_MODULES := erun-common erun-cli erun-mcp erun-integration erun-backend/erun
 # single module's own analysis has serial phases that leave cores idle: p1
 # (serial) 13.5s, p2 10.3s, p3 9.3s, p4 9.6s, p6 (all modules at once) 8.7s
 # wall, peak memory climbing from 2.5GiB at p1 to 4.1GiB at p6 (see erun#1690).
-# Scaled off `nproc` rather than a flat constant so a small pod runs fewer
-# concurrent golangci-lint processes -- each wants the full core count, and a
-# flat width sized for a 12-core pod would oversubscribe a 4-core one far
-# harder and multiply its peak memory for no wall-clock benefit it has the
-# cores to use anyway. Capped at the module count: more workers than modules
-# cannot help.
-LINT_PARALLELISM ?= $(shell n=$$(nproc 2>/dev/null || echo 4); m=$(words $(LINT_MODULES)); if [ "$$n" -lt "$$m" ]; then echo "$$n"; else echo "$$m"; fi)
+# Sized by scripts/parallel-gate.sh's `width` mode off the environment's real
+# CPU quota (cgroup cpu.max, not the `nproc` affinity mask -- see #1702) and a
+# per-job memory cost, not `nproc` alone: a flat width sized for a 12-core pod
+# would oversubscribe a smaller one, and #1702 found this recipe was the one
+# gate width in the repo not accounting for the memory it demonstrably scales
+# with. Capped at the module count: more workers than modules cannot help.
+# LINT_JOB_MEMORY_MIB is the measured p6 peak (4.1GiB) averaged across its 6
+# concurrent processes (~700MiB/job) -- conservative, since golangci-lint's
+# own fixed overhead (most of the 2.5GiB seen at p1) doesn't actually scale
+# per added job, but there is no measured marginal-cost figure to use instead.
+LINT_JOB_MEMORY_MIB := 700
+LINT_PARALLELISM ?= $(shell ./scripts/parallel-gate.sh width $(words $(LINT_MODULES)) $(LINT_JOB_MEMORY_MIB))
 
 # Run golangci-lint across the gated modules concurrently (bounded by
 # LINT_PARALLELISM), each against its own .golangci.yml (erun-integration has
@@ -156,11 +161,17 @@ test-frontend:
 # template` render (no cluster, no docker), so unlike lint this scales cleanly
 # with width and memory stays flat: measured on a 12-core pod at p1 2.7s, p2
 # 2.4s, p4 1.9s, p8 (every current script at once) 1.1s wall, ~1.25-1.3GiB
-# peak memory across all widths (see erun#1690). Scaled off `nproc` like
-# LINT_PARALLELISM anyway, capped at the actual script count, so a small pod
-# doesn't launch more `helm template` processes than it has cores for and a
-# growing k8s/ directory can't launch unboundedly many at once.
-HELM_CHART_TEST_PARALLELISM ?= $(shell n=$$(nproc 2>/dev/null || echo 4); m=$(words $(wildcard erun-devops/k8s/*_test.sh)); if [ "$$n" -lt "$$m" ]; then echo "$$n"; else echo "$$m"; fi)
+# peak memory across all widths (see erun#1690) -- i.e. no per-job slope to
+# derive a cost from, unlike LINT_JOB_MEMORY_MIB above. Sized by
+# scripts/parallel-gate.sh's `width` mode off the real CPU quota like
+# LINT_PARALLELISM (see its comment for why that isn't `nproc`), capped at the
+# actual script count so a growing k8s/ directory can't launch unboundedly
+# many at once. HELM_CHART_TEST_JOB_MEMORY_MIB is the flat measured total
+# (~1.3GiB) divided across the current script count -- deliberately not a
+# fabricated per-job slope, since none was observed; the memory term is
+# expected to stay non-binding here and CPU/script-count to decide the width.
+HELM_CHART_TEST_JOB_MEMORY_MIB := 163
+HELM_CHART_TEST_PARALLELISM ?= $(shell ./scripts/parallel-gate.sh width $(words $(wildcard erun-devops/k8s/*_test.sh)) $(HELM_CHART_TEST_JOB_MEMORY_MIB))
 
 # Helm-render assertions for the erun-devops/k8s charts (erun-devops,
 # erun-backend-postgres, erun-backend-db, erun-backend-api, erun-oci-registry,

--- a/erun-ui/playwright/playwright.config.ts
+++ b/erun-ui/playwright/playwright.config.ts
@@ -30,7 +30,11 @@ isolatedRoot();
 // a smaller one. os.availableParallelism() honours the cgroup CPU quota (unlike
 // os.cpus().length, which reports the host's cores), and the memory ceiling is
 // read from the cgroup when present so a container limit is respected rather
-// than the node's total RAM.
+// than the node's total RAM. scripts/parallel-gate.sh's `width` mode is the
+// analogous derivation for the Makefile's gate widths (#1702) -- it can't
+// share this function across languages, but reads the same cgroup files with
+// the same v2-then-v1-then-unlimited fallback order and the same
+// Number.MAX_SAFE_INTEGER treatment of v1's huge "unlimited" sentinel below.
 const WORKER_BUDGET_MIB = 900;
 
 function cgroupMemoryLimitMib(): number | null {

--- a/scripts/parallel-gate.sh
+++ b/scripts/parallel-gate.sh
@@ -19,6 +19,121 @@
 # "<failure-message-prefix> failed in:<space-separated short-names>" to
 # stderr (matching the exact "lint failed in:..." text the lint recipe
 # already produced) and exits 1.
+#
+# A second mode answers a different question -- not "run these jobs bounded
+# by a width", but "what should that width even be":
+#
+#   Usage: parallel-gate.sh width <job-count> <mem-per-job-mib>
+#
+# Prints one integer: min(job-count, CPUs available to this environment,
+# memory available / mem-per-job-mib). Kept in this script rather than a
+# separate one because #1702 found two independent parallelism sizers in this
+# repo (this file's Makefile callers, and erun-ui/playwright/playwright.config.ts)
+# that disagreed about which resource is the ceiling; this is now the one
+# shell-side answer, read the same cgroup files with the same fallbacks the
+# TypeScript side already used for its memory ceiling. The TypeScript side
+# doesn't need a matching CPU rewrite: it already gets the CPU quota (not the
+# affinity mask) for free from Node's os.availableParallelism(), which is
+# quota-aware via libuv -- see that file's own comment. `nproc` is not
+# quota-aware (it reads sched_getaffinity), so the shell side has to read the
+# quota itself.
+#
+# CPU: cgroup v2 cpu.max (quota/period), then cgroup v1
+# cpu.cfs_quota_us/cpu.cfs_period_us, then `nproc`, then a constant. A quota
+# of "max" (v2) or -1 (v1) means unlimited and falls through to the next
+# source, same as an unreadable/absent file.
+#
+# Memory: cgroup v2 memory.max, then cgroup v1 memory/memory.limit_in_bytes,
+# then unlimited (the memory term is dropped from the min() entirely, since
+# there is nothing to divide by). A value of "max" (v2) or >= 2^53-1 (v1's
+# practical unlimited sentinel, mirroring playwright.config.ts's
+# `Number.MAX_SAFE_INTEGER` check -- the same value cannot be represented
+# exactly as a JS number, so that is the largest limit either side can treat
+# as real) means unlimited.
+#
+# PARALLEL_GATE_CGROUP_ROOT overrides the cgroup root (default
+# /sys/fs/cgroup) so tests can point at a synthetic tree instead of faking
+# /sys/fs/cgroup itself.
+if [ "${1:-}" = "width" ]; then
+	set -eu
+	job_count=$2
+	mem_per_job_mib=$3
+	cgroup_root="${PARALLEL_GATE_CGROUP_ROOT:-/sys/fs/cgroup}"
+	# JS's Number.MAX_SAFE_INTEGER (2^53 - 1). cgroup v1's unlimited sentinel
+	# for memory.limit_in_bytes is ~2^63, far above this, and cannot itself be
+	# represented exactly as a JS number -- so this is the largest limit value
+	# playwright.config.ts's parallel memory check can treat as real, and this
+	# script matches it rather than trusting a v1 host's literal sentinel value.
+	max_safe_int=9007199254740991
+
+	is_positive_int() {
+		case "$1" in
+		'' | *[!0-9]*) return 1 ;;
+		*) [ "$1" -gt 0 ] ;;
+		esac
+	}
+
+	cpu_quota() {
+		if [ -r "$cgroup_root/cpu.max" ]; then
+			read -r quota period <"$cgroup_root/cpu.max" 2>/dev/null || quota=""
+			if [ "${quota:-}" != "max" ] && is_positive_int "${quota:-}" && is_positive_int "${period:-}"; then
+				echo $((quota / period))
+				return
+			fi
+		fi
+		if [ -r "$cgroup_root/cpu/cpu.cfs_quota_us" ] && [ -r "$cgroup_root/cpu/cpu.cfs_period_us" ]; then
+			quota=$(cat "$cgroup_root/cpu/cpu.cfs_quota_us" 2>/dev/null) || quota=""
+			period=$(cat "$cgroup_root/cpu/cpu.cfs_period_us" 2>/dev/null) || period=""
+			if is_positive_int "$quota" && is_positive_int "$period"; then
+				echo $((quota / period))
+				return
+			fi
+		fi
+		n=$(nproc 2>/dev/null) || n=""
+		if is_positive_int "$n"; then
+			echo "$n"
+			return
+		fi
+		echo 4
+	}
+
+	# mem_limit_mib prints the memory ceiling in MiB, or nothing when
+	# unlimited/unreadable -- an empty result means "drop the memory term",
+	# not "zero memory available".
+	mem_limit_mib() {
+		if [ -r "$cgroup_root/memory.max" ]; then
+			val=$(cat "$cgroup_root/memory.max" 2>/dev/null) || val=""
+			if [ "$val" != "max" ] && is_positive_int "$val" && [ "$val" -lt "$max_safe_int" ]; then
+				echo $((val / 1024 / 1024))
+				return
+			fi
+		fi
+		if [ -r "$cgroup_root/memory/memory.limit_in_bytes" ]; then
+			val=$(cat "$cgroup_root/memory/memory.limit_in_bytes" 2>/dev/null) || val=""
+			if is_positive_int "$val" && [ "$val" -lt "$max_safe_int" ]; then
+				echo $((val / 1024 / 1024))
+				return
+			fi
+		fi
+	}
+
+	width=$job_count
+	cpu=$(cpu_quota)
+	if is_positive_int "$cpu" && [ "$cpu" -lt "$width" ]; then
+		width=$cpu
+	fi
+	mem_mib=$(mem_limit_mib)
+	if [ -n "$mem_mib" ] && is_positive_int "$mem_per_job_mib"; then
+		by_mem=$((mem_mib / mem_per_job_mib))
+		[ "$by_mem" -ge 1 ] || by_mem=1
+		if [ "$by_mem" -lt "$width" ]; then
+			width=$by_mem
+		fi
+	fi
+	echo "$width"
+	exit 0
+fi
+
 set -eu
 
 max_parallel=$1

--- a/scripts/parallel-gate_test.sh
+++ b/scripts/parallel-gate_test.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+# Tests for parallel-gate.sh's `width` mode: the fan-out-sizing helper #1702
+# added so the Makefile's gate widths stop ignoring memory the way #1701 left
+# them. Covers every fallback branch (cgroup v2, cgroup v1, unlimited quota,
+# no cgroup at all, and no `nproc` at all) plus the memory term actually
+# lowering the width below job-count/cpu when the environment is small.
+#
+# Run directly (not wired into `make check`), same reasoning as
+# agent-gate_test.sh: this drives PARALLEL_GATE_CGROUP_ROOT against synthetic
+# cgroup trees, not the real job-running mode.
+
+set -eu
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+gate="${script_dir}/parallel-gate.sh"
+
+work_root="$(mktemp -d 2>/dev/null || mktemp -d -t parallel-gate-test)"
+trap 'rm -rf "${work_root}"' EXIT INT TERM
+
+fail() {
+	echo "FAIL: $1" >&2
+	exit 1
+}
+
+assert_width() {
+	label="$1"
+	expected="$2"
+	shift 2
+	got=$("$gate" width "$@")
+	[ "$got" = "$expected" ] || fail "$label: expected width $expected, got $got (args: $*)"
+}
+
+# --- cgroup v2 present: cpu.max quota/period and memory.max both read. A
+# 4-core/8GiB environment (the "ux" env from #1701/#1702) must land on 4 for
+# both the lint (6 modules, 700MiB/job) and helm-chart-tests (8 scripts,
+# 163MiB/job) shapes, exactly as before this change.
+case_dir="${work_root}/v2"
+mkdir -p "$case_dir"
+echo "400000 100000" >"${case_dir}/cpu.max"
+echo "$((8 * 1024 * 1024 * 1024))" >"${case_dir}/memory.max"
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "v2 lint shape" 4 6 700
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "v2 helm shape" 4 8 163
+
+# --- cgroup v1 present (no v2 files at all): cpu.cfs_quota_us/period_us and
+# memory/memory.limit_in_bytes, same 4-core/8GiB shape, must agree with v2.
+case_dir="${work_root}/v1"
+mkdir -p "${case_dir}/cpu" "${case_dir}/memory"
+echo "400000" >"${case_dir}/cpu/cpu.cfs_quota_us"
+echo "100000" >"${case_dir}/cpu/cpu.cfs_period_us"
+echo "$((8 * 1024 * 1024 * 1024))" >"${case_dir}/memory/memory.limit_in_bytes"
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "v1 lint shape" 4 6 700
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "v1 helm shape" 4 8 163
+
+# --- v1's practical "unlimited" sentinel for memory (~2^63, far past
+# Number.MAX_SAFE_INTEGER) must be treated as unlimited, not as a real limit
+# that happens to be huge -- the memory term must drop out entirely, leaving
+# CPU/job-count to decide the width.
+case_dir="${work_root}/v1-huge-mem"
+mkdir -p "${case_dir}/cpu" "${case_dir}/memory"
+echo "1200000" >"${case_dir}/cpu/cpu.cfs_quota_us"
+echo "100000" >"${case_dir}/cpu/cpu.cfs_period_us"
+echo "9223372036854771712" >"${case_dir}/memory/memory.limit_in_bytes"
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "v1 huge sentinel memory is unlimited" 6 6 700
+
+# --- v2 quota "max" (unlimited) and memory.max "max" (unlimited): both terms
+# must fall through past the cgroup reads. CPU falls to `nproc`; with the
+# real PATH that is whatever this host has, so pin the expectation via a
+# stubbed `nproc` instead of trusting the live host's core count.
+case_dir="${work_root}/v2-unlimited"
+mkdir -p "$case_dir"
+echo "max 100000" >"${case_dir}/cpu.max"
+echo "max" >"${case_dir}/memory.max"
+stub_bin="${work_root}/stub-nproc-12"
+mkdir -p "$stub_bin"
+cat >"${stub_bin}/nproc" <<'EOF'
+#!/bin/sh
+echo 12
+EOF
+chmod +x "${stub_bin}/nproc"
+got=$(PATH="${stub_bin}:$PATH" PARALLEL_GATE_CGROUP_ROOT="$case_dir" "$gate" width 6 700)
+[ "$got" = 6 ] || fail "v2 unlimited quota+memory: expected job-count cap 6 (cpu falls to stubbed nproc=12), got $got"
+
+# --- no cgroup files at all (bare empty root): both terms fall through to
+# non-cgroup sources, same as the "unlimited" case above.
+case_dir="${work_root}/empty"
+mkdir -p "$case_dir"
+got=$(PATH="${stub_bin}:$PATH" PARALLEL_GATE_CGROUP_ROOT="$case_dir" "$gate" width 6 700)
+[ "$got" = 6 ] || fail "no cgroup at all: expected job-count cap 6 (cpu falls to stubbed nproc=12), got $got"
+
+# --- nproc itself unavailable/failing: CPU falls to the final constant (4).
+stub_bin_fail="${work_root}/stub-nproc-fail"
+mkdir -p "$stub_bin_fail"
+cat >"${stub_bin_fail}/nproc" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "${stub_bin_fail}/nproc"
+got=$(PATH="${stub_bin_fail}:$PATH" PARALLEL_GATE_CGROUP_ROOT="${work_root}/empty" "$gate" width 6 700)
+[ "$got" = 4 ] || fail "nproc unavailable: expected the constant fallback 4, got $got"
+
+# --- memory term actually binds: a small memory ceiling must pull the width
+# below what CPU/job-count alone would allow, proving the memory term isn't
+# just plumbed through inert.
+case_dir="${work_root}/mem-binds"
+mkdir -p "$case_dir"
+echo "1200000 100000" >"${case_dir}/cpu.max"
+echo "$((2 * 1024 * 1024 * 1024))" >"${case_dir}/memory.max"
+# 12 CPUs, 6 job-count cap, but 2GiB / 700MiB/job = 2 -- memory must win.
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "memory term binds below cpu/job-count" 2 6 700
+
+# --- job-count is always a hard ceiling, even with abundant CPU and memory.
+case_dir="${work_root}/plenty"
+mkdir -p "$case_dir"
+echo "1200000 100000" >"${case_dir}/cpu.max"
+echo "$((64 * 1024 * 1024 * 1024))" >"${case_dir}/memory.max"
+PARALLEL_GATE_CGROUP_ROOT="$case_dir" assert_width "job-count caps an abundant environment" 3 3 700
+
+echo "ok: parallel-gate.sh width"


### PR DESCRIPTION
## Summary

- `scripts/parallel-gate.sh` gains a `width` mode: `parallel-gate.sh width <job-count> <mem-per-job-mib>` derives how wide a fan-out may run from the environment's real CPU quota (cgroup v2 `cpu.max`, falling back to v1 `cpu.cfs_quota_us`/`cpu.cfs_period_us`, then `nproc`, then a constant) and its memory ceiling (`memory.max`, falling back to v1 `memory/memory.limit_in_bytes`, then unlimited), capped at the job count.
- `Makefile`'s `LINT_PARALLELISM` and `HELM_CHART_TEST_PARALLELISM` now call this instead of their own `min(nproc, job-count)` one-liners, adding the memory term #1701 measured but never consulted (lint peak memory climbing 2.5→4.1 GiB from p1→p6). `LINT_JOB_MEMORY_MIB=700` (the measured p6 peak averaged across 6 concurrent processes); `HELM_CHART_TEST_JOB_MEMORY_MIB=163` (the measured flat ~1.3 GiB divided across the 8 current chart scripts — no fabricated slope, since chart-test memory doesn't scale with width).
- `nproc` reads the CPU affinity mask, not the CFS quota Kubernetes actually enforces, which is the latent bug #1702 flagged (dormant today because both agent envs' cpusets happen to match their quotas). The new CPU-quota read closes that gap on the shell side.
- `erun-ui/playwright/playwright.config.ts` needed no functional change: its CPU term already goes through `os.availableParallelism()`, which is quota-aware via libuv (unlike `nproc`), and its memory-ceiling read already used the same v2→v1→unlimited fallback order and the same `Number.MAX_SAFE_INTEGER` treatment of v1's huge "unlimited" sentinel that the new shell helper now mirrors. Added a one-line cross-reference comment only.

**Why two implementations, not one shared helper:** the issue allowed this — a shell helper can't cleanly serve the TypeScript config, and vice versa. Both read the same cgroup files with the same fallback order and the same constants (documented in `scripts/parallel-gate.sh`'s header and cross-referenced from `playwright.config.ts`), so a duplicated-but-identical rule replaces the two previously-disagreeing ones.

- `scripts/parallel-gate_test.sh` (new, run directly — same not-wired-into-`make check` convention as `agent-gate_test.sh`) drives the `width` mode against synthetic cgroup trees, covering: v2 present, v1 present, v1's huge "unlimited" memory sentinel, v2 `max`/unlimited quota+memory falling through to `nproc`, no cgroup files at all, `nproc` itself failing (falls to the constant), the memory term actually binding below cpu/job-count, and job-count always capping an abundant environment.

## Verification

- **Derived width on this pod (12 cores / 23 GiB, cpu.max `1200000 100000`, memory.max `24696061952` = 23552 MiB):** lint width = 6, helm-chart-tests width = 8 — unchanged from #1701.
- **All four required fallback branches driven directly** via `PARALLEL_GATE_CGROUP_ROOT` pointed at synthetic trees, plus the `nproc`-unavailable constant fallback and the v1 huge-sentinel case — see `scripts/parallel-gate_test.sh`, all passing.
- **No regression on the constrained environment:** simulated the "ux" env's cgroup values (4 cores / 8 GiB) via `PARALLEL_GATE_CGROUP_ROOT` (both v2 and v1 shapes) — width = 4 for both lint and helm-chart-tests, matching #1701. (No literal access to that pod from this session; verified by feeding its documented cgroup values through the same code path this PR ships.)
- **Benchmarked against `541ff598` (interleaved, warm cache, 5 samples each, via a scratch `git worktree`):** `make helm-chart-tests` ~1.05–1.12s both branches; `make lint` ~0.65–0.79s both branches (both at width 6/8 as before — the runner code path is untouched, only how the width number gets computed changed). No measurable regression.
- **`make check` green as a detached job**, blocking on the job's own completion (single `job await`, no timeout re-poll needed): lint 0 issues across all 6 modules, `go test` green, frontend gates green, all 8 chart tests pass, integration suite green at 75.8% coverage (meets the 75.8% gate).

Closes #1702