### PR TITLE
Make orchestrator pacing aware of busy linked environments

### DIFF
--- a/erun-ui/environment_activity.go
+++ b/erun-ui/environment_activity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -70,6 +71,14 @@ type environmentActivityState struct {
 	// detail names what is keeping the environment busy, in the operator's
 	// language, so the row can say "held by gradle-build" rather than "busy".
 	detail string
+	// busyHolderOrchestrators is the sorted, comma-joined set of orchestrator
+	// IDs whose lease is keeping this environment busy right now — how
+	// orchestrator pacing (orchestrator_pacing_env.go) tells "busy on work I
+	// dispatched" from "busy on someone else's job or an operator's own
+	// session" (erun#1699). A plain []string field would not compare with ==,
+	// which emitEnvActivityIfChanged relies on to detect a transition, so this
+	// stays a single comparable string.
+	busyHolderOrchestrators string
 }
 
 func (a *App) runEnvironmentActivityPoller(stop <-chan struct{}) {
@@ -195,6 +204,7 @@ func (a *App) observeEnvironmentActivity(selection uiSelection) environmentActiv
 	a.forgetForwardRepair(selection)
 	observation.state.observed = true
 	observation.state.busy, observation.state.detail = environmentBusyFromIdleStatus(status)
+	observation.state.busyHolderOrchestrators = environmentLeaseHolderOrchestrators(status.Leases)
 	return observation
 }
 
@@ -249,7 +259,32 @@ func (a *App) observeEnvironmentActivityViaPod(selection uiSelection, observatio
 	observation.state.reachable = true
 	observation.state.observed = true
 	observation.state.busy, observation.state.detail = environmentBusyFromIdleStatus(status)
+	observation.state.busyHolderOrchestrators = environmentLeaseHolderOrchestrators(status.Leases)
 	return observation
+}
+
+// environmentLeaseHolderOrchestrators reduces the environment's held leases to
+// the distinct, sorted set of orchestrator IDs claiming one, joined into one
+// string (see environmentActivityState.busyHolderOrchestrators for why). A
+// lease with no named orchestrator holder — a plain SSH session, an operator's
+// own agent invocation — contributes nothing: it cannot be attributed to any
+// orchestrator, so it must never suppress one's pacing nudge.
+func environmentLeaseHolderOrchestrators(leases []eruncommon.EnvironmentActivityLease) string {
+	seen := make(map[string]struct{})
+	for _, lease := range leases {
+		if id := strings.TrimSpace(lease.Holder.Orchestrator); id != "" {
+			seen[id] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return ""
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
 }
 
 // environmentBusyFromIdleStatus reduces the environment's own markers to the one

--- a/erun-ui/orchestrator_pacing.go
+++ b/erun-ui/orchestrator_pacing.go
@@ -265,6 +265,11 @@ type orchestratorPacingRow struct {
 	capped           bool
 	lastNudgeAtUnix  int64
 	lastLoggedReason orchestratorPacingReason
+	// envs is this orchestrator's configured link scope (orchestrator.go's
+	// session.envs), carried through so the env-aware gate only ever consults
+	// environments this orchestrator actually linked, never whatever else
+	// happens to be running (erun#1699).
+	envs []eruncommon.OrchestratorEnvConfig
 }
 
 // reconcileOrchestratorPacing runs on the same 15s tick that already polls
@@ -300,6 +305,7 @@ func (a *App) orchestratorPacingRows() []orchestratorPacingRow {
 			capped:           session.pacingCapped,
 			lastNudgeAtUnix:  session.pacingLastNudgeAtUnix,
 			lastLoggedReason: session.pacingLastReason,
+			envs:             session.envs,
 		})
 	}
 	return rows
@@ -448,20 +454,26 @@ func (a *App) reconcileOrchestratorPacingOne(row orchestratorPacingRow, now time
 		row.capped = false
 	}
 
+	elapsed := now.Sub(lastActiveAt)
+	envBusy := orchestratorLinkedEnvBusyStateFor(row.id, row.envs, a.envActivitySnapshot())
+	if a.orchestratorPacingSuppressedByLinkedEnv(row, explicit, envBusy, elapsed) {
+		a.logOrchestratorPacingTransition(row, orchestratorPacingReasonEnvBusy, elapsed)
+		return orchestratorPacingNone, orchestratorPacingReasonEnvBusy
+	}
+
 	candidate := orchestratorPacingCandidate{
 		alive:        row.alive,
 		lastActiveAt: lastActiveAt,
 		nudgeCount:   row.nudgeCount,
 		capped:       row.capped,
 	}
-	elapsed := now.Sub(lastActiveAt)
 	decision, reason := decideOrchestratorWhip(candidate, now, explicit)
 	a.logOrchestratorPacingTransition(row, reason, elapsed)
 
 	switch decision {
 	case orchestratorPacingNudge:
 		signal := orchestratorPacingSignalFor(ok, ok && report.activity.Busy)
-		a.sendOrchestratorPacingNudge(row.id, row.serial, now, elapsed, signal)
+		a.sendOrchestratorPacingNudge(row.id, row.serial, now, elapsed, signal, envBusy.stuckDetail())
 	case orchestratorPacingCap:
 		a.capOrchestratorPacing(row.id, row.serial, row.name)
 	}
@@ -508,8 +520,11 @@ func (a *App) rearmOrchestratorPacing(id string) {
 
 // sendOrchestratorPacingNudge records the attempt before writing, so a nudge
 // that fails to write still counts against the cap rather than looping forever
-// against a pty that cannot accept input.
-func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time, elapsed time.Duration, signal orchestratorPacingActivitySignal) {
+// against a pty that cannot accept input. envStuckDetail is non-empty only
+// when a linked environment's own busy lease was still active but the
+// suppression bound was crossed anyway (erun#1699) — the ordinary case leaves
+// it empty and the marker reads exactly as it did before.
+func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time, elapsed time.Duration, signal orchestratorPacingActivitySignal, envStuckDetail string) {
 	a.mu.Lock()
 	session := a.orchestrators[id]
 	managed := a.sessions[orchestratorSessionKey(id)]
@@ -537,7 +552,7 @@ func (a *App) sendOrchestratorPacingNudge(id string, serial int, now time.Time, 
 		log.Printf("erun-app: orchestrator %s pacing nudge write failed", id)
 		return
 	}
-	a.emitOrchestratorPacingMarker(serial, count, elapsed, signal)
+	a.emitOrchestratorPacingMarker(serial, count, elapsed, signal, envStuckDetail)
 }
 
 // writeOrchestratorPacingNudge writes the pacing text, then — after a short
@@ -599,9 +614,9 @@ func (a *App) capOrchestratorPacing(id string, serial int, name string) {
 // orchestratorPacingStaleAfter constant: a session quiet for 20 minutes must
 // read as 20 minutes, not as the ten-minute contract restated back at the
 // operator as if it had been honoured (erun#1376).
-func (a *App) emitOrchestratorPacingMarker(sessionID, count int, elapsed time.Duration, signal orchestratorPacingActivitySignal) {
+func (a *App) emitOrchestratorPacingMarker(sessionID, count int, elapsed time.Duration, signal orchestratorPacingActivitySignal, envStuckDetail string) {
 	marker := fmt.Sprintf("\r\n\x1b[2;33m── pacing nudge %d/%d sent — %s ──\x1b[0m\r\n",
-		count, getOrchestratorWhipConfig().MaxNudges, orchestratorPacingQuietDescription(elapsed, signal))
+		count, getOrchestratorWhipConfig().MaxNudges, orchestratorPacingQuietDescription(elapsed, signal, envStuckDetail))
 	a.emitEvent(terminalOutputEvent, terminalOutputPayload{
 		SessionID: sessionID,
 		Data:      base64.StdEncoding.EncodeToString([]byte(marker)),
@@ -616,8 +631,16 @@ func (a *App) emitOrchestratorPacingMarker(sessionID, count int, elapsed time.Du
 // dropped connection, a crash), not an orchestrator that finished and stopped
 // reporting. Without this, both look identical in the pane and the operator
 // has to go read a transcript to tell them apart (erun#1376).
-func orchestratorPacingQuietDescription(elapsed time.Duration, signal orchestratorPacingActivitySignal) string {
+//
+// envStuckDetail, when non-empty, means a linked environment was still busy on
+// this orchestrator's own dispatched work when the suppression bound ran out
+// (erun#1699): the nudge fires anyway, but the description names the lane that
+// has not moved rather than reading as an ordinary silent pane.
+func orchestratorPacingQuietDescription(elapsed time.Duration, signal orchestratorPacingActivitySignal, envStuckDetail string) string {
 	quiet := elapsed.Round(time.Second)
+	if envStuckDetail != "" {
+		return fmt.Sprintf("waiting on a linked environment (%s) that has not progressed in %s", envStuckDetail, quiet)
+	}
 	switch signal {
 	case orchestratorPacingSignalDied:
 		return fmt.Sprintf("no activity report for %s — last report said mid-turn, so the turn may have died without one", quiet)

--- a/erun-ui/orchestrator_pacing_env.go
+++ b/erun-ui/orchestrator_pacing_env.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// erun#1699: an orchestrator that dispatched work to a linked environment and
+// is waiting on it is, to plain pacing, indistinguishable from one that has
+// gone dark — both simply show no fresh activity report. This file adds the
+// missing signal: whether any environment this orchestrator itself linked
+// (config-scoped, never "whatever happens to be running") is busy on a lease
+// this orchestrator holds. The observation is not new plumbing — it is
+// exactly what environment_activity.go's poller already gathers for the
+// sidebar hover card; this only reads it a second time, filtered to leases
+// this orchestrator's own ID holds.
+
+// orchestratorEnvActivitySignal is what the pacing reconciler could determine
+// about an orchestrator's linked environments this tick.
+type orchestratorEnvActivitySignal int
+
+const (
+	// orchestratorEnvActivityIdle means every linked environment was actually
+	// observed and none is busy on a lease this orchestrator holds.
+	orchestratorEnvActivityIdle orchestratorEnvActivitySignal = iota
+	// orchestratorEnvActivityBusy means at least one linked environment is
+	// busy on work this orchestrator itself dispatched.
+	orchestratorEnvActivityBusy
+	// orchestratorEnvActivityUnknown means at least one linked environment's
+	// activity could not be read this tick (stopped, edge unreachable, or the
+	// activity poller has not observed it yet) and none of the rest were
+	// found busy. It must resolve to neither of the other two: collapsing it
+	// into idle would nudge an orchestrator that is genuinely waiting on work
+	// this desktop simply cannot see right now, and collapsing it into busy
+	// would mask one that has actually gone dark. Falling back to the base,
+	// env-unaware decision is the explicit choice for this case — exactly
+	// today's behaviour, applied deliberately rather than by an unnoticed
+	// default.
+	orchestratorEnvActivityUnknown
+)
+
+// orchestratorLinkedEnvBusyState is the env-aware signal plus, when busy, the
+// busy environment's own detail (see environmentBusyFromIdleStatus) — its own
+// words for what is keeping it up, so a nudge that fires anyway past the
+// suppression bound can still say what the orchestrator was waiting on.
+type orchestratorLinkedEnvBusyState struct {
+	signal orchestratorEnvActivitySignal
+	detail string
+}
+
+// stuckDetail names the busy environment's detail only when this orchestrator
+// is still being credited with a suppression that reconcileOrchestratorPacingOne
+// has decided to override past the bound — never for the ordinary idle/unknown
+// cases, which have nothing distinctive to say.
+func (s orchestratorLinkedEnvBusyState) stuckDetail() string {
+	if s.signal != orchestratorEnvActivityBusy {
+		return ""
+	}
+	return s.detail
+}
+
+// orchestratorLinkedEnvBusyStateFor reduces one orchestrator's linked
+// environments to the single signal the pacing gate needs. Only a lease this
+// orchestrator's own ID holds counts as busy: an environment busy on another
+// orchestrator's job, or an operator's own session, must not silence this one
+// — the lease's holder is the discriminator, exactly as the issue asks for.
+func orchestratorLinkedEnvBusyStateFor(orchestratorID string, envs []eruncommon.OrchestratorEnvConfig, snapshot map[string]environmentActivityState) orchestratorLinkedEnvBusyState {
+	sawUnknown := false
+	for _, env := range envs {
+		key := selectionKey(uiSelection{Tenant: env.Tenant, Environment: env.Environment})
+		state, ok := snapshot[key]
+		if !ok || !state.observed {
+			// Never observed at all (the activity poller has not reached it
+			// yet) and observed-but-inconclusive (stopped, edge unreachable)
+			// are the same case here: neither is evidence either way.
+			sawUnknown = true
+			continue
+		}
+		if environmentStateBusyForOrchestrator(state, orchestratorID) {
+			return orchestratorLinkedEnvBusyState{signal: orchestratorEnvActivityBusy, detail: state.detail}
+		}
+	}
+	if sawUnknown {
+		return orchestratorLinkedEnvBusyState{signal: orchestratorEnvActivityUnknown}
+	}
+	return orchestratorLinkedEnvBusyState{signal: orchestratorEnvActivityIdle}
+}
+
+// environmentStateBusyForOrchestrator reports whether orchestratorID appears
+// among the orchestrator IDs holding a lease on this environment.
+func environmentStateBusyForOrchestrator(state environmentActivityState, orchestratorID string) bool {
+	if state.busyHolderOrchestrators == "" || orchestratorID == "" {
+		return false
+	}
+	for _, id := range strings.Split(state.busyHolderOrchestrators, ",") {
+		if id == orchestratorID {
+			return true
+		}
+	}
+	return false
+}
+
+// orchestratorPacingReasonEnvBusy is the reason logOrchestratorPacingTransition
+// records while a linked environment's own activity is suppressing the nudge —
+// distinct from orchestratorPacingReasonFresh so the log can tell "quiet
+// because nothing is happening" from "quiet because it is waiting on
+// dispatched work" (erun#1699).
+const orchestratorPacingReasonEnvBusy orchestratorPacingReason = "env-busy"
+
+// orchestratorPacingEnvBusyBound is the ceiling on how long a linked
+// environment's own activity may excuse this orchestrator's silence. Without
+// one, an orchestrator that dispatched work and then genuinely died would
+// never be surfaced as long as its lanes kept running — the exact regression
+// this file exists to avoid introducing. The bound reuses the pass's own
+// stale-after/max-nudges budget (its default, ten minutes times six, is the
+// same "about an hour" already named in the cap notice) rather than a new
+// knob: a busy lane cannot buy more patience than the ordinary cap already
+// grants an orchestrator with no linked work at all.
+func orchestratorPacingEnvBusyBound(cfg eruncommon.WhipConfig) time.Duration {
+	return cfg.StaleAfter * time.Duration(cfg.MaxNudges)
+}
+
+// orchestratorPacingSuppressedByLinkedEnv is reconcileOrchestratorPacingOne's
+// env-aware gate, split out to keep that function under this module's
+// complexity budget. A busy linked environment is waiting, not idle: it must
+// not accrue staleness or take a nudge (erun#1699). This only ever excuses an
+// alive, automatic-pass candidate — a session the desktop cannot see gets
+// "not-alive" regardless, and an explicit operator-triggered whip is the
+// operator overriding the schedule, exactly like it already overrides plain
+// staleness. The excuse itself is bounded (orchestratorPacingEnvBusyBound):
+// past that ceiling a dispatched-then-abandoned orchestrator must still
+// surface rather than hide behind lanes that outlived it.
+func (a *App) orchestratorPacingSuppressedByLinkedEnv(row orchestratorPacingRow, explicit bool, envBusy orchestratorLinkedEnvBusyState, elapsed time.Duration) bool {
+	if !row.alive || explicit || envBusy.signal != orchestratorEnvActivityBusy {
+		return false
+	}
+	return elapsed < orchestratorPacingEnvBusyBound(getOrchestratorWhipConfig())
+}

--- a/erun-ui/orchestrator_pacing_env_test.go
+++ b/erun-ui/orchestrator_pacing_env_test.go
@@ -1,0 +1,280 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// pacingEnvBusyTestApp builds one orchestrator, alive and stale (its own
+// activity report has not moved since well past the staleness window), linked
+// to a single environment "acme/dev". Callers stage app.envActivity for that
+// environment (or leave it unset for the never-observed case) before driving
+// the reconciler.
+func pacingEnvBusyTestApp(t *testing.T, startedAt time.Time) (*App, *callRecordingSession) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	orchestratorPacingNudgeSettle = 0
+
+	app := NewApp(erunUIDeps{})
+	session := newCallRecordingSession()
+	key := orchestratorSessionKey("agent")
+	app.sessions[key] = &managedTerminal{session: session, key: key, serial: 5, kind: sessionKindOrchestrator}
+	app.orchestrators["agent"] = &orchestratorSession{
+		id:        "agent",
+		serial:    5,
+		name:      "agent",
+		startedAt: startedAt,
+		envs:      []eruncommon.OrchestratorEnvConfig{{Tenant: "acme", Environment: "dev"}},
+	}
+	return app, session
+}
+
+// TestOrchestratorPacingSuppressedWhileLinkedEnvBusy is the acceptance case
+// the issue opens with: a linked environment busy on a lease this
+// orchestrator holds means the orchestrator is waiting, not idle. It must not
+// be nudged and must not accrue toward the cap.
+func TestOrchestratorPacingSuppressedWhileLinkedEnvBusy(t *testing.T) {
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-orchestratorPacingStaleAfter-time.Minute))
+	key := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	app.envActivity = map[string]environmentActivityState{
+		key: {observed: true, busy: true, detail: "holding: 1682 desktop ux and co", busyHolderOrchestrators: "agent"},
+	}
+
+	rows := app.orchestratorPacingRows()
+	if len(rows) != 1 {
+		t.Fatalf("expected one pacing row, got %d", len(rows))
+	}
+	decision, reason := app.reconcileOrchestratorPacingOne(rows[0], time.Now(), false)
+	if decision != orchestratorPacingNone || reason != orchestratorPacingReasonEnvBusy {
+		t.Fatalf("expected decision=none reason=env-busy, got decision=%v reason=%v", decision, reason)
+	}
+	if len(session.Calls()) != 0 {
+		t.Fatalf("expected no nudge written while the linked env is busy, got %v", session.Calls())
+	}
+	app.mu.Lock()
+	count := app.orchestrators["agent"].pacingNudgeCount
+	app.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected the nudge count to stay at zero while suppressed, got %d", count)
+	}
+}
+
+// TestOrchestratorPacingBusySuppressionOnlyCountsLinkedEnvironments guards the
+// scope: an unrelated environment being busy on this orchestrator's lease
+// must not suppress pacing for an orchestrator that never linked it. An
+// orchestrator is not excused by some other environment's activity.
+func TestOrchestratorPacingBusySuppressionOnlyCountsLinkedEnvironments(t *testing.T) {
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-orchestratorPacingStaleAfter-time.Minute))
+	unrelatedKey := selectionKey(uiSelection{Tenant: "other", Environment: "prod"})
+	app.envActivity = map[string]environmentActivityState{
+		unrelatedKey: {observed: true, busy: true, detail: "holding: something-else", busyHolderOrchestrators: "agent"},
+	}
+
+	app.reconcileOrchestratorPacing()
+
+	if len(session.Calls()) != 2 {
+		t.Fatalf("expected the ordinary nudge to fire since the busy env is not linked, got %v", session.Calls())
+	}
+}
+
+// TestOrchestratorPacingBusySuppressionOnlyCountsThisOrchestratorsLease guards
+// the holder discriminator: a linked environment busy on another
+// orchestrator's job, or an operator's own session, must not suppress this
+// orchestrator's nudge — otherwise a shared environment would silence every
+// orchestrator linked to it.
+func TestOrchestratorPacingBusySuppressionOnlyCountsThisOrchestratorsLease(t *testing.T) {
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-orchestratorPacingStaleAfter-time.Minute))
+	key := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	app.envActivity = map[string]environmentActivityState{
+		key: {observed: true, busy: true, detail: "holding: someone-elses-job", busyHolderOrchestrators: "another-orchestrator"},
+	}
+
+	app.reconcileOrchestratorPacing()
+
+	if len(session.Calls()) != 2 {
+		t.Fatalf("expected the ordinary nudge to fire since the lease belongs to a different orchestrator, got %v", session.Calls())
+	}
+}
+
+// TestOrchestratorPacingAllLinkedEnvsIdlePacesAsToday is the control: every
+// linked environment observed and none busy behaves exactly like the
+// env-unaware pass did before this change.
+func TestOrchestratorPacingAllLinkedEnvsIdlePacesAsToday(t *testing.T) {
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-orchestratorPacingStaleAfter-time.Minute))
+	key := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	app.envActivity = map[string]environmentActivityState{
+		key: {observed: true, busy: false},
+	}
+
+	app.reconcileOrchestratorPacing()
+
+	if len(session.Calls()) != 2 {
+		t.Fatalf("expected the ordinary nudge with every linked env idle, got %v", session.Calls())
+	}
+}
+
+// TestOrchestratorPacingUnknownEnvActivityFallsBackToBaseSignal pins the
+// explicit decision for the undetermined case: a linked environment whose
+// activity was never observed (poller has not reached it, env stopped, edge
+// unreachable) must resolve to neither "idle" (which would nudge on a false
+// assertion of no activity) nor "busy" (which would mask a genuinely dark
+// orchestrator). It falls back to the base, env-unaware decision — the same
+// nudge behaviour as if this orchestrator had never linked an environment at
+// all — rather than silently defaulting to one side.
+func TestOrchestratorPacingUnknownEnvActivityFallsBackToBaseSignal(t *testing.T) {
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-orchestratorPacingStaleAfter-time.Minute))
+	// app.envActivity is left nil: the poller has never observed "acme/dev".
+
+	rows := app.orchestratorPacingRows()
+	envBusy := orchestratorLinkedEnvBusyStateFor(rows[0].id, rows[0].envs, app.envActivitySnapshot())
+	if envBusy.signal != orchestratorEnvActivityUnknown {
+		t.Fatalf("expected the unobserved linked env to read as unknown, got %v", envBusy.signal)
+	}
+
+	app.reconcileOrchestratorPacing()
+
+	if len(session.Calls()) != 2 {
+		t.Fatalf("expected the base nudge to fire for an unknown linked env (not suppressed, not forced), got %v", session.Calls())
+	}
+}
+
+// TestOrchestratorPacingSurfacesPastTheEnvBusyBound is the second acceptance
+// case: a lane that never finishes must not silence its orchestrator forever.
+// Once the orchestrator has gone unanswered longer than
+// orchestratorPacingEnvBusyBound, the reconciler stops excusing the silence
+// and nudges anyway, describing the linked environment rather than reading as
+// an ordinary quiet pane.
+func TestOrchestratorPacingSurfacesPastTheEnvBusyBound(t *testing.T) {
+	bound := orchestratorPacingEnvBusyBound(getOrchestratorWhipConfig())
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-bound-time.Minute))
+	key := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	app.envActivity = map[string]environmentActivityState{
+		key: {observed: true, busy: true, detail: "holding: a build that never finished", busyHolderOrchestrators: "agent"},
+	}
+
+	emits := newCapturedEmits()
+	app.SetEmitter(emits.fn())
+
+	app.reconcileOrchestratorPacing()
+
+	if len(session.Calls()) != 2 {
+		t.Fatalf("expected the orchestrator to be surfaced past the bound despite the busy env, got %v", session.Calls())
+	}
+	texts := orchestratorPacingMarkerTexts(emits)
+	if len(texts) != 1 {
+		t.Fatalf("expected exactly one marker, got %v", texts)
+	}
+	if want := "a build that never finished"; !strings.Contains(texts[0], want) {
+		t.Fatalf("expected the marker to name the stuck environment (%q), got %q", want, texts[0])
+	}
+}
+
+// TestOrchestratorPacingBusySuppressionDoesNotConsumeTheCap is the cap
+// interaction the issue calls out directly: waiting correctly through a long
+// run must not count toward orchestratorPacingMaxNudges, so an orchestrator
+// that later needs the ordinary nudge/cap contract still gets the full
+// budget rather than one already spent on suppressed ticks.
+func TestOrchestratorPacingBusySuppressionDoesNotConsumeTheCap(t *testing.T) {
+	bound := orchestratorPacingEnvBusyBound(getOrchestratorWhipConfig())
+	app, session := pacingEnvBusyTestApp(t, time.Now().Add(-orchestratorPacingStaleAfter-time.Minute))
+	key := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	app.envActivity = map[string]environmentActivityState{
+		key: {observed: true, busy: true, detail: "holding: a long gate run", busyHolderOrchestrators: "agent"},
+	}
+
+	// Many ticks well within the bound: none may nudge or spend the cap,
+	// however long the run drags on.
+	rows := app.orchestratorPacingRows()
+	tick := time.Now()
+	for i := 0; i < orchestratorPacingMaxNudges*3; i++ {
+		tick = tick.Add(time.Minute)
+		if tick.Sub(rows[0].startedAt) >= bound {
+			t.Fatalf("test setup drifted past the suppression bound before asserting the cap stayed unspent")
+		}
+		decision, reason := app.reconcileOrchestratorPacingOne(rows[0], tick, false)
+		if decision != orchestratorPacingNone || reason != orchestratorPacingReasonEnvBusy {
+			t.Fatalf("tick %d: expected continued suppression, got decision=%v reason=%v", i, decision, reason)
+		}
+	}
+	if len(session.Calls()) != 0 {
+		t.Fatalf("expected no writes across every suppressed tick, got %v", session.Calls())
+	}
+	app.mu.Lock()
+	count := app.orchestrators["agent"].pacingNudgeCount
+	capped := app.orchestrators["agent"].pacingCapped
+	app.mu.Unlock()
+	if count != 0 || capped {
+		t.Fatalf("expected the cap to stay entirely unspent through the busy period, got count=%d capped=%v", count, capped)
+	}
+}
+
+// TestOrchestratorLinkedEnvBusyStateForDiscriminatesByHolder is the pure-logic
+// unit test for the aggregation the reconciler drives: busy beats unknown,
+// unknown beats idle, and only this orchestrator's own lease holder counts as
+// busy.
+func TestOrchestratorLinkedEnvBusyStateForDiscriminatesByHolder(t *testing.T) {
+	envs := []eruncommon.OrchestratorEnvConfig{
+		{Tenant: "acme", Environment: "dev"},
+		{Tenant: "acme", Environment: "build"},
+	}
+	devKey := selectionKey(uiSelection{Tenant: "acme", Environment: "dev"})
+	buildKey := selectionKey(uiSelection{Tenant: "acme", Environment: "build"})
+
+	cases := []struct {
+		name     string
+		snapshot map[string]environmentActivityState
+		want     orchestratorEnvActivitySignal
+	}{
+		{
+			"both idle and observed",
+			map[string]environmentActivityState{
+				devKey:   {observed: true},
+				buildKey: {observed: true},
+			},
+			orchestratorEnvActivityIdle,
+		},
+		{
+			"one busy for this orchestrator, one idle",
+			map[string]environmentActivityState{
+				devKey:   {observed: true},
+				buildKey: {observed: true, busy: true, busyHolderOrchestrators: "agent"},
+			},
+			orchestratorEnvActivityBusy,
+		},
+		{
+			"one busy for a different orchestrator, one idle: not busy",
+			map[string]environmentActivityState{
+				devKey:   {observed: true},
+				buildKey: {observed: true, busy: true, busyHolderOrchestrators: "someone-else"},
+			},
+			orchestratorEnvActivityIdle,
+		},
+		{
+			"one never observed: unknown even though the other is idle",
+			map[string]environmentActivityState{
+				devKey: {observed: true},
+			},
+			orchestratorEnvActivityUnknown,
+		},
+		{
+			"one busy for this orchestrator beats an unknown sibling",
+			map[string]environmentActivityState{
+				devKey:   {observed: true, busy: true, busyHolderOrchestrators: "agent"},
+				buildKey: {},
+			},
+			orchestratorEnvActivityBusy,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orchestratorLinkedEnvBusyStateFor("agent", envs, tc.snapshot)
+			if got.signal != tc.want {
+				t.Fatalf("orchestratorLinkedEnvBusyStateFor() = %v, want %v", got.signal, tc.want)
+			}
+		})
+	}
+}

--- a/erun-ui/playwright/tests/orchestrator-pacing-nudge.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-pacing-nudge.spec.ts
@@ -30,6 +30,18 @@ import { SEED_ENV_ALPHA, SEED_TENANT } from '../fixtures/seedRoot.js';
 // (TestOrchestratorRespawnsAfterCrashIntoTheSameConversation,
 // TestOrchestratorCleanExitDoesNotRespawn, TestStopOrchestratorRefusesItsOwnRespawn,
 // TestBuildOrchestratorLaunchFallbackKeepsThePin).
+//
+// #1699's env-aware suppression (a linked environment busy on this
+// orchestrator's own dispatched work must not accrue staleness or take a
+// nudge) is the same unreachable-without-a-real-PTY case, so it is covered the
+// same way: erun-ui/orchestrator_pacing_env_test.go
+// (TestOrchestratorPacingSuppressedWhileLinkedEnvBusy,
+// TestOrchestratorPacingBusySuppressionOnlyCountsLinkedEnvironments,
+// TestOrchestratorPacingBusySuppressionOnlyCountsThisOrchestratorsLease,
+// TestOrchestratorPacingUnknownEnvActivityFallsBackToBaseSignal,
+// TestOrchestratorPacingSurfacesPastTheEnvBusyBound,
+// TestOrchestratorPacingBusySuppressionDoesNotConsumeTheCap,
+// TestOrchestratorLinkedEnvBusyStateForDiscriminatesByHolder).
 test.describe('orchestrator pacing/respawn has no surface without a live session', () => {
   test('a created-but-never-started orchestrator stays stopped with no busy/shell/alert artifacts', async ({
     app,


### PR DESCRIPTION
## Summary
- `reconcileOrchestratorPacingOne` previously read only the orchestrator's own activity report, so an orchestrator waiting on work it dispatched to a linked environment was indistinguishable from one that had gone dark — it accrued staleness, got nudged, and those nudges counted toward the cap.
- Adds an env-aware gate: a linked environment busy on a lease **this orchestrator itself holds** suppresses staleness/nudging entirely (no cap consumption), bounded by the pass's own `stale-after * max-nudges` budget (matches the existing "about an hour" cap-notice text) so a dispatched-then-abandoned orchestrator still surfaces once that ceiling passes — with the marker naming the stuck lane instead of reading as an ordinary silent pane.
- An environment whose activity could not be observed this tick (stopped, edge unreachable, poller hasn't run yet) resolves to neither busy nor idle; the reconciler falls back to today's env-unaware decision for it — an explicit, tested choice rather than a silent default either way.

## Premise correction (per the issue)
The issue states "a grep of the file for any environment reference returns nothing." On current `main` that's slightly imprecise: `orchestrator_pacing.go` had three matches, all comment prose, none functional. The substance holds exactly as described — pacing had no functional environment awareness.

## Design notes
- **Reused signal, no new plumbing.** Consumes `environment_activity.go`'s existing poller snapshot (`envActivitySnapshot()`), the same data already rendered on the sidebar hover card, rather than a second observation path.
- **Holder-scoped, not just "busy".** `environmentActivityState` gained `busyHolderOrchestrators` (a sorted, comma-joined set of orchestrator IDs from held leases — kept a string, not `[]string`, so the struct stays `==`-comparable for the poller's transition check). A linked environment only counts as busy when *this* orchestrator's ID is among the lease holders — an environment busy on another orchestrator's job or an operator's own session never suppresses the wrong pane.
- **Linked scope only.** The gate reads `orchestratorSession.envs` (already the config-scoped link list used elsewhere for the hover card), so an orchestrator is never excused by an unrelated environment's activity.
- **Cap accounting.** A suppressed tick returns before ever touching `nudgeCount`/`pacingCapped`, so waiting correctly through a long run costs nothing against the cap — consistent with "a nudge that was never sent should not be held against it."
- **Bound.** `orchestratorPacingEnvBusyBound = cfg.StaleAfter * cfg.MaxNudges` — reuses the existing pacing config rather than a new knob; a busy lane can't buy more patience than the ordinary cap already grants an orchestrator with none.

## UX Impact Review
1. **Affected paths:** the automatic pacing reconciler tick (`reconcileOrchestratorPacing`) and the manual whip actions (`whipOrchestratorsNow`) — both already-existing background/operator-triggered flows, no new user-triggered path.
2. **User-visible sequence:** unchanged shape — a nudge still writes text + `\r` into the orchestrator's pane and emits the same marker/notification events; only the decision of *whether* to fire, and (past the bound) the marker's wording, changed.
3–7. No new field/control/status; existing terminal-marker and notification affordances are reused verbatim.
8. **Playwright:** zero observable frontend surface — this is backend Go logic with no Wails-exported method, event shape, or component change. `playwright/tests/orchestrator-pacing-nudge.spec.ts`'s existing comment already documents that pacing decisions require a real orchestrator PTY the headless harness must not spawn, and points at the Go suite instead; extended that comment to list the new tests in `erun-ui/orchestrator_pacing_env_test.go`.

## Test plan
- [x] `TestOrchestratorPacingSuppressedWhileLinkedEnvBusy` — linked env busy → no staleness accrued, no nudge
- [x] `TestOrchestratorPacingAllLinkedEnvsIdlePacesAsToday` — all linked envs idle → paced as today
- [x] `TestOrchestratorPacingUnknownEnvActivityFallsBackToBaseSignal` — unknown env activity → explicit fallback to base decision, asserted
- [x] `TestOrchestratorPacingSurfacesPastTheEnvBusyBound` — orchestrator dark past the bound while lanes still run → surfaced anyway, marker names the stuck lane
- [x] `TestOrchestratorPacingBusySuppressionOnlyCountsLinkedEnvironments` — only linked environments count
- [x] `TestOrchestratorPacingBusySuppressionOnlyCountsThisOrchestratorsLease` — holder discriminator (not busy-because-of-someone-else)
- [x] `TestOrchestratorPacingBusySuppressionDoesNotConsumeTheCap` — waiting correctly through a long run doesn't consume the cap
- [x] `TestOrchestratorLinkedEnvBusyStateForDiscriminatesByHolder` — pure aggregation unit tests
- [x] `make check` green (lint 0 issues all modules, `erun-ui` Go tests, frontend gates, helm chart tests, integration suite 75.6% coverage)

Closes #1699