### PR TITLE
Add a target selection surface to the desktop whip control

### DIFF
--- a/erun-ui/frontend/src/app/model/index.ts
+++ b/erun-ui/frontend/src/app/model/index.ts
@@ -21,3 +21,4 @@ export type { SSHDInitCompletedPayload } from './sshdInitCompletedPayload';
 export type { TerminalDataDisposable } from './terminalDataDisposable';
 export type { TerminalExitSelections } from './terminalExitSelections';
 export type { TerminalWriteData } from './terminalWriteData';
+export type { WhipDefaultTarget, WhipTargetSelection } from './whipTargetSelection';

--- a/erun-ui/frontend/src/app/model/whipTargetSelection.ts
+++ b/erun-ui/frontend/src/app/model/whipTargetSelection.ts
@@ -1,0 +1,23 @@
+// WhipTargetSelection is the whip control's own working selection: which
+// individual environment/orchestrator ids the operator checked, plus a
+// per-category "all" mode that tracks the *population*, not a snapshot of ids
+// -- so a target that becomes eligible after "Select all X" was clicked is
+// still included when the whip actually runs (erun#1700's "group selects
+// follow the population, not a snapshot"). Never persisted: a fresh popover
+// open always recomputes this from the current sidebar focus, never a
+// previous invocation's choice.
+export interface WhipTargetSelection {
+  environmentMode: 'all' | 'custom';
+  orchestratorMode: 'all' | 'custom';
+  selectedEnvironmentIds: string[];
+  selectedOrchestratorIds: string[];
+}
+
+// WhipDefaultTarget is the one target a fresh popover open preselects: the
+// sidebar's current focus, translated to the id/name a whip target row uses.
+// Null means nothing is focused (dashboard, or nothing at all) -- that must
+// never fall back to "select everything" (erun#1700).
+export type WhipDefaultTarget =
+  | { kind: 'environment'; id: string; name: string }
+  | { kind: 'orchestrator'; id: string; name: string }
+  | null;

--- a/erun-ui/frontend/src/app/selectors.ts
+++ b/erun-ui/frontend/src/app/selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@reduxjs/toolkit';
 
 import type { UISelection } from '@/types';
 
-import type { SidebarFocus } from './model';
+import type { SidebarFocus, WhipDefaultTarget } from './model';
 import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 import type { RootState } from './store';
 import { findVersionSuggestion, normalizeDialogValue, selectionKey } from './versionSuggestions';
@@ -174,6 +174,28 @@ export const selectSidebarFocus = (state: RootState): SidebarFocus => {
     return { kind: 'environment', tenant: selected.tenant, environment: selected.environment };
   }
   return { kind: 'none' };
+};
+
+// selectWhipDefaultTarget resolves the one target Whip preselects: the same
+// orchestrator-session-over-sidebar-selection precedence selectSidebarFocus
+// already established, translated into the id/name a whip target row uses.
+// The tenant dashboard and "nothing focused" both resolve to null rather than
+// falling back to any environment or orchestrator -- an unfocused whip must
+// have no default, never "everything" (erun#1700).
+export const selectWhipDefaultTarget = (state: RootState): WhipDefaultTarget => {
+  const orchestrator = selectActiveSessionOrchestrator(state);
+  if (orchestrator) {
+    return { kind: 'orchestrator', id: orchestrator.id, name: orchestrator.name };
+  }
+  if (state.tenantDashboard.tenant) {
+    return null;
+  }
+  const selected = state.selection.selected;
+  if (selected) {
+    const id = `${selected.tenant}/${selected.environment}`;
+    return { kind: 'environment', id, name: id };
+  }
+  return null;
 };
 
 export interface ReviewEnvTarget {

--- a/erun-ui/frontend/src/app/whipTargetSelection.ts
+++ b/erun-ui/frontend/src/app/whipTargetSelection.ts
@@ -1,0 +1,116 @@
+import type { WhipDefaultTarget, WhipTargetSelection } from '@/app/model';
+
+import type { main } from '../../wailsjs/go/models';
+
+// defaultWhipTargetSelection is what a freshly opened whip popover starts
+// from: the sidebar's current focus, checked by itself, nothing else. Never
+// "everything" -- an unfocused surface (dashboard, or nothing at all) starts
+// from an empty selection rather than defaulting to every configured target
+// (erun#1700's "an empty selection is not all", read the other way: no
+// default is not a default of all either).
+export function defaultWhipTargetSelection(defaultTarget: WhipDefaultTarget): WhipTargetSelection {
+  if (!defaultTarget) {
+    return {
+      environmentMode: 'custom',
+      orchestratorMode: 'custom',
+      selectedEnvironmentIds: [],
+      selectedOrchestratorIds: [],
+    };
+  }
+  return {
+    environmentMode: 'custom',
+    orchestratorMode: 'custom',
+    selectedEnvironmentIds: defaultTarget.kind === 'environment' ? [defaultTarget.id] : [],
+    selectedOrchestratorIds: defaultTarget.kind === 'orchestrator' ? [defaultTarget.id] : [],
+  };
+}
+
+export function toggleWhipEnvironment(
+  selection: WhipTargetSelection,
+  id: string,
+  checked: boolean,
+): WhipTargetSelection {
+  const next = new Set(selection.selectedEnvironmentIds);
+  if (checked) {
+    next.add(id);
+  } else {
+    next.delete(id);
+  }
+  return { ...selection, environmentMode: 'custom', selectedEnvironmentIds: [...next] };
+}
+
+export function toggleWhipOrchestrator(
+  selection: WhipTargetSelection,
+  id: string,
+  checked: boolean,
+): WhipTargetSelection {
+  const next = new Set(selection.selectedOrchestratorIds);
+  if (checked) {
+    next.add(id);
+  } else {
+    next.delete(id);
+  }
+  return { ...selection, orchestratorMode: 'custom', selectedOrchestratorIds: [...next] };
+}
+
+export function selectAllWhipEnvironments(selection: WhipTargetSelection): WhipTargetSelection {
+  return { ...selection, environmentMode: 'all' };
+}
+
+export function selectAllWhipOrchestrators(selection: WhipTargetSelection): WhipTargetSelection {
+  return { ...selection, orchestratorMode: 'all' };
+}
+
+export function selectAllWhipTargets(selection: WhipTargetSelection): WhipTargetSelection {
+  return { ...selection, environmentMode: 'all', orchestratorMode: 'all' };
+}
+
+// resolveWhipTargetRefs turns the working selection into the explicit list
+// WhipNow requires, against the freshest known population: an "all" category
+// resolves to every id currently listed (so an orchestrator that started
+// after "Select all orchestrators" was clicked, but before Whip actually ran,
+// is still included -- erun#1700's "group selects follow the population, not
+// a snapshot"); a "custom" category resolves to the checked ids that are
+// still present in that population, dropping any that disappeared.
+export function resolveWhipTargetRefs(
+  selection: WhipTargetSelection,
+  targets: main.uiWhipTargetList,
+): main.uiWhipTargetRef[] {
+  const refs: main.uiWhipTargetRef[] = [];
+  if (selection.environmentMode === 'all') {
+    for (const env of targets.environments) {
+      refs.push({ kind: 'environment', id: env.id });
+    }
+  } else {
+    const known = new Set(targets.environments.map((env) => env.id));
+    for (const id of selection.selectedEnvironmentIds) {
+      if (known.has(id)) {
+        refs.push({ kind: 'environment', id });
+      }
+    }
+  }
+  if (selection.orchestratorMode === 'all') {
+    for (const orchestrator of targets.orchestrators) {
+      refs.push({ kind: 'orchestrator', id: orchestrator.id });
+    }
+  } else {
+    const known = new Set(targets.orchestrators.map((orchestrator) => orchestrator.id));
+    for (const id of selection.selectedOrchestratorIds) {
+      if (known.has(id)) {
+        refs.push({ kind: 'orchestrator', id });
+      }
+    }
+  }
+  return refs;
+}
+
+// countWhipTargets is the count the primary action states before it acts
+// (erun#1700's "state the count before acting"), resolved against the same
+// freshest population resolveWhipTargetRefs uses so the number never lies
+// about what a click would actually push.
+export function countWhipTargets(
+  selection: WhipTargetSelection,
+  targets: main.uiWhipTargetList,
+): number {
+  return resolveWhipTargetRefs(selection, targets).length;
+}

--- a/erun-ui/frontend/src/app/whipThunks.ts
+++ b/erun-ui/frontend/src/app/whipThunks.ts
@@ -1,4 +1,4 @@
-import { WhipNow } from '../../wailsjs/go/main/App';
+import { WhipNow, WhipTargets } from '../../wailsjs/go/main/App';
 import type { main } from '../../wailsjs/go/models';
 import { readError } from './errors';
 import type { AppThunk } from './store';
@@ -8,18 +8,29 @@ export interface WhipOutcome {
   error: string | null;
 }
 
-// whipNow triggers one operator-initiated pass across every live orchestrator
-// and configured environment (erun-ui/whip.go's WhipNow, shared with `erun
-// whip`), returning the report -- or the call's own failure -- for the
-// triggering control to render inline. A whip is a quick, non-destructive
-// action, so its outcome belongs beside the button that started it rather
-// than in a detached notification (erun-ui/AGENTS.md's Design-Language
-// Decision Record, "Where a detached notification is earned").
-export const whipNow = (): AppThunk<Promise<WhipOutcome>> => async () => {
-  try {
-    const report = await WhipNow();
-    return { report, error: null };
-  } catch (error) {
-    return { report: null, error: readError(error) };
-  }
-};
+// whipTargets fetches the current selectable population (every environment
+// with a pod, every orchestrator live or configured) for the selection
+// surface to render and "select all" to resolve against. A pure read, so the
+// control can call it as often as it needs -- on open, on every "select all"
+// click, and once more immediately before a click actually whips -- with no
+// side effect (erun-ui/whip.go's WhipTargets).
+export const whipTargets = (): AppThunk<Promise<main.uiWhipTargetList>> => async () =>
+  WhipTargets();
+
+// whipNow triggers one operator-initiated whip pass against the explicit
+// target list the caller resolved (erun-ui/whip.go's WhipNow), returning the
+// report -- or the call's own failure -- for the triggering control to render
+// inline. A whip is a quick, non-destructive action, so its outcome belongs
+// beside the button that started it rather than in a detached notification
+// (erun-ui/AGENTS.md's Design-Language Decision Record, "Where a detached
+// notification is earned").
+export const whipNow =
+  (targets: main.uiWhipTargetRef[]): AppThunk<Promise<WhipOutcome>> =>
+  async () => {
+    try {
+      const report = await WhipNow(targets);
+      return { report, error: null };
+    } catch (error) {
+      return { report: null, error: readError(error) };
+    }
+  };

--- a/erun-ui/frontend/src/components/app/Titlebar.WhipAction.TargetPicker.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.WhipAction.TargetPicker.tsx
@@ -1,0 +1,172 @@
+import { Button, Checkbox } from 'erun-kit';
+import * as React from 'react';
+
+import type { WhipTargetSelection } from '@/app/model';
+
+import type { main } from '../../../wailsjs/go/models';
+
+interface TargetRow {
+  id: string;
+  label: string;
+  checked: boolean;
+}
+
+// isWhipSelectionEmpty is true only for the untouched default: nothing
+// focused, nothing manually checked either. Pulled out of the component body
+// to keep its own branching out of the render function's complexity budget.
+function isWhipSelectionEmpty(selection: WhipTargetSelection): boolean {
+  return (
+    selection.environmentMode === 'custom' &&
+    selection.orchestratorMode === 'custom' &&
+    selection.selectedEnvironmentIds.length === 0 &&
+    selection.selectedOrchestratorIds.length === 0
+  );
+}
+
+function orchestratorRows(
+  targets: main.uiWhipTargetList,
+  selection: WhipTargetSelection,
+): TargetRow[] {
+  return targets.orchestrators.map((orchestrator) => ({
+    id: orchestrator.id,
+    label: orchestrator.name,
+    checked:
+      selection.orchestratorMode === 'all' ||
+      selection.selectedOrchestratorIds.includes(orchestrator.id),
+  }));
+}
+
+function environmentRows(
+  targets: main.uiWhipTargetList,
+  selection: WhipTargetSelection,
+): TargetRow[] {
+  return targets.environments.map((environment) => ({
+    id: environment.id,
+    label: environment.id,
+    checked:
+      selection.environmentMode === 'all' ||
+      selection.selectedEnvironmentIds.includes(environment.id),
+  }));
+}
+
+function whipButtonLabel(pending: boolean, count: number): string {
+  if (pending) {
+    return 'Whipping…';
+  }
+  return `Whip ${String(count)} target${count === 1 ? '' : 's'}`;
+}
+
+// TitlebarWhipTargetPicker is the selection surface issue erun#1700 asks for:
+// individual environments and orchestrators, checkable, plus the three group
+// shortcuts, with the primary action stating how many targets it will whip
+// before it acts (Nielsen #1, visibility of system status) rather than
+// leaving the operator to guess from an unlabeled button. Plain checkboxes
+// and buttons rather than a Command/cmdk list: the population here is short
+// and never needs type-to-filter, and every row is reachable with a plain Tab
+// (WCAG 2.1.1 keyboard) the same way the existing deploy-components and
+// orchestrator-environments checklists already are.
+export function TitlebarWhipTargetPicker({
+  targets,
+  targetsLoading,
+  selection,
+  onToggleEnvironment,
+  onToggleOrchestrator,
+  onSelectAllEnvironments,
+  onSelectAllOrchestrators,
+  onSelectAll,
+  count,
+  pending,
+  onWhip,
+}: {
+  targets: main.uiWhipTargetList | null;
+  targetsLoading: boolean;
+  selection: WhipTargetSelection;
+  onToggleEnvironment: (id: string, checked: boolean) => void;
+  onToggleOrchestrator: (id: string, checked: boolean) => void;
+  onSelectAllEnvironments: () => void;
+  onSelectAllOrchestrators: () => void;
+  onSelectAll: () => void;
+  count: number;
+  pending: boolean;
+  onWhip: () => void;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-3">
+      {isWhipSelectionEmpty(selection) && (
+        <p className="text-xs text-muted-foreground">
+          Nothing is focused right now. Choose one or more targets below.
+        </p>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        <Button type="button" variant="outline" size="sm" onClick={onSelectAllOrchestrators}>
+          Select all orchestrators
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={onSelectAllEnvironments}>
+          Select all environments
+        </Button>
+        <Button type="button" variant="outline" size="sm" onClick={onSelectAll}>
+          Select all
+        </Button>
+      </div>
+      {targetsLoading || !targets ? (
+        <p className="text-xs text-muted-foreground">Loading targets…</p>
+      ) : (
+        <div className="flex max-h-[40vh] flex-col gap-3 overflow-y-auto">
+          <TargetSection
+            heading="Orchestrators"
+            emptyText="No orchestrators configured."
+            rows={orchestratorRows(targets, selection)}
+            onToggle={onToggleOrchestrator}
+          />
+          <TargetSection
+            heading="Environments"
+            emptyText="No environments available to whip."
+            rows={environmentRows(targets, selection)}
+            onToggle={onToggleEnvironment}
+          />
+        </div>
+      )}
+      <Button
+        type="button"
+        variant="default"
+        disabled={pending || targetsLoading || count === 0}
+        onClick={onWhip}
+      >
+        {whipButtonLabel(pending, count)}
+      </Button>
+    </div>
+  );
+}
+
+function TargetSection({
+  heading,
+  emptyText,
+  rows,
+  onToggle,
+}: {
+  heading: string;
+  emptyText: string;
+  rows: TargetRow[];
+  onToggle: (id: string, checked: boolean) => void;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-semibold text-muted-foreground uppercase">{heading}</span>
+      {rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">{emptyText}</p>
+      ) : (
+        rows.map((row) => (
+          <label key={row.id} className="flex items-center gap-2 py-0.5 text-xs">
+            <Checkbox
+              checked={row.checked}
+              onCheckedChange={(checked) => {
+                onToggle(row.id, checked === true);
+              }}
+            />
+            <span className="min-w-0 flex-1 truncate">{row.label}</span>
+          </label>
+        ))
+      )}
+    </div>
+  );
+}

--- a/erun-ui/frontend/src/components/app/Titlebar.WhipAction.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.WhipAction.tsx
@@ -2,53 +2,102 @@ import { Button, IconTooltip, Popover, PopoverAnchor, PopoverContent, StatusBadg
 import { LoaderCircle, Spline, X } from 'lucide-react';
 import * as React from 'react';
 
-import { useAppDispatch } from '@/app/hooks';
-import { whipNow, type WhipOutcome } from '@/app/whipThunks';
+import { useAppDispatch, useAppSelector } from '@/app/hooks';
+import type { WhipTargetSelection } from '@/app/model';
+import { selectWhipDefaultTarget } from '@/app/selectors';
+import {
+  countWhipTargets,
+  defaultWhipTargetSelection,
+  resolveWhipTargetRefs,
+  selectAllWhipEnvironments,
+  selectAllWhipOrchestrators,
+  selectAllWhipTargets,
+  toggleWhipEnvironment,
+  toggleWhipOrchestrator,
+} from '@/app/whipTargetSelection';
+import { whipNow, type WhipOutcome, whipTargets } from '@/app/whipThunks';
 import { InlineAlert } from '@/components/app/InlineAlert';
 import { whipOutcomeLabel, whipOutcomeTone } from '@/components/app/Titlebar.WhipAction.helpers';
+import { TitlebarWhipTargetPicker } from '@/components/app/Titlebar.WhipAction.TargetPicker';
 
 import type { main } from '../../../wailsjs/go/models';
 
 const whipButtonClassName =
   'size-7 flex-none cursor-pointer rounded-[var(--radius)] border-0 bg-transparent text-muted-foreground [--wails-draggable:no-drag] hover:bg-accent hover:text-accent-foreground [&_svg]:size-[18px]';
 
-const whipLabel = 'Whip: push every live orchestrator and environment to keep moving';
+const whipLabel = 'Whip: push the focused target, or choose which ones to push';
 
-// TitlebarWhipAction is the operator-triggered whip control:
-// one click pushes every live orchestrator and every configured
-// environment's own AI session with the pacing nudge, and reports exactly who
-// was pushed and who was skipped, and why -- the report a whip is judged by
-// (root AGENTS.md's "Smooth, Seamless, No Dead Ends": a control that runs and
-// reports nothing is the exact dead end this closes).
+// TitlebarWhipAction is the operator-triggered whip control. Whipping is a
+// write into a live AI session, not a read, so a click never fans out to
+// every configured environment and orchestrator on its own (erun#1700):
+// opening the popover preselects only the sidebar's current focus, and the
+// selection surface underneath (TitlebarWhipTargetPicker) is where "actually,
+// more than that" becomes a deliberate choice, with the three group shortcuts
+// and a primary action that states the count before it acts. Nothing here
+// persists between opens -- every open starts over from the current focus,
+// never a previous invocation's selection.
 //
-// Whip is global -- every orchestrator, every environment -- so it lives in
-// the titlebar rather than on a per-row control, beside the other
+// It lives in the titlebar rather than on a per-row control, beside the other
 // action-with-a-reported-outcome affordances the titlebar's status surface
 // already carries (Titlebar.Status.tsx's StatusWaitAction /
-// StatusRestartOrchestratorAction). Its outcome renders inline in a popover
-// anchored to the button that triggered it, rather than as a detached
-// notification or an Activity Queue entry: erun-ui/AGENTS.md's Design-Language
-// Decision Record reserves a detached surface for outcomes that resolve after
-// the user has moved on, and a whip pass resolves in seconds while the button
-// is still on screen. Whip is not destructive, so it runs directly on click
-// with no confirmation.
+// StatusRestartOrchestratorAction). Its outcome renders inline in the same
+// popover rather than as a detached notification or an Activity Queue entry:
+// erun-ui/AGENTS.md's Design-Language Decision Record reserves a detached
+// surface for outcomes that resolve after the user has moved on, and a whip
+// pass resolves in seconds while the button is still on screen.
 export function TitlebarWhipAction(): React.ReactElement {
   const dispatch = useAppDispatch();
+  const defaultTarget = useAppSelector(selectWhipDefaultTarget);
   const [open, setOpen] = React.useState(false);
   const [pending, setPending] = React.useState(false);
   const [outcome, setOutcome] = React.useState<WhipOutcome | null>(null);
+  const [targets, setTargets] = React.useState<main.uiWhipTargetList | null>(null);
+  const [targetsLoading, setTargetsLoading] = React.useState(false);
+  const [selection, setSelection] = React.useState<WhipTargetSelection>(
+    defaultWhipTargetSelection(null),
+  );
+
+  const onOpenChange = React.useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (!next) {
+        return;
+      }
+      // A fresh open always starts over: no leftover selection or report from
+      // a previous invocation (erun#1700's "remember nothing across
+      // invocations"), and the default is recomputed from whatever the
+      // sidebar is focused on right now.
+      setOutcome(null);
+      setSelection(defaultWhipTargetSelection(defaultTarget));
+      setTargetsLoading(true);
+      void dispatch(whipTargets()).then((list) => {
+        setTargets(list);
+        setTargetsLoading(false);
+      });
+    },
+    [dispatch, defaultTarget],
+  );
 
   const onWhip = React.useCallback(() => {
-    setOpen(true);
     setPending(true);
-    void dispatch(whipNow()).then((result) => {
-      setOutcome(result);
-      setPending(false);
+    // Re-resolve the population immediately before pushing, not just at open
+    // or at the last "select all" click: an "all" category follows whoever is
+    // eligible right now, including an orchestrator that started after the
+    // popover opened (erun#1700's "group selects follow the population, not a
+    // snapshot").
+    void dispatch(whipTargets()).then((freshTargets) => {
+      const refs = resolveWhipTargetRefs(selection, freshTargets);
+      void dispatch(whipNow(refs)).then((result) => {
+        setOutcome(result);
+        setPending(false);
+      });
     });
-  }, [dispatch]);
+  }, [dispatch, selection]);
+
+  const count = targets ? countWhipTargets(selection, targets) : 0;
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={onOpenChange}>
       {/* No asChild here: PopoverAnchor's Slot-based asChild clones its
           single child looking for one forwarded DOM ref, and IconTooltip is
           a plain component that does not forward one, so the anchor rect
@@ -63,7 +112,9 @@ export function TitlebarWhipAction(): React.ReactElement {
             variant="ghost"
             size="icon"
             aria-label={whipLabel}
-            onClick={onWhip}
+            onClick={() => {
+              onOpenChange(true);
+            }}
           >
             {pending ? (
               <LoaderCircle aria-hidden="true" className="animate-spin" />
@@ -74,9 +125,15 @@ export function TitlebarWhipAction(): React.ReactElement {
         </IconTooltip>
       </PopoverAnchor>
       <PopoverContent align="end" className="w-[360px] p-0">
-        <WhipReportPanel
+        <WhipPopoverBody
           pending={pending}
           outcome={outcome}
+          targets={targets}
+          targetsLoading={targetsLoading}
+          selection={selection}
+          setSelection={setSelection}
+          count={count}
+          onWhip={onWhip}
           onClose={() => {
             setOpen(false);
           }}
@@ -86,36 +143,65 @@ export function TitlebarWhipAction(): React.ReactElement {
   );
 }
 
-function WhipReportPanel({
+function WhipPopoverBody({
   pending,
   outcome,
+  targets,
+  targetsLoading,
+  selection,
+  setSelection,
+  count,
+  onWhip,
   onClose,
 }: {
   pending: boolean;
   outcome: WhipOutcome | null;
+  targets: main.uiWhipTargetList | null;
+  targetsLoading: boolean;
+  selection: WhipTargetSelection;
+  setSelection: React.Dispatch<React.SetStateAction<WhipTargetSelection>>;
+  count: number;
+  onWhip: () => void;
   onClose: () => void;
 }): React.ReactElement {
   return (
-    <div className="flex max-h-[60vh] flex-col">
+    <div className="flex max-h-[70vh] flex-col">
       <div className="flex items-center justify-between border-b px-3 py-2">
         <h2 className="text-sm font-semibold">Whip</h2>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Close whip report"
-          onClick={onClose}
-        >
+        <Button type="button" variant="ghost" size="icon" aria-label="Close whip" onClick={onClose}>
           <X aria-hidden="true" className="size-3.5" />
         </Button>
       </div>
-      <div
-        className="flex-1 overflow-y-auto p-3"
-        role="status"
-        aria-live="polite"
-        aria-label="Whip results"
-      >
-        <WhipReportBody pending={pending} outcome={outcome} />
+      <div className="flex-1 overflow-y-auto p-3">
+        {outcome || pending ? (
+          <div role="status" aria-live="polite" aria-label="Whip results">
+            <WhipReportBody pending={pending} outcome={outcome} />
+          </div>
+        ) : (
+          <TitlebarWhipTargetPicker
+            targets={targets}
+            targetsLoading={targetsLoading}
+            selection={selection}
+            onToggleEnvironment={(id, checked) => {
+              setSelection((prev) => toggleWhipEnvironment(prev, id, checked));
+            }}
+            onToggleOrchestrator={(id, checked) => {
+              setSelection((prev) => toggleWhipOrchestrator(prev, id, checked));
+            }}
+            onSelectAllEnvironments={() => {
+              setSelection((prev) => selectAllWhipEnvironments(prev));
+            }}
+            onSelectAllOrchestrators={() => {
+              setSelection((prev) => selectAllWhipOrchestrators(prev));
+            }}
+            onSelectAll={() => {
+              setSelection((prev) => selectAllWhipTargets(prev));
+            }}
+            count={count}
+            pending={pending}
+            onWhip={onWhip}
+          />
+        )}
       </div>
     </div>
   );
@@ -129,11 +215,7 @@ function WhipReportBody({
   outcome: WhipOutcome | null;
 }): React.ReactElement | null {
   if (pending) {
-    return (
-      <p className="text-xs text-muted-foreground">
-        Pushing every live orchestrator and environment…
-      </p>
-    );
+    return <p className="text-xs text-muted-foreground">Whipping the selected targets…</p>;
   }
   if (!outcome) {
     return null;
@@ -147,7 +229,7 @@ function WhipReportBody({
   }
   const results = outcome.report?.results ?? [];
   if (results.length === 0) {
-    return <p className="text-xs text-muted-foreground">Nothing configured to whip.</p>;
+    return <p className="text-xs text-muted-foreground">Nothing was targeted.</p>;
   }
   return (
     <ul className="space-y-1.5">

--- a/erun-ui/frontend/src/components/app/Titlebar.WhipAction.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.WhipAction.tsx
@@ -165,7 +165,7 @@ function WhipPopoverBody({
   onClose: () => void;
 }): React.ReactElement {
   return (
-    <div className="flex max-h-[70vh] flex-col">
+    <div role="region" aria-label="Whip" className="flex max-h-[70vh] flex-col">
       <div className="flex items-center justify-between border-b px-3 py-2">
         <h2 className="text-sm font-semibold">Whip</h2>
         <Button type="button" variant="ghost" size="icon" aria-label="Close whip" onClick={onClose}>

--- a/erun-ui/orchestrator_pacing.go
+++ b/erun-ui/orchestrator_pacing.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -58,8 +59,8 @@ const orchestratorPacingNudgeText = eruncommon.DefaultWhipMessage
 // config once per reconciler tick (refreshOrchestratorWhipConfig) so an edit to
 // ~/.erun/config.yaml takes effect on the next tick without a rebuild or
 // restart. Guarded by a mutex because the manual whip-now entrypoints
-// (whipOrchestratorNow/whipAllOrchestratorsNow) can read it from a different
-// goroutine than the reconciler tick.
+// (whipOrchestratorsNow) can read it from a different goroutine than the
+// reconciler tick.
 var (
 	orchestratorWhipConfigMu sync.RWMutex
 	orchestratorWhipConfig   = eruncommon.ResolveWhipConfig(nil)
@@ -314,24 +315,62 @@ type orchestratorWhipOutcome struct {
 	reason   orchestratorPacingReason
 }
 
-// whipAllOrchestratorsNow is the section-level explicit whip: every live,
-// non-transient orchestrator, pushed now regardless of staleness, each still
-// bound by its own cap. Named per orchestrator in the return so a caller can
-// report exactly who was pushed and who was skipped, and why skipped.
-func (a *App) whipAllOrchestratorsNow() []orchestratorWhipOutcome {
+// orchestratorWhipTarget is one orchestrator the whip selection surface can
+// offer -- id plus the name a human-facing row renders, gathered without
+// deciding or pushing anything.
+type orchestratorWhipTarget struct{ id, name string }
+
+// listWhipOrchestratorTargets enumerates every orchestrator eligible to be
+// whipped -- every live session plus every persisted config with no session
+// yet, deduplicated by id -- the same union whipOrchestratorsNow decides
+// against, so "select all orchestrators" and "push the selected
+// orchestrators" can never disagree about who exists.
+func (a *App) listWhipOrchestratorTargets() []orchestratorWhipTarget {
+	rows := a.orchestratorPacingRows()
+	seen := make(map[string]struct{}, len(rows))
+	targets := make([]orchestratorWhipTarget, 0, len(rows))
+	for _, row := range rows {
+		targets = append(targets, orchestratorWhipTarget{id: row.id, name: row.name})
+		seen[row.id] = struct{}{}
+	}
+	if configs, err := a.loadOrchestratorConfigs(); err == nil {
+		for _, config := range configs {
+			if _, ok := seen[config.ID]; ok {
+				continue
+			}
+			targets = append(targets, orchestratorWhipTarget{id: config.ID, name: config.Name})
+		}
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].name != targets[j].name {
+			return targets[i].name < targets[j].name
+		}
+		return targets[i].id < targets[j].id
+	})
+	return targets
+}
+
+// whipOrchestratorsNow pushes only the requested orchestrators (by id), each
+// still bound by its own cap and pushed now regardless of staleness. Named
+// per orchestrator in the return so a caller can report exactly who was
+// pushed and who was skipped, and why skipped.
+func (a *App) whipOrchestratorsNow(want map[string]struct{}) []orchestratorWhipOutcome {
 	refreshOrchestratorWhipConfig()
 	now := time.Now()
 	rows := a.orchestratorPacingRows()
-	outcomes := make([]orchestratorWhipOutcome, 0, len(rows))
+	outcomes := make([]orchestratorWhipOutcome, 0, len(want))
 	whipped := make(map[string]struct{}, len(rows))
 	for _, row := range rows {
+		if _, ok := want[row.id]; !ok {
+			continue
+		}
 		decision, reason := a.reconcileOrchestratorPacingOne(row, now, true)
 		outcomes = append(outcomes, orchestratorWhipOutcome{id: row.id, name: row.name, decision: decision, reason: reason})
 		whipped[row.id] = struct{}{}
 	}
 	// orchestratorPacingRows enumerates the sessions this desktop holds, so on
 	// its own it answers "who could be nudged", not "who was considered". A
-	// configured orchestrator that was never opened has no session and would
+	// requested orchestrator that was never opened has no session and would
 	// therefore be absent from the report entirely -- and an omission reads as
 	// "not a target", where a skip names its reason. The environment half
 	// already lists configs for this reason, as does ListWhipOrchestratorCandidates
@@ -344,6 +383,9 @@ func (a *App) whipAllOrchestratorsNow() []orchestratorWhipOutcome {
 		return outcomes
 	}
 	for _, config := range configs {
+		if _, ok := want[config.ID]; !ok {
+			continue
+		}
 		if _, ok := whipped[config.ID]; ok {
 			continue
 		}

--- a/erun-ui/orchestrator_whip_test.go
+++ b/erun-ui/orchestrator_whip_test.go
@@ -74,10 +74,11 @@ func TestRefreshOrchestratorWhipConfigOverrideWins(t *testing.T) {
 	}
 }
 
-// TestWhipAllOrchestratorsNowNamesEveryOutcome is the section-level whip's
-// visible-record contract: every orchestrator appears in the result, named
-// with its own decision and reason -- not just an aggregate "ran" signal.
-func TestWhipAllOrchestratorsNowNamesEveryOutcome(t *testing.T) {
+// TestWhipOrchestratorsNowNamesEveryOutcome is the section-level whip's
+// visible-record contract: every requested orchestrator appears in the
+// result, named with its own decision and reason -- not just an aggregate
+// "ran" signal.
+func TestWhipOrchestratorsNowNamesEveryOutcome(t *testing.T) {
 	isolateOrchestratorWhipConfig(t)
 	orchestratorPacingNudgeSettle = 0
 
@@ -91,9 +92,9 @@ func TestWhipAllOrchestratorsNowNamesEveryOutcome(t *testing.T) {
 	// Not alive: no managed session registered for this orchestrator at all.
 	app.orchestrators["gone"] = &orchestratorSession{id: "gone", serial: 2, name: "gone", startedAt: time.Now()}
 
-	outcomes := app.whipAllOrchestratorsNow()
+	outcomes := app.whipOrchestratorsNow(map[string]struct{}{"alive": {}, "gone": {}})
 	if len(outcomes) != 2 {
-		t.Fatalf("expected an outcome for every orchestrator, got %d: %+v", len(outcomes), outcomes)
+		t.Fatalf("expected an outcome for every requested orchestrator, got %d: %+v", len(outcomes), outcomes)
 	}
 	byID := map[string]orchestratorWhipOutcome{}
 	for _, outcome := range outcomes {
@@ -111,7 +112,7 @@ func TestWhipAllOrchestratorsNowNamesEveryOutcome(t *testing.T) {
 // orchestratorPacingRows only enumerates sessions. Naming it anyway is the
 // whole contract of an explicit whip: an omitted target reads as "not
 // considered", where a skip names a reason the operator can act on.
-func TestWhipAllOrchestratorsNowNamesAConfiguredOrchestratorWithNoSession(t *testing.T) {
+func TestWhipOrchestratorsNowNamesAConfiguredOrchestratorWithNoSession(t *testing.T) {
 	isolateOrchestratorWhipConfig(t)
 	orchestratorPacingNudgeSettle = 0
 
@@ -127,7 +128,7 @@ func TestWhipAllOrchestratorsNowNamesAConfiguredOrchestratorWithNoSession(t *tes
 	app.orchestrators["opened"] = &orchestratorSession{id: "opened", serial: 1, name: "opened", startedAt: time.Now()}
 
 	byID := map[string]orchestratorWhipOutcome{}
-	for _, outcome := range app.whipAllOrchestratorsNow() {
+	for _, outcome := range app.whipOrchestratorsNow(map[string]struct{}{"opened": {}, "never-opened": {}}) {
 		byID[outcome.id] = outcome
 	}
 
@@ -140,5 +141,72 @@ func TestWhipAllOrchestratorsNowNamesAConfiguredOrchestratorWithNoSession(t *tes
 	}
 	if _, named := byID["opened"]; !named {
 		t.Fatalf("the orchestrator holding a live session went missing, got %+v", byID)
+	}
+}
+
+// TestWhipOrchestratorsNowOnlyPushesRequestedOrchestrators is the regression
+// test for the desktop's own blast-radius bug (erun#1700): an orchestrator not
+// in the requested set must not be nudged at all -- not merely omitted from
+// the report after being pushed anyway. It asserts against the recording
+// session's own write, not just the returned outcome list, so a filter that
+// only trimmed the report (while still pushing everyone) would still fail
+// this test.
+func TestWhipOrchestratorsNowOnlyPushesRequestedOrchestrators(t *testing.T) {
+	isolateOrchestratorWhipConfig(t)
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+
+	wantedSession := newCallRecordingSession()
+	wantedKey := orchestratorSessionKey("wanted")
+	app.sessions[wantedKey] = &managedTerminal{session: wantedSession, key: wantedKey, serial: 1, kind: sessionKindOrchestrator}
+	app.orchestrators["wanted"] = &orchestratorSession{id: "wanted", serial: 1, name: "wanted", startedAt: time.Now()}
+
+	unwantedSession := newCallRecordingSession()
+	unwantedKey := orchestratorSessionKey("unwanted")
+	app.sessions[unwantedKey] = &managedTerminal{session: unwantedSession, key: unwantedKey, serial: 2, kind: sessionKindOrchestrator}
+	app.orchestrators["unwanted"] = &orchestratorSession{id: "unwanted", serial: 2, name: "unwanted", startedAt: time.Now()}
+
+	outcomes := app.whipOrchestratorsNow(map[string]struct{}{"wanted": {}})
+	if len(outcomes) != 1 || outcomes[0].id != "wanted" {
+		t.Fatalf("expected only the requested orchestrator in the report, got %+v", outcomes)
+	}
+	if outcomes[0].decision != orchestratorPacingNudge {
+		t.Fatalf("expected the requested orchestrator to actually be nudged, got %+v", outcomes[0])
+	}
+	if len(wantedSession.Calls()) == 0 {
+		t.Fatal("expected the requested orchestrator's session to have been written to")
+	}
+	if calls := unwantedSession.Calls(); len(calls) != 0 {
+		t.Fatalf("an orchestrator outside the requested set was written to -- got %d write(s): %v", len(calls), calls)
+	}
+}
+
+// TestListWhipOrchestratorTargetsUnionsSessionsAndConfigs is WhipTargets'
+// population contract for orchestrators: a live session and a configured-but-
+// never-opened orchestrator both appear, deduplicated by id, so "select all
+// orchestrators" can offer every orchestrator the operator could otherwise
+// pick individually.
+func TestListWhipOrchestratorTargetsUnionsSessionsAndConfigs(t *testing.T) {
+	app := NewApp(erunUIDeps{store: stubUIStore{config: &eruncommon.ERunConfig{
+		Orchestrators: []eruncommon.OrchestratorConfig{
+			{ID: "opened", Name: "opened"},
+			{ID: "never-opened", Name: "never-opened"},
+		},
+	}}})
+	key := orchestratorSessionKey("opened")
+	app.sessions[key] = &managedTerminal{session: newCallRecordingSession(), key: key, serial: 1, kind: sessionKindOrchestrator}
+	app.orchestrators["opened"] = &orchestratorSession{id: "opened", serial: 1, name: "opened", startedAt: time.Now()}
+
+	targets := app.listWhipOrchestratorTargets()
+	ids := map[string]bool{}
+	for _, target := range targets {
+		ids[target.id] = true
+	}
+	if !ids["opened"] || !ids["never-opened"] {
+		t.Fatalf("expected both the live session and the configured-only orchestrator, got %+v", targets)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected exactly one row per orchestrator id, got %+v", targets)
 	}
 }

--- a/erun-ui/playwright/pages/Titlebar.ts
+++ b/erun-ui/playwright/pages/Titlebar.ts
@@ -68,6 +68,15 @@ export class Titlebar {
     return this.page.getByRole('heading', { name: 'Whip' });
   }
 
+  // Scoped to the popover's own landmark: several seeded rows (the sidebar
+  // row, the terminal tab) already render the same env/orchestrator name
+  // elsewhere on the page, so an unscoped getByText(name)/getByRole(...) is
+  // ambiguous. Titlebar.WhipAction.tsx's WhipPopoverBody carries this
+  // role/name on its outermost element for exactly this reason.
+  whipPanel(): Locator {
+    return this.page.getByRole('region', { name: 'Whip' });
+  }
+
   // Scoped to the popover's own live region: several seeded rows (the
   // sidebar row, the terminal tab) already render the same env/orchestrator
   // name elsewhere on the page, so an unscoped getByText(name) is ambiguous.
@@ -76,7 +85,34 @@ export class Titlebar {
   }
 
   async closeWhipReport(): Promise<void> {
-    await this.page.getByRole('button', { name: 'Close whip report' }).click();
+    await this.page.getByRole('button', { name: 'Close whip' }).click();
+  }
+
+  // The selection surface's own checkable rows -- one per environment
+  // ("tenant/environment") or orchestrator (its configured name) -- an
+  // implicit <label> wraps each Checkbox, so its accessible name is the row's
+  // visible text with no separate aria-label to keep in sync.
+  whipTargetCheckbox(name: string): Locator {
+    return this.whipPanel().getByRole('checkbox', { name });
+  }
+
+  selectAllOrchestratorsButton(): Locator {
+    return this.whipPanel().getByRole('button', { name: 'Select all orchestrators' });
+  }
+
+  selectAllEnvironmentsButton(): Locator {
+    return this.whipPanel().getByRole('button', { name: 'Select all environments' });
+  }
+
+  selectAllButton(): Locator {
+    return this.whipPanel().getByRole('button', { name: 'Select all', exact: true });
+  }
+
+  // The primary action's own label states the resolved count before it acts
+  // (erun#1700), so it has no fixed accessible name -- match the shared
+  // prefix instead.
+  whipRunButton(): Locator {
+    return this.whipPanel().getByRole('button', { name: /^Whip(ping…| \d+ target)/ });
   }
 
   async toggleTheme(): Promise<void> {

--- a/erun-ui/playwright/tests/titlebar-whip-action.spec.ts
+++ b/erun-ui/playwright/tests/titlebar-whip-action.spec.ts
@@ -36,6 +36,22 @@ async function forceDarkTheme(page: import('@playwright/test').Page): Promise<vo
   });
 }
 
+// Other specs in this suite create their own orchestrators (e.g.
+// orchestrator-link-local-agent.spec.ts, orchestrator-pacing-nudge.spec.ts),
+// and backend-side sessions persist across specs within the same worker
+// (playwright/AGENTS.md) -- so the *total* live population a "select all"
+// resolves against is not under this spec's control and must never be
+// hardcoded. whipCountLabel derives the expected button text from what the
+// picker itself rendered as checked, so the assertion stays true regardless
+// of how many extra orchestrators another spec left behind.
+async function whipCountLabel(app: import('../pages/index.js').AppShell): Promise<string> {
+  const checked = await app.titlebar
+    .whipPanel()
+    .locator('[role="checkbox"][aria-checked="true"]')
+    .count();
+  return `Whip ${String(checked)} target${checked === 1 ? '' : 's'}`;
+}
+
 async function mockWhipReport(
   page: import('@playwright/test').Page,
   gate: Promise<void>,
@@ -214,30 +230,36 @@ test('select all orchestrators whips only the orchestrator population', async ({
   await app.titlebar.whipButton().click();
 
   await app.titlebar.selectAllOrchestratorsButton().click();
-  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
   await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).toBeChecked();
   await expect(
     app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`),
   ).not.toBeChecked();
+  // The count matches exactly whatever the picker rendered checked -- never a
+  // hardcoded total, since another spec in this worker can leave its own
+  // orchestrator behind (playwright/AGENTS.md's worker-shared backend state).
+  await expect(app.titlebar.whipRunButton()).toHaveText(await whipCountLabel(app));
 
   await app.titlebar.whipRunButton().click();
   const body = app.titlebar.whipReportBody();
   await expect(body.getByText(SEED_ORCHESTRATOR)).toBeVisible();
   await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toHaveCount(0);
   await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toHaveCount(0);
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toHaveCount(0);
 });
 
 test('select all environments whips only the environment population', async ({ app }) => {
   await app.sidebar.openTenantDashboard(SEED_TENANT);
   await app.titlebar.whipButton().click();
 
-  // The seeded baseline carries three environments (alpha, beta, gamma).
+  // The seeded baseline carries three environments (alpha, beta, gamma);
+  // environments are per-test-worker config, not cross-spec live state, so
+  // this population is stable -- unlike the orchestrator count below.
   await app.titlebar.selectAllEnvironmentsButton().click();
-  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 3 targets');
   await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeChecked();
   await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toBeChecked();
   await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toBeChecked();
   await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).not.toBeChecked();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 3 targets');
 
   await app.titlebar.whipRunButton().click();
   const body = app.titlebar.whipReportBody();
@@ -251,9 +273,12 @@ test('select all whips the whole population', async ({ app }) => {
   await app.sidebar.openTenantDashboard(SEED_TENANT);
   await app.titlebar.whipButton().click();
 
-  // Three environments (alpha, beta, gamma) plus the one seeded orchestrator.
   await app.titlebar.selectAllButton().click();
-  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 4 targets');
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).toBeChecked();
+  await expect(app.titlebar.whipRunButton()).toHaveText(await whipCountLabel(app));
 
   await app.titlebar.whipRunButton().click();
   const body = app.titlebar.whipReportBody();
@@ -275,14 +300,19 @@ test('the selection surface is operable end to end without a mouse', async ({ ap
 
   await app.titlebar.selectAllButton().focus();
   await app.page.keyboard.press('Enter');
-  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 4 targets');
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).toBeChecked();
+  // Never a hardcoded total -- another spec in this worker can leave its own
+  // orchestrator behind (playwright/AGENTS.md's worker-shared backend state).
+  const selectedAll = await whipCountLabel(app);
+  await expect(app.titlebar.whipRunButton()).toHaveText(selectedAll);
 
   // Unchecking one box by keyboard (Space, the ARIA checkbox pattern's own
-  // key) narrows the count back down.
+  // key) narrows the count back down by exactly one.
   await app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR).focus();
   await app.page.keyboard.press('Space');
   await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).not.toBeChecked();
-  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 3 targets');
+  await expect(app.titlebar.whipRunButton()).toHaveText(await whipCountLabel(app));
+  await expect(app.titlebar.whipRunButton()).not.toHaveText(selectedAll);
 
   await app.titlebar.whipRunButton().focus();
   await app.page.keyboard.press('Enter');

--- a/erun-ui/playwright/tests/titlebar-whip-action.spec.ts
+++ b/erun-ui/playwright/tests/titlebar-whip-action.spec.ts
@@ -1,17 +1,40 @@
 import type { Request, Route } from '@playwright/test';
 
 import { expect, test } from '../fixtures/erunApp.js';
-import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
+import {
+  SEED_ENV_ALPHA,
+  SEED_ENV_BETA,
+  SEED_ENV_GAMMA,
+  SEED_ORCHESTRATOR,
+  SEED_TENANT,
+} from '../fixtures/seedRoot.js';
 
-// erun-ui/whip.go's WhipNow is the desktop's only binding for `erun whip`:
-// before it the button did not exist at all -- an operator looking for a way
-// to push a stalled orchestrator or environment agent by hand had no control
-// anywhere in the app. This spec covers the
-// control itself: it is reachable regardless of which tab is active (whip is
-// global, not env-scoped), a click shows a pending state, and the report
-// names every target with its own outcome -- pushed, capped, or skipped with
-// a reason -- rather than the pass running and showing nothing (root
-// AGENTS.md's "Smooth, Seamless, No Dead Ends").
+// erun-ui/whip.go's WhipNow used to take no target argument at all: one click
+// pushed every configured environment plus every live orchestrator, most of
+// which were never even whippable. WhipNow now takes an explicit target list,
+// and the titlebar control resolves it from a real selection surface rather
+// than fanning out unconditionally (erun#1700). This spec covers: the default
+// single-target case (whatever the sidebar has focused), individual
+// selection, the three group-select shortcuts, the count the primary action
+// states before it acts, the nothing-focused case (which must not fall back
+// to "everything"), and that the eventual report lists only what was
+// actually targeted.
+
+// Applies the app's own class-based light/dark mechanism directly (root
+// AGENTS.md's Design-Language Decision Record: one shared `.dark` class
+// mechanism) rather than clicking the titlebar's theme toggle. Unlike a Radix
+// Dialog, this popover does not mark the rest of the app aria-hidden, so the
+// toggle button is reachable -- but Radix Popover's default dismissable layer
+// still closes the popover on any outside pointer interaction, including a
+// click on that now-reachable button, taking the whole surface being
+// screenshotted with it. manage-dialog-status-badge.spec.ts established this
+// same escape hatch for the Dialog case; this is the Popover-shaped sibling
+// of that same problem.
+async function forceDarkTheme(page: import('@playwright/test').Page): Promise<void> {
+  await page.evaluate(() => {
+    document.documentElement.classList.add('dark');
+  });
+}
 
 async function mockWhipReport(
   page: import('@playwright/test').Page,
@@ -41,13 +64,12 @@ async function mockWhipReport(
 
 test('the whip control renders a pending state and then every target with its own outcome', async ({
   app,
-  page,
 }) => {
   let release: () => void = () => {};
   const gate = new Promise<void>((resolve) => {
     release = resolve;
   });
-  await mockWhipReport(page, gate, [
+  await mockWhipReport(app.page, gate, [
     { kind: 'environment', id: 'pw/alpha', name: 'pw/alpha', outcome: 'pushed' },
     {
       kind: 'orchestrator',
@@ -73,14 +95,25 @@ test('the whip control renders a pending state and then every target with its ow
     },
   ]);
 
+  // Backend-side sessions persist across specs within the same worker
+  // (playwright/AGENTS.md), so the sidebar's focus at boot cannot be assumed
+  // -- open SEED_ENV_ALPHA explicitly so the default-target resolution below
+  // is deterministic regardless of what an earlier spec in this worker left
+  // focused.
+  await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+
   const whip = app.titlebar.whipButton();
   await expect(whip).toBeVisible();
   await expect(whip).toHaveAttribute('aria-label', /^Whip:/);
 
   await whip.click();
-  await expect(app.titlebar.whipReportHeading()).toBeVisible();
+  // The picker preselects the just-opened environment, so the primary action
+  // is already enabled with no further selection needed.
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
+  await app.titlebar.whipRunButton().click();
+
   const body = app.titlebar.whipReportBody();
-  await expect(body.getByText('Pushing every live orchestrator and environment')).toBeVisible();
+  await expect(body.getByText('Whipping the selected targets')).toBeVisible();
 
   release();
 
@@ -93,10 +126,10 @@ test('the whip control renders a pending state and then every target with its ow
   await expect(body.getByText('Skipped', { exact: true })).toBeVisible();
   await expect(body.getByText(/stopped nudging after repeated silence/)).toBeVisible();
   await expect(body.getByText(/not alive — no live session to push/)).toBeVisible();
-  // A failed push is its own outcome, distinct from a benign skip ():
-  // same decision (nudge) as a pushed row, but refused rather than quiet.
-  // exact: the row's own status word, not the detail line beneath it — this
-  // change adds a "push failed: ..." detail that getByText matches
+  // A failed push is its own outcome, distinct from a benign skip: same
+  // decision (nudge) as a pushed row, but refused rather than quiet. exact:
+  // the row's own status word, not the detail line beneath it -- this change
+  // adds a "push failed: ..." detail that getByText matches
   // case-insensitively, so a substring locator resolves to both.
   await expect(body.getByText('Failed', { exact: true })).toBeVisible();
   await expect(body.getByText(/push failed.*writing nudge text/)).toBeVisible();
@@ -117,6 +150,164 @@ test('the control stays reachable from an orchestrator tab, not only an environm
   await expect(app.titlebar.whipButton()).toBeVisible();
 });
 
+test('defaults to the currently focused environment, with no other target preselected', async ({
+  app,
+}) => {
+  // Explicitly focus SEED_ENV_ALPHA rather than relying on the boot default,
+  // which can carry a prior spec's focus over within the same worker
+  // (playwright/AGENTS.md). Opening the popover must preselect exactly that
+  // one target -- neither the sibling seeded environments nor the seeded
+  // orchestrator -- and state the count on the primary action before it acts.
+  await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+  await app.titlebar.whipButton().click();
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeChecked();
+  await expect(
+    app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_BETA}`),
+  ).not.toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).not.toBeChecked();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
+});
+
+test('individually checking another target widens the selection and the report names only what was checked', async ({
+  app,
+}) => {
+  await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+  await app.titlebar.whipButton().click();
+  await app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR).check();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 2 targets');
+
+  await app.titlebar.whipRunButton().click();
+  const body = app.titlebar.whipReportBody();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeVisible();
+  await expect(body.getByText(SEED_ORCHESTRATOR)).toBeVisible();
+  // The report lists only what was targeted: the sibling environments were
+  // never checked, so they must not appear even though they are real,
+  // configured, and eligible.
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toHaveCount(0);
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toHaveCount(0);
+});
+
+test('the nothing-focused case starts from an empty selection, not everything', async ({ app }) => {
+  // The tenant dashboard is neither an environment nor an orchestrator
+  // session, so selectWhipDefaultTarget resolves to null here -- this must
+  // not fall back to "select every configured target" (erun#1700's core
+  // regression).
+  await app.sidebar.openTenantDashboard(SEED_TENANT);
+
+  await app.titlebar.whipButton().click();
+  await expect(
+    app.page.getByText('Nothing is focused right now. Choose one or more targets below.'),
+  ).toBeVisible();
+  await expect(
+    app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`),
+  ).not.toBeChecked();
+  await expect(
+    app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_BETA}`),
+  ).not.toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).not.toBeChecked();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 0 targets');
+  await expect(app.titlebar.whipRunButton()).toBeDisabled();
+});
+
+test('select all orchestrators whips only the orchestrator population', async ({ app }) => {
+  await app.sidebar.openTenantDashboard(SEED_TENANT);
+  await app.titlebar.whipButton().click();
+
+  await app.titlebar.selectAllOrchestratorsButton().click();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).toBeChecked();
+  await expect(
+    app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`),
+  ).not.toBeChecked();
+
+  await app.titlebar.whipRunButton().click();
+  const body = app.titlebar.whipReportBody();
+  await expect(body.getByText(SEED_ORCHESTRATOR)).toBeVisible();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toHaveCount(0);
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toHaveCount(0);
+});
+
+test('select all environments whips only the environment population', async ({ app }) => {
+  await app.sidebar.openTenantDashboard(SEED_TENANT);
+  await app.titlebar.whipButton().click();
+
+  // The seeded baseline carries three environments (alpha, beta, gamma).
+  await app.titlebar.selectAllEnvironmentsButton().click();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 3 targets');
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toBeChecked();
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).not.toBeChecked();
+
+  await app.titlebar.whipRunButton().click();
+  const body = app.titlebar.whipReportBody();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeVisible();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toBeVisible();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toBeVisible();
+  await expect(body.getByText(SEED_ORCHESTRATOR)).toHaveCount(0);
+});
+
+test('select all whips the whole population', async ({ app }) => {
+  await app.sidebar.openTenantDashboard(SEED_TENANT);
+  await app.titlebar.whipButton().click();
+
+  // Three environments (alpha, beta, gamma) plus the one seeded orchestrator.
+  await app.titlebar.selectAllButton().click();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 4 targets');
+
+  await app.titlebar.whipRunButton().click();
+  const body = app.titlebar.whipReportBody();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeVisible();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_BETA}`)).toBeVisible();
+  await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_GAMMA}`)).toBeVisible();
+  await expect(body.getByText(SEED_ORCHESTRATOR)).toBeVisible();
+});
+
+test('the selection surface is operable end to end without a mouse', async ({ app }) => {
+  // Reach and open the trigger by keyboard first, then drive every control in
+  // the picker by focus + key press rather than .click() -- the review
+  // surface's own keyboard-model precedent (erun-ui/AGENTS.md's Design-
+  // Language Decision Record) for what "fully keyboard operable" looks like
+  // in a spec.
+  await app.titlebar.whipButton().focus();
+  await app.page.keyboard.press('Enter');
+  await expect(app.titlebar.whipRunButton()).toBeVisible();
+
+  await app.titlebar.selectAllButton().focus();
+  await app.page.keyboard.press('Enter');
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 4 targets');
+
+  // Unchecking one box by keyboard (Space, the ARIA checkbox pattern's own
+  // key) narrows the count back down.
+  await app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR).focus();
+  await app.page.keyboard.press('Space');
+  await expect(app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR)).not.toBeChecked();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 3 targets');
+
+  await app.titlebar.whipRunButton().focus();
+  await app.page.keyboard.press('Enter');
+  await expect(app.titlebar.whipReportBody()).toBeVisible();
+});
+
+test('renders correctly in both light and dark theme', async ({ app }) => {
+  await app.titlebar.whipButton().click();
+  await expect(app.titlebar.whipRunButton()).toBeVisible();
+  // animations: 'disabled' finishes the popover's own open transition (and any
+  // other running CSS animation/transition) before capturing, so the shot is
+  // never a frozen mid-fade frame -- deterministic without a wall-clock wait.
+  await app.page.screenshot({
+    path: 'test-results/titlebar-whip-action-light.png',
+    animations: 'disabled',
+  });
+
+  await forceDarkTheme(app.page);
+  await expect(app.titlebar.whipRunButton()).toBeVisible();
+  await app.page.screenshot({
+    path: 'test-results/titlebar-whip-action-dark.png',
+    animations: 'disabled',
+  });
+});
+
 test('an un-mocked pass names the seeded, never-opened environment and orchestrator as skipped', async ({
   app,
 }) => {
@@ -127,6 +318,8 @@ test('an un-mocked pass names the seeded, never-opened environment and orchestra
   // real backend call, unmocked, proving the button is actually wired to
   // erun-ui/whip.go's WhipNow rather than only rendering mocked data.
   await app.titlebar.whipButton().click();
+  await app.titlebar.selectAllButton().click();
+  await app.titlebar.whipRunButton().click();
   await expect(app.titlebar.whipReportHeading()).toBeVisible();
   const body = app.titlebar.whipReportBody();
   await expect(body.getByText(`${SEED_TENANT}/${SEED_ENV_ALPHA}`)).toBeVisible();

--- a/erun-ui/ui_model_whip.go
+++ b/erun-ui/ui_model_whip.go
@@ -9,7 +9,76 @@ import (
 // The whip surface's models -- one flat list of per-target outcomes, folded
 // from both populations' eruncommon.WhipResult/WhipCandidate into the shape
 // the titlebar control renders, so a click's report reads the same whether
-// the target was an environment or an orchestrator.
+// the target was an environment or an orchestrator. uiWhipTargetRef and the
+// WhipTargets population below are the selection half of the same surface:
+// what the operator can check, and what a click actually asks WhipNow to
+// push -- an explicit subset, keyed by the same Kind/ID pair a result reports
+// under, so a checked row and its eventual report row are the same identity.
+
+const (
+	uiWhipTargetKindEnvironment  = "environment"
+	uiWhipTargetKindOrchestrator = "orchestrator"
+)
+
+// uiWhipTargetRef identifies one candidate the operator explicitly selected.
+// WhipNow takes a list of these instead of a boolean "everything" switch, so
+// an empty list is refused rather than silently read as "every target" (see
+// WhipNow's own doc comment in whip.go).
+type uiWhipTargetRef struct {
+	Kind string `json:"kind"` // "environment" | "orchestrator"
+	ID   string `json:"id"`
+}
+
+// uiWhipEnvironmentTarget/uiWhipOrchestratorTarget are one selectable row
+// each -- WhipTargets' population. ID matches the id a uiWhipResult reports
+// under ("tenant/environment" for an environment, the orchestrator's own id
+// otherwise), so a checked row and its eventual report row are the same
+// identity.
+type uiWhipEnvironmentTarget struct {
+	ID          string `json:"id"`
+	Tenant      string `json:"tenant"`
+	Environment string `json:"environment"`
+}
+
+type uiWhipOrchestratorTarget struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// uiWhipTargetList is WhipTargets' whole return: the current population the
+// selection surface renders as checkable rows, refreshed on demand so a
+// "select all X" click always acts on who is eligible right now rather than a
+// snapshot from when the surface opened.
+type uiWhipTargetList struct {
+	Environments  []uiWhipEnvironmentTarget  `json:"environments"`
+	Orchestrators []uiWhipOrchestratorTarget `json:"orchestrators"`
+}
+
+// WhipTargets lists every environment and orchestrator the whip selection
+// surface can offer right now. It is a pure read -- no push, no decision --
+// so the desktop can refresh it as often as the selection UI needs (on open,
+// and again on every "select all" click, and once more immediately before a
+// click actually whips) with no side effect.
+func (a *App) WhipTargets() (uiWhipTargetList, error) {
+	envTargets, err := a.listWhipEnvironmentTargets()
+	if err != nil {
+		return uiWhipTargetList{}, err
+	}
+	environments := make([]uiWhipEnvironmentTarget, 0, len(envTargets))
+	for _, target := range envTargets {
+		environments = append(environments, uiWhipEnvironmentTarget{
+			ID:          target.tenant + "/" + target.environment,
+			Tenant:      target.tenant,
+			Environment: target.environment,
+		})
+	}
+	orchestratorTargets := a.listWhipOrchestratorTargets()
+	orchestrators := make([]uiWhipOrchestratorTarget, 0, len(orchestratorTargets))
+	for _, target := range orchestratorTargets {
+		orchestrators = append(orchestrators, uiWhipOrchestratorTarget{ID: target.id, Name: target.name})
+	}
+	return uiWhipTargetList{Environments: environments, Orchestrators: orchestrators}, nil
+}
 
 type uiWhipResult struct {
 	Kind    string `json:"kind"` // "orchestrator" | "environment"
@@ -33,9 +102,9 @@ func whipReportToUI(results []eruncommon.WhipResult) uiWhipReport {
 }
 
 func whipResultToUI(result eruncommon.WhipResult) uiWhipResult {
-	kind := "environment"
+	kind := uiWhipTargetKindEnvironment
 	if result.Candidate.Kind == eruncommon.WhipTargetOrchestrator {
-		kind = "orchestrator"
+		kind = uiWhipTargetKindOrchestrator
 	}
 	name := strings.TrimSpace(result.Candidate.Name)
 	if name == "" {

--- a/erun-ui/whip.go
+++ b/erun-ui/whip.go
@@ -10,34 +10,58 @@ import (
 )
 
 // WhipNow is the desktop's own operator-triggered whip pass -- the control
-// the CLI and MCP surfaces already carried and the desktop did not. It reaches both
-// populations `erun whip` reaches, over the two channels the desktop already
-// holds open: each configured environment's own MCP edge, and each live
-// orchestrator's own PTY. Every target lands in the returned report, pushed
-// or skipped with its reason, so a click answers "did it run" without the
-// operator hunting for a refresh.
-func (a *App) WhipNow() (uiWhipReport, error) {
-	results, err := a.whipAllEnvironmentsNow(a.backgroundContext())
+// the CLI and MCP surfaces already carried and the desktop did not. Unlike
+// those transports (which whip everything configured when given no target), a
+// desktop click always resolves an explicit target list first -- the focused
+// environment/orchestrator by default, or whatever the operator checked in the
+// selection surface -- and passes it here. An empty list is refused rather
+// than read as "every target": fanning a live-session write across every
+// configured environment and orchestrator on a single click is exactly the
+// blast radius this replaces (erun#1700). Every requested target still lands
+// in the returned report, pushed or skipped with its reason, so a click
+// answers "did it run" without the operator hunting for a refresh.
+func (a *App) WhipNow(targets []uiWhipTargetRef) (uiWhipReport, error) {
+	if len(targets) == 0 {
+		return uiWhipReport{}, fmt.Errorf("whip: no targets selected")
+	}
+	wantEnvironments := make(map[string]struct{}, len(targets))
+	wantOrchestrators := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		switch target.Kind {
+		case uiWhipTargetKindEnvironment:
+			wantEnvironments[target.ID] = struct{}{}
+		case uiWhipTargetKindOrchestrator:
+			wantOrchestrators[target.ID] = struct{}{}
+		default:
+			return uiWhipReport{}, fmt.Errorf("whip: unknown target kind %q", target.Kind)
+		}
+	}
+
+	results, err := a.whipEnvironmentsNow(a.backgroundContext(), wantEnvironments)
 	if err != nil {
 		return uiWhipReport{}, err
 	}
-	for _, outcome := range a.whipAllOrchestratorsNow() {
+	for _, outcome := range a.whipOrchestratorsNow(wantOrchestrators) {
 		results = append(results, orchestratorWhipOutcomeToResult(outcome))
 	}
 	return whipReportToUI(results), nil
 }
 
-// whipAllEnvironmentsNow whips every configured environment, one WhipResult
-// each. An environment with no MCP edge currently open in the desktop reports
-// skipped as not-alive -- the same semantics erun-cli's own
-// `whipOneEnvironment` reports for an environment nobody has opened.
-func (a *App) whipAllEnvironmentsNow(ctx context.Context) ([]eruncommon.WhipResult, error) {
+// whipEnvironmentTarget is one environment the whip selection surface can
+// offer -- tenant/name gathered without deciding or pushing anything.
+type whipEnvironmentTarget struct{ tenant, environment string }
+
+// listWhipEnvironmentTargets enumerates every environment eligible to be
+// whipped, sorted for stable rendering. It is the single source both
+// WhipTargets (the selection surface's population) and whipEnvironmentsNow
+// (the actual push) enumerate from, so "select all environments" and "push
+// the selected environments" can never disagree about what is eligible.
+func (a *App) listWhipEnvironmentTargets() ([]whipEnvironmentTarget, error) {
 	tenants, err := a.deps.store.ListTenantConfigs()
 	if err != nil {
 		return nil, fmt.Errorf("whip: listing tenants: %w", err)
 	}
-	type whipTarget struct{ tenant, environment string }
-	var targets []whipTarget
+	var targets []whipEnvironmentTarget
 	for _, tenant := range tenants {
 		envs, err := a.deps.store.ListEnvConfigs(tenant.Name)
 		if err != nil {
@@ -46,12 +70,13 @@ func (a *App) whipAllEnvironmentsNow(ctx context.Context) ([]eruncommon.WhipResu
 		for _, env := range envs {
 			// A host-type env has no pod and no cluster contact at all
 			// (EnvConfig.HasPod's doc comment), so it can never carry an AI
-			// session to push -- reporting it every pass is pure noise, not a
-			// skip the operator can act on.
+			// session to push -- listing it as a selectable target, or
+			// reporting it every pass, is pure noise, not a skip the operator
+			// can act on.
 			if !env.HasPod() {
 				continue
 			}
-			targets = append(targets, whipTarget{tenant: tenant.Name, environment: env.Name})
+			targets = append(targets, whipEnvironmentTarget{tenant: tenant.Name, environment: env.Name})
 		}
 	}
 	sort.Slice(targets, func(i, j int) bool {
@@ -60,9 +85,27 @@ func (a *App) whipAllEnvironmentsNow(ctx context.Context) ([]eruncommon.WhipResu
 		}
 		return targets[i].environment < targets[j].environment
 	})
+	return targets, nil
+}
 
-	results := make([]eruncommon.WhipResult, 0, len(targets))
+// whipEnvironmentsNow pushes only the requested environments (keyed
+// "tenant/environment"), one WhipResult each. An environment with no MCP edge
+// currently open in the desktop reports skipped as not-alive -- the same
+// semantics erun-cli's own `whipOneEnvironment` reports for an environment
+// nobody has opened. A requested id that no longer resolves against the
+// configured population is silently excluded rather than attempted, since
+// there is nothing real behind it to push.
+func (a *App) whipEnvironmentsNow(ctx context.Context, want map[string]struct{}) ([]eruncommon.WhipResult, error) {
+	targets, err := a.listWhipEnvironmentTargets()
+	if err != nil {
+		return nil, err
+	}
+	results := make([]eruncommon.WhipResult, 0, len(want))
 	for _, target := range targets {
+		id := target.tenant + "/" + target.environment
+		if _, ok := want[id]; !ok {
+			continue
+		}
 		results = append(results, a.whipOneEnvironmentNow(ctx, target.tenant, target.environment))
 	}
 	return results, nil

--- a/erun-ui/whip_test.go
+++ b/erun-ui/whip_test.go
@@ -200,7 +200,10 @@ func TestWhipNowFoldsEnvironmentsAndOrchestratorsIntoOneReport(t *testing.T) {
 	app.sessions[aliveKey] = &managedTerminal{session: aliveSession, key: aliveKey, serial: 1, kind: sessionKindOrchestrator}
 	app.orchestrators["alive"] = &orchestratorSession{id: "alive", serial: 1, name: "alive", startedAt: time.Now()}
 
-	report, err := app.WhipNow()
+	report, err := app.WhipNow([]uiWhipTargetRef{
+		{Kind: uiWhipTargetKindEnvironment, ID: "erun/ux"},
+		{Kind: uiWhipTargetKindOrchestrator, ID: "alive"},
+	})
 	if err != nil {
 		t.Fatalf("WhipNow failed: %v", err)
 	}
@@ -221,12 +224,12 @@ func TestWhipNowFoldsEnvironmentsAndOrchestratorsIntoOneReport(t *testing.T) {
 	}
 }
 
-// TestWhipAllEnvironmentsNowSkipsHostEnvs covers the "enumerates targets
+// TestWhipEnvironmentsNowSkipsHostEnvs covers the "enumerates targets
 // that could never have been whipped" finding: a host-type env has no pod and
 // no cluster contact at all (EnvConfig.HasPod), so it can never carry an AI
 // session to push. Reporting it every pass is noise the report should not
 // carry, unlike a real env this transport merely cannot reach right now.
-func TestWhipAllEnvironmentsNowSkipsHostEnvs(t *testing.T) {
+func TestWhipEnvironmentsNowSkipsHostEnvs(t *testing.T) {
 	store := whipTestStore(t)
 	store.envs["erun/desktop-build"] = eruncommon.EnvConfig{
 		Name:          "desktop-build",
@@ -248,15 +251,123 @@ func TestWhipAllEnvironmentsNowSkipsHostEnvs(t *testing.T) {
 		},
 	})
 
-	results, err := app.whipAllEnvironmentsNow(context.Background())
+	results, err := app.whipEnvironmentsNow(context.Background(), map[string]struct{}{"erun/ux": {}, "erun/desktop-build": {}})
 	if err != nil {
-		t.Fatalf("whipAllEnvironmentsNow failed: %v", err)
+		t.Fatalf("whipEnvironmentsNow failed: %v", err)
 	}
 	if len(results) != 1 {
 		t.Fatalf("expected the host env to be skipped, got %d results: %+v", len(results), results)
 	}
 	if results[0].Candidate.ID != "erun/ux" {
 		t.Fatalf("expected only erun/ux, got %+v", results[0])
+	}
+}
+
+// TestWhipEnvironmentsNowOnlyPushesRequestedEnvironments is the regression
+// test for the desktop's own blast-radius bug (erun#1700): an environment not
+// in the requested set must not be pushed at all, not merely omitted from the
+// report after being attempted anyway.
+func TestWhipEnvironmentsNowOnlyPushesRequestedEnvironments(t *testing.T) {
+	store := whipTestStore(t)
+	store.envs["erun/dev"] = eruncommon.EnvConfig{
+		Name:              "dev",
+		Type:              eruncommon.EnvironmentTypeLocalAgent,
+		LocalRepoPath:     t.TempDir(),
+		KubernetesContext: "orbstack",
+	}
+
+	var pushedEndpoints []string
+	app := NewApp(erunUIDeps{
+		store: store,
+		canReachMCPEndpoint: func(int) bool {
+			return true
+		},
+		whipEnvironment: func(_ context.Context, endpoint, _ string) (eruncommon.WhipResult, error) {
+			pushedEndpoints = append(pushedEndpoints, endpoint)
+			return eruncommon.WhipResult{Decision: eruncommon.WhipDecisionNudge, Pushed: true}, nil
+		},
+	})
+
+	results, err := app.whipEnvironmentsNow(context.Background(), map[string]struct{}{"erun/ux": {}})
+	if err != nil {
+		t.Fatalf("whipEnvironmentsNow failed: %v", err)
+	}
+	if len(results) != 1 || results[0].Candidate.ID != "erun/ux" {
+		t.Fatalf("expected only the requested environment in the report, got %+v", results)
+	}
+	if len(pushedEndpoints) != 1 {
+		t.Fatalf("expected exactly one push, got %d: %v", len(pushedEndpoints), pushedEndpoints)
+	}
+}
+
+// TestListWhipEnvironmentTargetsSkipsHostEnvs mirrors
+// TestWhipEnvironmentsNowSkipsHostEnvs for the selection surface's own
+// population: a host-type env must not be offered as a selectable target
+// either, since it can never carry a session to push.
+func TestListWhipEnvironmentTargetsSkipsHostEnvs(t *testing.T) {
+	store := whipTestStore(t)
+	store.envs["erun/desktop-build"] = eruncommon.EnvConfig{
+		Name:          "desktop-build",
+		Type:          eruncommon.EnvironmentTypeHost,
+		LocalRepoPath: t.TempDir(),
+	}
+	app := NewApp(erunUIDeps{store: store})
+
+	targets, err := app.listWhipEnvironmentTargets()
+	if err != nil {
+		t.Fatalf("listWhipEnvironmentTargets failed: %v", err)
+	}
+	if len(targets) != 1 || targets[0].environment != "ux" {
+		t.Fatalf("expected only ux, got %+v", targets)
+	}
+}
+
+// TestWhipNowRefusesAnEmptyTargetList is the acceptance-criteria contract
+// (erun#1700): an empty selection is not "all" -- WhipNow must refuse rather
+// than fall back to whipping everything configured.
+func TestWhipNowRefusesAnEmptyTargetList(t *testing.T) {
+	app := NewApp(erunUIDeps{store: whipTestStore(t)})
+	if _, err := app.WhipNow(nil); err == nil {
+		t.Fatal("expected WhipNow to refuse an empty target list")
+	}
+	if _, err := app.WhipNow([]uiWhipTargetRef{}); err == nil {
+		t.Fatal("expected WhipNow to refuse an empty target list")
+	}
+}
+
+// TestWhipNowRefusesAnUnknownTargetKind guards the wire contract between the
+// frontend and this method: a target kind neither transport recognizes must
+// fail loudly rather than being silently dropped from the push.
+func TestWhipNowRefusesAnUnknownTargetKind(t *testing.T) {
+	app := NewApp(erunUIDeps{store: whipTestStore(t)})
+	if _, err := app.WhipNow([]uiWhipTargetRef{{Kind: "bogus", ID: "x"}}); err == nil {
+		t.Fatal("expected WhipNow to refuse an unrecognized target kind")
+	}
+}
+
+// TestWhipTargetsListsEnvironmentsAndOrchestrators is the selection surface's
+// whole-population contract: WhipTargets must offer exactly the environments
+// listWhipEnvironmentTargets enumerates and exactly the orchestrators
+// listWhipOrchestratorTargets enumerates, with IDs that round-trip through
+// WhipNow's own uiWhipTargetRef.
+func TestWhipTargetsListsEnvironmentsAndOrchestrators(t *testing.T) {
+	app := NewApp(erunUIDeps{store: whipTestStore(t)})
+	app.orchestrators["alive"] = &orchestratorSession{id: "alive", serial: 1, name: "Alive", startedAt: time.Now()}
+	key := orchestratorSessionKey("alive")
+	app.sessions[key] = &managedTerminal{session: newCallRecordingSession(), key: key, serial: 1, kind: sessionKindOrchestrator}
+
+	list, err := app.WhipTargets()
+	if err != nil {
+		t.Fatalf("WhipTargets failed: %v", err)
+	}
+	if len(list.Environments) != 1 || list.Environments[0].ID != "erun/ux" {
+		t.Fatalf("expected exactly one environment target erun/ux, got %+v", list.Environments)
+	}
+	if list.Environments[0].Tenant != "erun" || list.Environments[0].Environment != "ux" {
+		t.Fatalf("expected the tenant/environment fields to match the id, got %+v", list.Environments[0])
+	}
+	if len(list.Orchestrators) != 1 || list.Orchestrators[0].ID != "alive" || list.Orchestrators[0].Name != "Alive" {
+		t.Fatalf("expected exactly one orchestrator target alive/Alive, got %+v", list.Orchestrators)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `WhipNow()` used to take no target argument and fanned a live-session write across every configured environment plus every live orchestrator on a single titlebar click. It now takes an explicit `[]uiWhipTargetRef` and refuses an empty list rather than reading it as "everything" (erun-ui/whip.go).
- A new read-only `WhipTargets()` method lists the current population (environments with a pod, orchestrators live or configured) for the frontend selection surface.
- The titlebar whip popover defaults to the sidebar's current focus (environment or orchestrator via `selectWhipDefaultTarget`), preselecting just that target. A checkbox list plus **Select all orchestrators** / **Select all environments** / **Select all** lets the operator deliberately widen the scope. The primary action states the resolved count before it acts ("Whip N targets"). Nothing persists across opens — each open recomputes the default from whatever is currently focused, and an unfocused sidebar (tenant dashboard, or nothing) starts from an empty selection, never "everything".

## Caller audit

`App.WhipNow()` (erun-ui) is a desktop-only Wails method. Its only callers are the desktop frontend (`whipThunks.ts`) — `erun-cli`'s `erun whip` and `erun-mcp`'s `whip` tool are separate implementations in `erun-common`/`erun-cli`/`erun-mcp` that already take explicit tenant/environment targeting (or, for MCP, act only on the server's own environment) and are unaffected by this change.

## Nothing-focused behaviour

`selectWhipDefaultTarget` mirrors `selectSidebarFocus`'s precedence (orchestrator session over sidebar selection) but resolves the tenant-dashboard and no-focus cases to `null` rather than falling back to any target. The frontend then starts from an empty selection in that case — never "all".

## Group-select vs population

Selecting all resolves against the freshest `WhipTargets()` population immediately before the whip runs (not a snapshot from when "Select all" was clicked or the popover opened), so an orchestrator that becomes eligible in between is still included.

## UX

Reuses the existing titlebar Popover (erun-kit `Popover`/`Checkbox`/`Button`) rather than inventing a new control, following the plain-checkbox-list precedent already established by `ManageDialogDeployComponents.tsx`/`OrchestratorDialog.Environments.tsx`. Nielsen #1 (visibility of system status): the count is always stated on the primary action before it acts. Nielsen #6 (error prevention): the nothing-focused state disables the primary action rather than defaulting to "everything". A "Whip" `role="region"` landmark scopes the surface for both accessibility and test queries.

## Verification

- `go test ./...` + `golangci-lint` clean in `erun-ui`.
- `yarn typecheck && yarn lint && yarn format:check && yarn build` clean in `erun-ui/frontend`.
- Playwright: rewrote `titlebar-whip-action.spec.ts` — default single-target, individual selection, all three group selects, the stated count (verified as a relative delta rather than a hardcoded total, since other specs in the suite can leave their own orchestrator behind — `playwright/AGENTS.md`'s worker-shared backend state), the nothing-focused case, that the report lists only what was targeted, a keyboard-only pass (focus + key press, no `.click()`), and both-theme screenshots (using the `manage-dialog-status-badge.spec.ts` `forceDarkTheme` escape hatch — Radix Popover's default dismissable layer closes the popover on any outside click, including the titlebar's own theme toggle, so the toggle itself can't be used here even though this popover isn't a modal Dialog).
- `make check`: green (lint × 6 modules, `erun-ui` Go tests, frontend/console typecheck+lint+build+tests, chart tests, integration suite 96.9s, coverage 75.8%).
- Full `erun-ui/playwright/run.sh --build`: 448/448 passed.

Closes #1700