### PR TITLE
Route the AWS bearer-refresh mint through the existing federation self-heal

### DIFF
--- a/erun-cli/cmd/cloud.go
+++ b/erun-cli/cmd/cloud.go
@@ -702,24 +702,15 @@ func runCloudOIDCCommand(ctx common.Context, store common.CloudStore, _ PromptRu
 	if provider.Provider != common.CloudProviderAWS {
 		return fmt.Errorf("cloud provider alias %q is a %q-type alias, which does not use AWS web-identity federation; its OIDC issuer is set at `cloud init`", provider.Alias, provider.Provider)
 	}
-	if ctx.DryRun {
-		audience := strings.TrimSpace(params.Audience)
-		if audience == "" {
-			audience = common.CloudProviderBearerAudience
-		}
-		ctx.Trace("check cloud provider token status")
-		ctx.TraceCommand("", "aws", "sso", "login", "--profile", provider.Profile)
-		traceAWSEnableOIDCCommand(ctx, provider.Profile)
-		traceAWSBearerTokenCommand(ctx, provider.Profile, audience)
-		ctx.Trace("write cloud provider OIDC issuer resolved from AWS web identity token")
-		_, err := fmt.Fprintln(ctx.Stdout, "Dry run: cloud provider OIDC setup planned.")
-		return err
-	}
 	status, _, err := common.SetupCloudProviderOIDC(ctx, store, common.CloudBearerParams{
 		Alias:    alias,
 		Audience: params.Audience,
 	}, deps)
 	if err != nil {
+		return err
+	}
+	if ctx.DryRun {
+		_, err := fmt.Fprintln(ctx.Stdout, "Dry run: cloud provider OIDC setup planned.")
 		return err
 	}
 	_, err = fmt.Fprintf(ctx.Stdout, "Saved OIDC issuer %s for %s\n", status.OIDCIssuerURL, status.Alias)

--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -543,12 +543,16 @@ func awsCloudProviderBearerToken(ctx Context, provider CloudProviderConfig, para
 
 func awsBearerTokenWithOIDCRetry(ctx Context, provider CloudProviderConfig, audience string, deps CloudDependencies) (string, error) {
 	rawToken, err := deps.RunAWSBearerToken(ctx, provider.Profile, audience)
-	if err == nil {
-		return rawToken, nil
-	}
-	if !isAWSOutboundWebIdentityFederationDisabled(err) {
+	if err != nil && !isAWSOutboundWebIdentityFederationDisabled(err) {
 		return "", err
 	}
+	if err == nil && !ctx.DryRun {
+		return rawToken, nil
+	}
+	// Either federation was reported disabled on a real run, or this is a dry
+	// run: RunAWSBearerToken always reports success without ever invoking AWS,
+	// so the only way to preview the recovery this command would perform is to
+	// trace it unconditionally here too.
 	if _, enableErr := deps.RunAWSEnableOIDC(ctx, provider.Profile); enableErr != nil {
 		return "", enableErr
 	}
@@ -1191,9 +1195,20 @@ func defaultRunAWSEnableOIDC(ctx Context, profile string) (string, error) {
 		if isAWSOutboundWebIdentityFederationAlreadyEnabledMessage(message) {
 			return "", nil
 		}
+		if isAWSAccessDeniedMessage(message) {
+			return "", fmt.Errorf("enable AWS outbound web identity federation requires the iam:EnableOutboundWebIdentityFederation permission: %s", message)
+		}
 		return "", fmt.Errorf("enable AWS outbound web identity federation: %s", message)
 	}
 	return normalizeOIDCIssuerURL(stdout.String()), nil
+}
+
+func isAWSAccessDeniedMessage(message string) bool {
+	message = strings.ToLower(message)
+	return strings.Contains(message, "accessdenied") ||
+		strings.Contains(message, "access denied") ||
+		strings.Contains(message, "unauthorizedaccess") ||
+		strings.Contains(message, "not authorized to perform")
 }
 
 func isAWSOutboundWebIdentityFederationDisabled(err error) bool {

--- a/erun-integration/testdata/cloud/oidc_dry_run_traces_bearer_token_command.txt
+++ b/erun-integration/testdata/cloud/oidc_dry_run_traces_bearer_token_command.txt
@@ -1,7 +1,9 @@
 Dry run: cloud provider OIDC setup planned.
 audit: erun cloud oidc --alias rihards+123456789012@aws --audience https://api.example --dry-run
-check cloud provider token status
+cloud oidc: refresh issuer for alias=rihards+123456789012@aws
 aws sso login --profile test-profile
+aws sts get-web-identity-token --audience https://api.example --signing-algorithm RS256 --duration-seconds 900 --query WebIdentityToken --output text --profile test-profile
 aws iam enable-outbound-web-identity-federation --query IssuerIdentifier --output text --profile test-profile
 aws sts get-web-identity-token --audience https://api.example --signing-algorithm RS256 --duration-seconds 900 --query WebIdentityToken --output text --profile test-profile
-write cloud provider OIDC issuer resolved from AWS web identity token
+cloud oidc: derived issuer = derived-from-aws-web-identity-token
+write cloud provider OIDC issuer for rihards+123456789012@aws

--- a/erun-integration/testdata/cloud/oidc_real_run_enable_federation_failure_fails.txt
+++ b/erun-integration/testdata/cloud/oidc_real_run_enable_federation_failure_fails.txt
@@ -1,4 +1,4 @@
 audit: erun cloud oidc --alias test-user@aws
 cloud oidc: refresh issuer for alias=test-user@aws
-cloud oidc: bearer token retrieval failed: enable AWS outbound web identity federation: An error occurred (AccessDenied) when calling the EnableOutboundWebIdentityFederation operation
-enable AWS outbound web identity federation: An error occurred (AccessDenied) when calling the EnableOutboundWebIdentityFederation operation
+cloud oidc: bearer token retrieval failed: enable AWS outbound web identity federation requires the iam:EnableOutboundWebIdentityFederation permission: An error occurred (AccessDenied) when calling the EnableOutboundWebIdentityFederation operation
+enable AWS outbound web identity federation requires the iam:EnableOutboundWebIdentityFederation permission: An error occurred (AccessDenied) when calling the EnableOutboundWebIdentityFederation operation


### PR DESCRIPTION
## Summary

`erun-common/cloud.go` already had a purpose-built detector
(`isAWSOutboundWebIdentityFederationDisabled`) and a one-command remedy
(`defaultRunAWSEnableOIDC`, `aws iam enable-outbound-web-identity-federation`)
for `OutboundWebIdentityFederationDisabledException`, wired into the AWS
bearer-token mint's retry helper (`awsBearerTokenWithOIDCRetry`,
`erun-common/cloud.go`). Investigation showed that helper is already the
single implementation behind every caller of `CloudProviderBearerToken` —
`cloud oidc`, `erun-cli`'s hosted-registry docker login
(`build_docker_commands.go`), `platform_commands.go`, the desktop app
(`erun-ui/config_handlers.go`), and `erun-mcp` — so on a **real** run, hitting
the exception during an ordinary bearer refresh already self-healed before
this PR. What was still missing, matching the issue's own acceptance criteria:

1. **IAM-permission-denied wasn't reported as such.** When the enable call
   failed with `AccessDenied` (missing `iam:EnableOutboundWebIdentityFederation`),
   the operator got a second raw, unexplained AWS error instead of a message
   naming the permission.
2. **`--dry-run` could never reach the enable/retry trace.** `RunAWSBearerToken`'s
   dry-run short-circuit always reports success without calling AWS, so the
   `err == nil` early return in the retry helper meant the enable-and-retry
   branch — and its trace lines — were structurally unreachable from any
   dry-run/preview caller.
3. `cloud oidc --dry-run` had its own **hand-rolled duplicate** of the
   enable/bearer-token command construction (`traceAWSEnableOIDCCommand`,
   `traceAWSBearerTokenCommand` called directly from `runCloudOIDCCommand`),
   bypassing the shared mint entirely for previews — a second copy of the
   same plan, and it previewed the actions in the wrong order (enable before
   the first token attempt, when real execution only enables after the first
   attempt fails).

## Changes

- `awsBearerTokenWithOIDCRetry` (erun-common/cloud.go): when `ctx.DryRun`,
  fall through to trace the enable+retry sequence unconditionally instead of
  returning early on the dry-run "success". Real-run behavior is unchanged
  (verified: `oidc_real_run_enables_federation_and_persists_issuer` and
  `oidc_real_run_tolerates_already_enabled_federation` pass byte-for-byte).
- `defaultRunAWSEnableOIDC`: added `isAWSAccessDeniedMessage`, a small
  classifier reused nowhere else. On a real `AccessDenied`-shaped failure the
  wrapped error now reads `enable AWS outbound web identity federation
  requires the iam:EnableOutboundWebIdentityFederation permission: <original
  AWS message>` — the raw AWS text is preserved via `%s`/wrapping, never
  replaced.
- `runCloudOIDCCommand` (erun-cli/cmd/cloud.go): deleted its dry-run-only
  hand-rolled trace and now calls `common.SetupCloudProviderOIDC` for both
  real and dry runs (it already supported `ctx.DryRun` end to end), so the
  preview is generated by the same code that runs for real. `cloud init
  aws`'s use of `traceAWSEnableOIDCCommand`/`traceAWSBearerTokenCommand` is
  untouched — that flow previews the whole onboarding sequence before any
  provider exists in the store, so it genuinely cannot call the shared
  function yet.

## Design notes (per the issue's checklist)

- **Reused, not duplicated.** No new detector or remedy function was written.
  `isAWSOutboundWebIdentityFederationDisabled` and `defaultRunAWSEnableOIDC`
  are exactly the same functions `cloud oidc` always used; this PR only
  changes when/how the existing retry helper calls them, plus the CLI
  deduplication described above.
- **Bounded retry.** Unchanged: `awsBearerTokenWithOIDCRetry` calls
  `RunAWSEnableOIDC` at most once and retries `RunAWSBearerToken` at most
  once. No loop.
- **Original error preserved.** The `AccessDenied` wrap uses `%s` on the
  trimmed AWS stderr, so the operator still sees AWS's actual message,
  prefixed with the permission name rather than replacing it.
- **Gating on the OIDC path's precedent.** `cloud oidc` performs the enable
  side effect unconditionally (no confirmation flag, no separate opt-in) —
  the issue itself notes this precedent settles the "should a read-shaped
  refresh mutate account config" question. This PR does not add a new gate;
  it makes every caller of the mint follow the same ungated precedent
  `cloud oidc` already established for the identical operation.
- **Credentials via stdin, never argv.** Untouched by this change; no new
  credential material is introduced.
- **"Already enabled" stays success.** Untouched — `oidc_real_run_tolerates_already_enabled_federation` still passes unmodified.

## Scope note

`erun-mcp`'s `cloud_oidc` tool has its own separate, hand-written `Preview`
plan (`erun-mcp/cloud.go`) that already names the enable step conditionally
("enable AWS outbound web identity federation if disabled"). It was not
touched — it already satisfies the same intent independently and unifying it
with the CLI's dry-run path is a separate, MCP-side refactor outside this
issue's blast radius.

## Test plan

- [x] `oidc_dry_run_traces_bearer_token_command` (erun-integration): now
      generated by the real shared code path; golden updated, reviewed by
      hand — new lines: `cloud oidc: refresh issuer for alias=...`, an
      initial `sts get-web-identity-token` attempt, then the enable call,
      then the retry attempt, then `cloud oidc: derived issuer = ...`. This
      is the acceptance criterion "a dry run traces the enable call it would
      make."
- [x] `oidc_real_run_enable_federation_failure_fails` (erun-integration):
      golden updated — the `AccessDenied` failure now names
      `iam:EnableOutboundWebIdentityFederation` while preserving AWS's raw
      message. This is the bounded-retry + preserved-original-error
      criterion (enable is attempted once, its failure is surfaced, no
      further retry).
- [x] `oidc_real_run_enables_federation_and_persists_issuer` (unchanged,
      still green): the exception on bearer refresh triggers remediation and
      the retry succeeds — this is the pre-existing test for the mint's core
      behavior, and it continues to pass byte-for-byte, so the already-working
      path is not regressed.
- [x] `oidc_real_run_tolerates_already_enabled_federation` (unchanged, still
      green): "already enabled" is not treated as an error.
- [x] `go test ./...` green in `erun-common`, `erun-cli`.
- [x] `make check` green (run as a detached in-pod job per this repo's
      `AGENTS.md`): 0 golangci-lint issues across every Go module,
      `erun-ui`/`erun-kit`/`erun-console` gates green, devops chart tests
      green, `erun-integration` suite green, coverage `75.8% (>= 75.8%)`.

Closes #1705