### PR TITLE
Reclaim finished agent job clones under the work root

### DIFF
--- a/erun-cli/cmd/job.go
+++ b/erun-cli/cmd/job.go
@@ -435,7 +435,23 @@ func jobExitedLine(job common.EnvironmentJob) string {
 	if strings.TrimSpace(job.Signal) != "" {
 		line += fmt.Sprintf(" (signal %s)", job.Signal)
 	}
-	return line + jobAgentSuffix(job) + jobWorktreeSuffix(job) + jobOutputSuffix(job)
+	return line + jobAgentSuffix(job) + jobWorktreeSuffix(job) + jobCloneSuffix(job) + jobOutputSuffix(job)
+}
+
+// jobCloneSuffix surfaces what happened to an agent job's own working
+// directory now that it has finished: reclaimed once nothing would be lost by
+// deleting it, or kept with the exact reason an operator would otherwise have
+// to work out by hand from git state. Silent either way, a vanished directory
+// and an accumulating one both read as the product doing nothing. See
+// work_clone_reclaim.go in erun-common.
+func jobCloneSuffix(job common.EnvironmentJob) string {
+	if job.CloneReclaimed {
+		return ", clone reclaimed"
+	}
+	if strings.TrimSpace(job.CloneKeptReason) != "" {
+		return ", clone kept: " + job.CloneKeptReason
+	}
+	return ""
 }
 
 // jobWorktreeSuffix surfaces a dirty working tree on any terminal line, so a

--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -270,6 +270,22 @@ type EnvironmentJob struct {
 	// pushed. Empty when WorktreeDirty is false, or when a commit was made and
 	// pushed cleanly.
 	WorktreeReason string `json:"worktreeReason,omitempty"`
+
+	// CloneReclaimed reports whether the supervisor removed this agent job's
+	// own Dir after it finished, because its working tree was clean and every
+	// commit reachable from HEAD was already reachable from a remote. False
+	// for a command job, a job that did not finish cleanly (see
+	// EnvironmentJobStateExited), a job whose Dir sat outside the work root,
+	// or one the supervisor judged unsafe to remove (see CloneKeptReason).
+	// See work_clone_reclaim.go.
+	CloneReclaimed bool `json:"cloneReclaimed,omitempty"`
+	// CloneKeptReason explains why an agent job's Dir was left in place: a
+	// dirty tree, unpushed commits with no proof they landed elsewhere under
+	// a different commit, a detached HEAD that is not provably pushed, or no
+	// upstream at all. Empty when CloneReclaimed is true, or when the job was
+	// never a candidate for reclaim (a command job, one outside the work
+	// root, or one that did not finish cleanly).
+	CloneKeptReason string `json:"cloneKeptReason,omitempty"`
 }
 
 // Finished reports whether the job reached a terminal state.

--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -646,6 +646,12 @@ func RunEnvironmentJobSupervisor(params EnvironmentJobSupervisorParams) error {
 // captureAgentJobWorktreeOutcome runs here too, before the exit code alone
 // could be read as the whole story: an agent job's own working tree is
 // something its exit status says nothing about at all (see job_worktree.go).
+//
+// reclaimAgentJobWorkClone runs after State is settled, using a fresh
+// snapshot so it sees this job's own final EnvironmentJobStateExited (or
+// abandoned/gate-incomplete, which it refuses) rather than the "running"
+// state the job still carried when finishEnvironmentJob was entered (see
+// work_clone_reclaim.go for why that ordering matters).
 func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *jobOutputWriter, childPID int, state *os.ProcessState, waitErr error) error {
 	// Fold the stream's tail before the outcome lands, so the finished record
 	// carries what the run last did rather than the poll's stale view of it.
@@ -665,6 +671,12 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		job.Reason = reason
 		job.ExitCode = &code
 		worktree.apply(job)
+	})
+
+	reclaimed, cloneReason := reclaimAgentJobWorkClone(recorder.snapshot())
+	recorder.update(func(job *EnvironmentJob) {
+		job.CloneReclaimed = reclaimed
+		job.CloneKeptReason = cloneReason
 	})
 	return nil
 }

--- a/erun-common/work_clone_reclaim.go
+++ b/erun-common/work_clone_reclaim.go
@@ -1,0 +1,400 @@
+package eruncommon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Every agent task that clones the repo into a work directory leaves that
+// clone behind once its job finishes -- nothing ever reclaimed it, so the
+// work directory grows without bound. The obvious fix, sweeping the whole
+// directory on a timer or `rm -rf`ing anything old, is destructive: a clone
+// can hold commits that exist nowhere else (never pushed) or a dirty tree
+// (never committed at all), and losing either is real work gone, not disk
+// reclaimed. This file is the safety check that has to hold before any clone
+// is removed, plus the one place it is actually acted on: the same job-finish
+// hook that already checkpoints a dirty tree (job_worktree.go).
+//
+// "Finished" is answered by construction rather than by a timestamp or a
+// directory scan: reclaim only ever runs once, from inside finishEnvironmentJob,
+// at the exact moment the supervisor that owns this job observes its process
+// exit. There is no window in which a running job's directory could be
+// mistaken for an idle one, because nothing here ever looks at an arbitrary
+// directory's mtime to guess whether work on it has stopped.
+
+// workCloneUserHomeDir is the seam a test overrides to point workCloneRoot at
+// a fixture home directory instead of the real one.
+var workCloneUserHomeDir = os.UserHomeDir
+
+// workCloneRoot resolves the directory that holds per-task agent clones
+// (conventionally /home/erun/work), distinct from the tenant's own runtime
+// repository (/home/erun/git/<tenant>). Reclaim only ever acts on a path
+// under this root -- see isUnderWorkRoot -- which is what keeps the runtime
+// repo itself unreachable no matter what a caller happens to set a job's Dir
+// to.
+func workCloneRoot(homeDir string) (string, error) {
+	resolved := strings.TrimSpace(homeDir)
+	if resolved == "" {
+		home, err := workCloneUserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		resolved = home
+	}
+	return filepath.Join(resolved, "work"), nil
+}
+
+// isUnderWorkRoot reports whether dir sits strictly inside root. root itself
+// does not count -- reclaim only ever removes a clone inside the work root,
+// never the work root directory.
+func isUnderWorkRoot(root, dir string) bool {
+	root = filepath.Clean(root)
+	dir = filepath.Clean(dir)
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+// WorkCloneReclaimDecision is the outcome of checking whether an agent job's
+// working directory is safe to remove now that the job has finished. It is
+// its own dry-run report: computing it never mutates or deletes anything.
+type WorkCloneReclaimDecision struct {
+	Dir string
+	// Reclaim is true only when nothing in dir would be lost by deleting it:
+	// no uncommitted change (tracked or untracked) and every commit reachable
+	// from HEAD already exists on a remote.
+	Reclaim bool
+	// Reason always explains the decision -- why it is safe to reclaim, or
+	// why it was kept.
+	Reason string
+}
+
+// DecideWorkCloneReclaim is the pure git-state check behind reclaim: given a
+// candidate directory, is deleting it safe? It never deletes anything itself
+// and never consults job records -- see reclaimAgentJobWorkClone for the
+// caller that also confirms the job that owned dir has actually finished
+// before acting on this.
+//
+// A missing answer is never read as safe. Every early return below keeps the
+// clone (Reclaim stays false) unless a specific, checked condition proves
+// deleting it loses nothing.
+func DecideWorkCloneReclaim(ctx Context, dir string) WorkCloneReclaimDecision {
+	decision := WorkCloneReclaimDecision{Dir: dir}
+
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		decision.Reason = "not a directory"
+		return decision
+	}
+	inside, err := gitIsInsideWorkTree(ctx, dir)
+	if err != nil || !inside {
+		decision.Reason = "not a git working tree"
+		return decision
+	}
+	changed, err := gitChangedWorkingTreeFiles(ctx, dir)
+	if err != nil {
+		decision.Reason = fmt.Sprintf("could not read working tree status: %v", err)
+		return decision
+	}
+	if len(changed) > 0 {
+		decision.Reason = fmt.Sprintf("working tree has %d uncommitted change(s) (e.g. %s), tracked or untracked", len(changed), changed[0])
+		return decision
+	}
+
+	// Best-effort: a stale local view of the remote can only make this check
+	// more conservative (it might miss a merge that landed since the last
+	// fetch and keep a clone that was actually safe), never less safe, so a
+	// fetch failure (no network, offline test fixture) is not fatal.
+	gitFetchOrigin(ctx, dir)
+
+	branch, err := GitCurrentBranch(ctx, dir)
+	if err != nil {
+		decision.Reason = fmt.Sprintf("could not read the current branch: %v", err)
+		return decision
+	}
+	if branch == "HEAD" {
+		return decideDetachedWorkCloneReclaim(ctx, dir, decision)
+	}
+	return decideBranchWorkCloneReclaim(ctx, dir, branch, decision)
+}
+
+// decideDetachedWorkCloneReclaim handles a clone left on a detached HEAD: safe
+// only when the exact commit checked out is already reachable from some
+// remote-tracking ref, since a detached commit is unreachable (and therefore
+// as good as lost) the moment nothing else points at it.
+func decideDetachedWorkCloneReclaim(ctx Context, dir string, decision WorkCloneReclaimDecision) WorkCloneReclaimDecision {
+	sha, ok, err := gitResolvedRef(ctx, dir, "HEAD")
+	if err != nil || !ok {
+		decision.Reason = "detached HEAD and its commit could not be resolved"
+		return decision
+	}
+	if ref, ok := gitRemoteRefContainingCommit(ctx, dir, sha); ok {
+		decision.Reclaim = true
+		decision.Reason = fmt.Sprintf("detached HEAD at %s is already reachable from remote ref %s", shortSHA(sha), ref)
+		return decision
+	}
+	decision.Reason = fmt.Sprintf("detached HEAD at %s is not reachable from any remote-tracking ref", shortSHA(sha))
+	return decision
+}
+
+// decideBranchWorkCloneReclaim handles a clone on a real branch. The ordinary
+// case is an upstream that already has every local commit; a repository that
+// squash-merges (this one included) leaves a second, equally common end
+// state for a landed branch -- the local commits are individually absent from
+// upstream (or upstream is gone entirely) because the merge tool folded them
+// into one commit on the default branch under a different SHA. That case is
+// only ever treated as safe when it can be proven (see findSquashMergeCommit);
+// otherwise the branch is kept exactly as an ordinary set of unpushed commits
+// would be.
+func decideBranchWorkCloneReclaim(ctx Context, dir, branch string, decision WorkCloneReclaimDecision) WorkCloneReclaimDecision {
+	upstream, hasUpstream := resolveBranchUpstreamCandidate(ctx, dir, branch)
+	if hasUpstream {
+		ahead, err := gitCommitsAhead(ctx, dir, upstream, branch)
+		if err != nil {
+			decision.Reason = fmt.Sprintf("could not compare %s against its upstream %s: %v", branch, upstream, err)
+			return decision
+		}
+		if ahead == 0 {
+			decision.Reclaim = true
+			decision.Reason = fmt.Sprintf("branch %s is fully pushed to %s", branch, upstream)
+			return decision
+		}
+		if sha, mergedBranch, ok := findSquashMergeCommit(ctx, dir, branch); ok {
+			decision.Reclaim = true
+			decision.Reason = fmt.Sprintf("%d commit(s) on %s are unpushed to %s, but that changeset is already merged into %s as %s",
+				ahead, branch, upstream, mergedBranch, shortSHA(sha))
+			return decision
+		}
+		decision.Reason = fmt.Sprintf("%d commit(s) on %s are ahead of %s and were not found merged anywhere else", ahead, branch, upstream)
+		return decision
+	}
+
+	if sha, mergedBranch, ok := findSquashMergeCommit(ctx, dir, branch); ok {
+		decision.Reclaim = true
+		decision.Reason = fmt.Sprintf("branch %s has no upstream, but its changeset is already merged into %s as %s", branch, mergedBranch, shortSHA(sha))
+		return decision
+	}
+	decision.Reason = fmt.Sprintf("branch %s has no upstream configured, and its commits were not found merged anywhere else", branch)
+	return decision
+}
+
+// resolveBranchUpstreamCandidate answers "what would branch be compared
+// against to know it is safe" -- branch's configured @{u} when it has one,
+// falling back to a same-named branch on origin otherwise. The fallback
+// matters because a plain `git push origin branch:branch` (exactly what the
+// job-finish checkpoint in job_worktree.go does) lands the commit on the
+// remote without ever configuring `@{u}`, so a missing upstream is not proof
+// nothing was pushed -- it is only proof that *if* something was pushed, it
+// was not pushed the way `-u` would have recorded it.
+func resolveBranchUpstreamCandidate(ctx Context, dir, branch string) (string, bool) {
+	if upstream, ok := gitUpstreamRef(ctx, dir, branch); ok {
+		return upstream, true
+	}
+	candidate := "origin/" + branch
+	if _, ok, err := gitResolvedRef(ctx, dir, candidate); err == nil && ok {
+		return candidate, true
+	}
+	return "", false
+}
+
+// findSquashMergeCommit proves a branch's exact changeset already landed on
+// the remote's default branch under a different commit, the normal end state
+// for a branch this repository squash-merged. Proof is a tree-hash match: a
+// commit on the default branch whose full resulting tree is byte-identical to
+// branch's own tip tree means every file branch would contribute is already
+// present there, which is a stronger, exact claim than comparing patches
+// (immune to context-line or whitespace differences a patch-id compare could
+// be fooled by). Search is bounded to commits between the branches' merge
+// base and the default branch's tip, so a large history costs one bounded
+// walk rather than the whole repository log.
+func findSquashMergeCommit(ctx Context, dir, branch string) (sha, defaultBranch string, ok bool) {
+	defaultBranch, hasDefault := resolveDefaultBranchForMerge(ctx, dir, "origin")
+	if !hasDefault {
+		return "", "", false
+	}
+	defaultRef := "origin/" + defaultBranch
+	if _, exists, err := gitResolvedRef(ctx, dir, defaultRef); err != nil || !exists {
+		return "", "", false
+	}
+
+	tipTree, ok := gitTreeHash(ctx, dir, branch)
+	if !ok || tipTree == "" {
+		return "", "", false
+	}
+
+	rangeSpec := defaultRef
+	if base, ok := gitMergeBase(ctx, dir, branch, defaultRef); ok {
+		rangeSpec = base + ".." + defaultRef
+	}
+	commits, err := gitCommitTreesInRange(ctx, dir, rangeSpec)
+	if err != nil {
+		return "", "", false
+	}
+	for _, commit := range commits {
+		if commit.tree == tipTree {
+			return commit.sha, defaultBranch, true
+		}
+	}
+	return "", "", false
+}
+
+// resolveDefaultBranchForMerge mirrors job_worktree.go's own
+// environmentJobWorktreeIsProtectedBranch fallback: origin/HEAD's symref is
+// authoritative when it is set, but a shallow or single-branch fetch (a real
+// layout this repository's own lanes use) never sets it, so the common
+// default names are checked directly against what actually exists on the
+// remote rather than guessed blindly.
+func resolveDefaultBranchForMerge(ctx Context, dir, remote string) (string, bool) {
+	if def, ok := gitRemoteDefaultBranch(ctx, dir, remote); ok {
+		return def, true
+	}
+	for _, candidate := range []string{"main", "master", "develop"} {
+		if _, ok, err := gitResolvedRef(ctx, dir, remote+"/"+candidate); err == nil && ok {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+// gitFetchOrigin refreshes the local view of the remote so the checks above
+// see recently landed merges rather than whatever the clone last observed.
+// Best-effort by design (see DecideWorkCloneReclaim): a failure here only
+// ever pushes the decision toward keeping a clone, never toward losing one.
+func gitFetchOrigin(ctx Context, dir string) {
+	ctx.TraceCommand("", "git", "-C", dir, "fetch", "origin", "--prune")
+	_ = Command("git", "-C", dir, "fetch", "origin", "--prune").Run()
+}
+
+func gitUpstreamRef(ctx Context, dir, branch string) (string, bool) {
+	ref := branch + "@{u}"
+	ctx.TraceCommand("", "git", "-C", dir, "rev-parse", "--abbrev-ref", ref)
+	output, err := Command("git", "-C", dir, "rev-parse", "--abbrev-ref", ref).Output()
+	if err != nil {
+		return "", false
+	}
+	upstream := strings.TrimSpace(string(output))
+	if upstream == "" {
+		return "", false
+	}
+	return upstream, true
+}
+
+func gitCommitsAhead(ctx Context, dir, base, tip string) (int, error) {
+	rangeSpec := base + ".." + tip
+	ctx.TraceCommand("", "git", "-C", dir, "rev-list", "--count", rangeSpec)
+	output, err := Command("git", "-C", dir, "rev-list", "--count", rangeSpec).Output()
+	if err != nil {
+		return 0, err
+	}
+	count, convErr := strconv.Atoi(strings.TrimSpace(string(output)))
+	if convErr != nil {
+		return 0, convErr
+	}
+	return count, nil
+}
+
+func gitMergeBase(ctx Context, dir, a, b string) (string, bool) {
+	ctx.TraceCommand("", "git", "-C", dir, "merge-base", a, b)
+	output, err := Command("git", "-C", dir, "merge-base", a, b).Output()
+	if err != nil {
+		return "", false
+	}
+	sha := strings.TrimSpace(string(output))
+	return sha, sha != ""
+}
+
+func gitTreeHash(ctx Context, dir, rev string) (string, bool) {
+	sha, ok, err := gitResolvedRef(ctx, dir, rev+"^{tree}")
+	if err != nil || !ok {
+		return "", false
+	}
+	return sha, true
+}
+
+// gitCommitTree pairs a commit with the tree it produced, as read from `git
+// log --format=%H %T`.
+type gitCommitTree struct {
+	sha  string
+	tree string
+}
+
+func gitCommitTreesInRange(ctx Context, dir, rangeSpec string) ([]gitCommitTree, error) {
+	ctx.TraceCommand("", "git", "-C", dir, "log", "--format=%H %T", rangeSpec)
+	output, err := Command("git", "-C", dir, "log", "--format=%H %T", rangeSpec).Output()
+	if err != nil {
+		return nil, err
+	}
+	var commits []gitCommitTree
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		commits = append(commits, gitCommitTree{sha: fields[0], tree: fields[1]})
+	}
+	return commits, nil
+}
+
+// gitRemoteRefContainingCommit reports the first remote-tracking ref that
+// contains sha, skipping a remote's symbolic HEAD line (e.g.
+// "origin/HEAD -> origin/main") which names no ref of its own.
+func gitRemoteRefContainingCommit(ctx Context, dir, sha string) (string, bool) {
+	ctx.TraceCommand("", "git", "-C", dir, "branch", "-r", "--contains", sha)
+	output, err := Command("git", "-C", dir, "branch", "-r", "--contains", sha).Output()
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.Contains(line, "->") {
+			continue
+		}
+		return line, true
+	}
+	return "", false
+}
+
+// reclaimAgentJobWorkClone runs once, at the same point captureAgentJobWorktreeOutcome
+// runs (finishEnvironmentJob), and only for a job whose own run just ended
+// cleanly (EnvironmentJobStateExited): never one still running, never one
+// that left unresolved background work behind it (abandoned/gate-incomplete
+// are excluded by that same check), and never anything outside the work root,
+// which is what keeps the runtime repo untouchable regardless of what a
+// caller set Dir to. Restricted to Kind == EnvironmentJobKindAgent, the kind
+// the actual problem is about; a command job's Dir is routinely the runtime
+// repo itself, and this never even inspects a command job's Dir.
+func reclaimAgentJobWorkClone(job EnvironmentJob) (reclaimed bool, reason string) {
+	if job.Kind != EnvironmentJobKindAgent || job.State != EnvironmentJobStateExited {
+		return false, ""
+	}
+	dir := strings.TrimSpace(job.Dir)
+	if dir == "" {
+		return false, ""
+	}
+	root, err := workCloneRoot("")
+	if err != nil || !isUnderWorkRoot(root, dir) {
+		return false, ""
+	}
+
+	ctx := Context{Logger: NewLogger(VerbosityInfo)}
+	decision := DecideWorkCloneReclaim(ctx, dir)
+	if !decision.Reclaim {
+		return false, decision.Reason
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return false, fmt.Sprintf("git state allowed reclaiming %s but removing it failed: %v", dir, err)
+	}
+	return true, ""
+}

--- a/erun-common/work_clone_reclaim_test.go
+++ b/erun-common/work_clone_reclaim_test.go
@@ -1,0 +1,458 @@
+package eruncommon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This repository squash-merges every branch. That means the *normal* end
+// state for a landed feature branch is: its commits are individually absent
+// from the default branch (folded into one squash commit under a different
+// SHA), and its own remote branch is very often deleted outright once GitHub
+// merges it. A reclaim check that reads "no upstream" or "commits not on
+// upstream" as unsafe by itself would therefore refuse to reclaim almost
+// every clone that actually finished cleanly. The tests below pin both
+// halves of that: the ordinary unpushed-and-truly-abandoned case stays kept,
+// and the squash-merged case is proven safe and reclaimed.
+
+func withFakeWorkHome(t *testing.T) (home, root string) {
+	t.Helper()
+	home = t.TempDir()
+	root = filepath.Join(home, "work")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir work root: %v", err)
+	}
+	original := workCloneUserHomeDir
+	workCloneUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { workCloneUserHomeDir = original })
+	return home, root
+}
+
+func initGitRepoAt(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir repo dir: %v", err)
+	}
+	runGitForTest(t, dir, "init", "-q", "-b", "main")
+	runGitForTest(t, dir, "config", "user.email", "test@example.com")
+	runGitForTest(t, dir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	runGitForTest(t, dir, "add", "seed.txt")
+	runGitForTest(t, dir, "commit", "-q", "-m", "seed")
+}
+
+func testContext() Context {
+	return Context{Logger: NewLogger(VerbosityInfo)}
+}
+
+// writeAndCommit writes name/content into dir and commits it, for building up
+// the exact commit graphs the decision tests below compare against.
+func writeAndCommit(t *testing.T, dir, name, content, message string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	runGitForTest(t, dir, "add", name)
+	runGitForTest(t, dir, "commit", "-q", "-m", message)
+}
+
+// newRepoWithBareRemote is newAgentJobTestRepo plus newBareRemoteForTest,
+// returning both paths for scenarios that need a second clone of the same
+// remote (simulating a separate actor merging the branch).
+func newRepoWithBareRemote(t *testing.T) (repo, bare string) {
+	t.Helper()
+	repo = newAgentJobTestRepo(t)
+	bare = newBareRemoteForTest(t, repo)
+	return repo, bare
+}
+
+func TestDecideWorkCloneReclaimCleanAndFullyPushedBranchIsReclaimed(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if !decision.Reclaim {
+		t.Fatalf("Reclaim = false, want true (reason: %s)", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimDirtyWorkingTreeIsKept(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+	dirtyWorkingTree(t, repo)
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for a dirty tree, want false")
+	}
+	if !strings.Contains(decision.Reason, "uncommitted") {
+		t.Fatalf("Reason %q does not explain the dirty tree", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimUntrackedFileOnlyStillCountsAsDirty(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+	if err := os.WriteFile(filepath.Join(repo, "scratch.txt"), []byte("not committed\n"), 0o644); err != nil {
+		t.Fatalf("write untracked file: %v", err)
+	}
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for an untracked-only tree, want false: an untracked file can still hold real work")
+	}
+}
+
+func TestDecideWorkCloneReclaimUnpushedCommitsWithNoProofTheyLandedElsewhereAreKept(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+	writeAndCommit(t, repo, "more.txt", "more work\n", "unpushed work")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for a branch with unpushed, unmerged commits, want false")
+	}
+	if !strings.Contains(decision.Reason, "ahead") {
+		t.Fatalf("Reason %q does not explain the unpushed commit(s)", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimBranchWithNoUpstreamAndNoProofOfMergeIsKept(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	writeAndCommit(t, repo, "more.txt", "more work\n", "never pushed")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for a branch that was never pushed at all, want false")
+	}
+	if !strings.Contains(decision.Reason, "no upstream") {
+		t.Fatalf("Reason %q does not explain the missing upstream", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimDetachedHeadReachableFromARemoteRefIsReclaimed(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "push", "-q", "origin", "main")
+	runGitForTest(t, repo, "checkout", "-q", "--detach", "HEAD")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if !decision.Reclaim {
+		t.Fatalf("Reclaim = false for a detached HEAD already pushed via main, want true (reason: %s)", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimDetachedHeadNotReachableAnywhereIsKept(t *testing.T) {
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "push", "-q", "origin", "main")
+	writeAndCommit(t, repo, "more.txt", "more work\n", "never pushed")
+	runGitForTest(t, repo, "checkout", "-q", "--detach", "HEAD")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for a detached HEAD with no remote ref containing it, want false")
+	}
+	if !strings.Contains(decision.Reason, "detached") {
+		t.Fatalf("Reason %q does not explain the unreachable detached HEAD", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimNotAGitWorkingTreeIsKept(t *testing.T) {
+	dir := t.TempDir()
+	decision := DecideWorkCloneReclaim(testContext(), dir)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for a plain directory, want false")
+	}
+}
+
+func TestDecideWorkCloneReclaimSquashMergedBranchWithADeletedRemoteBranchIsReclaimed(t *testing.T) {
+	repo, bare := newRepoWithBareRemote(t)
+	runGitForTest(t, repo, "push", "-q", "origin", "main")
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	writeAndCommit(t, repo, "feature-a.txt", "feature work a\n", "feature commit 1")
+	writeAndCommit(t, repo, "feature-b.txt", "feature work b\n", "feature commit 2")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	// A separate clone plays the role of the merge tool: squash-merge
+	// feature/lane into main, push main, then delete the remote feature
+	// branch outright -- the exact behavior GitHub's "delete branch on
+	// merge" performs, and the normal end state for a branch this
+	// repository lands.
+	merger := t.TempDir()
+	runGitForTest(t, filepath.Dir(merger), "clone", "-q", "--branch", "main", bare, merger)
+	runGitForTest(t, merger, "fetch", "-q", "origin", "feature/lane")
+	runGitForTest(t, merger, "merge", "-q", "--squash", "origin/feature/lane")
+	runGitForTest(t, merger, "commit", "-q", "-m", "Squash merge feature/lane (#1)")
+	runGitForTest(t, merger, "push", "-q", "origin", "main")
+	runGitForTest(t, merger, "push", "-q", "origin", "--delete", "feature/lane")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if !decision.Reclaim {
+		t.Fatalf("Reclaim = false for a branch squash-merged into main, want true (reason: %s)", decision.Reason)
+	}
+	if !strings.Contains(decision.Reason, "merged") {
+		t.Fatalf("Reason %q does not explain the squash-merge proof", decision.Reason)
+	}
+}
+
+func TestDecideWorkCloneReclaimUnpushedBranchThatOnlyLooksLikeASquashMergeIsKept(t *testing.T) {
+	repo, bare := newRepoWithBareRemote(t)
+	runGitForTest(t, repo, "push", "-q", "origin", "main")
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	writeAndCommit(t, repo, "feature-a.txt", "feature work a\n", "feature commit 1")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	// Somebody else's unrelated work lands on main -- main moves, but
+	// feature/lane's own changeset never gets merged anywhere.
+	other := t.TempDir()
+	runGitForTest(t, filepath.Dir(other), "clone", "-q", "--branch", "main", bare, other)
+	writeAndCommit(t, other, "unrelated.txt", "unrelated\n", "unrelated main work")
+	runGitForTest(t, other, "push", "-q", "origin", "main")
+
+	// Then feature/lane's own commit gets one more unpushed commit ahead of
+	// what it already pushed, so this is unambiguously "still live work in
+	// progress", not a landed branch.
+	writeAndCommit(t, repo, "feature-b.txt", "feature work b\n", "feature commit 2, unpushed")
+
+	decision := DecideWorkCloneReclaim(testContext(), repo)
+	if decision.Reclaim {
+		t.Fatalf("Reclaim = true for a branch that merely resembles a squash merge, want false (its changeset was never actually merged)")
+	}
+}
+
+func TestIsUnderWorkRoot(t *testing.T) {
+	cases := []struct {
+		name string
+		root string
+		dir  string
+		want bool
+	}{
+		{"clone inside root", "/home/erun/work", "/home/erun/work/erun-w2", true},
+		{"nested clone inside root", "/home/erun/work", "/home/erun/work/erun-w2/sub", true},
+		{"the root itself", "/home/erun/work", "/home/erun/work", false},
+		{"sibling runtime repo", "/home/erun/work", "/home/erun/git/erun", false},
+		{"parent of root", "/home/erun/work", "/home/erun", false},
+		{"path traversal escape", "/home/erun/work", "/home/erun/work/../git/erun", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnderWorkRoot(tc.root, tc.dir); got != tc.want {
+				t.Fatalf("isUnderWorkRoot(%q, %q) = %v, want %v", tc.root, tc.dir, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReclaimAgentJobWorkCloneCleanPushedIsRemoved(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w1")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	const tenant, environment, id = "reclaim-contract", "clean-pushed", "job"
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if !job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = false, want true (kept reason: %s)", job.CloneKeptReason)
+	}
+	if _, err := os.Stat(repo); !os.IsNotExist(err) {
+		t.Fatalf("clone dir still exists after being reported reclaimed: %v", err)
+	}
+}
+
+func TestReclaimAgentJobWorkCloneDirtyDetachedIsKept(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w2")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "--detach", "HEAD")
+
+	const tenant, environment, id = "reclaim-contract", "dirty-detached", "job"
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "printf 'work\\n' > uncommitted.txt"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = true for a dirty, detached-HEAD clone, want false")
+	}
+	if job.CloneKeptReason == "" {
+		t.Fatalf("CloneKeptReason is empty, want an explanation")
+	}
+	if _, err := os.Stat(repo); err != nil {
+		t.Fatalf("clone dir was removed even though it was kept: %v", err)
+	}
+}
+
+func TestReclaimAgentJobWorkCloneCheckpointedAndPushedIsReclaimedAfterTheCheckpoint(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w3")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+
+	const tenant, environment, id = "reclaim-contract", "checkpointed", "job"
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "printf 'work\\n' > uncommitted.txt"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if !job.WorktreePushed {
+		t.Fatalf("expected the dirty tree to be checkpointed and pushed first (reason: %s)", job.WorktreeReason)
+	}
+	if !job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = false after its own dirty tree was checkpointed and pushed, want true (kept reason: %s)", job.CloneKeptReason)
+	}
+	if _, err := os.Stat(repo); !os.IsNotExist(err) {
+		t.Fatalf("clone dir still exists after being reported reclaimed: %v", err)
+	}
+}
+
+func TestReclaimAgentJobWorkCloneCommandJobsAreNeverReclaimed(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w4")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	const tenant, environment, id = "reclaim-contract", "command-kind", "job"
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Command: []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = true for a command job, want false: only agent jobs are candidates")
+	}
+	if _, err := os.Stat(repo); err != nil {
+		t.Fatalf("a command job's Dir must never be touched: %v", err)
+	}
+}
+
+func TestReclaimAgentJobWorkCloneOutsideWorkRootIsNeverReclaimed(t *testing.T) {
+	isolateActivityCache(t)
+	withFakeWorkHome(t)
+	// Deliberately outside the fake home's work root -- stands in for the
+	// runtime repo itself, or any other directory a caller might mistakenly
+	// pass as Dir.
+	repo := newAgentJobTestRepo(t)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	const tenant, environment, id = "reclaim-contract", "outside-root", "job"
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = true for a clone outside the work root, want false")
+	}
+	if _, err := os.Stat(repo); err != nil {
+		t.Fatalf("a clone outside the work root must never be touched: %v", err)
+	}
+}
+
+func TestReclaimAgentJobWorkCloneStillRunningIsNeverTouched(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w5")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	const tenant, environment, id = "reclaim-contract", "still-running", "job"
+	done := make(chan error, 1)
+	go func() {
+		done <- RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+			Tenant: tenant, Environment: environment, ID: id, Name: id,
+			Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "sleep 0.5"},
+		})
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	sawRunning := false
+	for time.Now().Before(deadline) {
+		job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+		if err == nil && job.State == EnvironmentJobStateRunning {
+			sawRunning = true
+			if _, statErr := os.Stat(repo); statErr != nil {
+				t.Fatalf("clone dir must never be touched while its job is running: %v", statErr)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !sawRunning {
+		t.Fatalf("never observed the job in the running state; the assertion above never ran")
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if !job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = false once the job actually finished, want true (kept reason: %s)", job.CloneKeptReason)
+	}
+}

--- a/erun-integration/job_test.go
+++ b/erun-integration/job_test.go
@@ -821,6 +821,116 @@ func TestJob(t *testing.T) {
 		golden.Equal(t, "job/an_agent_job_that_ends_with_an_uncommitted_working_tree_is_checkpointed_pushed_and_not_reported_as_success", normalize.Apply(status.Combined+await.Combined))
 	})
 
+	t.Run("an_agent_jobs_clean_pushed_clone_under_the_work_root_is_reclaimed_after_it_finishes", func(t *testing.T) {
+		// The reproduction this closes: every agent task clones the repo into
+		// /home/erun/work/<name> and nothing ever reclaims it, so the work
+		// directory grows without bound (erun#1710). A clone under the work
+		// root whose tree is clean and fully pushed has nothing left to lose,
+		// so the supervisor removes it the moment the job that owned it exits
+		// -- proven here against a real git working tree and a real remote,
+		// not just the job record's own claim.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+
+		lane := filepath.Join(setup.Home, "work", "erun-w1")
+		fixture.SeedGitRepo(t, lane)
+		fixture.RunGit(t, lane, "checkout", "-q", "-b", "feature/lane")
+		remote := filepath.Join(setup.Home, "lane-origin.git")
+		fixture.RunGit(t, setup.Home, "init", "-q", "--bare", remote)
+		fixture.RunGit(t, lane, "remote", "add", "origin", remote)
+		fixture.RunGit(t, lane, "push", "-q", "-u", "origin", "feature/lane")
+
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinaryWithScript(t, stubs, "claude", "exit 0\n")
+		envVars := inEnvironment(append(setup.Env(), fixture.StubEnv(stubs, "claude")...))
+
+		start := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "lane",
+			"--dir", lane, "--agent", "claude", "--", "do the lane's work"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if start.ExitCode != 0 {
+			t.Fatalf("start: exit %d: %s", start.ExitCode, start.Combined)
+		}
+		t.Cleanup(func() {
+			erun.Run(t, []string{"job", "cancel", "--tenant", "team", "--environment", "dev", "--id", "lane", "--signal", "KILL"},
+				erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		})
+
+		var status erun.Result
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			status = erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "lane"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+			if !strings.HasPrefix(status.Combined, "running:") {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("job never left running: %s", status.Combined)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "lane", "--timeout", "1s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if await.ExitCode != 0 {
+			t.Fatalf("expected a clean, fully-pushed job to report success, got %d:\n%s", await.ExitCode, await.Combined)
+		}
+		// The clone itself is gone from disk -- not asserted only through the
+		// job record.
+		if _, err := os.Stat(lane); !os.IsNotExist(err) {
+			t.Fatalf("clone dir still exists after being reported reclaimed: %v", err)
+		}
+		golden.Equal(t, "job/an_agent_jobs_clean_pushed_clone_under_the_work_root_is_reclaimed_after_it_finishes", normalize.Apply(status.Combined+await.Combined))
+	})
+
+	t.Run("an_agent_jobs_dirty_detached_clone_is_kept_and_the_reason_is_named", func(t *testing.T) {
+		// The obvious reclaim is destructive: a detached HEAD with
+		// uncommitted work is exactly the shape the reported environment's
+		// stale clones had (erun#1710). The supervisor must refuse to remove
+		// it and say why, rather than leaving an operator to rediscover by
+		// hand that a clone still holds real work.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+
+		lane := filepath.Join(setup.Home, "work", "erun-w2")
+		fixture.SeedGitRepo(t, lane)
+		remote := filepath.Join(setup.Home, "lane-origin.git")
+		fixture.RunGit(t, setup.Home, "init", "-q", "--bare", remote)
+		fixture.RunGit(t, lane, "remote", "add", "origin", remote)
+		fixture.RunGit(t, lane, "push", "-q", "origin", "main")
+		fixture.RunGit(t, lane, "checkout", "-q", "--detach", "HEAD")
+
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinaryWithScript(t, stubs, "claude", "printf 'lane work\\n' > uncommitted.txt\nexit 0\n")
+		envVars := inEnvironment(append(setup.Env(), fixture.StubEnv(stubs, "claude")...))
+
+		start := erun.Run(t, []string{"job", "start", "--tenant", "team", "--environment", "dev", "--name", "lane",
+			"--dir", lane, "--agent", "claude", "--", "do the lane's work"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if start.ExitCode != 0 {
+			t.Fatalf("start: exit %d: %s", start.ExitCode, start.Combined)
+		}
+		t.Cleanup(func() {
+			erun.Run(t, []string{"job", "cancel", "--tenant", "team", "--environment", "dev", "--id", "lane", "--signal", "KILL"},
+				erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		})
+
+		var status erun.Result
+		deadline := time.Now().Add(30 * time.Second)
+		for {
+			status = erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "lane"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+			if !strings.HasPrefix(status.Combined, "running:") {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("job never left running: %s", status.Combined)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "lane", "--timeout", "1s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if await.ExitCode == 0 {
+			t.Fatalf("expected a dirty-worktree job to report a failure outcome, got 0:\n%s", await.Combined)
+		}
+		if _, err := os.Stat(lane); err != nil {
+			t.Fatalf("clone dir was removed even though it should have been kept: %v", err)
+		}
+		golden.Equal(t, "job/an_agent_jobs_dirty_detached_clone_is_kept_and_the_reason_is_named", normalize.Apply(status.Combined+await.Combined))
+	})
+
 	t.Run("a_job_started_on_a_different_pod_reads_back_as_pod_replaced_not_a_guess", func(t *testing.T) {
 		// The supervisor stamps the pod's hostname at start, so a record
 		// read back from a different hostname is definitive proof of pod

--- a/erun-integration/testdata/job/an_agent_jobs_clean_pushed_clone_under_the_work_root_is_reclaimed_after_it_finishes.txt
+++ b/erun-integration/testdata/job/an_agent_jobs_clean_pushed_clone_under_the_work_root_is_reclaimed_after_it_finishes.txt
@@ -1,0 +1,4 @@
+exited 0: lane, agent claude, no events yet, clone reclaimed, 0 bytes of output
+audit: erun job status --environment dev --id lane --tenant team
+exited 0: lane, agent claude, no events yet, clone reclaimed, 0 bytes of output
+audit: erun job await --environment dev --id lane --tenant team --timeout 1s

--- a/erun-integration/testdata/job/an_agent_jobs_dirty_detached_clone_is_kept_and_the_reason_is_named.txt
+++ b/erun-integration/testdata/job/an_agent_jobs_dirty_detached_clone_is_kept_and_the_reason_is_named.txt
@@ -1,0 +1,5 @@
+exited 0: lane, agent claude, no events yet, working tree was dirty and left uncommitted: the working tree had uncommitted changes when the job ended, but HEAD was detached; a checkpoint commit there would be unreachable the moment HEAD moves, so none was made, clone kept: working tree has 1 uncommitted change(s) (e.g. uncommitted.txt), tracked or untracked, 0 bytes of output
+audit: erun job status --environment dev --id lane --tenant team
+exited 0: lane, agent claude, no events yet, working tree was dirty and left uncommitted: the working tree had uncommitted changes when the job ended, but HEAD was detached; a checkpoint commit there would be unreachable the moment HEAD moves, so none was made, clone kept: working tree has 1 uncommitted change(s) (e.g. uncommitted.txt), tracked or untracked, 0 bytes of output
+audit: erun job await --environment dev --id lane --tenant team --timeout 1s
+job "lane" ended with an uncommitted working tree: working tree was dirty and left uncommitted: the working tree had uncommitted changes when the job ended, but HEAD was detached; a checkpoint commit there would be unreachable the moment HEAD moves, so none was made


### PR DESCRIPTION
## Summary
- Every agent task that clones the repo into `/home/erun/work/<name>` left the clone behind permanently — nothing ever reclaimed it, so the work directory grows without bound. Filed as #1710: 13 clones, 25GB, none touched in 2-5 days, three of which held the only copy of real work (2 and 5 unpushed commits, 590 modified files).
- Add a supervisor-side reclaim step in `erun-common/work_clone_reclaim.go` that runs once, at the exact moment an agent job's own process exits — the same hook point as the existing worktree-checkpoint (`job_worktree.go`). "Finished" is answered structurally, not by a timestamp: reclaim only ever runs from inside `finishEnvironmentJob`, so there is no window where a running job's directory could be mistaken for an idle one.
- A clone is removed only when its tree is clean (tracked or untracked) and every commit reachable from HEAD is already reachable from a remote — proven via a real upstream, a same-named remote branch (the job-finish checkpoint's own plain `push` never sets `@{u}`), a detached HEAD reachable from any remote-tracking ref, or — since this repository squash-merges everything — a tree-hash match against the resolved default branch when the branch's own remote copy is gone (GitHub's "delete branch on merge"). Anything that can't be proven safe is kept and named: `EnvironmentJob.CloneReclaimed`/`CloneKeptReason`, surfaced in `job status`/`job await` output (`, clone reclaimed` / `, clone kept: <reason>`).
- Reclaim only ever considers a job's own `Dir`, only after a clean `EnvironmentJobStateExited` finish (never abandoned/gate-incomplete/unknown, never a still-running job), and only inside the work root (`<home>/work`) — never the runtime repo itself, which lives beside it, not under it.
- Restricted to agent jobs (`Kind == EnvironmentJobKindAgent`), matching the actual reported problem; a command job's `Dir` is routinely the runtime repo itself and is never inspected.

## What this does not do
- The 13 clones already accumulated on the reported environment are untouched by this change (correctly — their job records expired long before this shipped, and there is no live completion event left to hook into). Reclaiming those needs a one-time manual pass; this closes the leak going forward.

## Test plan
- [x] `erun-common/work_clone_reclaim_test.go`: every decision branch (clean+pushed → reclaim, dirty → kept, untracked-only → kept, unpushed → kept, no-upstream → kept, detached+reachable → reclaim, detached+unreachable → kept, squash-merged-with-deleted-remote-branch → reclaim, unpushed-branch-that-only-resembles-a-squash → kept, not-a-git-tree → kept), plus `isUnderWorkRoot` boundary cases and full-pipeline tests via `RunEnvironmentJobSupervisor` (command jobs never reclaimed, outside-work-root never reclaimed, still-running never touched, checkpoint-then-reclaim synergy).
- [x] `erun-integration/job_test.go`: two new end-to-end scenarios against the compiled binary + real git repos/remotes (clean+pushed clone reclaimed after `job await`; dirty detached clone kept and named), both with reviewed goldens under `erun-integration/testdata/job/`.
- [x] `make check` green (detached job, replay-verified): all module lints 0 issues, `erun-integration` coverage 75.6% (>= 75.6%, unchanged threshold).
- [x] Did not touch any real clone under `/home/erun/work`; all fixtures are constructed temp repos.

Closes #1710