### PR TITLE
Settle clone-reclaim outcome before a job's state goes terminal

### DIFF
--- a/erun-common/job_supervisor.go
+++ b/erun-common/job_supervisor.go
@@ -647,11 +647,20 @@ func RunEnvironmentJobSupervisor(params EnvironmentJobSupervisorParams) error {
 // could be read as the whole story: an agent job's own working tree is
 // something its exit status says nothing about at all (see job_worktree.go).
 //
-// reclaimAgentJobWorkClone runs after State is settled, using a fresh
-// snapshot so it sees this job's own final EnvironmentJobStateExited (or
-// abandoned/gate-incomplete, which it refuses) rather than the "running"
-// state the job still carried when finishEnvironmentJob was entered (see
-// work_clone_reclaim.go for why that ordering matters).
+// reclaimAgentJobWorkClone needs a snapshot that already carries this job's
+// own final EnvironmentJobStateExited (or abandoned/gate-incomplete, which it
+// refuses) rather than the "running" state the job still carried when
+// finishEnvironmentJob was entered (see work_clone_reclaim.go for why that
+// ordering matters) -- but it must also run, and any removal it decides on
+// must actually finish, before that terminal state is written anywhere a
+// caller can observe it. job.Finished() (what await/status poll on) is true
+// the instant State reaches a terminal value, so settling State and
+// CloneReclaimed/CloneKeptReason in two separate recorder.update calls left a
+// window where a poll could read "finished" off the first write while the
+// clone was still fully present on disk -- a caller-visible false success,
+// not just a stale field. settle is applied to an in-memory copy first (no
+// disk write), reclaim is decided and acted on against that settled copy, and
+// only then does the single recorder.update below make any of it durable.
 func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *jobOutputWriter, childPID int, state *os.ProcessState, waitErr error) error {
 	// Fold the stream's tail before the outcome lands, so the finished record
 	// carries what the run last did rather than the poll's stale view of it.
@@ -659,9 +668,13 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 
 	code, signal, reason, jobState := resolveEnvironmentJobOutcome(recorder, childPID, state, waitErr)
 	worktree := captureAgentJobWorktreeOutcome(recorder.snapshot())
-	recorder.update(func(job *EnvironmentJob) {
+	// Captured once, before the reclaim decision runs, so EndedAt reflects
+	// when the child process actually exited rather than drifting later by
+	// however long reclaim's own git plumbing and removal take.
+	endedAt := time.Now()
+	settle := func(job *EnvironmentJob) {
 		job.State = jobState
-		job.EndedAt = time.Now()
+		job.EndedAt = endedAt
 		job.OutputBytes = writer.written()
 		job.OutputTruncated = writer.truncated()
 		job.Signal = signal
@@ -671,10 +684,14 @@ func finishEnvironmentJob(recorder *jobRecorder, beat *jobHeartbeat, writer *job
 		job.Reason = reason
 		job.ExitCode = &code
 		worktree.apply(job)
-	})
+	}
 
-	reclaimed, cloneReason := reclaimAgentJobWorkClone(recorder.snapshot())
+	settled := recorder.snapshot()
+	settle(&settled)
+	reclaimed, cloneReason := reclaimAgentJobWorkClone(settled)
+
 	recorder.update(func(job *EnvironmentJob) {
+		settle(job)
 		job.CloneReclaimed = reclaimed
 		job.CloneKeptReason = cloneReason
 	})

--- a/erun-common/work_clone_reclaim.go
+++ b/erun-common/work_clone_reclaim.go
@@ -396,5 +396,16 @@ func reclaimAgentJobWorkClone(job EnvironmentJob) (reclaimed bool, reason string
 	if err := os.RemoveAll(dir); err != nil {
 		return false, fmt.Sprintf("git state allowed reclaiming %s but removing it failed: %v", dir, err)
 	}
+	// os.RemoveAll returning nil is not, by itself, proof dir is gone -- it
+	// also returns nil when a path never existed, and nothing in this package
+	// guards against a future change trusting that return value alone. Stat
+	// the path directly so "reclaimed" can never be reported while dir still
+	// resolves on disk.
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		if err == nil {
+			return false, fmt.Sprintf("git state allowed reclaiming %s but it still exists on disk after removal", dir)
+		}
+		return false, fmt.Sprintf("git state allowed reclaiming %s but its post-removal state could not be confirmed: %v", dir, err)
+	}
 	return true, ""
 }

--- a/erun-common/work_clone_reclaim_test.go
+++ b/erun-common/work_clone_reclaim_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -454,5 +455,136 @@ func TestReclaimAgentJobWorkCloneStillRunningIsNeverTouched(t *testing.T) {
 	}
 	if !job.CloneReclaimed {
 		t.Fatalf("CloneReclaimed = false once the job actually finished, want true (kept reason: %s)", job.CloneKeptReason)
+	}
+}
+
+// TestReclaimAgentJobWorkCloneNeverReportsFinishedAheadOfSettledReclaim guards
+// the exact false success this repository just shipped: finishEnvironmentJob
+// used to settle State (a terminal value job.Finished() polls on) in one
+// recorder.update, then decide and act on reclaim, then settle
+// CloneReclaimed/CloneKeptReason in a *second* recorder.update. A caller
+// polling the job record between those two writes -- exactly what job
+// status/await do from a separate process -- could read "finished" while the
+// clone was still fully present on disk and the reclaim decision not yet
+// made, let alone acted on. A concurrent poller here stands in for that
+// caller: it fails the moment it ever observes the job as finished with
+// neither a reclaim nor a kept-reason recorded yet, or observes
+// CloneReclaimed=true while the directory still resolves on disk.
+// pollReclaimSettleOnce reads the job record once and flags either violation
+// the concurrent poller in the test below watches for.
+func pollReclaimSettleOnce(tenant, environment, id, repo string, sawUnsettledFinish, sawReclaimedWhilePresent *atomic.Bool) {
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		return
+	}
+	if job.Finished() && !job.CloneReclaimed && job.CloneKeptReason == "" {
+		sawUnsettledFinish.Store(true)
+	}
+	if job.CloneReclaimed {
+		if _, statErr := os.Stat(repo); !os.IsNotExist(statErr) {
+			sawReclaimedWhilePresent.Store(true)
+		}
+	}
+}
+
+func TestReclaimAgentJobWorkCloneNeverReportsFinishedAheadOfSettledReclaim(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w6")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	const tenant, environment, id = "reclaim-contract", "settle-order", "job"
+
+	stop := make(chan struct{})
+	var sawUnsettledFinish, sawReclaimedWhilePresent atomic.Bool
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			pollReclaimSettleOnce(tenant, environment, id, repo, &sawUnsettledFinish, &sawReclaimedWhilePresent)
+		}
+	}()
+
+	err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "exit 0"},
+	})
+	close(stop)
+	<-pollDone
+	if err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+	if sawUnsettledFinish.Load() {
+		t.Fatalf("observed the job record as finished before its clone-reclaim outcome settled -- a status/await poll could report success before reclaim ran")
+	}
+	if sawReclaimedWhilePresent.Load() {
+		t.Fatalf("observed CloneReclaimed=true while the clone still resolved on disk")
+	}
+}
+
+// TestReclaimAgentJobWorkCloneRemovalFailureIsKeptNeverReclaimed covers the
+// other direction of the same contract: a clone the git-state check judges
+// safe to delete, but whose actual removal fails (permission denied on a
+// nested entry here), must be reported kept with a reason -- never reclaimed
+// -- because a caller that trusted "reclaimed" would believe the disk is
+// clear when it is not.
+func TestReclaimAgentJobWorkCloneRemovalFailureIsKeptNeverReclaimed(t *testing.T) {
+	isolateActivityCache(t)
+	_, root := withFakeWorkHome(t)
+	repo := filepath.Join(root, "erun-w7")
+	initGitRepoAt(t, repo)
+	newBareRemoteForTest(t, repo)
+	runGitForTest(t, repo, "checkout", "-q", "-b", "feature/lane")
+	runGitForTest(t, repo, "push", "-q", "-u", "origin", "feature/lane")
+
+	// An untracked, gitignored subdirectory: it does not make the working
+	// tree look dirty (so the decision stays "safe to reclaim"), but its own
+	// permissions block os.RemoveAll from unlinking the file inside it.
+	locked := filepath.Join(repo, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatalf("mkdir locked dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, "file.txt"), []byte("data\n"), 0o644); err != nil {
+		t.Fatalf("write locked file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("locked/\n"), 0o644); err != nil {
+		t.Fatalf("write gitignore: %v", err)
+	}
+	runGitForTest(t, repo, "add", ".gitignore")
+	runGitForTest(t, repo, "commit", "-q", "-m", "ignore locked dir")
+	runGitForTest(t, repo, "push", "-q", "origin", "feature/lane")
+	if err := os.Chmod(locked, 0o555); err != nil {
+		t.Fatalf("chmod locked dir read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	const tenant, environment, id = "reclaim-contract", "removal-failure", "job"
+	if err := RunEnvironmentJobSupervisor(EnvironmentJobSupervisorParams{
+		Tenant: tenant, Environment: environment, ID: id, Name: id,
+		Dir: repo, Agent: "claude", Command: []string{"sh", "-c", "exit 0"},
+	}); err != nil {
+		t.Fatalf("RunEnvironmentJobSupervisor: %v", err)
+	}
+
+	job, err := LoadEnvironmentJob(tenant, environment, id, time.Now())
+	if err != nil {
+		t.Fatalf("LoadEnvironmentJob: %v", err)
+	}
+	if job.CloneReclaimed {
+		t.Fatalf("CloneReclaimed = true even though removal failed on a locked file")
+	}
+	if job.CloneKeptReason == "" {
+		t.Fatalf("CloneKeptReason is empty, want an explanation of the removal failure")
+	}
+	if _, err := os.Stat(repo); err != nil {
+		t.Fatalf("clone dir must still be present when removal failed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `finishEnvironmentJob` wrote a finished agent job's terminal `State` in one `recorder.update`, then decided and acted on clone reclaim, then wrote `CloneReclaimed`/`CloneKeptReason` in a *second*, later write. `job.Finished()` (what `job status`/`job await` poll on) goes true on the first write alone, so a poll landing between the two writes could report the job finished before reclaim had even run — while the clone was still fully present on disk. That is a caller-visible false success, not a flake, and it broke `main` via `TestJob/an_agent_jobs_clean_pushed_clone_under_the_work_root_is_reclaimed_after_it_finishes` (introduced in #1714 / #1710).
- Fix: settle the whole outcome (state fields plus the clone-reclaim decision, decided and acted on against that settled in-memory snapshot) before the single write that makes any of it durable, so a terminal read can never precede a settled reclaim outcome.
- Also stop trusting `os.RemoveAll`'s nil return alone as proof the clone is gone: stat the path afterward and refuse to report `reclaimed` if it still resolves on disk.
- New regression coverage in `erun-common/work_clone_reclaim_test.go`: a concurrent-poller test that fails on the old code (verified) and passes on the fix, plus a removal-failure test proving a clone that can't actually be deleted is reported kept-with-reason, never reclaimed.

Closes #1718

## Root cause / repro
Reproduced by running the erun-integration suite (both a plain `go test` and the coverage-instrumented `make integration-test`/`make check` path) — the race window is narrow enough that it did not reproduce reliably as a black-box CLI subprocess test in this environment, but a concurrent in-process poller against `RunEnvironmentJobSupervisor` reproduces it deterministically (100% failure rate over 10 runs against the pre-fix code, 0% after the fix — see `TestReclaimAgentJobWorkCloneNeverReportsFinishedAheadOfSettledReclaim`).

## Test plan
- [x] `go test ./...` in `erun-common` (new + existing reclaim tests, incl. the new regression test proven to fail against the pre-fix code)
- [x] `golangci-lint run ./...` in `erun-common` — 0 issues
- [x] `go test -run TestJob$ -count=10 ./...` in `erun-integration`
- [x] `make check` — full gate green (lint across all modules, unit/vitest suites, chart tests, integration suite at 75.6% coverage)