### PR TITLE
Distinguish tenant-unresolved from not-enrolled auth failures

### DIFF
--- a/erun-backend/erun-backend-api/auth.go
+++ b/erun-backend/erun-backend-api/auth.go
@@ -2,13 +2,16 @@ package backendapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
 
@@ -177,14 +180,14 @@ func (m *AuthMiddleware) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		claims, err := m.authenticate(r)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusUnauthorized)
+			writeAuthError(w, http.StatusUnauthorized, "UNAUTHENTICATED", err.Error())
 			return
 		}
 
 		identity, err := m.resolveIdentity(r.Context(), claims)
 		if err != nil {
 			log.Printf("erun api auth rejected method=%s path=%s issuer=%q subject=%q reason=%q", r.Method, r.URL.Path, claims.Issuer, claims.Subject, err.Error())
-			http.Error(w, err.Error(), http.StatusUnauthorized)
+			writeAuthError(w, http.StatusUnauthorized, authErrorCode(err), err.Error())
 			return
 		}
 
@@ -310,7 +313,8 @@ func (m *AuthMiddleware) resolveIdentity(ctx context.Context, claims Claims) (Id
 // bootstrap and must create tenant, issuer, and user atomically.
 func (m *AuthMiddleware) tenantAndUser(ctx context.Context, claims Claims) (Tenant, User, error) {
 	if m.identities != nil {
-		return resolvedIdentity(m.identities.ResolveIdentity(ctx, claims))
+		tenant, user, err := m.identities.ResolveIdentity(ctx, claims)
+		return resolvedIdentity(tenant, user, classifyIdentityError(err))
 	}
 	tenant, err := m.tenants.ResolveTenantByIssuer(ctx, claims)
 	if err != nil || strings.TrimSpace(tenant.TenantID) == "" {
@@ -323,16 +327,73 @@ func (m *AuthMiddleware) tenantAndUser(ctx context.Context, claims Claims) (Tena
 	return tenant, user, nil
 }
 
+// classifyIdentityError normalizes the combined IdentityResolver's error onto
+// the same ErrTenantNotResolved/ErrUserNotResolved split the separate
+// tenant/user resolver wiring above already produces, so Wrap reports which
+// half failed the same way regardless of which wiring is in play.
+// security.ErrTenantUnresolved means the tenant itself could not be
+// determined from the token (an org-scoped issuer whose token carries no
+// matching org claim, or an issuer with no tenant mapping at all) — distinct
+// from a repository.ErrNotFound reached after a tenant already resolved,
+// which means this external identity simply is not enrolled in it. Any other
+// error (an unexpected database failure, for instance) passes through
+// unclassified rather than being guessed at.
+func classifyIdentityError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, security.ErrTenantUnresolved) {
+		return fmt.Errorf("%w: %s", ErrTenantNotResolved, err.Error())
+	}
+	if errors.Is(err, repository.ErrNotFound) {
+		return fmt.Errorf("%w: %s", ErrUserNotResolved, err.Error())
+	}
+	return err
+}
+
 // resolvedIdentity treats a blank tenant or user as unresolved, so a resolver
 // that reports no error but no identity cannot authenticate a request.
 func resolvedIdentity(tenant Tenant, user User, err error) (Tenant, User, error) {
-	if err == nil && (strings.TrimSpace(tenant.TenantID) == "" || strings.TrimSpace(user.UserID) == "") {
+	if err == nil && strings.TrimSpace(tenant.TenantID) == "" {
+		err = ErrTenantNotResolved
+	}
+	if err == nil && strings.TrimSpace(user.UserID) == "" {
 		err = ErrUserNotResolved
 	}
 	if err != nil {
 		return Tenant{}, User{}, err
 	}
 	return tenant, user, nil
+}
+
+// authErrorCode reports the machine-readable code for a resolution failure so
+// a client can render "no tenant matched this token" apart from "you are not
+// enrolled" instead of collapsing both into one generic message — the
+// distinction the not-enrolled UI otherwise cannot make (erun#1721).
+func authErrorCode(err error) string {
+	switch {
+	case errors.Is(err, ErrTenantNotResolved):
+		return "TENANT_UNRESOLVED"
+	case errors.Is(err, ErrUserNotResolved):
+		return "NOT_ENROLLED"
+	default:
+		return "UNAUTHORIZED"
+	}
+}
+
+// authErrorEnvelope mirrors internal/routes' {code, message} error envelope
+// (see internal/routes/errors.go) so every API error response — including
+// this pre-route auth layer, which cannot import that internal package's
+// unexported writer — carries the same machine-readable shape.
+type authErrorEnvelope struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeAuthError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(authErrorEnvelope{Code: code, Message: message})
 }
 
 func (m *AuthMiddleware) resolveOrg(ctx context.Context, claims Claims) (string, error) {

--- a/erun-backend/erun-backend-api/auth_test.go
+++ b/erun-backend/erun-backend-api/auth_test.go
@@ -2,12 +2,28 @@ package backendapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
+
+// decodedAuthError reads the {code, message} envelope every auth-layer error
+// response now carries (erun#1721), failing the test if the body isn't that shape.
+func decodedAuthError(t *testing.T, rec *httptest.ResponseRecorder) authErrorEnvelope {
+	t.Helper()
+	var envelope authErrorEnvelope
+	if err := json.NewDecoder(rec.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode error envelope: %v (body: %s)", err, rec.Body.String())
+	}
+	return envelope
+}
 
 // mustEqual fails when a value the middleware passed through differs from the one
 // it resolved from.
@@ -250,6 +266,9 @@ func TestAuthMiddlewareRejectsUnknownTenantIssuer(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("unexpected status: %d", rec.Code)
 	}
+	if code := decodedAuthError(t, rec).Code; code != "TENANT_UNRESOLVED" {
+		t.Fatalf("code = %q, want TENANT_UNRESOLVED -- an unknown issuer means no tenant matched this token, not that the caller isn't enrolled", code)
+	}
 }
 
 func TestAuthMiddlewareRejectsUnknownExternalUser(t *testing.T) {
@@ -277,6 +296,136 @@ func TestAuthMiddlewareRejectsUnknownExternalUser(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if code := decodedAuthError(t, rec).Code; code != "NOT_ENROLLED" {
+		t.Fatalf("code = %q, want NOT_ENROLLED -- the tenant resolved fine, this external id just isn't a member", code)
+	}
+}
+
+// TestAuthMiddlewareReportsTenantUnresolvedForOrgClaimMissing is the erun#1721
+// regression test at the middleware boundary: a combined IdentityResolver
+// (the production wiring) reporting security.ErrTenantUnresolved -- an
+// org-scoped issuer whose token carries no matching org claim -- must render
+// as TENANT_UNRESOLVED, never the generic "not enrolled" message that sends
+// an already-enrolled operator to ask for an enrolment that already exists.
+func TestAuthMiddlewareReportsTenantUnresolvedForOrgClaimMissing(t *testing.T) {
+	underlying := fmt.Errorf("%w: issuer %q is org-scoped but the token carries no matching claim", security.ErrTenantUnresolved, "https://auth.example/shared")
+	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{
+		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
+			return Claims{Issuer: "https://auth.example/shared", Subject: "rihards@frs.lv"}, nil
+		}),
+		IdentityResolver: IdentityResolverFunc(func(ctx context.Context, claims Claims) (Tenant, User, error) {
+			return Tenant{}, User{}, underlying
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/whoami", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called")
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if code := decodedAuthError(t, rec).Code; code != "TENANT_UNRESOLVED" {
+		t.Fatalf("code = %q, want TENANT_UNRESOLVED", code)
+	}
+}
+
+// TestAuthMiddlewareReportsNotEnrolledForCombinedResolverNotFound mirrors the
+// same distinction through the combined IdentityResolver wiring: a tenant
+// that resolved fine but reports a plain repository.ErrNotFound (this
+// external identity is not one of its users) must render as NOT_ENROLLED,
+// not TENANT_UNRESOLVED.
+func TestAuthMiddlewareReportsNotEnrolledForCombinedResolverNotFound(t *testing.T) {
+	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{
+		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
+			return Claims{Issuer: "https://issuer.example", Subject: "a-stranger"}, nil
+		}),
+		IdentityResolver: IdentityResolverFunc(func(ctx context.Context, claims Claims) (Tenant, User, error) {
+			return Tenant{}, User{}, repository.ErrNotFound
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware failed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/whoami", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	rec := httptest.NewRecorder()
+	middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called")
+	})).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if code := decodedAuthError(t, rec).Code; code != "NOT_ENROLLED" {
+		t.Fatalf("code = %q, want NOT_ENROLLED", code)
+	}
+}
+
+func TestAuthMiddlewareReportsUnauthenticatedForMissingBearerToken(t *testing.T) {
+	middleware, err := NewAuthMiddleware(AuthMiddlewareOptions{
+		TokenVerifier: TokenVerifierFunc(func(ctx context.Context, token string) (Claims, error) {
+			t.Fatal("verifier should not be called")
+			return Claims{}, nil
+		}),
+		TenantResolver: TenantResolverFunc(func(ctx context.Context, claims Claims) (Tenant, error) {
+			t.Fatal("tenant resolver should not be called")
+			return Tenant{}, nil
+		}),
+		UserResolver: UserResolverFunc(func(ctx context.Context, tenantID string, issuer string, externalID string) (User, error) {
+			t.Fatal("user resolver should not be called")
+			return User{}, nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("NewAuthMiddleware failed: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	middleware.Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called")
+	})).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/whoami", nil))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unexpected status: %d", rec.Code)
+	}
+	if code := decodedAuthError(t, rec).Code; code != "UNAUTHENTICATED" {
+		t.Fatalf("code = %q, want UNAUTHENTICATED", code)
+	}
+}
+
+func TestClassifyIdentityErrorMapsTenantUnresolved(t *testing.T) {
+	err := classifyIdentityError(fmt.Errorf("%w: issuer unknown", security.ErrTenantUnresolved))
+	if !errors.Is(err, ErrTenantNotResolved) {
+		t.Fatalf("err = %v, want ErrTenantNotResolved", err)
+	}
+	if errors.Is(err, ErrUserNotResolved) {
+		t.Fatalf("err = %v, must not also satisfy ErrUserNotResolved", err)
+	}
+}
+
+func TestClassifyIdentityErrorMapsNotEnrolled(t *testing.T) {
+	err := classifyIdentityError(repository.ErrNotFound)
+	if !errors.Is(err, ErrUserNotResolved) {
+		t.Fatalf("err = %v, want ErrUserNotResolved", err)
+	}
+	if errors.Is(err, ErrTenantNotResolved) {
+		t.Fatalf("err = %v, must not also satisfy ErrTenantNotResolved", err)
+	}
+}
+
+func TestClassifyIdentityErrorPassesThroughUnexpectedErrors(t *testing.T) {
+	unexpected := errors.New("database connection reset")
+	if got := classifyIdentityError(unexpected); !errors.Is(got, unexpected) {
+		t.Fatalf("err = %v, want the unexpected error passed through unclassified", got)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -140,13 +141,30 @@ func (r *IdentityRepository) ResolveIdentity(ctx context.Context, claims securit
 		if !errors.Is(err, ErrNotFound) {
 			return model.Tenant{}, model.User{}, err
 		}
+		// The tenant resolved; this external identity is simply not one of
+		// its users (or, if the tenant has zero users, becomes its first).
+		// Either way this is a user-level outcome, not a tenant-resolution
+		// failure, so it is never wrapped in security.ErrTenantUnresolved.
 		user, err = r.bootstrapFirstTenantUser(ctx, tenant, claims)
 		return tenant, user, err
+	}
+	if errors.Is(err, security.ErrTenantUnresolved) {
+		return model.Tenant{}, model.User{}, err
 	}
 	if !errors.Is(err, ErrNotFound) {
 		return model.Tenant{}, model.User{}, err
 	}
-	return r.bootstrapFirstIdentity(ctx, claims)
+	tenant, user, err := r.bootstrapFirstIdentity(ctx, claims)
+	if err != nil {
+		// bootstrapFirstIdentity only ever succeeds against a genuinely empty
+		// tenants table, so a failure here means this token's issuer really
+		// maps to no tenant at all -- the same "unresolved" condition
+		// ResolveTenantByIssuer reports directly for an org-scoped issuer's
+		// missing/unmatched org claim, not "you are not enrolled" (there is
+		// no tenant to be enrolled in).
+		return model.Tenant{}, model.User{}, fmt.Errorf("%w: %s", security.ErrTenantUnresolved, err.Error())
+	}
+	return tenant, user, nil
 }
 
 func (r *IdentityRepository) refreshUserUsername(ctx context.Context, tenant model.Tenant, user model.User, claims security.Claims) (model.User, error) {
@@ -186,10 +204,14 @@ func (r *IdentityRepository) refreshUserUsername(ctx context.Context, tenant mod
 // (resolve by issuer alone, the common BYO/external-IdP case); a set key names
 // the token claim whose value selects the tenant among that issuer's orgs
 // (shared multi-tenant issuer, e.g. a hosted Zitadel). An org-scoped issuer
-// whose token carries no matching org claim returns ErrNotFound — unauthorized,
-// and never bootstraps once tenants exist (bootstrapFirstIdentity guards on an
-// empty tenants table). An unregistered issuer also returns ErrNotFound, which
-// routes to first-identity bootstrap when the database is empty.
+// whose token carries no matching org claim, or whose org claim matches no
+// registered tenant, returns security.ErrTenantUnresolved: the issuer is known,
+// but this token cannot be mapped to one of its tenants — distinct from "not
+// enrolled", which requires a tenant to already have been resolved. An
+// unregistered issuer returns plain ErrNotFound, which routes to
+// first-identity bootstrap when the database is empty (ResolveIdentity wraps
+// a failed bootstrap attempt in security.ErrTenantUnresolved too, since that
+// only ever fails once a tenant already exists elsewhere).
 func (r *IdentityRepository) ResolveTenantByIssuer(ctx context.Context, claims security.Claims) (model.Tenant, error) {
 	issuer := strings.TrimSpace(claims.Issuer)
 	orgFieldKey, registered, err := r.orgFieldKeyForIssuer(ctx, issuer)
@@ -201,10 +223,11 @@ func (r *IdentityRepository) ResolveTenantByIssuer(ctx context.Context, claims s
 	}
 
 	var tenant model.Tenant
+	var org string
 	if orgFieldKey != "" {
-		org := orgClaimValue(claims.Raw, orgFieldKey)
+		org = orgClaimValue(claims.Raw, orgFieldKey)
 		if org == "" {
-			return model.Tenant{}, ErrNotFound
+			return model.Tenant{}, fmt.Errorf("%w: issuer %q is org-scoped (claim %q) but the token carries no matching claim", security.ErrTenantUnresolved, issuer, orgFieldKey)
 		}
 		err = r.db.NewRaw(`
 			SELECT t.tenant_id, t.name, t.type, t.created_at, t.updated_at
@@ -221,7 +244,14 @@ func (r *IdentityRepository) ResolveTenantByIssuer(ctx context.Context, claims s
 		`, issuer).Scan(ctx, &tenant)
 	}
 	if err != nil {
-		return model.Tenant{}, normalizeNoRows(err)
+		err = normalizeNoRows(err)
+		if errors.Is(err, ErrNotFound) {
+			if orgFieldKey != "" {
+				return model.Tenant{}, fmt.Errorf("%w: issuer %q has no tenant registered for org %q", security.ErrTenantUnresolved, issuer, org)
+			}
+			return model.Tenant{}, fmt.Errorf("%w: issuer %q is registered but has no tenant mapping", security.ErrTenantUnresolved, issuer)
+		}
+		return model.Tenant{}, err
 	}
 	return tenant, nil
 }

--- a/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"testing"
 
@@ -56,12 +57,13 @@ func TestBootstrapFirstIdentityEnrolsPlatformTenantWhenERUNTenantSet(t *testing.
 	assertHasReadAllAndWriteAll(t, db, user.UserID)
 }
 
-// TestFirstTenantUserBootstrapGrantsBothPredefinedRoles proves the
+// TestFirstTenantUserBootstrapGrantsTenantAdminForACompanyTenant proves the
 // per-tenant-first-user path (a token resolving to an already-registered
-// tenant with zero users) grants the same ReadAll+WriteAll shape as
-// empty-database bootstrap, so the role-assignment API added alongside it
-// changes nothing about how a new tenant gets its first admin.
-func TestFirstTenantUserBootstrapGrantsBothPredefinedRoles(t *testing.T) {
+// tenant with zero users) grants a COMPANY tenant's first user TenantAdmin --
+// full administration of that tenant, without the platform-operator reach
+// ReadAll/WriteAll would also carry inside an OPERATIONS tenant (see
+// insertTenantFirstUserAccess).
+func TestFirstTenantUserBootstrapGrantsTenantAdminForACompanyTenant(t *testing.T) {
 	db := identityBootstrapDatabase(t)
 	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
 	repo := NewIdentityRepository(db, DialectPostgres, "frs")
@@ -95,7 +97,7 @@ func TestFirstTenantUserBootstrapGrantsBothPredefinedRoles(t *testing.T) {
 	if tenant.TenantID != secondTenantID {
 		t.Fatalf("expected the second tenant, got %q", tenant.TenantID)
 	}
-	assertHasReadAllAndWriteAll(t, db, user.UserID)
+	assertHasExactlyRoles(t, db, user.UserID, "TenantAdmin")
 }
 
 // TestSecondOperationsTenantFirstUserBootstrapGrantsItsOwnRoles is the
@@ -152,10 +154,11 @@ func TestSecondOperationsTenantFirstUserBootstrapGrantsItsOwnRoles(t *testing.T)
 	}
 }
 
-// assertHasReadAllAndWriteAll locks in that bootstrap keeps granting exactly
-// the predefined ReadAll+WriteAll shape, so the fine-grained role-assignment
-// API added alongside it stays additive rather than changing the default.
-func assertHasReadAllAndWriteAll(t *testing.T, db *sql.DB, userID string) {
+// assertHasExactlyRoles locks in exactly which predefined roles a bootstrap
+// path granted a user, so a fine-grained role-assignment API added alongside
+// it stays additive rather than changing the default. want must already be in
+// the alphabetical order the underlying query sorts by.
+func assertHasExactlyRoles(t *testing.T, db *sql.DB, userID string, want ...string) {
 	t.Helper()
 	var names []string
 	rows, err := db.Query(`
@@ -173,9 +176,22 @@ func assertHasReadAllAndWriteAll(t *testing.T, db *sql.DB, userID string) {
 		names = append(names, name)
 	}
 	mustNoErr(t, rows.Err(), "iterate role names")
-	if len(names) != 2 || names[0] != "ReadAll" || names[1] != "WriteAll" {
-		t.Fatalf("expected exactly [ReadAll WriteAll], got %v", names)
+	if len(names) != len(want) {
+		t.Fatalf("expected exactly %v, got %v", want, names)
 	}
+	for i, name := range names {
+		if name != want[i] {
+			t.Fatalf("expected exactly %v, got %v", want, names)
+		}
+	}
+}
+
+// assertHasReadAllAndWriteAll locks in that bootstrap keeps granting exactly
+// the predefined ReadAll+WriteAll shape, so the fine-grained role-assignment
+// API added alongside it stays additive rather than changing the default.
+func assertHasReadAllAndWriteAll(t *testing.T, db *sql.DB, userID string) {
+	t.Helper()
+	assertHasExactlyRoles(t, db, userID, "ReadAll", "WriteAll")
 }
 
 // TestBootstrapFirstIdentityRegistersSharedIssuerOrgScopedWithCallersOrgAsFirstMapping
@@ -298,6 +314,177 @@ func TestBootstrapFirstIdentityLeavesAlreadyBootstrappedDatabaseAlone(t *testing
 	mustNoErr(t, db.QueryRow(`SELECT name FROM tenants WHERE tenant_id = $1`, original.TenantID).Scan(&name), "read seeded tenant name")
 	if name != defaultBootstrapTenantName {
 		t.Fatalf("expected the seeded tenant's name untouched at %q, got %q", defaultBootstrapTenantName, name)
+	}
+}
+
+// TestSecondTenantOnSharedIssuerDoesNotBreakFirstTenantsResolution is the
+// regression test for erun#1721: an OPERATIONS-tenant user (rihards@frs.lv on
+// frs-prod) stopped resolving after a second tenant was registered on the
+// same issuer, despite tenant_issuers and user_external_ids both being
+// intact. The suspected mechanism was that org-scoping an issuer silently
+// leaves the first tenant's mapping behind; TenantIssuerRepository.UpdateOrgScope
+// instead backfills it atomically as one explicit, operations-only step (see
+// TestTenantIssuerRepositoryUpdateOrgScopeConvertsAndBackfills), and this
+// proves that backfill is what keeps the first tenant's already-enrolled user
+// resolving once a second tenant shares the issuer -- registering tenant B
+// must never change how tenant A resolves.
+func TestSecondTenantOnSharedIssuerDoesNotBreakFirstTenantsResolution(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+
+	const issuer = "https://auth.erunpaas.example/1721"
+	const orgClaimKey = "urn:zitadel:iam:user:resourceowner:id"
+	const firstOrg = "386994597030592700"
+	const secondOrg = "388520359030161586"
+
+	// The first tenant bootstraps single-tenant (no org claim on this token) --
+	// the state a platform's own OPERATIONS tenant is in before any other
+	// tenant ever shares its issuer.
+	firstTenant, firstUser, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  issuer,
+		Subject: "rihards@frs.lv",
+	})
+	mustNoErr(t, err, "bootstrap the first tenant single-tenant")
+
+	// Convert the issuer to org-scoped, backfilling the first tenant's own
+	// mapping to its org value -- the documented, explicit remedy
+	// (PATCH /v1/tenant-issuers), never a silent side effect of registering
+	// the second tenant below.
+	issuers := NewTenantIssuerRepository(NewTxManager(db, DialectPostgres))
+	opsCtx := security.WithContext(context.Background(), security.Context{TenantID: firstTenant.TenantID, TenantType: string(model.TenantTypeOperations)})
+	_, err = issuers.UpdateOrgScope(opsCtx, issuer, orgClaimKey, firstOrg)
+	mustNoErr(t, err, "convert the issuer to org-scoped and backfill the first tenant's mapping")
+
+	// Register a second tenant on the same issuer under a different org --
+	// the action the issue reports as breaking the first tenant.
+	tenants := NewTenantRepository(NewTxManager(db, DialectPostgres))
+	_, err = tenants.Create(opsCtx, CreateTenantParams{
+		Name:          "validationagent",
+		Type:          model.TenantTypeCompany,
+		Issuer:        issuer,
+		OrgFieldKey:   orgClaimKey,
+		OrgFieldValue: secondOrg,
+	})
+	mustNoErr(t, err, "register the second tenant on the shared issuer")
+
+	// The first tenant's already-enrolled user must still resolve, presenting
+	// the org claim their token actually carries.
+	resolvedTenant, resolvedUser, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  issuer,
+		Subject: "rihards@frs.lv",
+		Raw:     map[string]any{orgClaimKey: firstOrg},
+	})
+	mustNoErr(t, err, "resolve the first tenant's existing user after a second tenant shares the issuer")
+	if resolvedTenant.TenantID != firstTenant.TenantID {
+		t.Fatalf("resolved tenant %q, want the first tenant %q", resolvedTenant.TenantID, firstTenant.TenantID)
+	}
+	if resolvedUser.UserID != firstUser.UserID {
+		t.Fatalf("resolved user %q, want the first tenant's original user %q", resolvedUser.UserID, firstUser.UserID)
+	}
+}
+
+// TestResolveTenantByIssuerReportsUnresolvedForMissingOrgClaim proves the
+// erun#1721 root cause is reported distinctly: once an issuer is org-scoped,
+// a token that simply carries no matching org claim (exactly what erun-console
+// presented before requesting the org scope) must not be confused with "not
+// enrolled" -- the caller may be a genuine member of a tenant this one token
+// cannot resolve to.
+func TestResolveTenantByIssuerReportsUnresolvedForMissingOrgClaim(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+
+	const issuer = "https://auth.erunpaas.example/1721-unresolved"
+	const orgClaimKey = "urn:zitadel:iam:user:resourceowner:id"
+
+	_, _, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  issuer,
+		Subject: "operator-subject",
+		Raw:     map[string]any{orgClaimKey: "111111111111111111"},
+	})
+	mustNoErr(t, err, "bootstrap an org-scoped issuer")
+
+	_, err = repo.ResolveTenantByIssuer(context.Background(), security.Claims{
+		Issuer: issuer,
+		// No org claim -- exactly what an OIDC client that never requested the
+		// org scope presents.
+	})
+	if !errors.Is(err, security.ErrTenantUnresolved) {
+		t.Fatalf("err = %v, want security.ErrTenantUnresolved", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, must not also satisfy plain ErrNotFound -- ResolveIdentity must not attempt empty-database bootstrap for an issuer it already knows", err)
+	}
+}
+
+// TestResolveIdentityDistinguishesNotEnrolledFromUnresolved locks in the
+// erun#1721 acceptance criterion directly: a genuinely-unenrolled identity (a
+// real tenant exists, this subject simply isn't one of its users) must report
+// differently from an identity whose tenant could not be resolved at all --
+// even when, in the second case, the very same already-enrolled subject
+// presents a token this one time cannot resolve.
+func TestResolveIdentityDistinguishesNotEnrolledFromUnresolved(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+	repo := NewIdentityRepository(db, DialectPostgres, "frs")
+
+	const singleTenantIssuer = "https://issuer.example/1721-not-enrolled"
+	_, _, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  singleTenantIssuer,
+		Subject: "first-operator",
+	})
+	mustNoErr(t, err, "bootstrap the tenant's first user")
+
+	_, _, notEnrolledErr := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  singleTenantIssuer,
+		Subject: "a-stranger",
+	})
+	if notEnrolledErr == nil {
+		t.Fatal("expected a stranger to an already-populated tenant to be rejected")
+	}
+	if errors.Is(notEnrolledErr, security.ErrTenantUnresolved) {
+		t.Fatalf("not-enrolled err = %v, must not be classified as tenant-unresolved -- the tenant resolved fine", notEnrolledErr)
+	}
+	if !errors.Is(notEnrolledErr, ErrNotFound) {
+		t.Fatalf("not-enrolled err = %v, want ErrNotFound", notEnrolledErr)
+	}
+
+	// A tenant already exists at this point (seeded above), so registering the
+	// org-scoped issuer's tenant explicitly through TenantRepository.Create --
+	// not empty-database bootstrap, which only ever fires once -- mirrors how
+	// a second tenant is actually added to a platform.
+	const orgScopedIssuer = "https://auth.erunpaas.example/1721-unresolved-vs-enrolled"
+	const orgClaimKey = "urn:zitadel:iam:user:resourceowner:id"
+	const org = "222222222222222222"
+	tenants := NewTenantRepository(NewTxManager(db, DialectPostgres))
+	opsCtx := security.WithContext(context.Background(), security.Context{TenantType: string(model.TenantTypeOperations)})
+	_, err = tenants.Create(opsCtx, CreateTenantParams{
+		Name:          "org-scoped-tenant",
+		Type:          model.TenantTypeCompany,
+		Issuer:        orgScopedIssuer,
+		OrgFieldKey:   orgClaimKey,
+		OrgFieldValue: org,
+	})
+	mustNoErr(t, err, "register the org-scoped tenant")
+
+	_, _, err = repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  orgScopedIssuer,
+		Subject: "operator-subject",
+		Raw:     map[string]any{orgClaimKey: org},
+	})
+	mustNoErr(t, err, "bootstrap the org-scoped tenant's first user")
+
+	_, _, unresolvedErr := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:  orgScopedIssuer,
+		Subject: "operator-subject", // the same, already-enrolled subject
+		// No org claim this time.
+	})
+	if unresolvedErr == nil {
+		t.Fatal("expected a missing org claim to be rejected")
+	}
+	if !errors.Is(unresolvedErr, security.ErrTenantUnresolved) {
+		t.Fatalf("unresolved err = %v, want security.ErrTenantUnresolved even though this exact subject is enrolled", unresolvedErr)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/repository/tenant_issuers_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenant_issuers_e2e_test.go
@@ -91,3 +91,41 @@ func TestTenantIssuerRepositoryUpdateOrgScopeConvertsAndBackfills(t *testing.T) 
 		t.Fatalf("tenant_issuers.org_field_value = %+v, want the existing tenant's mapping backfilled to %q, not left NULL", storedValue, orgFieldValue)
 	}
 }
+
+// TestTenantIssuersUniqueConstraintRejectsAmbiguousMapping proves the
+// erun#1721 acceptance criterion that ambiguity between two candidate
+// tenant_issuers rows for the same (issuer, org) is impossible by
+// construction, not a runtime coin flip: the UNIQUE NULLS NOT DISTINCT
+// (issuer, org_field_value) constraint refuses a second row before
+// ResolveTenantByIssuer's exact-match query could ever see two candidates for
+// the same resolution key.
+func TestTenantIssuersUniqueConstraintRejectsAmbiguousMapping(t *testing.T) {
+	db := tenantIssuersDatabase(t)
+	const issuer = "https://auth.erunpaas.example/1721-ambiguity"
+	const org = "999999999999999999"
+
+	var firstTenantID, secondTenantID string
+	mustNoErr(t, db.QueryRow(`INSERT INTO tenants (name, type) VALUES ($1, 'COMPANY') RETURNING tenant_id`, "ambiguity-first").Scan(&firstTenantID), "seed first tenant")
+	mustNoErr(t, db.QueryRow(`INSERT INTO tenants (name, type) VALUES ($1, 'COMPANY') RETURNING tenant_id`, "ambiguity-second").Scan(&secondTenantID), "seed second tenant")
+	t.Cleanup(func() {
+		_, _ = db.Exec(`DELETE FROM tenant_issuers WHERE tenant_id IN ($1, $2)`, firstTenantID, secondTenantID)
+		_, _ = db.Exec(`DELETE FROM tenants WHERE tenant_id IN ($1, $2)`, firstTenantID, secondTenantID)
+		_, _ = db.Exec(`DELETE FROM issuers WHERE issuer = $1`, issuer)
+	})
+
+	_, err := db.Exec(`INSERT INTO issuers (issuer, org_field_key) VALUES ($1, $2)`, issuer, "urn:zitadel:iam:user:resourceowner:id")
+	mustNoErr(t, err, "seed an org-scoped issuer")
+	_, err = db.Exec(`INSERT INTO tenant_issuers (tenant_id, issuer, org_field_value, name) VALUES ($1, $2, $3, $4)`, firstTenantID, issuer, org, "first")
+	mustNoErr(t, err, "seed the first mapping")
+
+	_, err = db.Exec(`INSERT INTO tenant_issuers (tenant_id, issuer, org_field_value, name) VALUES ($1, $2, $3, $4)`, secondTenantID, issuer, org, "second")
+	if err == nil {
+		t.Fatal("expected a second tenant_issuers row for the same (issuer, org_field_value) to be rejected by the unique constraint")
+	}
+
+	var rowCount int
+	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM tenant_issuers WHERE issuer = $1 AND org_field_value = $2`, issuer, org).Scan(&rowCount), "count mappings")
+	if rowCount != 1 {
+		t.Fatalf("expected exactly one mapping to survive the rejected duplicate insert, got %d", rowCount)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/security/context.go
+++ b/erun-backend/erun-backend-api/internal/security/context.go
@@ -7,6 +7,18 @@ import (
 
 var ErrMissingContext = errors.New("missing security context")
 
+// ErrTenantUnresolved marks a tenant-resolution failure that is not "not
+// enrolled": the token's issuer could not be mapped to a tenant at all, most
+// commonly because an org-scoped (shared) issuer's token carries no matching
+// org claim. This is deliberately distinct from a resolution that succeeds in
+// naming a tenant but finds no user for the caller's external identity in
+// it — that caller may be a genuine member of some tenant this exact token
+// simply cannot resolve to, so telling them to "ask an operator to enrol you"
+// would be advice that cannot work. Implementations of the identity
+// resolution contract wrap this so a caller can classify the failure with
+// errors.Is(err, ErrTenantUnresolved).
+var ErrTenantUnresolved = errors.New("tenant could not be resolved from token")
+
 type Claims struct {
 	Issuer   string
 	Subject  string

--- a/erun-console/src/App.test.tsx
+++ b/erun-console/src/App.test.tsx
@@ -199,3 +199,41 @@ describe('App not-enrolled route', () => {
     ).toBeInTheDocument();
   });
 });
+
+// erun#1721: a 401 coded TENANT_UNRESOLVED (an org-scoped issuer whose token
+// carries no matching org claim, most commonly) must render distinctly from
+// the not-enrolled card above -- the caller may already be enrolled
+// somewhere, so "an operator has to enrol you" would be wrong advice.
+describe('App tenant-unresolved route', () => {
+  it('shows the tenant-unresolved card, not the not-enrolled card, for a TENANT_UNRESOLVED 401', async () => {
+    vi.stubEnv('VITE_DEV_BEARER_TOKEN', 'dev-token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL) => {
+        const url = input instanceof URL ? input.href : input;
+        if (url.includes('/v1/platform')) {
+          return Promise.resolve(jsonResponse(PLATFORM));
+        }
+        if (url.includes('/v1/config')) {
+          return Promise.resolve({
+            ok: false,
+            status: 401,
+            json: () =>
+              Promise.resolve({
+                code: 'TENANT_UNRESOLVED',
+                message:
+                  'issuer "https://auth.acme.example" is org-scoped but the token carries no matching claim',
+              }),
+          } as unknown as Response);
+        }
+        return Promise.resolve(jsonResponse([]));
+      }),
+    );
+
+    renderWithStore(<App />);
+
+    await screen.findByText('Could not determine your tenant');
+    expect(screen.getByText(/carries no matching claim/)).toBeInTheDocument();
+    expect(screen.queryByText('Not yet part of a tenant')).not.toBeInTheDocument();
+  });
+});

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -12,7 +12,12 @@ import { fetchPlatformConfig } from './config/platform';
 import { AcceptInvitePage } from './identity/AcceptInvitePage';
 import { AppShell } from './shell/AppShell';
 import { LandingScreen } from './shell/LandingScreen';
-import { ErrorScreen, LoadingScreen, NotEnrolledScreen } from './shell/PreShellScreens';
+import {
+  ErrorScreen,
+  LoadingScreen,
+  NotEnrolledScreen,
+  TenantUnresolvedScreen,
+} from './shell/PreShellScreens';
 import { beginTenantSwitch, consumeTenantSwitchIntent } from './shell/tenantSwitch';
 import type { TenantSwitchMismatch } from './shell/TenantSwitchMismatchBanner';
 import { applyTheme, initialTheme } from './shell/theme';
@@ -26,6 +31,12 @@ type LoadState =
   // the recovery is completely different: signing in again just repeats the
   // same successful sign-in and lands here once more (#1167).
   | { status: 'not-enrolled'; token: string }
+  // Signed in, and the caller may well already be enrolled somewhere — the
+  // API could simply not determine which tenant this token resolves to (a
+  // shared, org-scoped issuer whose token carries no matching org claim, most
+  // commonly). Distinct from not-enrolled because "ask an operator to enrol
+  // you" is advice that cannot work here (erun#1721).
+  | { status: 'tenant-unresolved'; token: string; message: string }
   | { status: 'error'; message: string };
 
 interface AuthPhase {
@@ -44,16 +55,26 @@ interface ConfigQueryPhase {
   data?: TenantConfigView;
 }
 
-// A 401 means two completely different things depending on whether a token was
-// held. With no token the caller is simply signed out. With a token, the
-// identity provider authenticated them and the API still said no — so the
-// identity is not enrolled, and telling them to sign in is a loop (#1167).
+// A 401 means at least two completely different things depending on whether a
+// token was held, and — once one is — which of two causes the API itself
+// reports via its {code, message} envelope (erun#1721). With no token the
+// caller is simply signed out. With a token, the identity provider
+// authenticated them and the API still said no: either this identity really
+// is not enrolled anywhere (NOT_ENROLLED, telling them to sign in again is a
+// loop, #1167), or the API could not determine which tenant this token
+// resolves to at all (TENANT_UNRESOLVED) — a state the caller may already be
+// enrolled past, so "ask an operator to enrol you" would be wrong advice.
+// Anything else 401-shaped falls back to the same not-enrolled card the API
+// has always produced for an unclassified auth rejection.
 function loadStateFromConfigQuery(token: string, configQuery: ConfigQueryPhase): LoadState {
   if (configQuery.isLoading || configQuery.isUninitialized) {
     return { status: 'loading' };
   }
   if (configQuery.error !== undefined) {
     const described = describeQueryError(configQuery.error);
+    if (described.status === 401 && described.code === 'TENANT_UNRESOLVED') {
+      return { status: 'tenant-unresolved', token, message: described.message };
+    }
     return described.status === 401
       ? { status: 'not-enrolled', token }
       : { status: 'error', message: described.message };
@@ -175,6 +196,15 @@ function AppContent({
       );
     case 'not-enrolled':
       return <NotEnrolledScreen brand={brand} token={state.token} onSignOut={onSignOut} />;
+    case 'tenant-unresolved':
+      return (
+        <TenantUnresolvedScreen
+          brand={brand}
+          token={state.token}
+          message={state.message}
+          onSignOut={onSignOut}
+        />
+      );
     case 'error':
       return <ErrorScreen brand={brand} message={state.message} />;
     case 'ready':

--- a/erun-console/src/app/api/httpBaseQuery.ts
+++ b/erun-console/src/app/api/httpBaseQuery.ts
@@ -11,19 +11,26 @@ import { isRecord, type PlatformApiRequest, type PlatformBaseQuery } from 'erun-
 // same auth edge that fronts the API.
 const API_BASE = import.meta.env.VITE_API_BASE ?? '';
 
-// errorMessage prefers the backend's own {code, message} envelope (see
-// erun-backend-api/internal/routes/errors.go) over the generic fallback, so a
-// caller sees why a request was rejected (e.g. which field failed validation)
-// rather than only its status code. Falls back when the body isn't that
-// envelope — an auth-layer 401/403 is still plain text today (see
-// erun-docs/docs/agent-reference/api-protocol.md#errors).
-async function errorMessage(response: Response, label: string | undefined): Promise<string> {
-  const fallback = `${label ?? 'request'} failed (${String(response.status)})`;
+// parsedError prefers the backend's own {code, message} envelope (see
+// erun-backend-api/internal/routes/errors.go, and auth.go's authErrorEnvelope
+// for the pre-route auth layer -- both 401 and 403 now carry it too) over the
+// generic fallback, so a caller sees why a request was rejected (e.g. which
+// field failed validation, or TENANT_UNRESOLVED vs NOT_ENROLLED) rather than
+// only its status code. Falls back to a message-only result when the body
+// isn't that envelope.
+async function parsedError(
+  response: Response,
+  label: string | undefined,
+): Promise<{ message: string; code?: string }> {
+  const fallback = { message: `${label ?? 'request'} failed (${String(response.status)})` };
   try {
     const body: unknown = await response.json();
-    return isRecord(body) && typeof body.message === 'string' && body.message.length > 0
-      ? body.message
-      : fallback;
+    if (!isRecord(body) || typeof body.message !== 'string' || body.message.length === 0) {
+      return fallback;
+    }
+    return typeof body.code === 'string' && body.code.length > 0
+      ? { message: body.message, code: body.code }
+      : { message: body.message };
   } catch {
     return fallback;
   }
@@ -61,7 +68,7 @@ export const httpBaseQuery: PlatformBaseQuery = async ({
   if (!response.ok) {
     return {
       error: {
-        message: await errorMessage(response, label),
+        ...(await parsedError(response, label)),
         status: response.status,
       },
     };

--- a/erun-console/src/app/queryError.ts
+++ b/erun-console/src/app/queryError.ts
@@ -1,14 +1,21 @@
 import { isRecord } from 'erun-kit';
 
-// Reads a human message (and, where present, an HTTP status) out of whatever
-// shape a platformApi RTK Query mutation/query rejected or errored with: the
-// shared PlatformApiError ({message, status}) for a transport/HTTP failure,
-// or RTK Query's own thrown-in-transformResponse shape for a malformed body.
-export function describeQueryError(error: unknown): { status?: number; message: string } {
+// Reads a human message (and, where present, an HTTP status and machine
+// {code, message} envelope code -- e.g. TENANT_UNRESOLVED vs NOT_ENROLLED,
+// erun#1721) out of whatever shape a platformApi RTK Query mutation/query
+// rejected or errored with: the shared PlatformApiError
+// ({message, status, code}) for a transport/HTTP failure, or RTK Query's own
+// thrown-in-transformResponse shape for a malformed body.
+export function describeQueryError(error: unknown): {
+  status?: number;
+  code?: string;
+  message: string;
+} {
   if (isRecord(error)) {
     if (typeof error.status === 'number') {
       return {
         status: error.status,
+        code: typeof error.code === 'string' ? error.code : undefined,
         message: typeof error.message === 'string' ? error.message : 'unexpected error',
       };
     }

--- a/erun-console/src/auth/auth.test.ts
+++ b/erun-console/src/auth/auth.test.ts
@@ -87,11 +87,18 @@ let realLocation: Location | undefined;
 function stubLocationAssign(): ReturnType<typeof vi.fn> {
   const assign = vi.fn();
   realLocation = window.location;
-  // beginLogin only ever calls .assign(...) on window.location, so the stub
-  // needs nothing else — copying the rest of the real Location instance would
-  // lose its prototype (its own methods aren't plain data properties).
+  // beginLogin only ever calls .assign(...) on window.location; origin,
+  // pathname, and search are copied through (plain data properties, unlike
+  // the real Location's own methods) because resolveToken's invalid_scope
+  // retry reads search (via authCallbackError) before calling beginLogin, and
+  // cleanCallbackUrl reads origin/pathname to rewrite the visible URL.
   Object.defineProperty(window, 'location', {
-    value: { assign },
+    value: {
+      assign,
+      origin: realLocation.origin,
+      pathname: realLocation.pathname,
+      search: realLocation.search,
+    },
     writable: true,
     configurable: true,
   });
@@ -139,6 +146,38 @@ describe('beginLogin', () => {
 
     const url = new URL(assign.mock.calls[0]?.[0] as string);
     expect(url.searchParams.get('prompt')).toBe('select_account');
+  });
+
+  // erun#1721: without this scope a shared, org-scoped issuer's token carries
+  // no org claim, so an already-enrolled operator's console session cannot
+  // resolve its tenant even though the CLI/desktop (which already request
+  // this scope by default) resolve fine.
+  it('requests the org-claim scope by default', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse(DISCOVERY))),
+    );
+    const assign = stubLocationAssign();
+
+    await beginLogin(config);
+
+    const url = new URL(assign.mock.calls[0]?.[0] as string);
+    expect(url.searchParams.get('scope')).toBe(
+      'openid profile email urn:zitadel:iam:user:resourceowner',
+    );
+  });
+
+  it('omits the org-claim scope when told not to include it (the invalid_scope retry)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse(DISCOVERY))),
+    );
+    const assign = stubLocationAssign();
+
+    await beginLogin(config, undefined, false);
+
+    const url = new URL(assign.mock.calls[0]?.[0] as string);
+    expect(url.searchParams.get('scope')).toBe('openid profile email');
   });
 });
 
@@ -205,6 +244,38 @@ describe('resolveToken', () => {
   it('returns undefined when there is no token at all', async () => {
     vi.stubEnv('VITE_DEV_BEARER_TOKEN', '');
     expect(await resolveToken(undefined)).toBeUndefined();
+  });
+
+  // erun#1721: a dedicated/BYO issuer has never heard of the org-claim scope
+  // and refuses the authorization request with error=invalid_scope. resolveToken
+  // must retry sign-in once, without that scope, rather than treating the
+  // refusal as "no token" (which would loop back to the landing screen).
+  it('retries sign-in without the org-claim scope after an invalid_scope callback', async () => {
+    setCallbackUrl('?error=invalid_scope&error_description=nope');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse(DISCOVERY))),
+    );
+    const assign = stubLocationAssign();
+
+    const result = await resolveToken(config);
+
+    expect(result).toBeUndefined();
+    expect(assign).toHaveBeenCalledTimes(1);
+    const url = new URL(assign.mock.calls[0]?.[0] as string);
+    expect(url.searchParams.get('scope')).toBe('openid profile email');
+  });
+
+  it('does not retry a second time in the same session', async () => {
+    sessionStorage.setItem('erun.console.oidcOrgScopeRetried', '1');
+    setCallbackUrl('?error=invalid_scope&error_description=nope');
+    vi.stubEnv('VITE_DEV_BEARER_TOKEN', '');
+    const assign = stubLocationAssign();
+
+    const result = await resolveToken(config);
+
+    expect(result).toBeUndefined();
+    expect(assign).not.toHaveBeenCalled();
   });
 });
 

--- a/erun-console/src/auth/auth.ts
+++ b/erun-console/src/auth/auth.ts
@@ -26,6 +26,20 @@ import { fetchPlatformConfig } from '../config/platform';
 const TOKEN_STORAGE_KEY = 'erun.console.idToken';
 const PKCE_VERIFIER_KEY = 'erun.console.pkceVerifier';
 const PKCE_STATE_KEY = 'erun.console.oauthState';
+const ORG_SCOPE_RETRIED_KEY = 'erun.console.oidcOrgScopeRetried';
+
+// ORG_CLAIM_SCOPE asks the shipped Zitadel IdP to include the org
+// (resourceowner) claim erun's tenant resolution reads for a shared,
+// org-scoped issuer -- the same scope erun-common's CLI/desktop OIDC login
+// requests by default (see erun-common/cloud_erun_oidc.go's
+// erunOrgClaimScope). Without it, a console session's token carries no org
+// claim, so once an issuer is org-scoped, the console cannot resolve its
+// tenant even for an already-enrolled operator (erun#1721). A dedicated/BYO
+// issuer has never heard of this scope; beginLogin retries once without it
+// (see resolveToken's authCallbackError handling) when the issuer redirects
+// back with error=invalid_scope, so sign-in still succeeds exactly as it did
+// before this default was added.
+const ORG_CLAIM_SCOPE = 'urn:zitadel:iam:user:resourceowner';
 
 export interface OidcConfig {
   issuer: string;
@@ -137,17 +151,26 @@ async function pkceChallenge(verifier: string): Promise<string> {
 // so the IdP offers an account/org picker instead of silently reusing
 // whatever session it already holds, which would make "switch" a no-op for a
 // caller who is still signed into the browser as the same identity.
-export async function beginLogin(config: OidcConfig, prompt?: string): Promise<void> {
+// `includeOrgScope` defaults to true; resolveToken passes false on the
+// one-shot retry after an issuer refuses ORG_CLAIM_SCOPE.
+export async function beginLogin(
+  config: OidcConfig,
+  prompt?: string,
+  includeOrgScope = true,
+): Promise<void> {
   const discovery = await discover(config.issuer);
   const verifier = randomString();
   const state = randomString();
   sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier);
   sessionStorage.setItem(PKCE_STATE_KEY, state);
+  const scope = includeOrgScope
+    ? `openid profile email ${ORG_CLAIM_SCOPE}`
+    : 'openid profile email';
   const params = new URLSearchParams({
     client_id: config.clientId,
     redirect_uri: config.redirectUri,
     response_type: 'code',
-    scope: 'openid profile email',
+    scope,
     code_challenge: await pkceChallenge(verifier),
     code_challenge_method: 'S256',
     state,
@@ -163,6 +186,14 @@ export async function beginLogin(config: OidcConfig, prompt?: string): Promise<v
 export function isAuthCallback(): boolean {
   const params = new URLSearchParams(window.location.search);
   return params.has('code') && params.has('state');
+}
+
+// authCallbackError reads the OIDC error code from a failed redirect (the
+// issuer sends ?error=...&error_description=... instead of ?code=&state=
+// when it refuses the request).
+function authCallbackError(): string | undefined {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('error') ?? undefined;
 }
 
 // completeLogin finishes the callback: it validates the state, exchanges the
@@ -230,9 +261,26 @@ export function signOut(): void {
 // callback exchange when this is a redirect callback, else a token already held
 // this session, else the dev-token fallback. undefined means no token — the
 // operator must sign in (OIDC) or set a dev token.
+//
+// A callback that failed with error=invalid_scope means the issuer refused
+// ORG_CLAIM_SCOPE (a dedicated/BYO IdP that has never heard of it) — this
+// retries sign-in once without that scope, the same one-shot fallback
+// erun-common's CLI/desktop login already does, so a dedicated issuer signs
+// in exactly as it did before the org-scope default was added. The
+// sessionStorage flag bounds the retry to once per browser session.
 export async function resolveToken(config: OidcConfig | undefined): Promise<string | undefined> {
   if (config !== undefined && isAuthCallback()) {
     return completeLogin(config);
+  }
+  if (
+    config !== undefined &&
+    authCallbackError() === 'invalid_scope' &&
+    sessionStorage.getItem(ORG_SCOPE_RETRIED_KEY) === null
+  ) {
+    sessionStorage.setItem(ORG_SCOPE_RETRIED_KEY, '1');
+    cleanCallbackUrl();
+    await beginLogin(config, undefined, false);
+    return undefined;
   }
   return storedToken() ?? devBearerToken();
 }

--- a/erun-console/src/shell/PreShellScreens.test.tsx
+++ b/erun-console/src/shell/PreShellScreens.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { NotEnrolledScreen } from './PreShellScreens';
+import { NotEnrolledScreen, TenantUnresolvedScreen } from './PreShellScreens';
 
 // Builds a JWT-shaped string with the given payload — the same shape
 // src/auth/identity.test.ts uses, since NotEnrolledScreen decodes the token
@@ -59,6 +59,63 @@ describe('NotEnrolledScreen', () => {
       <NotEnrolledScreen
         brand="Acme"
         token={tokenWith({ sub: '387534471668170904' })}
+        onSignOut={onSignOut}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+});
+
+// erun#1721: this screen is the "unresolvable" counterpart to NotEnrolledScreen
+// above -- shown when the API cannot tell which tenant a token resolves to,
+// as distinct from a genuinely-unenrolled identity. It must not repeat the
+// "an operator must enrol you" copy, since the caller may already be enrolled.
+describe('TenantUnresolvedScreen', () => {
+  it('shows the API-reported reason instead of the not-enrolled copy', () => {
+    render(
+      <TenantUnresolvedScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904', iss: 'https://auth.example.com' })}
+        message='issuer "https://auth.example.com" is org-scoped but the token carries no matching claim'
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/could not tell which tenant/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/is org-scoped but the token carries no matching claim/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/an operator has to enrol you/i)).not.toBeInTheDocument();
+  });
+
+  it('names the identity from the token the same way NotEnrolledScreen does', () => {
+    render(
+      <TenantUnresolvedScreen
+        brand="Acme"
+        token={tokenWith({
+          sub: '387534471668170904',
+          email: 'rihards@frs.lv',
+          iss: 'https://auth.erunpaas.com',
+        })}
+        message="unresolved"
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    const identityLine = screen.getByText(/Identity:/);
+    expect(identityLine).toHaveTextContent('rihards@frs.lv');
+    expect(identityLine).toHaveTextContent('https://auth.erunpaas.com');
+  });
+
+  it('offers a sign-out', () => {
+    const onSignOut = vi.fn();
+    render(
+      <TenantUnresolvedScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904' })}
+        message="unresolved"
         onSignOut={onSignOut}
       />,
     );

--- a/erun-console/src/shell/PreShellScreens.tsx
+++ b/erun-console/src/shell/PreShellScreens.tsx
@@ -66,6 +66,58 @@ export function NotEnrolledScreen({
   );
 }
 
+// TenantUnresolvedScreen is shown when the API could authenticate the token
+// but could not determine which tenant it resolves to at all -- most
+// commonly a shared, org-scoped issuer whose token carries no matching org
+// claim. Unlike NotEnrolledScreen, this deliberately does not tell the
+// caller to ask an operator to enrol them: they may already be enrolled
+// somewhere, and that advice would not help (erun#1721). `message` carries
+// the API's own diagnosis (issuer, org claim seen or its absence) so an
+// operator debugging this does not have to query the database for it.
+export function TenantUnresolvedScreen({
+  brand,
+  token,
+  message,
+  onSignOut,
+}: {
+  brand: string | undefined;
+  token: string;
+  message: string;
+  onSignOut: () => void;
+}): React.ReactElement {
+  const identity = readTokenIdentity(token);
+  const named = identity.email ?? identity.subject;
+  return (
+    <CenteredCard brand={brand} title="Could not determine your tenant" role="alert">
+      <p className="text-sm text-muted-foreground">
+        You signed in successfully, but this platform could not tell which tenant your account
+        belongs to. This is not the same as not being enrolled — you may already be a member of a
+        tenant here.
+      </p>
+      <p className="text-sm text-destructive">{message}</p>
+      {named !== undefined && (
+        <p className="text-xs text-muted-foreground">
+          Identity: {named}
+          {identity.email !== undefined && identity.subject !== undefined
+            ? ` (subject ${identity.subject})`
+            : ''}
+          {identity.issuer !== undefined ? ` from ${identity.issuer}` : ''}
+        </p>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="justify-self-start"
+        onClick={onSignOut}
+      >
+        <LogOut aria-hidden="true" />
+        Sign out
+      </Button>
+    </CenteredCard>
+  );
+}
+
 export function ErrorScreen({
   brand,
   message,

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -24,6 +24,8 @@ ERun resolves the tenant from the token itself, not from the request path. Two d
 - **`issuers`** registers each OIDC issuer **once**, by its `iss` URL, with an org-scoping mode (`org_field_key`):
   - `org_field_key` **NULL** → a **single-tenant issuer**: the `iss` alone resolves the tenant. This is the common case — a tenant's own IdP or a cloud workload-identity issuer (e.g. AWS IAM/OIDC).
   - `org_field_key` **set** → an **org-scoped (shared) issuer** (e.g. one hosted Zitadel serving every tenant): the value names the **token claim** whose value selects which tenant the call belongs to.
+
+  **A client of an org-scoped issuer must request the scope that puts this claim on the token, or it cannot resolve to any tenant.** For the erun-shipped Zitadel, that claim is `urn:zitadel:iam:user:resourceowner:id`, minted only when the client requests the `urn:zitadel:iam:user:resourceowner` OAuth scope. The CLI/desktop OIDC login requests it by default (falling back to a plain login, once, if the issuer refuses the scope — the common shape for a dedicated/BYO issuer that has never heard of it), and the console does the same. A client of your own that talks to a shared issuer directly needs to request this scope itself; omitting it produces `401 TENANT_UNRESOLVED` (see [Errors](#errors)) for every caller on that issuer, even one who is already enrolled in a tenant there.
 - **`tenant_issuers`** maps `(issuer, org_field_value) → tenant`:
   - A single-tenant issuer has exactly one row with a NULL `org_field_value`.
   - An org-scoped issuer has one row per org value, all sharing the same `iss`.
@@ -125,7 +127,7 @@ When no trust anchor is configured the edge stays loopback-only (legacy, unauthe
 ### Endpoints
 
 :::note Shipped vs planned
-The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name, or convert a single-tenant issuer to org-scoped), and [`PATCH /v1/tenants/reconcile-bootstrap-name`](#patch-v1tenantsreconcile-bootstrap-name) (the platform's own one-way legacy-name repair). New tenants and their issuer mapping can be registered through the operations-only `POST /v1/tenants` below; for an existing tenant, additional issuers and their org-scoping mode are still provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a tenant-self-service endpoint. `POST /v1/users` enrolls additional users beyond the first-user bootstrap. A tenant-self-service **trust-management** API (a tenant adding/removing its own issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the structured machine-readable error `code` field for authentication/authorization failures specifically — today those return bare HTTP status codes with a plain-text body (see [Errors](#errors) below). Business-logic errors past the auth layer do carry a `code` today — see [Reviews · Errors](/collaboration/reviews#errors).
+The `(iss, org) → tenant` resolution model and first-identity bootstrap above are **shipped**, as are `GET /v1/whoami`, `GET /v1/tenant-issuers` (list), `PATCH /v1/tenant-issuers` (rename a trusted issuer's display name, or convert a single-tenant issuer to org-scoped), and [`PATCH /v1/tenants/reconcile-bootstrap-name`](#patch-v1tenantsreconcile-bootstrap-name) (the platform's own one-way legacy-name repair). New tenants and their issuer mapping can be registered through the operations-only `POST /v1/tenants` below; for an existing tenant, additional issuers and their org-scoping mode are still provisioned directly in the `issuers` / `tenant_issuers` tables (migrations or the bootstrap path), not via a tenant-self-service endpoint. `POST /v1/users` enrolls additional users beyond the first-user bootstrap. A tenant-self-service **trust-management** API (a tenant adding/removing its own issuers with `audience`/`tenantClaim`/`allowedSubjects`, and the `409`/`422` codes below) is `(Planned.)`, as is the deeper JWT-verification-level structured `code` catalogue (`UNSUPPORTED_ALG`, `INVALID_SIGNATURE`, etc.) further down. The tenant/user **resolution** outcome does carry a machine-readable `{code, message}` envelope today — `TENANT_UNRESOLVED` vs `NOT_ENROLLED` vs `UNAUTHENTICATED` (see [Errors](#errors) below) — since collapsing those into one generic message told already-enrolled callers to ask for an enrolment that already existed. Business-logic errors past the auth layer do carry a `code` today too — see [Reviews · Errors](/collaboration/reviews#errors).
 :::
 
 | Method | Path | Description | Required scope |
@@ -1145,21 +1147,22 @@ When the token expires (typical lifetime 1 hour), the Agent's client refreshes i
 
 ### Errors
 
-Today the API rejects with a bare HTTP status code and a **plain-text** body — there is no JSON error envelope and no machine-readable `code` field. The underlying reason (which issuer, which claim) is logged server-side, not returned. The shipped contract:
+Every `401` the auth layer produces carries a JSON `{code, message}` envelope (the same shape `writeErrorCode` uses elsewhere in the API — see `internal/routes/errors.go`); `403` (a permission denial, not an auth-resolution failure) is still a bare status with a plain-text body. `message` is the underlying reason (which issuer, which claim, or its absence) in prose; server logs also carry it. The shipped contract:
 
-| Status | Body | Condition | Recovery |
-|---|---|---|---|
-| `401` | `missing bearer token` | No `Authorization` header, or it is not a single `Bearer <jwt>` pair. | Send `Authorization: Bearer <jwt>`. |
-| `401` | `invalid bearer token` | Signature/claims (`exp`/`nbf`/`iat`) failed, token expired, the issuer is not on the allow-list, or `iss`/`sub` is empty. | Re-mint a valid token from a registered issuer. |
-| `401` | `tenant not resolved` | Token verified, but no `(iss, org)` mapping resolves a tenant (and the `tenants` table is non-empty, so first-identity bootstrap does not apply). | Register the issuer/org in `tenant_issuers`. |
-| `401` | `user not resolved` | Tenant resolved, but no `user_external_ids` row matches `(tenant, iss, sub)` (and the tenant already has users). | Enrol the subject for the tenant. |
-| `403` | `Forbidden` | Authenticated, but the user's roles/permissions do not allow the request's method + path. | Grant the needed role/permission (admin action). |
+| Status | `code` | Example `message` | Condition | Recovery |
+|---|---|---|---|---|
+| `401` | `UNAUTHENTICATED` | `missing bearer token` | No `Authorization` header, or it is not a single `Bearer <jwt>` pair. | Send `Authorization: Bearer <jwt>`. |
+| `401` | `UNAUTHENTICATED` | `invalid bearer token` | Signature/claims (`exp`/`nbf`/`iat`) failed, token expired, the issuer is not on the allow-list, or `iss`/`sub` is empty. | Re-mint a valid token from a registered issuer. |
+| `401` | `TENANT_UNRESOLVED` | `tenant could not be resolved from token: issuer "…" is org-scoped (claim "…") but the token carries no matching claim` | Token verified and the issuer is known, but `(iss, org)` could not be resolved to a tenant — most commonly an org-scoped issuer whose token carries no matching org claim, or one whose claim value matches no registered tenant. **Distinct from `NOT_ENROLLED`**: the caller may already be a member of a tenant this exact token simply cannot resolve to, so "ask an operator to enrol you" would be the wrong advice (erun#1721). | Request the scope that puts the claim on the token (see [the org-scoped issuer note](#tenant-issuers) above), or check the org value against [`GET /v1/tenant-issuers`](#endpoints). |
+| `401` | `NOT_ENROLLED` | `record not found` | The tenant resolved fine, but no `user_external_ids` row matches `(tenant, iss, sub)`, and the tenant already has users (so per-tenant first-user bootstrap does not apply). | Enrol the subject for the tenant (`POST /v1/users`). |
+| `401` | `UNAUTHORIZED` | (varies) | A resolution failure not covered by either case above — e.g. an entirely unregistered issuer with no empty `tenants` table left to bootstrap into. | Register the issuer, or check the server log for the underlying reason. |
+| `403` | *(none — plain text)* | `Forbidden` | Authenticated, but the user's roles/permissions do not allow the request's method + path. | Grant the needed role/permission (admin action). |
 
-The audit trail records every authorized request with `issuer`, `sub`, org, and timestamp.
+The audit trail records every authorized request with `issuer`, `sub`, org, and timestamp. Rejected requests (missing/invalid token, unknown issuer, unresolved tenant, unenrolled subject, denied permission) are **not** audited — see [the audit log spec](/agent-reference/audit-log).
 
 #### Structured error codes `(Planned.)`
 
-A future structured error envelope will return a machine-readable `code` (and, where useful, a `details` object) per failure. It is **not implemented yet** — clients must branch on the HTTP status and plain-text body above, not on these codes:
+The resolution-level codes above (`UNAUTHENTICATED`/`TENANT_UNRESOLVED`/`NOT_ENROLLED`/`UNAUTHORIZED`) are shipped. This deeper, JWT-verification-specific catalogue — plus the codes the still-unimplemented self-service trust-management API would return — is **not implemented yet**; a client must not branch on these:
 
 | Status | `code` | Condition | Recovery |
 |---|---|---|---|

--- a/erun-kit/src/api/platformConfigEndpoints.ts
+++ b/erun-kit/src/api/platformConfigEndpoints.ts
@@ -27,6 +27,13 @@ export interface PlatformApiRequest {
 export interface PlatformApiError {
   message: string;
   status?: number;
+  // code is the backend's machine-readable {code, message} envelope code
+  // (erun-backend-api/internal/routes/errors.go and, for the pre-route auth
+  // layer, auth.go's authErrorEnvelope) when the transport could read one —
+  // e.g. TENANT_UNRESOLVED vs NOT_ENROLLED on a 401, which a caller must
+  // render as two different messages rather than one generic "not enrolled"
+  // (erun#1721). Absent when the response carried no such envelope.
+  code?: string;
 }
 
 export type PlatformBaseQuery = BaseQueryFn<PlatformApiRequest, unknown, PlatformApiError>;


### PR DESCRIPTION
## Summary

Fixes erun#1721: an already-enrolled OPERATIONS-tenant user (`rihards@frs.lv` on `frs-prod`) was shown "Not yet part of a tenant" after `validationagent` was registered as a second tenant on the same shared Zitadel issuer.

**Root cause, confirmed with evidence — the "silent conversion" hypothesis in the issue does not hold.** `TenantRoutes.createTenant` already refuses (409, naming the exact remedy) to add a second tenant to a still-single-tenant issuer; the only way to add one is the explicit, operations-only `PATCH /v1/tenant-issuers` → `TenantIssuerRepository.UpdateOrgScope`, which converts the issuer to org-scoped **and** backfills the existing tenant's mapping in the same transaction. The issue's own evidence table shows `frs`'s `tenant_issuers` row already carrying the correct, non-NULL `org_field_value` — consistent with that conversion having run correctly.

**The real bug:** the console's OIDC login requests only `openid profile email`, never `urn:zitadel:iam:user:resourceowner` — the scope erun-common's CLI/desktop login already requests by default. Once an issuer is org-scoped, `IdentityRepository.ResolveTenantByIssuer` requires the token to carry the matching org claim; a console token without it can't resolve to any tenant. That failure collapsed into the exact same generic 401 as a genuinely-unenrolled identity, so the console showed "an operator has to enrol you" to someone who already was enrolled.

## Changes

- **erun-backend-api**: `ResolveTenantByIssuer`/`ResolveIdentity` now classify an unresolvable `(issuer, org)` pair as `security.ErrTenantUnresolved`, kept distinct from a tenant that resolved fine but found no matching user. `auth.go` renders a `{code, message}` envelope (`TENANT_UNRESOLVED` / `NOT_ENROLLED` / `UNAUTHENTICATED`) instead of a bare 401 body, for both the combined `IdentityResolver` wiring and the separate tenant/user resolver wiring.
- **erun-console**: `beginLogin` requests the org-claim scope by default, with a one-shot retry without it when the issuer refuses (`error=invalid_scope`) — mirroring `erun-common/cloud_erun_oidc.go`'s existing fallback exactly. A new `TenantUnresolvedScreen` renders distinctly from `NotEnrolledScreen` when the API reports `TENANT_UNRESOLVED`.
- **erun-kit**: `PlatformApiError` gains an optional `code` field so the console can read the new envelope.
- **erun-docs**: documents the shipped `{code, message}` auth-resolution envelope and the org-scope requirement for a client of a shared, org-scoped issuer.
- Fixed a pre-existing failing e2e test (`TestFirstTenantUserBootstrapGrantsBothPredefinedRoles`, renamed) that asserted stale behaviour (ReadAll+WriteAll) for a COMPANY tenant's first user; current, documented behaviour grants `TenantAdmin`.

## Invariants

- **A single-tenant issuer keeps working**: unaffected code path (`orgFieldKey == ""`), locked in by existing tests.
- **Adding tenant B never changes how tenant A resolves**: already enforced by `UpdateOrgScope`'s one-transaction convert+backfill (pre-existing), now also covered end-to-end by `TestSecondTenantOnSharedIssuerDoesNotBreakFirstTenantsResolution`, which reproduces the exact reported scenario (NULL-org tenant → convert → second org-scoped tenant registered → first tenant's user still resolves).
- **Unresolvable ≠ not-enrolled**, in both the API (`TENANT_UNRESOLVED` vs `NOT_ENROLLED` codes, `TestResolveIdentityDistinguishesNotEnrolledFromUnresolved`) and the console (`TenantUnresolvedScreen` vs `NotEnrolledScreen`).
- **Ambiguity is impossible by construction**, not a coin flip: `TestTenantIssuersUniqueConstraintRejectsAmbiguousMapping` proves the DB's `UNIQUE NULLS NOT DISTINCT (issuer, org_field_value)` constraint refuses a second candidate row before `ResolveTenantByIssuer`'s exact-match query could ever see two.

## Production data

No repair needed. `frs`'s `tenant_issuers` row already carries the correct, non-NULL `org_field_value` — the conversion ran correctly. The fix is entirely in how the console requests its token's claims and how the API reports an unresolvable one; no migration or data change is required.

## Test plan

- [x] `go test ./...` in `erun-backend-api`, including new e2e tests run against a locally migrated PostgreSQL (`ERUN_E2E_IDENTITY_DATABASE_URL`, `ERUN_E2E_TENANT_ISSUERS_DATABASE_URL`)
- [x] `golangci-lint run ./...` clean in `erun-backend-api`
- [x] `yarn test`/`typecheck`/`lint`/`format:check`/`build` in `erun-console` and `erun-kit` (plus `yarn shadcn:check` — no drift)
- [x] `erun-docs` `yarn build` clean
- [x] `make check` green (lint, unit tests, chart tests, integration suite, coverage 75.6% ≥ threshold)

Closes #1721

🤖 Generated with [Claude Code](https://claude.com/claude-code)