### PR TITLE
Request the org-claim scope from the console, with a one-shot fallback

### DIFF
--- a/erun-console/src/auth/auth.ts
+++ b/erun-console/src/auth/auth.ts
@@ -26,6 +26,29 @@ import { fetchPlatformConfig } from '../config/platform';
 const TOKEN_STORAGE_KEY = 'erun.console.idToken';
 const PKCE_VERIFIER_KEY = 'erun.console.pkceVerifier';
 const PKCE_STATE_KEY = 'erun.console.oauthState';
+const SCOPE_FALLBACK_KEY = 'erun.console.scopeFallback';
+
+// BASE_SCOPE is what every login asks for. ORG_CLAIM_SCOPE is asked for on top,
+// so a shared, org-scoped issuer's tokens carry the discriminator erun's tenant
+// resolution reads (erun-backend-api's orgClaimValue): without it the API sees
+// no org claim and resolves the caller to no tenant at all, however correctly
+// they are enrolled. erun-common/cloud_erun.go has requested it by default for
+// every CLI login since org-scoping existed; the console was the one client
+// that never did, so converting an issuer to org-scoped silently locked it out.
+const BASE_SCOPE = 'openid profile email';
+const ORG_CLAIM_SCOPE = 'urn:zitadel:iam:user:resourceowner';
+
+// loginScope adds the org-claim scope unless this session already had it
+// refused. An issuer that has never heard of it — a dedicated or BYO IdP, the
+// common case — rejects the authorize request outright rather than ignoring the
+// unknown scope, so login must still work without it. This is the browser-side
+// equivalent of erun-common's fallbackScope: asked for by default, dropped once
+// on refusal, never retried in a loop.
+function loginScope(): string {
+  return sessionStorage.getItem(SCOPE_FALLBACK_KEY) === '1'
+    ? BASE_SCOPE
+    : BASE_SCOPE + ' ' + ORG_CLAIM_SCOPE;
+}
 
 export interface OidcConfig {
   issuer: string;
@@ -147,7 +170,7 @@ export async function beginLogin(config: OidcConfig, prompt?: string): Promise<v
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     response_type: 'code',
-    scope: 'openid profile email',
+    scope: loginScope(),
     code_challenge: await pkceChallenge(verifier),
     code_challenge_method: 'S256',
     state,
@@ -226,6 +249,33 @@ export function signOut(): void {
   sessionStorage.removeItem(TOKEN_STORAGE_KEY);
 }
 
+// authCallbackError returns the OIDC error code when the redirect came back as
+// a failure instead of a code. Distinct from isAuthCallback, which only reports
+// the success shape (?code=&state=) — an error redirect carries neither, so
+// without this the failure is silently indistinguishable from never having
+// signed in.
+export function authCallbackError(): string | undefined {
+  const params = new URLSearchParams(window.location.search);
+  const error = params.get('error');
+  return error !== null && error.length > 0 ? error : undefined;
+}
+
+// isOrgScopeRefusal reports whether a failed callback is the issuer rejecting
+// the org-claim scope. Issuers differ on which code they use for an unknown
+// scope, so both spellings the spec allows are treated as a refusal.
+function isOrgScopeRefusal(error: string): boolean {
+  return error === 'invalid_scope' || error === 'invalid_request';
+}
+
+// retryLoginWithoutOrgScope arms the fallback and restarts the flow, once. The
+// marker lives in sessionStorage, so a second refusal in the same session
+// cannot loop, and a new session asks for the scope again — an issuer that
+// gains org-claim support is picked up without anyone clearing state by hand.
+async function retryLoginWithoutOrgScope(config: OidcConfig): Promise<void> {
+  sessionStorage.setItem(SCOPE_FALLBACK_KEY, '1');
+  await beginLogin(config);
+}
+
 // resolveToken produces the bearer token to present to the API on load: the OIDC
 // callback exchange when this is a redirect callback, else a token already held
 // this session, else the dev-token fallback. undefined means no token — the
@@ -233,6 +283,16 @@ export function signOut(): void {
 export async function resolveToken(config: OidcConfig | undefined): Promise<string | undefined> {
   if (config !== undefined && isAuthCallback()) {
     return completeLogin(config);
+  }
+  const callbackError = authCallbackError();
+  if (
+    config !== undefined &&
+    callbackError !== undefined &&
+    isOrgScopeRefusal(callbackError) &&
+    sessionStorage.getItem(SCOPE_FALLBACK_KEY) !== '1'
+  ) {
+    await retryLoginWithoutOrgScope(config);
+    return undefined;
   }
   return storedToken() ?? devBearerToken();
 }


### PR DESCRIPTION
## Summary

The console requested `openid profile email` and nothing else. Once an issuer is org-scoped, erun's tenant resolution reads an org claim from the token (`repository/identity.go`'s `orgClaimValue`) and returns `ErrNotFound` when it is absent — so every console sign-in against such an issuer failed with "not yet part of a tenant", however correctly the caller was enrolled.

This adds the org-claim scope to the console's authorize request, with a one-shot fallback for an issuer that refuses it.

## Why this shape

`erun-common/cloud_erun.go:141-149` has requested `urn:zitadel:iam:user:resourceowner` by default for every CLI login since org-scoping existed, and retries once with a `fallbackScope` when an issuer that has never heard of the scope refuses it. The console is the one client that never did.

This mirrors that behaviour rather than inventing a second pattern:

- requested by default on top of the baseline;
- dropped once when the redirect returns `error=invalid_scope` (or `invalid_request`, which some issuers use for an unknown scope);
- never retried in a loop — the marker is in `sessionStorage`, so a second refusal in the same session cannot bounce, and a new session asks again, so an issuer that later gains org-claim support is picked up without anyone clearing state by hand.

It also adds `authCallbackError()`. `isAuthCallback()` only recognises the success shape (`?code=&state=`); an error redirect carries neither, so a failed callback was previously indistinguishable from never having signed in — the browser landed on the signed-out view with the reason discarded.

## Verified

Observed live before the change, on the deployed bundle (`/assets/index-92jXDquS.js`, served identically from `console.erunpaas.com` and `console.frs-prod.services.erunpaas.com`):

```
scope: `openid profile email`, code_challenge: …, code_challenge_method: `S256`
```

Against a platform whose `issuers.org_field_key` is `urn:zitadel:iam:user:resourceowner:id`, that token carries no org claim and resolution fails before it runs a query.

## Test plan

- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [ ] `yarn test` — **20 pre-existing failures, unrelated to this change.** Identical counts (`20 failed | 130 passed`) with this change stashed on clean `main`: `localStorage` is `undefined` in the test environment, so every test that mounts `AppShell` errors in `theme.ts:20`. Filed as **#1725** and deliberately not fixed here, per root `AGENTS.md`'s deferral rule — it is a test-environment/dependency question with its own root cause, not something this change should absorb.

Closes #1721
