### PR TITLE
Render each orchestrator restore notice at its own severity

### DIFF
--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -70,6 +70,45 @@ type orchestratorRestoreState struct {
 	ResumePrompt string `json:"resumePrompt,omitempty"`
 }
 
+// orchestratorNoticeKind classifies how loudly an operator-facing notice about
+// a reopened orchestrator should read. Only two kinds are ever minted here:
+// resuming the tracked conversation is the mechanism working (info); every
+// other resolution this file reports — an unconfirmed record, a claimed
+// conversation, a refused hand-off, a changed scope, a hand-off left
+// mid-task — means something the operator asked for, or something a session
+// recorded, could not be honoured (warning). Mirrors
+// orchestratorConversationNoticeKind's rule for the notices that originate
+// there.
+type orchestratorNoticeKind string
+
+const (
+	orchestratorNoticeInfo    orchestratorNoticeKind = "info"
+	orchestratorNoticeWarning orchestratorNoticeKind = "warning"
+)
+
+// orchestratorNotice is one operator-facing notice about a reopened
+// orchestrator: which one it is about (empty when it names several, such as
+// the hand-offs-not-reopened summary), how loudly it reads, and the text
+// itself. Several orchestrators can each produce their own notice on the same
+// restore, and each keeps its own kind rather than being flattened into one
+// joined string — a warning sitting among several successes must stay
+// visually distinct from them, not disappear into the same paragraph.
+type orchestratorNotice struct {
+	OrchestratorID string                 `json:"orchestratorId,omitempty"`
+	Kind           orchestratorNoticeKind `json:"kind"`
+	Text           string                 `json:"text"`
+}
+
+// appendOrchestratorNotice appends notice to notices when it carries text, so
+// a producer that found nothing to report need not be special-cased at every
+// call site.
+func appendOrchestratorNotice(notices []orchestratorNotice, notice orchestratorNotice) []orchestratorNotice {
+	if strings.TrimSpace(notice.Text) == "" {
+		return notices
+	}
+	return append(notices, notice)
+}
+
 // relaunchTarget is the JSON-safe view the frontend reads on boot. OrchestratorID
 // is the one this launch resumes and that OWNS THE TERMINAL PANE — the pane is
 // single, so exactly one orchestrator gets it. AlsoReopen lists every other
@@ -78,14 +117,16 @@ type orchestratorRestoreState struct {
 // because ResumePrompt is a field of this one target, not of each entry in
 // AlsoReopen — but every entry, owner included, carries the conversation id it
 // should resume: see resolveReopenSessionID for how that id is decided, which
-// is never a re-derivation from the orchestrator id. Notice explains,
-// when non-empty, why the pane owner is not continuing a task it asked to.
+// is never a re-derivation from the orchestrator id. Notices carries one entry
+// per surprising resolution — the pane owner's, or another reopened
+// orchestrator's — each with its own kind, rather than one joined string that
+// would flatten several different severities into one paragraph.
 type relaunchTarget struct {
 	OrchestratorID string                  `json:"orchestratorId"`
 	ConversationID string                  `json:"conversationId"`
 	ResumePrompt   string                  `json:"resumePrompt"`
 	AlsoReopen     []orchestratorReopenRef `json:"alsoReopen,omitempty"`
-	Notice         string                  `json:"notice"`
+	Notices        []orchestratorNotice    `json:"notices,omitempty"`
 }
 
 // orchestratorReopenRef is one orchestrator in AlsoReopen: its id and the
@@ -244,54 +285,58 @@ func readAndClearOrchestratorRestoreTarget(path string) (orchestratorRestoreStat
 // it.
 func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 	state, notReopened := consumeOrchestratorRestoreTargets(a.deps.orchestratorRestoreDir, time.Now())
-	notice := orchestratorHandoffsNotReopenedNotice(notReopened)
+	var notices []orchestratorNotice
+	notices = appendOrchestratorNotice(notices, orchestratorHandoffsNotReopenedNotice(notReopened))
 	openEntries := readOpenOrchestrators(a.deps.orchestratorOpenPath)
 
 	if state.OrchestratorID == "" {
 		if len(openEntries) == 0 {
-			return relaunchTarget{Notice: notice}
+			return relaunchTarget{Notices: notices}
 		}
 		owner := openEntries[len(openEntries)-1]
 		alsoRefs, alsoNotices := a.reopenRefs(removeOrchestratorEntry(openEntries, owner.OrchestratorID))
 		conversationID, conversationNotice := a.resolveReopenSessionID(owner)
-		notices := append([]string{orchestratorScopeChangedNoticeIfAny(owner, a.currentOrchestratorScope(owner.OrchestratorID))}, alsoNotices...)
-		notices = append(notices, conversationNotice, notice)
+		notices = appendOrchestratorNotice(notices, orchestratorScopeChangedNoticeIfAny(owner, a.currentOrchestratorScope(owner.OrchestratorID)))
+		notices = append(notices, alsoNotices...)
+		notices = appendOrchestratorNotice(notices, conversationNotice)
 		return relaunchTarget{
 			OrchestratorID: owner.OrchestratorID,
 			ConversationID: conversationID,
 			AlsoReopen:     alsoRefs,
-			Notice:         joinOrchestratorNotices(notices...),
+			Notices:        notices,
 		}
 	}
 
 	alsoRefs, alsoNotices := a.reopenRefs(removeOrchestratorEntry(openEntries, state.OrchestratorID))
+	notices = append(notices, alsoNotices...)
 	target := relaunchTarget{
 		OrchestratorID: state.OrchestratorID,
 		AlsoReopen:     alsoRefs,
-		Notice:         joinOrchestratorNotices(append(alsoNotices, notice)...),
 	}
 	entry := orchestratorEntryOrEmpty(openEntries, state.OrchestratorID)
 	if state.ResumePrompt != "" {
 		refusal := a.resumeRefusal(state)
-		if refusal == "" {
+		if refusal.Text == "" {
 			target.ConversationID = state.ConversationID
 			target.ResumePrompt = state.ResumePrompt
+			target.Notices = notices
 			return target
 		}
 		// The refusal above already covers a scope mismatch (it compares the
 		// hand-off's own recorded scope against the orchestrator's current one),
 		// so the durable-record scope check below is skipped here to avoid saying
 		// the same thing twice.
-		target.Notice = joinOrchestratorNotices(refusal, target.Notice)
-	} else if n := orchestratorScopeChangedNoticeIfAny(entry, a.currentOrchestratorScope(state.OrchestratorID)); n != "" {
-		target.Notice = joinOrchestratorNotices(n, target.Notice)
+		notices = appendOrchestratorNotice(notices, refusal)
+	} else {
+		notices = appendOrchestratorNotice(notices, orchestratorScopeChangedNoticeIfAny(entry, a.currentOrchestratorScope(state.OrchestratorID)))
 	}
 	// No prompt to deliver, or the hand-off was refused: still resume the exact
 	// conversation this orchestrator is on, rather than leaving it for a
 	// re-derivation that can land on a different, older one.
 	conversationID, conversationNotice := a.resolveReopenSessionID(entry)
 	target.ConversationID = conversationID
-	target.Notice = joinOrchestratorNotices(target.Notice, conversationNotice)
+	notices = appendOrchestratorNotice(notices, conversationNotice)
+	target.Notices = notices
 	return target
 }
 
@@ -303,13 +348,20 @@ func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 // to vouch for it and why an unconfirmed one falls back loudly instead of
 // quietly. A transient orchestrator has no id to derive from and gets a fresh
 // conversation.
-func (a *App) resolveReopenSessionID(entry orchestratorOpenEntry) (string, string) {
+func (a *App) resolveReopenSessionID(entry orchestratorOpenEntry) (string, orchestratorNotice) {
 	if strings.TrimSpace(entry.OrchestratorID) == "" {
-		return uuid.NewString(), ""
+		return uuid.NewString(), orchestratorNotice{}
 	}
 	choice := a.resolveOrchestratorConversation(entry)
 	a.markConversationChoiceReported(entry.OrchestratorID, choice)
-	return choice.ConversationID, choice.Notice
+	if choice.Notice == "" {
+		return choice.ConversationID, orchestratorNotice{}
+	}
+	return choice.ConversationID, orchestratorNotice{
+		OrchestratorID: entry.OrchestratorID,
+		Kind:           orchestratorNoticeKind(orchestratorConversationNoticeKind(choice.Source)),
+		Text:           choice.Notice,
+	}
 }
 
 // orchestratorEntryOrEmpty finds id's entry in entries, or a zero-value entry
@@ -345,24 +397,20 @@ func removeOrchestratorEntry(entries []orchestratorOpenEntry, id string) []orche
 // means an AlsoReopen entry is exactly the no-note, no-task case a re-scoped
 // id can silently resume into, so it gets the same scope check as the pane
 // owner rather than a silent pass.
-func (a *App) reopenRefs(entries []orchestratorOpenEntry) ([]orchestratorReopenRef, []string) {
+func (a *App) reopenRefs(entries []orchestratorOpenEntry) ([]orchestratorReopenRef, []orchestratorNotice) {
 	if len(entries) == 0 {
 		return nil, nil
 	}
 	out := make([]orchestratorReopenRef, 0, len(entries))
-	var notices []string
+	var notices []orchestratorNotice
 	for _, entry := range entries {
 		conversationID, conversationNotice := a.resolveReopenSessionID(entry)
 		out = append(out, orchestratorReopenRef{
 			OrchestratorID: entry.OrchestratorID,
 			ConversationID: conversationID,
 		})
-		if conversationNotice != "" {
-			notices = append(notices, conversationNotice)
-		}
-		if n := orchestratorScopeChangedNoticeIfAny(entry, a.currentOrchestratorScope(entry.OrchestratorID)); n != "" {
-			notices = append(notices, n)
-		}
+		notices = appendOrchestratorNotice(notices, conversationNotice)
+		notices = appendOrchestratorNotice(notices, orchestratorScopeChangedNoticeIfAny(entry, a.currentOrchestratorScope(entry.OrchestratorID)))
 	}
 	return out, notices
 }
@@ -381,14 +429,19 @@ func (a *App) currentOrchestratorScope(id string) []string {
 }
 
 // orchestratorScopeChangedNoticeIfAny reports, for one reopened entry, that its
-// recorded scope no longer matches the orchestrator's current one — or "" when
-// it does, or when the entry predates scope recording (Environments empty,
-// read as unknown rather than a guaranteed match).
-func orchestratorScopeChangedNoticeIfAny(entry orchestratorOpenEntry, currentScope []string) string {
+// recorded scope no longer matches the orchestrator's current one — or a zero
+// value when it does, or when the entry predates scope recording (Environments
+// empty, read as unknown rather than a guaranteed match). A caution to verify
+// stale context rather than a fault, so it reports as a warning.
+func orchestratorScopeChangedNoticeIfAny(entry orchestratorOpenEntry, currentScope []string) orchestratorNotice {
 	if len(entry.Environments) == 0 || equalOrchestratorScope(entry.Environments, currentScope) {
-		return ""
+		return orchestratorNotice{}
 	}
-	return orchestratorScopeChangedNotice(entry.OrchestratorID, entry.Environments, currentScope)
+	return orchestratorNotice{
+		OrchestratorID: entry.OrchestratorID,
+		Kind:           orchestratorNoticeWarning,
+		Text:           orchestratorScopeChangedNotice(entry.OrchestratorID, entry.Environments, currentScope),
+	}
 }
 
 // orchestratorScopeChangedNotice explains that a reopened orchestrator's
@@ -404,36 +457,32 @@ func orchestratorScopeChangedNotice(id string, was, now []string) string {
 
 // orchestratorHandoffsNotReopenedNotice names the orchestrators that restarted
 // mid-task and are not being reopened. Their work is only recoverable if the
-// operator learns which sessions stopped and which note each left behind.
-func orchestratorHandoffsNotReopenedNotice(states []orchestratorRestoreState) string {
+// operator learns which sessions stopped and which note each left behind. It
+// names several orchestrators at once, so it carries no single OrchestratorID;
+// each of those sessions being left mid-task is not the healthy case, so this
+// reports as a warning.
+func orchestratorHandoffsNotReopenedNotice(states []orchestratorRestoreState) orchestratorNotice {
 	if len(states) == 0 {
-		return ""
+		return orchestratorNotice{}
 	}
 	described := make([]string, 0, len(states))
 	for _, state := range states {
 		described = append(described, fmt.Sprintf("%s (%s)", state.OrchestratorID, orchestratorReturnNoteName(state.OrchestratorID)))
 	}
 	sort.Strings(described)
-	return fmt.Sprintf("Also restarted mid-task but not reopened: %s. "+
-		"A launch reopens one orchestrator, so start each of these and have it read its return note "+
-		"in the orchestrators working directory.", strings.Join(described, ", "))
-}
-
-func joinOrchestratorNotices(parts ...string) string {
-	kept := make([]string, 0, len(parts))
-	for _, part := range parts {
-		if strings.TrimSpace(part) != "" {
-			kept = append(kept, part)
-		}
+	return orchestratorNotice{
+		Kind: orchestratorNoticeWarning,
+		Text: fmt.Sprintf("Also restarted mid-task but not reopened: %s. "+
+			"A launch reopens one orchestrator, so start each of these and have it read its return note "+
+			"in the orchestrators working directory.", strings.Join(described, ", ")),
 	}
-	return strings.Join(kept, " ")
 }
 
-// resumeRefusal reports why a restart hand-off must not be delivered, or "" when
-// it may. A resume prompt is a first turn telling the woken session to CONTINUE,
-// so it is only safe against the conversation that asked for it, in the scope
-// that conversation knew — an id alone names neither.
-func (a *App) resumeRefusal(state orchestratorRestoreState) string {
+// resumeRefusal reports why a restart hand-off must not be delivered, or a zero
+// value when it may. A resume prompt is a first turn telling the woken session
+// to CONTINUE, so it is only safe against the conversation that asked for it,
+// in the scope that conversation knew — an id alone names neither.
+func (a *App) resumeRefusal(state orchestratorRestoreState) orchestratorNotice {
 	if state.ConversationID == "" {
 		return orchestratorResumeRefusedNotice(state.OrchestratorID,
 			"the conversation that asked for it was not identified")
@@ -452,17 +501,22 @@ func (a *App) resumeRefusal(state orchestratorRestoreState) string {
 			"its environments changed (was %s, now %s)",
 			describeOrchestratorScope(state.Environments), describeOrchestratorScope(current)))
 	}
-	return ""
+	return orchestratorNotice{}
 }
 
 // orchestratorResumeRefusedNotice is what the operator reads when a restart
 // hand-off was withheld. It names the orchestrator, the reason, and where the
 // unfinished work is described, because the session came back idle and nothing
-// else will say so.
-func orchestratorResumeRefusedNotice(id, reason string) string {
-	return fmt.Sprintf("Reopened %s without continuing its task: %s. "+
-		"Check %s in the orchestrators working directory before telling it to carry on.",
-		id, reason, orchestratorReturnNoteName(id))
+// else will say so. A refusal is always a warning: something the operator
+// asked for could not be honoured.
+func orchestratorResumeRefusedNotice(id, reason string) orchestratorNotice {
+	return orchestratorNotice{
+		OrchestratorID: id,
+		Kind:           orchestratorNoticeWarning,
+		Text: fmt.Sprintf("Reopened %s without continuing its task: %s. "+
+			"Check %s in the orchestrators working directory before telling it to carry on.",
+			id, reason, orchestratorReturnNoteName(id)),
+	}
 }
 
 // describeOrchestratorScope renders an environment set for an operator-facing

--- a/erun-ui/app_restart_test.go
+++ b/erun-ui/app_restart_test.go
@@ -70,6 +70,17 @@ func readRestoreState(t *testing.T, dir, orchestratorID string) orchestratorRest
 	return state
 }
 
+// noticeText joins every notice's text with a space, so a test that only cares
+// whether some notice named a given substring can keep asserting on one
+// string rather than searching a slice by hand.
+func noticeText(notices []orchestratorNotice) string {
+	texts := make([]string, 0, len(notices))
+	for _, notice := range notices {
+		texts = append(texts, notice.Text)
+	}
+	return strings.Join(texts, " ")
+}
+
 // stagedRestoreIDs lists the orchestrators with a hand-off still on disk, so a
 // test can assert that consuming one did not silently take another with it.
 func stagedRestoreIDs(t *testing.T, dir string) []string {
@@ -166,7 +177,7 @@ func TestRestartAppRecordsTheLiveConversationAndResumesIt(t *testing.T) {
 	if target.OrchestratorID != id || target.ConversationID != state.ConversationID {
 		t.Fatalf("expected the recorded conversation to be resumed, got %+v", target)
 	}
-	if target.ResumePrompt != orchestratorRestartResumePrompt(id) || target.Notice != "" {
+	if target.ResumePrompt != orchestratorRestartResumePrompt(id) || noticeText(target.Notices) != "" {
 		t.Fatalf("expected the task to be delivered with no notice, got %+v", target)
 	}
 	// The resume prompt has to name the note it means: the working directory is
@@ -297,10 +308,10 @@ func TestTheHandOffThatIsNotReopenedIsReported(t *testing.T) {
 		t.Fatalf("expected %s's own conversation to be resumed, got %+v", delivered, target)
 	}
 	assertNamesOwnNote(t, "the resume prompt", delivered, target.ResumePrompt)
-	if !strings.Contains(target.Notice, notReopened) {
-		t.Fatalf("expected the notice to name %s, got %q", notReopened, target.Notice)
+	if !strings.Contains(noticeText(target.Notices), notReopened) {
+		t.Fatalf("expected the notice to name %s, got %q", notReopened, noticeText(target.Notices))
 	}
-	assertNamesOwnNote(t, "the notice", notReopened, target.Notice)
+	assertNamesOwnNote(t, "the notice", notReopened, noticeText(target.Notices))
 	assertNoHandOffsLeftStaged(t, restoreDir)
 }
 
@@ -410,13 +421,71 @@ func TestResumeIsRefusedWhenTheScopeChanged(t *testing.T) {
 	if target.ConversationID != liveConversation {
 		t.Fatalf("expected the orchestrator's own conversation to still be resumed idle, got %+v", target)
 	}
-	if !strings.Contains(target.Notice, "frs/dev") || !strings.Contains(target.Notice, "frs/laptop") {
-		t.Fatalf("expected the notice to name both scopes, got %q", target.Notice)
+	if !strings.Contains(noticeText(target.Notices), "frs/dev") || !strings.Contains(noticeText(target.Notices), "frs/laptop") {
+		t.Fatalf("expected the notice to name both scopes, got %q", noticeText(target.Notices))
 	}
 	// A refusal points at the note it declined to act on, by name — the operator
 	// is reading it in a directory holding every orchestrator's.
-	if !strings.Contains(target.Notice, orchestratorReturnNoteName(id)) {
-		t.Fatalf("expected the notice to name %q, got %q", orchestratorReturnNoteName(id), target.Notice)
+	if !strings.Contains(noticeText(target.Notices), orchestratorReturnNoteName(id)) {
+		t.Fatalf("expected the notice to name %q, got %q", orchestratorReturnNoteName(id), noticeText(target.Notices))
+	}
+	// A refusal is not a steady state; it must never read at the same severity
+	// as a routine, successful resume.
+	for _, notice := range target.Notices {
+		if notice.Kind != orchestratorNoticeWarning {
+			t.Fatalf("expected every notice from a refused hand-off to be a warning, got %+v", notice)
+		}
+	}
+}
+
+// The heart of the bug this fixes: several orchestrators resolving on the same
+// restore must each carry their own kind. A genuine warning sitting among
+// routine successes must stay distinguishable from them rather than being
+// flattened into one string that reads uniformly as either.
+func TestMixedRestoreCarriesDistinctKindsPerOrchestrator(t *testing.T) {
+	app, openPath, _ := openStateTestApp(t)
+	defer app.shutdown(context.Background())
+
+	stale := createAndStartOrchestrator(t, app)
+	stageOrchestratorConversation(t, orchestratorSessionID(stale))
+	if _, err := app.UpdateOrchestrator(stale, "agent", []orchestratorEnvInput{{Tenant: "frs", Environment: "laptop"}}); err != nil {
+		t.Fatalf("UpdateOrchestrator failed: %v", err)
+	}
+
+	current := createAndStartNamedOrchestrator(t, app, "other", "laptop")
+	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	stageOrchestratorConversation(t, orchestratorSessionID(current))
+	stageOrchestratorConversation(t, live)
+	writeLiveConversationRecord(t, current, orchestratorLiveConversation{
+		ConversationID: live,
+		LaunchID:       recordedLaunchID(t, openPath, current),
+	})
+
+	target := app.ResolveOrchestratorToReopen()
+	if target.OrchestratorID != current {
+		t.Fatalf("expected %q (started last) to own the pane, got %q", current, target.OrchestratorID)
+	}
+
+	var infoCount, warningCount int
+	for _, notice := range target.Notices {
+		switch notice.Kind {
+		case orchestratorNoticeInfo:
+			infoCount++
+			if notice.OrchestratorID != current {
+				t.Fatalf("expected the info notice to belong to %q, got %+v", current, notice)
+			}
+		case orchestratorNoticeWarning:
+			warningCount++
+			if notice.OrchestratorID != stale {
+				t.Fatalf("expected the warning notice to belong to %q, got %+v", stale, notice)
+			}
+		default:
+			t.Fatalf("unexpected notice kind %+v", notice)
+		}
+	}
+	if infoCount != 1 || warningCount != 1 {
+		t.Fatalf("expected exactly one info notice (%s's resumed tracked conversation) and one warning "+
+			"notice (%s's changed scope), got %+v", current, stale, target.Notices)
 	}
 }
 
@@ -434,7 +503,7 @@ func TestResumeIsRefusedWhenTheConversationIsGone(t *testing.T) {
 	if target.OrchestratorID != id {
 		t.Fatalf("expected the orchestrator to still be reopened, got %+v", target)
 	}
-	if target.ResumePrompt != "" || target.Notice == "" {
+	if target.ResumePrompt != "" || noticeText(target.Notices) == "" {
 		t.Fatalf("expected the task withheld with a visible reason, got %+v", target)
 	}
 }

--- a/erun-ui/app_restart_test.go
+++ b/erun-ui/app_restart_test.go
@@ -431,9 +431,16 @@ func TestResumeIsRefusedWhenTheScopeChanged(t *testing.T) {
 	}
 	// A refusal is not a steady state; it must never read at the same severity
 	// as a routine, successful resume.
-	for _, notice := range target.Notices {
+	assertAllNoticesAreWarnings(t, target.Notices)
+}
+
+// assertAllNoticesAreWarnings fails unless every notice given is a warning —
+// used where a refused hand-off leaves nothing routine to report.
+func assertAllNoticesAreWarnings(t *testing.T, notices []orchestratorNotice) {
+	t.Helper()
+	for _, notice := range notices {
 		if notice.Kind != orchestratorNoticeWarning {
-			t.Fatalf("expected every notice from a refused hand-off to be a warning, got %+v", notice)
+			t.Fatalf("expected every notice to be a warning, got %+v", notice)
 		}
 	}
 }
@@ -465,27 +472,36 @@ func TestMixedRestoreCarriesDistinctKindsPerOrchestrator(t *testing.T) {
 	if target.OrchestratorID != current {
 		t.Fatalf("expected %q (started last) to own the pane, got %q", current, target.OrchestratorID)
 	}
+	assertExactlyOneInfoAndOneWarning(t, target.Notices, current, stale)
+}
 
+// assertExactlyOneInfoAndOneWarning fails unless notices carries exactly one
+// info notice (belonging to wantInfoID) and one warning notice (belonging to
+// wantWarningID) — the shape a mixed restore must produce, with each kind kept
+// distinct and attributed to the right orchestrator rather than merged.
+func assertExactlyOneInfoAndOneWarning(t *testing.T, notices []orchestratorNotice, wantInfoID, wantWarningID string) {
+	t.Helper()
 	var infoCount, warningCount int
-	for _, notice := range target.Notices {
-		switch notice.Kind {
-		case orchestratorNoticeInfo:
+	for _, notice := range notices {
+		if notice.Kind == orchestratorNoticeInfo {
 			infoCount++
-			if notice.OrchestratorID != current {
-				t.Fatalf("expected the info notice to belong to %q, got %+v", current, notice)
+			if notice.OrchestratorID != wantInfoID {
+				t.Fatalf("expected the info notice to belong to %q, got %+v", wantInfoID, notice)
 			}
-		case orchestratorNoticeWarning:
-			warningCount++
-			if notice.OrchestratorID != stale {
-				t.Fatalf("expected the warning notice to belong to %q, got %+v", stale, notice)
-			}
-		default:
-			t.Fatalf("unexpected notice kind %+v", notice)
+			continue
 		}
+		if notice.Kind == orchestratorNoticeWarning {
+			warningCount++
+			if notice.OrchestratorID != wantWarningID {
+				t.Fatalf("expected the warning notice to belong to %q, got %+v", wantWarningID, notice)
+			}
+			continue
+		}
+		t.Fatalf("unexpected notice kind %+v", notice)
 	}
 	if infoCount != 1 || warningCount != 1 {
 		t.Fatalf("expected exactly one info notice (%s's resumed tracked conversation) and one warning "+
-			"notice (%s's changed scope), got %+v", current, stale, target.Notices)
+			"notice (%s's changed scope), got %+v", wantInfoID, wantWarningID, notices)
 	}
 }
 

--- a/erun-ui/frontend/src/app/orchestratorRestore.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { planOrchestratorRestore, readRestoreNotice } from './orchestratorRestore';
+import { planOrchestratorRestore, readRestoreNotices } from './orchestratorRestore';
 import type { OrchestratorInfo } from './slices/orchestratorsSlice';
 
 function orchestrator(id: string, transient = false): OrchestratorInfo {
@@ -196,12 +196,49 @@ test('no resolved conversation plans a fresh start, not a guessed one', () => {
 });
 
 // The target crosses a process boundary, so a payload without the field must
-// read as "no refusal" rather than throw and take the restore down with it.
-test('a missing notice reads as no refusal', () => {
-  assert.equal(readRestoreNotice({ orchestratorId: 'agent-1', resumePrompt: '' }), '');
-  assert.equal(readRestoreNotice(null), '');
-  assert.equal(
-    readRestoreNotice({ orchestratorId: 'agent-1', notice: '  scope changed  ' }),
-    'scope changed',
+// read as "nothing to report" rather than throw and take the restore down
+// with it.
+test('a missing notices list reads as nothing to report', () => {
+  assert.deepEqual(readRestoreNotices({ orchestratorId: 'agent-1', resumePrompt: '' }), []);
+  assert.deepEqual(readRestoreNotices(null), []);
+});
+
+// Each notice keeps its own kind and the orchestrator it is about, trimmed of
+// incidental whitespace; an entry with no text is dropped rather than
+// rendered as an empty line.
+test('notices carry their own kind and orchestrator, and blank text is dropped', () => {
+  assert.deepEqual(
+    readRestoreNotices({
+      orchestratorId: 'agent-1',
+      notices: [
+        { orchestratorId: 'agent-1', kind: 'info', text: '  resumed the tracked conversation  ' },
+        { orchestratorId: 'agent-2', kind: 'warning', text: 'scope changed' },
+        { kind: 'warning', text: '   ' },
+      ],
+    }),
+    [
+      { orchestratorId: 'agent-1', kind: 'info', text: 'resumed the tracked conversation' },
+      { orchestratorId: 'agent-2', kind: 'warning', text: 'scope changed' },
+    ],
+  );
+});
+
+// A kind this launch does not recognise — absent, or from a backend version
+// that classified notices differently — must not silently become 'info'
+// (hiding a real problem) or 'warning' (crying wolf over what might be
+// routine). It becomes its own 'unknown' kind instead.
+test('an unrecognised or missing kind normalizes to unknown, never info or warning', () => {
+  assert.deepEqual(
+    readRestoreNotices({
+      orchestratorId: 'agent-1',
+      notices: [
+        { orchestratorId: 'agent-1', text: 'no kind at all' },
+        { orchestratorId: 'agent-2', kind: 'critical', text: 'a kind this launch does not know' },
+      ],
+    }),
+    [
+      { orchestratorId: 'agent-1', kind: 'unknown', text: 'no kind at all' },
+      { orchestratorId: 'agent-2', kind: 'unknown', text: 'a kind this launch does not know' },
+    ],
   );
 });

--- a/erun-ui/frontend/src/app/orchestratorRestore.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.ts
@@ -11,20 +11,53 @@ export interface OrchestratorReopenRef {
   conversationId?: string;
 }
 
+// OrchestratorNoticeKind mirrors the Go side's orchestratorNoticeKind: 'info'
+// is the mechanism working (a resumed tracked conversation), 'warning' is
+// every other resolution this restore reports. 'unknown' is a frontend-only
+// value for a notice whose kind this launch could not classify — a raw
+// payload missing the field, or naming something other than the two kinds the
+// backend ever mints. It exists so that case renders as its own visibly
+// distinct thing rather than defaulting to 'info' (which would hide a real
+// problem behind a routine-looking notice) or to 'warning' (which would cry
+// wolf over what might be entirely routine).
+export type OrchestratorNoticeKind = 'info' | 'warning' | 'unknown';
+
+// OrchestratorNotice is one operator-facing notice about a reopened
+// orchestrator: which one it is about (absent when it names several, such as
+// the hand-offs-not-reopened summary), how loudly it reads, and the text
+// itself.
+export interface OrchestratorNotice {
+  orchestratorId?: string;
+  kind: OrchestratorNoticeKind;
+  text: string;
+}
+
+// RawOrchestratorNotice is the wire shape one entry in the backend's notices
+// list can actually carry: kind and text are typed as optional/untrusted here
+// even though the Go side always sets them, because the payload crosses a
+// process boundary and a stale or hand-crafted one must degrade rather than
+// throw.
+interface RawOrchestratorNotice {
+  orchestratorId?: string;
+  kind?: string;
+  text?: string;
+}
+
 // What the backend answers when boot asks which orchestrators to reopen:
 // orchestratorId is the one that OWNS THE TERMINAL PANE — the pane is single,
 // so exactly one orchestrator gets it — and alsoReopen lists every other
 // orchestrator that was open too, restored alongside it but idle. Only the
 // pane owner can carry a resume PROMPT; that is why resumePrompt lives on the
-// target itself rather than per id in alsoReopen. A notice means a hand-off
-// was refused: the pane owner still reopens, idle, and the notice says why
-// nothing is being continued.
+// target itself rather than per id in alsoReopen. notices carries one entry
+// per surprising resolution — the pane owner's, or another reopened
+// orchestrator's — each with its own kind, rather than one joined string that
+// would flatten several different severities together.
 export interface OrchestratorReopenTarget {
   orchestratorId?: string;
   conversationId?: string;
   resumePrompt?: string;
   alsoReopen?: OrchestratorReopenRef[];
-  notice?: string;
+  notices?: RawOrchestratorNotice[];
 }
 
 // How boot should reopen one orchestrator: which one, which of its
@@ -46,12 +79,37 @@ export interface OrchestratorRestoreOutcome {
 
 const trimmed = (value: string | undefined): string => value?.trim() ?? '';
 
-// readRestoreNotice is the refusal the backend attached to the target, if any.
-// It reads tolerantly because the target crosses a process boundary: a payload
-// that omits the field must degrade to "no notice" rather than throw and take
-// the whole restore down with it.
-export function readRestoreNotice(target: OrchestratorReopenTarget | null | undefined): string {
-  return trimmed(target?.notice);
+// normalizeOrchestratorNoticeKind maps the raw wire value to one of the two
+// kinds the backend actually mints, or 'unknown' for anything else -- absent,
+// misspelled, or from a payload written by a backend version that classified
+// notices differently. See OrchestratorNoticeKind for why 'unknown' is its own
+// case rather than folded into either of the other two.
+function normalizeOrchestratorNoticeKind(kind: string | undefined): OrchestratorNoticeKind {
+  if (kind === 'info' || kind === 'warning') {
+    return kind;
+  }
+  return 'unknown';
+}
+
+// readRestoreNotices is every notice the backend attached to the target, each
+// with its own kind. It reads tolerantly because the target crosses a process
+// boundary: a payload that omits the field, or one entry within it, must
+// degrade rather than throw and take the whole restore down with it.
+export function readRestoreNotices(
+  target: OrchestratorReopenTarget | null | undefined,
+): OrchestratorNotice[] {
+  return (target?.notices ?? []).reduce<OrchestratorNotice[]>((kept, raw) => {
+    const text = trimmed(raw.text);
+    if (text === '') {
+      return kept;
+    }
+    kept.push({
+      orchestratorId: trimmed(raw.orchestratorId) || undefined,
+      kind: normalizeOrchestratorNoticeKind(raw.kind),
+      text,
+    });
+    return kept;
+  }, []);
 }
 
 // planOrchestratorRestore decides what a launch actually restores, given the

--- a/erun-ui/frontend/src/app/orchestratorThunks.ts
+++ b/erun-ui/frontend/src/app/orchestratorThunks.ts
@@ -22,7 +22,7 @@ import { readError } from './errors';
 import type { IDEKind, OrchestratorGuidanceLayer } from './model';
 import { showNotification } from './notificationThunks';
 import { planOrchestratorBusySeed } from './orchestratorBusySeed';
-import { planOrchestratorRestore, readRestoreNotice } from './orchestratorRestore';
+import { planOrchestratorRestore, readRestoreNotices } from './orchestratorRestore';
 import { planOrchestratorShellSeed } from './orchestratorShellActivitySeed';
 import { setAIBusyForSession } from './slices/aiActivitySlice';
 import { setShellActivityForSession } from './slices/orchestratorShellActivitySlice';
@@ -30,6 +30,7 @@ import {
   closeOrchestratorDialog,
   type OrchestratorEnvRef,
   type OrchestratorInfo,
+  setOrchestratorRestoreNotices,
   setOrchestrators,
   setOrchestratorsBusy,
   setOrchestratorsError,
@@ -222,8 +223,9 @@ export const restartApp =
 // resume prompt, so a plain launch resumes every restored orchestrator idle; a
 // restart hand-off's prompt auto-runs for the one orchestrator it named, never
 // for the rest of the set. A refused hand-off still reopens its orchestrator
-// and surfaces the backend's notice beside the orchestrator list, so a resume
-// that declined to continue is never silent. Which conversation each
+// and surfaces the backend's notice beside the orchestrator list, each at its
+// own kind, so a resume that declined to continue is never silent and never
+// reads at the same severity as the routine case beside it. Which conversation each
 // orchestrator resumes is the backend's call, not a re-derivation here: this
 // thunk just resumes whatever conversationId the target names, or starts
 // fresh when none was resolved.
@@ -231,9 +233,9 @@ export const restoreOpenOrchestrators =
   (): AppThunk<Promise<boolean>> => async (dispatch, getState) => {
     try {
       const target = await ResolveOrchestratorToReopen();
-      const notice = readRestoreNotice(target);
-      if (notice) {
-        dispatch(setOrchestratorsError(notice));
+      const notices = readRestoreNotices(target);
+      if (notices.length > 0) {
+        dispatch(setOrchestratorRestoreNotices(notices));
       }
       const { primary, alsoReopen } = planOrchestratorRestore(
         target,

--- a/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
+++ b/erun-ui/frontend/src/app/slices/orchestratorsSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+import type { OrchestratorNotice } from '@/app/orchestratorRestore';
 import type { UIEnvironmentActivity } from '@/uiEnvironmentActivityTypes';
 import type { UIEnvironmentUsageSnapshot } from '@/uiEnvironmentUsageTypes';
 
@@ -74,6 +75,11 @@ export interface OrchestratorsState {
   editing: OrchestratorInfo | null;
   busy: boolean;
   error: string;
+  // restoreNotices is what a restore had to say about how it resolved this
+  // launch's set of reopened orchestrators -- kept apart from `error` because
+  // most of these are not errors: a resumed tracked conversation is the
+  // mechanism working, not a failure to render through the same field as one.
+  restoreNotices: OrchestratorNotice[];
 }
 
 const initialState: OrchestratorsState = {
@@ -82,6 +88,7 @@ const initialState: OrchestratorsState = {
   editing: null,
   busy: false,
   error: '',
+  restoreNotices: [],
 };
 
 export const orchestratorsSlice = createSlice({
@@ -95,6 +102,7 @@ export const orchestratorsSlice = createSlice({
       state.dialogOpen = true;
       state.editing = action.payload;
       state.error = '';
+      state.restoreNotices = [];
     },
     closeOrchestratorDialog(state) {
       state.dialogOpen = false;
@@ -104,11 +112,15 @@ export const orchestratorsSlice = createSlice({
       state.busy = action.payload;
       if (action.payload) {
         state.error = '';
+        state.restoreNotices = [];
       }
     },
     setOrchestratorsError(state, action: PayloadAction<string>) {
       state.busy = false;
       state.error = action.payload;
+    },
+    setOrchestratorRestoreNotices(state, action: PayloadAction<OrchestratorNotice[]>) {
+      state.restoreNotices = action.payload;
     },
     // setEnvActivityForOrchestratorEnvs is the live half of the activity join:
     // a fetch (setOrchestrators) joins the poller's snapshot onto each env ref
@@ -167,6 +179,7 @@ export const {
   closeOrchestratorDialog,
   setOrchestratorsBusy,
   setOrchestratorsError,
+  setOrchestratorRestoreNotices,
   setEnvActivityForOrchestratorEnvs,
   setEnvUsageForOrchestratorEnvs,
 } = orchestratorsSlice.actions;

--- a/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.ErunSection.tsx
@@ -30,6 +30,7 @@ import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
 import { openOrchestratorDialog } from '@/app/slices/orchestratorsSlice';
 import { BusyRowSpinner } from '@/components/app/Sidebar.BusyRowSpinner';
 import { OrchestratorHoverCard } from '@/components/app/Sidebar.OrchestratorHoverCard';
+import { OrchestratorNoticeList } from '@/components/app/Sidebar.OrchestratorNotice';
 import { StatusDotGlyph } from '@/components/app/Sidebar.StatusDot';
 
 // ErunSection is the top-level "ERUN" sidebar block above ENVIRONMENTS: the
@@ -135,6 +136,7 @@ function OrchestratorsArea(): React.ReactElement {
   const dispatch = useAppDispatch();
   const items = useAppSelector((state) => state.orchestrators.items);
   const error = useAppSelector((state) => state.orchestrators.error);
+  const restoreNotices = useAppSelector((state) => state.orchestrators.restoreNotices);
   const focus = useAppSelector(selectSidebarFocus);
 
   // The orchestrator a rebuild+restart returns to is restored by boot(), which
@@ -183,6 +185,7 @@ function OrchestratorsArea(): React.ReactElement {
           ))}
         </ul>
       )}
+      <OrchestratorNoticeList notices={restoreNotices} />
       {error ? (
         <p role="alert" className="px-3.5 pb-1 text-[11px] break-words text-destructive">
           {error}

--- a/erun-ui/frontend/src/components/app/Sidebar.OrchestratorNotice.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.OrchestratorNotice.tsx
@@ -1,0 +1,66 @@
+import { HelpCircle, Info } from 'lucide-react';
+import * as React from 'react';
+
+import type { OrchestratorNotice } from '@/app/orchestratorRestore';
+import { InlineAlert } from '@/components/app/InlineAlert';
+
+// OrchestratorNoticeList renders every restore notice at its own severity,
+// one line each, instead of the single destructive paragraph they used to be
+// joined into — a warning among several routine successes must stay visually
+// distinct from them, not disappear into the same red block.
+export function OrchestratorNoticeList({
+  notices,
+}: {
+  notices: OrchestratorNotice[];
+}): React.ReactElement | null {
+  if (notices.length === 0) {
+    return null;
+  }
+  return (
+    <ul className="flex flex-col gap-1 px-3.5 pb-1" aria-label="Orchestrator restore notices">
+      {notices.map((notice, index) => (
+        <li key={`${notice.orchestratorId ?? 'restore'}-${notice.kind}-${String(index)}`}>
+          <OrchestratorNoticeRow notice={notice} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// warning keeps the same destructive alert treatment InlineAlert already gives
+// a write that was attempted and refused — these notices report exactly that
+// kind of failed resolution.
+function OrchestratorNoticeRow({ notice }: { notice: OrchestratorNotice }): React.ReactElement {
+  if (notice.kind === 'warning') {
+    return <InlineAlert>{notice.text}</InlineAlert>;
+  }
+  if (notice.kind === 'info') {
+    // The mechanism working correctly is information, not a fault: role="status"
+    // announces politely instead of interrupting the way role="alert" does, and
+    // the layout matches InlineAlert's without borrowing its destructive colour.
+    return (
+      <div
+        role="status"
+        className="flex w-full items-start gap-2 rounded-[var(--radius)] border border-border bg-muted/40 px-[11px] py-[9px] text-[13px] leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
+      >
+        <Info className="mt-px size-3.5 shrink-0" aria-hidden="true" />
+        <span className="min-w-0">{notice.text}</span>
+      </div>
+    );
+  }
+  // notice.kind === 'unknown': a launch that could not classify this notice's
+  // severity. Defaulting it to info would hide a real problem behind a
+  // routine-looking line; defaulting it to warning would cry wolf over what
+  // might be entirely routine. role="status" keeps it from interrupting like
+  // an alert while the distinct icon and dashed border make clear this is
+  // neither of the two known kinds.
+  return (
+    <div
+      role="status"
+      className="flex w-full items-start gap-2 rounded-[var(--radius)] border border-dashed border-border px-[11px] py-[9px] text-[13px] leading-[1.35] text-muted-foreground [overflow-wrap:anywhere]"
+    >
+      <HelpCircle className="mt-px size-3.5 shrink-0" aria-hidden="true" />
+      <span className="min-w-0">{notice.text}</span>
+    </div>
+  );
+}

--- a/erun-ui/orchestrator_conversations_test.go
+++ b/erun-ui/orchestrator_conversations_test.go
@@ -254,8 +254,8 @@ func TestAnAttachedConversationThatIsGoneIsReportedNotIgnored(t *testing.T) {
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected the derived conversation, got %q", target.ConversationID)
 	}
-	if !strings.Contains(target.Notice, gone) || !strings.Contains(target.Notice, "no longer on disk") {
-		t.Fatalf("expected the notice to name the attachment it could not honour, got %q", target.Notice)
+	if !strings.Contains(noticeText(target.Notices), gone) || !strings.Contains(noticeText(target.Notices), "no longer on disk") {
+		t.Fatalf("expected the notice to name the attachment it could not honour, got %q", noticeText(target.Notices))
 	}
 }
 

--- a/erun-ui/orchestrator_live_conversation_test.go
+++ b/erun-ui/orchestrator_live_conversation_test.go
@@ -97,8 +97,8 @@ func TestRestoreResumesTheConversationTheSessionIsLiveOnNotTheStaleDerivedOne(t 
 	// won is the work they expect: coming back on a different conversation with
 	// nothing said is the same defect wearing the opposite sign.
 	for _, want := range []string{id, live, derived} {
-		if !strings.Contains(target.Notice, want) {
-			t.Fatalf("expected the notice to name %q, got %q", want, target.Notice)
+		if !strings.Contains(noticeText(target.Notices), want) {
+			t.Fatalf("expected the notice to name %q, got %q", want, noticeText(target.Notices))
 		}
 	}
 }
@@ -182,8 +182,8 @@ func TestRestoreNeverResumesAnotherOrchestratorsConversation(t *testing.T) {
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected its own derived conversation, got %q", target.ConversationID)
 	}
-	if !strings.Contains(target.Notice, other.ID) {
-		t.Fatalf("expected the notice to name the orchestrator that owns it, got %q", target.Notice)
+	if !strings.Contains(noticeText(target.Notices), other.ID) {
+		t.Fatalf("expected the notice to name the orchestrator that owns it, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -200,8 +200,8 @@ func TestAFirstLaunchWithNothingTrackedResumesTheDerivedConversation(t *testing.
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected the derived conversation %q, got %q", orchestratorSessionID(id), target.ConversationID)
 	}
-	if target.Notice != "" {
-		t.Fatalf("expected a first launch to say nothing, got %q", target.Notice)
+	if noticeText(target.Notices) != "" {
+		t.Fatalf("expected a first launch to say nothing, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -227,8 +227,8 @@ func TestATrackedConversationFromAnotherLaunchIsNotSilentlyAuthoritative(t *test
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected the derived conversation, got %q", target.ConversationID)
 	}
-	if !strings.Contains(target.Notice, stranded) {
-		t.Fatalf("expected the notice to name the unconfirmed conversation, got %q", target.Notice)
+	if !strings.Contains(noticeText(target.Notices), stranded) {
+		t.Fatalf("expected the notice to name the unconfirmed conversation, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -255,23 +255,29 @@ func TestRestoreReportsARepeatedTrackedConversationOnlyOnce(t *testing.T) {
 	if first.ConversationID != live {
 		t.Fatalf("expected the first launch to resume the live conversation %q, got %q", live, first.ConversationID)
 	}
-	if first.Notice == "" {
+	if noticeText(first.Notices) == "" {
 		t.Fatal("expected the first divergence between tracked and derived to be reported")
+	}
+	// The mechanism working correctly is information, not a fault: a resumed
+	// tracked conversation must never be reported at the same severity as a
+	// refusal or an unconfirmed record.
+	if len(first.Notices) != 1 || first.Notices[0].Kind != orchestratorNoticeInfo {
+		t.Fatalf("expected exactly one info-kind notice for the resumed tracked conversation, got %+v", first.Notices)
 	}
 
 	second := app.ResolveOrchestratorToReopen()
 	if second.ConversationID != live {
 		t.Fatalf("expected the second launch to resume the same live conversation %q, got %q", live, second.ConversationID)
 	}
-	if second.Notice != "" {
-		t.Fatalf("expected a launch that resumes the conversation already reported to say nothing, got %q", second.Notice)
+	if noticeText(second.Notices) != "" {
+		t.Fatalf("expected a launch that resumes the conversation already reported to say nothing, got %q", noticeText(second.Notices))
 	}
 
 	// The record still resolves the same tracked conversation; only the notice
 	// about it is quiet the second time.
 	third := app.ResolveOrchestratorToReopen()
-	if third.Notice != "" {
-		t.Fatalf("expected a third repeat launch to stay silent too, got %q", third.Notice)
+	if noticeText(third.Notices) != "" {
+		t.Fatalf("expected a third repeat launch to stay silent too, got %q", noticeText(third.Notices))
 	}
 }
 
@@ -293,11 +299,11 @@ func TestRestoreReportsAChangeToADifferentTrackedConversation(t *testing.T) {
 		LaunchID:       recordedLaunchID(t, openPath, id),
 	})
 
-	if target := app.ResolveOrchestratorToReopen(); target.Notice == "" || target.ConversationID != firstLive {
-		t.Fatalf("expected the first divergence reported and resumed, got conversation %q notice %q", target.ConversationID, target.Notice)
+	if target := app.ResolveOrchestratorToReopen(); noticeText(target.Notices) == "" || target.ConversationID != firstLive {
+		t.Fatalf("expected the first divergence reported and resumed, got conversation %q notice %q", target.ConversationID, noticeText(target.Notices))
 	}
-	if target := app.ResolveOrchestratorToReopen(); target.Notice != "" {
-		t.Fatalf("expected the repeat of the same tracked conversation to say nothing, got %q", target.Notice)
+	if target := app.ResolveOrchestratorToReopen(); noticeText(target.Notices) != "" {
+		t.Fatalf("expected the repeat of the same tracked conversation to say nothing, got %q", noticeText(target.Notices))
 	}
 
 	// A new launch under the SAME entry's launch id, whose session now reports a
@@ -310,11 +316,11 @@ func TestRestoreReportsAChangeToADifferentTrackedConversation(t *testing.T) {
 	if target.ConversationID != secondLive {
 		t.Fatalf("expected the changed tracked conversation %q resumed, got %q", secondLive, target.ConversationID)
 	}
-	if target.Notice == "" {
+	if noticeText(target.Notices) == "" {
 		t.Fatal("expected a change to a different tracked conversation to be reported")
 	}
-	if target := app.ResolveOrchestratorToReopen(); target.Notice != "" {
-		t.Fatalf("expected the repeat of the newly reported conversation to say nothing, got %q", target.Notice)
+	if target := app.ResolveOrchestratorToReopen(); noticeText(target.Notices) != "" {
+		t.Fatalf("expected the repeat of the newly reported conversation to say nothing, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -338,8 +344,8 @@ func TestAnUnconfirmedTrackedConversationIsReportedOnEveryLaunch(t *testing.T) {
 	first := app.ResolveOrchestratorToReopen()
 	second := app.ResolveOrchestratorToReopen()
 	for _, target := range []relaunchTarget{first, second} {
-		if !strings.Contains(target.Notice, stranded) {
-			t.Fatalf("expected every launch to report the unconfirmed conversation, got %q", target.Notice)
+		if !strings.Contains(noticeText(target.Notices), stranded) {
+			t.Fatalf("expected every launch to report the unconfirmed conversation, got %q", noticeText(target.Notices))
 		}
 	}
 }
@@ -361,8 +367,8 @@ func TestATrackedConversationWithNoTranscriptFallsBackAndSaysSo(t *testing.T) {
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected the derived conversation, got %q", target.ConversationID)
 	}
-	if !strings.Contains(target.Notice, "no longer on disk") {
-		t.Fatalf("expected the notice to say the transcript is gone, got %q", target.Notice)
+	if !strings.Contains(noticeText(target.Notices), "no longer on disk") {
+		t.Fatalf("expected the notice to say the transcript is gone, got %q", noticeText(target.Notices))
 	}
 }
 

--- a/erun-ui/orchestrator_open_state_test.go
+++ b/erun-ui/orchestrator_open_state_test.go
@@ -341,8 +341,8 @@ func TestPlainReopenSurfacesANoticeWhenScopeChanged(t *testing.T) {
 	if target.ResumePrompt != "" {
 		t.Fatalf("expected no task delivered on a plain reopen, got %+v", target)
 	}
-	if !strings.Contains(target.Notice, "frs/dev") || !strings.Contains(target.Notice, "frs/laptop") {
-		t.Fatalf("expected the notice to name both scopes, got %q", target.Notice)
+	if !strings.Contains(noticeText(target.Notices), "frs/dev") || !strings.Contains(noticeText(target.Notices), "frs/laptop") {
+		t.Fatalf("expected the notice to name both scopes, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -374,8 +374,8 @@ func TestAlsoReopenSurfacesANoticeWhenScopeChanged(t *testing.T) {
 	if target.AlsoReopen[0].ConversationID != staleConversation {
 		t.Fatalf("expected %q to still resume its own conversation idle, got %q", stale, target.AlsoReopen[0].ConversationID)
 	}
-	if !strings.Contains(target.Notice, stale) || !strings.Contains(target.Notice, "frs/dev") || !strings.Contains(target.Notice, "frs/laptop") {
-		t.Fatalf("expected the notice to name %q and both scopes, got %q", stale, target.Notice)
+	if !strings.Contains(noticeText(target.Notices), stale) || !strings.Contains(noticeText(target.Notices), "frs/dev") || !strings.Contains(noticeText(target.Notices), "frs/laptop") {
+		t.Fatalf("expected the notice to name %q and both scopes, got %q", stale, noticeText(target.Notices))
 	}
 }
 

--- a/erun-ui/playwright/pages/Sidebar.ts
+++ b/erun-ui/playwright/pages/Sidebar.ts
@@ -231,9 +231,25 @@ export class Sidebar {
 
   // The persistent alert under the orchestrator list: how the operator learns an
   // orchestrator action failed, or that a restart hand-off was refused and the
-  // reopened session is idle rather than continuing.
+  // reopened session is idle rather than continuing. A 'warning'-kind restore
+  // notice (Sidebar.OrchestratorNotice.tsx) renders through this same role, but
+  // an 'info' or 'unknown'-kind one does not -- see orchestratorRestoreNotices()
+  // and orchestratorRestoreStatusNotices() for those.
   orchestratorsAlert(): Locator {
     return this.erunSection().getByRole('alert');
+  }
+
+  // Every notice a restore had to say about how it resolved this launch's
+  // reopened orchestrators, one list item per notice at its own severity.
+  orchestratorRestoreNotices(): Locator {
+    return this.erunSection().getByRole('list', { name: 'Orchestrator restore notices' });
+  }
+
+  // A non-alert restore notice ('info' or 'unknown' kind): role="status" so it
+  // is announced politely rather than interrupting the way orchestratorsAlert()
+  // does.
+  orchestratorRestoreStatusNotices(): Locator {
+    return this.orchestratorRestoreNotices().getByRole('status');
   }
 
   // A persisted orchestrator's row is identified by its "…" details button,

--- a/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts
@@ -31,6 +31,16 @@ function runningOrchestratorInfo(id: string, sessionId: number) {
 
 const runningOrchestrator = runningOrchestratorInfo(SEED_ORCHESTRATOR, RESTORED_SESSION_ID);
 
+// A raw notice entry the way the backend's JSON actually shapes one (see
+// orchestratorNotice, erun-ui/app_restart.go) -- kind and text untyped as
+// `string` here rather than the narrowed union the frontend normalizes to, so
+// a spec can also stage a kind the frontend does not recognise.
+interface StubNotice {
+  orchestratorId?: string;
+  kind?: string;
+  text: string;
+}
+
 // stubReopen answers the boot restore round-trip and records every method the
 // frontend invoked, so a spec can assert which start call the launch made — and
 // that it made none at all when there is nothing to reopen. `running` maps every
@@ -43,7 +53,7 @@ async function stubReopen(
     conversationId?: string;
     resumePrompt: string;
     alsoReopen?: { orchestratorId: string; conversationId?: string }[];
-    notice?: string;
+    notices?: StubNotice[];
   },
   calls: string[],
   running: Record<string, ReturnType<typeof runningOrchestratorInfo>> = {
@@ -167,11 +177,18 @@ test.describe('reopening the orchestrator that was open', () => {
       'Check RESUME-NOTE.pw-orch.md in the orchestrators working directory before telling it to carry on.';
     await stubReopen(
       page,
-      { orchestratorId: SEED_ORCHESTRATOR, conversationId: 'conv-own', resumePrompt: '', notice },
+      {
+        orchestratorId: SEED_ORCHESTRATOR,
+        conversationId: 'conv-own',
+        resumePrompt: '',
+        notices: [{ orchestratorId: SEED_ORCHESTRATOR, kind: 'warning', text: notice }],
+      },
       calls,
     );
     await app.reboot();
 
+    // A refusal is a warning: it renders through the destructive role="alert"
+    // treatment, never the muted role="status" a routine resume gets.
     await expect(app.sidebar.orchestratorsAlert()).toContainText(notice);
     expect(calls).toContain('StartOrchestratorWithResume');
     expect(calls).not.toContain('StartOrchestrator');
@@ -198,7 +215,10 @@ test.describe('reopening the orchestrator that was open', () => {
         orchestratorId: SEED_ORCHESTRATOR,
         conversationId: 'conv-1',
         resumePrompt: 'Read RESUME-NOTE.pw-orch.md in this working directory',
-        notice,
+        // This notice names several orchestrators at once, so the backend
+        // attributes it to none in particular (erun-ui/app_restart.go's
+        // orchestratorHandoffsNotReopenedNotice).
+        notices: [{ kind: 'warning', text: notice }],
       },
       calls,
     );
@@ -273,5 +293,156 @@ test.describe('restoring every orchestrator that was open', () => {
     // restart hand-off) carries no prompt to auto-run.
     expect(calls).toContain('StartOrchestratorWithResume');
     expect(calls).not.toContain('StartOrchestrator');
+  });
+});
+
+// erun#1695: the kind orchestratorConversationNoticeKind computes on the Go
+// side (erun-ui/orchestrator_live_conversation.go) used to be discarded at the
+// frontend boundary, and every restore notice rendered through one destructive
+// role="alert" paragraph regardless of what it actually reported — so a
+// resumed tracked conversation (the mechanism working) read identically to a
+// genuine refusal. These specs assert the rendered role per kind, which prose
+// cannot substitute for.
+test.describe('orchestrator restore notices render by kind', () => {
+  test('a single info notice renders as a status, not a destructive alert', async ({
+    app,
+    page,
+  }) => {
+    const calls: string[] = [];
+    const text =
+      'Reopened pw-orch on the conversation its session was last live on (conv-live), ' +
+      'not the one derived from its id (conv-derived). Manage the orchestrator to see every ' +
+      'conversation it can resume and attach a different one.';
+    await stubReopen(
+      page,
+      {
+        orchestratorId: SEED_ORCHESTRATOR,
+        conversationId: 'conv-live',
+        resumePrompt: '',
+        notices: [{ orchestratorId: SEED_ORCHESTRATOR, kind: 'info', text }],
+      },
+      calls,
+    );
+    await app.reboot();
+
+    // role="status" only — never role="alert", the treatment reserved for an
+    // actual fault.
+    await expect(app.sidebar.orchestratorRestoreStatusNotices()).toContainText(text);
+    await expect(app.sidebar.orchestratorsAlert()).toHaveCount(0);
+
+    await page.screenshot({ path: 'test-results/orchestrator-restore-notice-info-light.png' });
+    await app.titlebar.toggleTheme();
+    await expect(app.documentElement()).toHaveClass(/dark/);
+    await page.screenshot({ path: 'test-results/orchestrator-restore-notice-info-dark.png' });
+  });
+
+  test('a single warning notice keeps the destructive alert treatment it deserves', async ({
+    app,
+    page,
+  }) => {
+    const calls: string[] = [];
+    const text =
+      'Reopened pw-orch without continuing its task: the conversation that asked for it no longer exists. ' +
+      'Check RESUME-NOTE.pw-orch.md in the orchestrators working directory before telling it to carry on.';
+    await stubReopen(
+      page,
+      {
+        orchestratorId: SEED_ORCHESTRATOR,
+        conversationId: 'conv-own',
+        resumePrompt: '',
+        notices: [{ orchestratorId: SEED_ORCHESTRATOR, kind: 'warning', text }],
+      },
+      calls,
+    );
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorsAlert()).toContainText(text);
+    await expect(app.sidebar.orchestratorRestoreStatusNotices()).toHaveCount(0);
+
+    await page.screenshot({ path: 'test-results/orchestrator-restore-notice-warning-light.png' });
+    await app.titlebar.toggleTheme();
+    await expect(app.documentElement()).toHaveClass(/dark/);
+    await page.screenshot({ path: 'test-results/orchestrator-restore-notice-warning-dark.png' });
+  });
+
+  // The heart of the bug: several orchestrators resolved on the same restore
+  // must each keep their own kind. Before the fix, this exact case (a genuine
+  // warning sitting among routine successes) rendered as one indistinguishable
+  // red paragraph — the warning was as easy to miss as it was to mistake a
+  // success for a fault.
+  test('a mixed batch renders the warning distinctly from the info notices beside it', async ({
+    app,
+    page,
+  }) => {
+    const calls: string[] = [];
+    const infoText =
+      'Reopened pw-orch-2 on the conversation its session was last live on (conv-owner-live), ' +
+      'not the one derived from its id (conv-owner-derived).';
+    const warningText =
+      'Reopened pw-orch: its environments changed since its last session (was pw/alpha, now pw/beta). ' +
+      'Its conversation may hold context for environments it is no longer wired to; ' +
+      'check RESUME-NOTE.pw-orch.md before treating it as current.';
+    const owner = runningOrchestratorInfo(SEED_ORCHESTRATOR_2, RESTORED_SESSION_ID + 2);
+    await stubReopen(
+      page,
+      {
+        orchestratorId: SEED_ORCHESTRATOR_2,
+        conversationId: 'conv-owner-live',
+        resumePrompt: '',
+        alsoReopen: [{ orchestratorId: SEED_ORCHESTRATOR, conversationId: 'conv-also' }],
+        notices: [
+          { orchestratorId: SEED_ORCHESTRATOR, kind: 'warning', text: warningText },
+          { orchestratorId: SEED_ORCHESTRATOR_2, kind: 'info', text: infoText },
+        ],
+      },
+      calls,
+      { [SEED_ORCHESTRATOR]: runningOrchestrator, [SEED_ORCHESTRATOR_2]: owner },
+    );
+    await app.reboot();
+
+    // Two distinct list items, not one joined paragraph...
+    await expect(app.sidebar.orchestratorRestoreNotices().locator('li')).toHaveCount(2);
+    // ...each at its own role: the warning is the only one that alerts...
+    await expect(app.sidebar.orchestratorsAlert()).toHaveCount(1);
+    await expect(app.sidebar.orchestratorsAlert()).toContainText(warningText);
+    await expect(app.sidebar.orchestratorsAlert()).not.toContainText(infoText);
+    // ...and the info notice is the only one that merely reports status.
+    await expect(app.sidebar.orchestratorRestoreStatusNotices()).toHaveCount(1);
+    await expect(app.sidebar.orchestratorRestoreStatusNotices()).toContainText(infoText);
+    await expect(app.sidebar.orchestratorRestoreStatusNotices()).not.toContainText(warningText);
+
+    await page.screenshot({ path: 'test-results/orchestrator-restore-notice-mixed-light.png' });
+    await app.titlebar.toggleTheme();
+    await expect(app.documentElement()).toHaveClass(/dark/);
+    await page.screenshot({ path: 'test-results/orchestrator-restore-notice-mixed-dark.png' });
+  });
+
+  // A kind this launch does not recognise — a payload from a backend version
+  // that classified notices differently, or one missing the field — must not
+  // silently become 'info' (hiding a real problem behind a routine-looking
+  // line) or 'warning' (crying wolf over what might be entirely routine). It
+  // renders as its own visibly distinct case: role="status" like info (never
+  // interrupts like an alert would), but with its own icon and border so it
+  // reads as neither of the two known kinds.
+  test('an unrecognised kind renders as its own distinct case, never silently as info or a fault', async ({
+    app,
+    page,
+  }) => {
+    const calls: string[] = [];
+    const text = 'a notice this launch does not know how to classify';
+    await stubReopen(
+      page,
+      {
+        orchestratorId: SEED_ORCHESTRATOR,
+        conversationId: 'conv-own',
+        resumePrompt: '',
+        notices: [{ orchestratorId: SEED_ORCHESTRATOR, kind: 'mystery-kind', text }],
+      },
+      calls,
+    );
+    await app.reboot();
+
+    await expect(app.sidebar.orchestratorRestoreStatusNotices()).toContainText(text);
+    await expect(app.sidebar.orchestratorsAlert()).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
- Carries orchestrator restore notices as structured `{orchestratorId, kind, text}` entries end to end instead of concatenating them into one joined string, so the info/warning classification `orchestratorConversationNoticeKind` already computes survives to the frontend.
- Renders each notice at its own severity in the sidebar: `info` as `role="status"` (non-interrupting), `warning` on `InlineAlert`'s `role="alert"` treatment, and an unrecognized kind as its own visibly distinct case rather than silently defaulting to either.
- Adds Playwright coverage for a single info notice, a single warning notice, an unrecognised kind, and the mixed batch that is the heart of the bug — several orchestrators resolving on one restore, with a warning among routine successes rendering as a distinct list item instead of one merged, uniformly red block.

## Why
A successful conversation resume (the mechanism working correctly) rendered identically to a genuine warning: every restore notice went through one `role="alert"` destructive paragraph, and joining several orchestrators' notices into one string made a real warning indistinguishable from the routine ones beside it.

Closes #1695

## UX Impact Review Checklist
1. **Affected paths.** Desktop boot → orchestrator restore → sidebar restore-notice rendering (`Sidebar.ErunSection.tsx` / new `Sidebar.OrchestratorNotice.tsx`).
2. **User-visible sequence.** On launch, restored orchestrators resolve; the sidebar renders one entry per notice, each colored/roled by its own kind, instead of one merged alert block.
3. **State-without-affordance.** `state.orchestrators.restoreNotices` is new, dedicated state (kept apart from the existing `error` field) with a direct render — no orphaned mutation.
4. **Visibility of system status (Nielsen #1).** Each notice is rendered persistently in the sidebar for the operator to read, not a transient overlay.
5. **Success and failure feedback (Nielsen #1, #9).** A routine successful resume now reads as `role="status"` success/info, distinct from an actionable warning.
6. **Consistency with comparable flows (Nielsen #4).** Reuses the existing `InlineAlert` (`role="alert"`) / plain `role="status"` notice vocabulary already used elsewhere in the desktop rather than inventing a new visual treatment.
7. **One-line heuristic pass.** Match between system and real world: a success no longer looks like a failure. Recognition over recall: the operator does not have to parse UUID-heavy prose to figure out which line, if any, needs attention. Other heuristics unaffected.
8. **Playwright coverage.** `erun-ui/playwright/tests/orchestrator-reopen-on-launch.spec.ts`, extended with cases for a single info notice, a single warning notice, an unrecognised kind, and the mixed-kind batch, in both themes.

## Test plan
- [x] `make check` — green (all module lints 0 issues, all Go/frontend test suites pass, integration suite 91.486s ok, coverage 75.6% ≥ 75.6%)
- [x] `erun-ui/playwright/run.sh --build` — 452 passed