### PR TITLE
Console: end the IdP session on sign-out (RP-initiated logout)

### DIFF
--- a/erun-console/playwright/tests/oidc-signin.spec.ts
+++ b/erun-console/playwright/tests/oidc-signin.spec.ts
@@ -66,7 +66,10 @@ test('operator signs in through Zitadel OIDC, registers an environment, and sees
   // a literal name, and the actual invariant under test (an OPERATIONS-type
   // tenant bootstrapped) is the type text on the next line.
   await expect(page.getByRole('heading', { level: 2 })).toBeVisible();
-  await expect(page.getByText('Tenant · OPERATIONS')).toBeVisible();
+  // scoped to the main region: the sidebar's TenantSwitcher (#1614) renders
+  // the same "Tenant · <type>" text as a plain label whenever only one
+  // tenant is reachable, so the unscoped locator is ambiguous.
+  await expect(page.getByRole('main').getByText('Tenant · OPERATIONS')).toBeVisible();
   // erun-kit's CardTitle renders a styled <div>, not a semantic heading
   // element, so the section title is asserted via the Card's own
   // role="region" + aria-labelledby (its accessible name), not getByRole
@@ -78,7 +81,7 @@ test('operator signs in through Zitadel OIDC, registers an environment, and sees
   // 5. The session is real, not a one-shot render: a reload resolves the held
   //    token and re-authenticates against the API without another sign-in.
   await page.reload();
-  await expect(page.getByText('Tenant · OPERATIONS')).toBeVisible();
+  await expect(page.getByRole('main').getByText('Tenant · OPERATIONS')).toBeVisible();
 
   // 6. The app shell renders exactly one section at a time (#1207): the
   //    register/deploy forms live under the "Environments" nav entry, not the
@@ -114,4 +117,21 @@ test('operator signs in through Zitadel OIDC, registers an environment, and sees
   await expect(
     page.getByText('The deploy executor is not configured on this control plane.'),
   ).toBeVisible();
+
+  // 9. Signing out must actually end the identity provider's session
+  //    (erun#1720) — clearing only the local token left the IdP's session
+  //    alive, so the next sign-in was silently re-authenticated as the same
+  //    account with no way to reach a different one. Clicking Sign out
+  //    redirects to Zitadel's discovered end_session_endpoint and back to
+  //    this origin, landing on the signed-out landing page.
+  await page.getByRole('button', { name: 'Sign out' }).click();
+  await expect(page).toHaveURL(/^http:\/\/localhost:5173\/$/);
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+
+  // 10. The proof that matters: signing in again must not silently reuse the
+  //     ended IdP session. Had RP-initiated logout not actually ended it,
+  //     this would skip straight back into the console with no login prompt
+  //     at all — exactly the dead end erun#1720 reported.
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page).toHaveURL(/\/ui\/v2\/login\/loginname/);
 });

--- a/erun-console/src/App.tsx
+++ b/erun-console/src/App.tsx
@@ -195,7 +195,9 @@ function AppContent({
         />
       );
     case 'not-enrolled':
-      return <NotEnrolledScreen brand={brand} token={state.token} onSignOut={onSignOut} />;
+      return (
+        <NotEnrolledScreen brand={brand} token={state.token} oidc={oidc} onSignOut={onSignOut} />
+      );
     case 'tenant-unresolved':
       return (
         <TenantUnresolvedScreen
@@ -319,8 +321,18 @@ export function App(): React.ReactElement {
           void configQuery.refetch();
         }}
         onSignOut={() => {
-          signOut();
-          dispatch(clearAuth());
+          void (async () => {
+            // signOut clears the local token unconditionally, then redirects
+            // to the IdP to end its session too when discovery says that's
+            // possible. When it redirects, the browser is already leaving
+            // this page — dispatching clearAuth would be pointless and the
+            // reload that follows the IdP's redirect back here resolves the
+            // signed-out state fresh anyway.
+            const result = await signOut(auth.oidc);
+            if (!result.idpSessionEnded) {
+              dispatch(clearAuth());
+            }
+          })();
         }}
         onDismissSwitchMismatch={() => {
           setSwitchMismatch(undefined);

--- a/erun-console/src/auth/auth.test.ts
+++ b/erun-console/src/auth/auth.test.ts
@@ -433,11 +433,11 @@ describe('signOut', () => {
     expect(storedToken()).toBeUndefined();
   });
 
-  // erun#1720/erun#1721 interaction: the org-claim scope retry is meant to
-  // bound one sign-in attempt, not survive a sign-out. Without this, a
-  // dedicated/BYO issuer that already consumed its one retry would get no
-  // retry on the next sign-in after sign-out either, and resolveToken would
-  // bounce back to the sign-in screen forever instead of retrying.
+  // The org-claim scope retry is meant to bound one sign-in attempt, not
+  // survive a sign-out. Without this, a dedicated/BYO issuer that already
+  // consumed its one retry would get no retry on the next sign-in after
+  // sign-out either, and resolveToken would bounce back to the sign-in
+  // screen forever instead of retrying.
   it('clears the org-claim scope retry flag so the next sign-in can retry again', async () => {
     sessionStorage.setItem('erun.console.oidcOrgScopeRetried', '1');
     vi.stubGlobal(

--- a/erun-console/src/auth/auth.test.ts
+++ b/erun-console/src/auth/auth.test.ts
@@ -4,10 +4,12 @@ import {
   beginLogin,
   completeLogin,
   devBearerToken,
+  endSessionSupported,
   isAuthCallback,
   oidcConfig,
   resolveOidcConfig,
   resolveToken,
+  signOut,
   storedToken,
 } from './auth';
 
@@ -338,5 +340,151 @@ describe('resolveOidcConfig', () => {
     );
 
     expect(await resolveOidcConfig()).toEqual({ config: undefined });
+  });
+});
+
+const TOKEN_STORAGE_KEY = 'erun.console.idToken';
+
+describe('signOut', () => {
+  it('clears the local token and redirects to the end_session_endpoint with id_token_hint and post_logout_redirect_uri', async () => {
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, 'the.jwt.token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            ...DISCOVERY,
+            end_session_endpoint: 'http://localhost:8080/oidc/v1/end_session',
+          }),
+        ),
+      ),
+    );
+    const assign = stubLocationAssign();
+
+    const result = await signOut(config);
+
+    expect(result).toEqual({ idpSessionEnded: true });
+    const url = new URL(assign.mock.calls[0]?.[0] as string);
+    expect(url.origin + url.pathname).toBe('http://localhost:8080/oidc/v1/end_session');
+    expect(url.searchParams.get('id_token_hint')).toBe('the.jwt.token');
+    expect(url.searchParams.get('post_logout_redirect_uri')).toBe(config.redirectUri);
+    expect(storedToken()).toBeUndefined();
+  });
+
+  it('redirects with no id_token_hint when no token was held', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            ...DISCOVERY,
+            end_session_endpoint: 'http://localhost:8080/oidc/v1/end_session',
+          }),
+        ),
+      ),
+    );
+    const assign = stubLocationAssign();
+
+    const result = await signOut(config);
+
+    expect(result).toEqual({ idpSessionEnded: true });
+    const url = new URL(assign.mock.calls[0]?.[0] as string);
+    expect(url.searchParams.has('id_token_hint')).toBe(false);
+  });
+
+  it('clears the local token but does not redirect when the IdP has no end_session_endpoint', async () => {
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, 'the.jwt.token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse(DISCOVERY))),
+    );
+    const assign = stubLocationAssign();
+
+    const result = await signOut(config);
+
+    expect(result).toEqual({ idpSessionEnded: false });
+    expect(assign).not.toHaveBeenCalled();
+    expect(storedToken()).toBeUndefined();
+  });
+
+  it('clears the local token but does not redirect when discovery fails', async () => {
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, 'the.jwt.token');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse('not found', 404))),
+    );
+    const assign = stubLocationAssign();
+
+    const result = await signOut(config);
+
+    expect(result).toEqual({ idpSessionEnded: false });
+    expect(assign).not.toHaveBeenCalled();
+    expect(storedToken()).toBeUndefined();
+  });
+
+  it('clears the local token but does not redirect with no OIDC config (dev-token fallback)', async () => {
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, 'the.jwt.token');
+    const assign = stubLocationAssign();
+
+    const result = await signOut(undefined);
+
+    expect(result).toEqual({ idpSessionEnded: false });
+    expect(assign).not.toHaveBeenCalled();
+    expect(storedToken()).toBeUndefined();
+  });
+
+  // erun#1720/erun#1721 interaction: the org-claim scope retry is meant to
+  // bound one sign-in attempt, not survive a sign-out. Without this, a
+  // dedicated/BYO issuer that already consumed its one retry would get no
+  // retry on the next sign-in after sign-out either, and resolveToken would
+  // bounce back to the sign-in screen forever instead of retrying.
+  it('clears the org-claim scope retry flag so the next sign-in can retry again', async () => {
+    sessionStorage.setItem('erun.console.oidcOrgScopeRetried', '1');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse(DISCOVERY))),
+    );
+    stubLocationAssign();
+
+    await signOut(config);
+
+    expect(sessionStorage.getItem('erun.console.oidcOrgScopeRetried')).toBeNull();
+  });
+});
+
+describe('endSessionSupported', () => {
+  it('is true when discovery reports an end_session_endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            ...DISCOVERY,
+            end_session_endpoint: 'http://localhost:8080/oidc/v1/end_session',
+          }),
+        ),
+      ),
+    );
+    expect(await endSessionSupported(config)).toBe(true);
+  });
+
+  it('is false when discovery has no end_session_endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse(DISCOVERY))),
+    );
+    expect(await endSessionSupported(config)).toBe(false);
+  });
+
+  it('is false when discovery fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(jsonResponse('not found', 404))),
+    );
+    expect(await endSessionSupported(config)).toBe(false);
+  });
+
+  it('is false with no OIDC config (dev-token fallback)', async () => {
+    expect(await endSessionSupported(undefined)).toBe(false);
   });
 });

--- a/erun-console/src/auth/auth.ts
+++ b/erun-console/src/auth/auth.ts
@@ -20,6 +20,15 @@
 // RCE-sensitive (its `raw` tool can `kubectl exec`) and needs a deployed env
 // carrying the backend's public key to verify against. Minting the token is
 // already implemented (src/mcp/).
+//
+// signOut performs RP-initiated logout (OIDC Session Management) rather than
+// clearing the local token alone: the IdP's session otherwise outlives the
+// console's, so the next sign-in is silently re-authenticated as the same
+// account with no way to reach a different one. Not every IdP advertises
+// end_session_endpoint, so callers that state what sign-out will do (the
+// not-enrolled screen) check endSessionSupported first rather than assume it.
+// The redirect target (post_logout_redirect_uri, this origin) must be
+// registered on the IdP client the same way redirect_uri already is.
 
 import { fetchPlatformConfig } from '../config/platform';
 
@@ -105,6 +114,10 @@ function trimmed(value: string | undefined): string | undefined {
 interface Discovery {
   authorization_endpoint: string;
   token_endpoint: string;
+  // Not every IdP advertises RP-initiated logout (OIDC Session Management is
+  // an optional extension), so this is the one discovery field callers must
+  // treat as absent rather than assume present.
+  end_session_endpoint?: string;
 }
 
 async function discover(issuer: string): Promise<Discovery> {
@@ -121,7 +134,13 @@ async function discover(issuer: string): Promise<Discovery> {
   ) {
     throw new Error('OIDC discovery document is missing endpoints');
   }
-  return doc as Discovery;
+  const record = doc as Record<string, unknown>;
+  return {
+    authorization_endpoint: record.authorization_endpoint as string,
+    token_endpoint: record.token_endpoint as string,
+    end_session_endpoint:
+      typeof record.end_session_endpoint === 'string' ? record.end_session_endpoint : undefined,
+  };
 }
 
 function base64url(bytes: Uint8Array): string {
@@ -252,9 +271,68 @@ export function storedToken(): string | undefined {
   return token !== null && token.length > 0 ? token : undefined;
 }
 
-// signOut clears the held token.
-export function signOut(): void {
+export interface SignOutResult {
+  // Whether this call redirected the browser to the IdP's end_session_endpoint
+  // to end its session there too. false means only the local token was
+  // cleared — no OIDC config, no discovered end_session_endpoint, or
+  // discovery failed — so the caller (whose UI made a claim about what
+  // sign-out does) must not treat this as "the IdP session ended" silently.
+  idpSessionEnded: boolean;
+}
+
+// signOut always clears the locally-held token first, then attempts
+// RP-initiated logout: it redirects to the IdP's discovered
+// end_session_endpoint with id_token_hint (the id_token this session held, so
+// the IdP knows which session to end without prompting) and
+// post_logout_redirect_uri back to this origin. Not every IdP advertises
+// end_session_endpoint (it's an optional OIDC extension), and discovery
+// itself can fail (network, misconfigured issuer) — either case falls back
+// to the local-only clear rather than throwing, since a failed logout
+// redirect must never leave the caller signed in.
+//
+// It also clears ORG_SCOPE_RETRIED_KEY: that flag exists to bound a single
+// sign-in attempt to one retry, not to survive past a sign-out. Leaving it
+// set would mean a dedicated/BYO issuer that already consumed its one retry
+// gets no retry on the next sign-in after sign-out either — resolveToken
+// would treat the resulting invalid_scope callback as "no token" and bounce
+// back to the sign-in screen with no explanation, forever.
+export async function signOut(config: OidcConfig | undefined): Promise<SignOutResult> {
+  const idToken = storedToken();
   sessionStorage.removeItem(TOKEN_STORAGE_KEY);
+  sessionStorage.removeItem(ORG_SCOPE_RETRIED_KEY);
+  if (config === undefined) {
+    return { idpSessionEnded: false };
+  }
+  const endSessionEndpoint = await discoverEndSessionEndpoint(config.issuer);
+  if (endSessionEndpoint === undefined) {
+    return { idpSessionEnded: false };
+  }
+  const params = new URLSearchParams({ post_logout_redirect_uri: config.redirectUri });
+  if (idToken !== undefined) {
+    params.set('id_token_hint', idToken);
+  }
+  window.location.assign(endSessionEndpoint + '?' + params.toString());
+  return { idpSessionEnded: true };
+}
+
+async function discoverEndSessionEndpoint(issuer: string): Promise<string | undefined> {
+  try {
+    return (await discover(issuer)).end_session_endpoint;
+  } catch {
+    return undefined;
+  }
+}
+
+// endSessionSupported reports whether signOut(config) will be able to end the
+// IdP session, without performing sign-out. A screen that advises "sign out
+// to use a different account" must know this before the click — advising a
+// remedy discovery cannot back up is the same dead end as a wrong error
+// message (see root AGENTS.md § "Smooth, Seamless, No Dead Ends").
+export async function endSessionSupported(config: OidcConfig | undefined): Promise<boolean> {
+  if (config === undefined) {
+    return false;
+  }
+  return (await discoverEndSessionEndpoint(config.issuer)) !== undefined;
 }
 
 // resolveToken produces the bearer token to present to the API on load: the OIDC

--- a/erun-console/src/shell/PreShellScreens.test.tsx
+++ b/erun-console/src/shell/PreShellScreens.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { NotEnrolledScreen, TenantUnresolvedScreen } from './PreShellScreens';
@@ -15,8 +15,23 @@ function tokenWith(payload: Record<string, unknown>): string {
   return `${encode('{"alg":"RS256"}')}.${encode(JSON.stringify(payload))}.signature`;
 }
 
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+const oidc = {
+  issuer: 'https://auth.example.com',
+  clientId: 'console-client',
+  redirectUri: 'http://localhost/',
+};
+
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe('NotEnrolledScreen', () => {
@@ -29,6 +44,7 @@ describe('NotEnrolledScreen', () => {
           email: 'someone@example.com',
           iss: 'https://auth.example.com',
         })}
+        oidc={undefined}
         onSignOut={vi.fn()}
       />,
     );
@@ -44,6 +60,7 @@ describe('NotEnrolledScreen', () => {
       <NotEnrolledScreen
         brand="Acme"
         token={tokenWith({ sub: '387534471668170904', iss: 'https://auth.example.com' })}
+        oidc={undefined}
         onSignOut={vi.fn()}
       />,
     );
@@ -59,12 +76,112 @@ describe('NotEnrolledScreen', () => {
       <NotEnrolledScreen
         brand="Acme"
         token={tokenWith({ sub: '387534471668170904' })}
+        oidc={undefined}
         onSignOut={onSignOut}
       />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
     expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not claim sign-out can reach a different account with no OIDC config (dev-token fallback)', () => {
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904' })}
+        oidc={undefined}
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/cannot end your identity provider's session from here/),
+    ).toBeInTheDocument();
+  });
+
+  it('does not claim sign-out can reach a different account when the IdP has no end_session_endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+          }),
+        ),
+      ),
+    );
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904' })}
+        oidc={oidc}
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/cannot end your identity provider's session from here/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('advises that sign-out also ends the IdP session once discovery confirms end_session_endpoint', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          jsonResponse({
+            authorization_endpoint: 'https://auth.example.com/authorize',
+            token_endpoint: 'https://auth.example.com/token',
+            end_session_endpoint: 'https://auth.example.com/endsession',
+          }),
+        ),
+      ),
+    );
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({ sub: '387534471668170904' })}
+        oidc={oidc}
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/it also/)).toHaveTextContent(
+        'it also ends your identity provider session',
+      );
+    });
+    expect(
+      screen.queryByText(/cannot end your identity provider's session from here/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers the filled-in enroll command and copies it', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(
+      <NotEnrolledScreen
+        brand="Acme"
+        token={tokenWith({
+          sub: '387534471668170904',
+          email: 'someone@example.com',
+          iss: 'https://auth.example.com',
+        })}
+        oidc={undefined}
+        onSignOut={vi.fn()}
+      />,
+    );
+
+    const expectedCommand =
+      'erun platform user enroll --username someone@example.com --issuer https://auth.example.com --subject 387534471668170904';
+    expect(screen.getByText(expectedCommand)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }));
+    expect(writeText).toHaveBeenCalledWith(expectedCommand);
   });
 });
 

--- a/erun-console/src/shell/PreShellScreens.tsx
+++ b/erun-console/src/shell/PreShellScreens.tsx
@@ -1,7 +1,9 @@
 import { Button } from 'erun-kit';
-import { LoaderCircle, LogOut } from 'lucide-react';
-import type * as React from 'react';
+import { Copy, LoaderCircle, LogOut } from 'lucide-react';
+import * as React from 'react';
 
+import type { OidcConfig } from '../auth/auth';
+import { endSessionSupported } from '../auth/auth';
 import { readTokenIdentity } from '../auth/identity';
 import { CenteredCard } from './CenteredCard';
 
@@ -16,32 +18,104 @@ export function LoadingScreen({ brand }: { brand: string | undefined }): React.R
   );
 }
 
+// useCanEndIdpSession reports whether sign-out can also end the IdP session
+// for `oidc`, defaulting to false (the safe direction: a claim this screen
+// cannot yet back up must never render as if it could) until discovery
+// confirms an end_session_endpoint. It only ever upgrades false -> true, so
+// the card's wording never flashes a promise it then has to retract.
+function useCanEndIdpSession(oidc: OidcConfig | undefined): boolean {
+  const [supported, setSupported] = React.useState(false);
+  React.useEffect(() => {
+    let cancelled = false;
+    endSessionSupported(oidc)
+      .then((result) => {
+        if (!cancelled) {
+          setSupported(result);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [oidc]);
+  return supported;
+}
+
+// enrollCommand fills in `erun platform user enroll` with what the token
+// tells us — the same hand-off shape the desktop's NotEnrolledState offers,
+// so an administrator gets a command to run and verify rather than raw
+// values to reassemble into one by hand.
+function enrollCommand(identity: ReturnType<typeof readTokenIdentity>): string {
+  const username = identity.email ?? '<username>';
+  const issuer = identity.issuer ?? '<issuer>';
+  const subject = identity.subject ?? '<subject>';
+  return `erun platform user enroll --username ${username} --issuer ${issuer} --subject ${subject}`;
+}
+
+function CopyCommandButton({ command }: { command: string }): React.ReactElement {
+  const [copied, setCopied] = React.useState(false);
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        void navigator.clipboard.writeText(command).then(() => {
+          setCopied(true);
+        });
+      }}
+    >
+      <Copy aria-hidden="true" />
+      {copied ? 'Copied' : 'Copy'}
+    </Button>
+  );
+}
+
 // NotEnrolledScreen is the dead end a self-signed-up user hits: OIDC
 // succeeded, so a token is held, but the API rejects the identity because it
 // is enrolled in no tenant. This says what actually has to happen (an
 // operator must enrol them), names the identity an operator needs in order to
 // do it, and offers a sign-out — signing in again as the *same* identity just
 // returns here, but signing in as a different one is the actual escape, so
-// this screen must not be a true dead end for that case.
+// this screen must not be a true dead end for that case. Whether sign-out
+// can actually reach a different account depends on whether this platform's
+// IdP supports RP-initiated logout (useCanEndIdpSession), and the wording
+// below only ever claims what that check confirms.
 export function NotEnrolledScreen({
   brand,
   token,
+  oidc,
   onSignOut,
 }: {
   brand: string | undefined;
   token: string;
+  oidc: OidcConfig | undefined;
   onSignOut: () => void;
 }): React.ReactElement {
   const identity = readTokenIdentity(token);
   const named = identity.email ?? identity.subject;
+  const canEndIdpSession = useCanEndIdpSession(oidc);
   return (
     <CenteredCard brand={brand} title="Not yet part of a tenant" role="status">
       <p className="text-sm text-muted-foreground">
         You are signed in, but your account is not yet part of a tenant on this platform.
       </p>
       <p className="text-sm text-muted-foreground">
-        An operator has to enrol you before you can see any environments. Signing in again as this
-        same account will not change that — sign out below if you meant to use a different one.
+        {canEndIdpSession ? (
+          <>
+            An operator has to enrol you before you can see any environments. Signing in again as
+            this same account will not change that. Sign out below — it also ends your identity
+            provider session, so signing in again lets you choose a different one.
+          </>
+        ) : (
+          <>
+            An operator has to enrol you before you can see any environments. Signing in again as
+            this same account will not change that, and sign-out here only clears this
+            browser&apos;s session — it cannot end your identity provider&apos;s session from here.
+            To use a different account, sign out of your identity provider directly, then sign in
+            here again.
+          </>
+        )}
       </p>
       {named !== undefined && (
         <p className="text-xs text-muted-foreground">
@@ -52,6 +126,17 @@ export function NotEnrolledScreen({
           {identity.issuer !== undefined ? ` from ${identity.issuer}` : ''}
         </p>
       )}
+      <div className="grid gap-2 rounded-[var(--radius)] border border-border bg-muted/30 p-3 text-left">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-xs font-medium text-muted-foreground">
+            Or ask an administrator to run
+          </span>
+          <CopyCommandButton command={enrollCommand(identity)} />
+        </div>
+        <code className="block overflow-x-hidden whitespace-pre-wrap break-words rounded bg-background px-2 py-1.5 text-[12px]">
+          {enrollCommand(identity)}
+        </code>
+      </div>
       <Button
         type="button"
         variant="outline"


### PR DESCRIPTION
## Summary

- `signOut()` (`erun-console/src/auth/auth.ts`) now performs RP-initiated logout: it always clears the locally-held token first, then redirects to the IdP's discovered `end_session_endpoint` with `id_token_hint` (the id_token this session already held — the console never stores a separate access token) and `post_logout_redirect_uri` back to this origin. Previously it only cleared the local token, so Zitadel's session survived and the next sign-in silently re-authenticated as the same account.
- The not-enrolled card (`erun-console/src/shell/PreShellScreens.tsx`) only claims "sign out reaches a different account" once `endSessionSupported()` confirms the IdP actually advertises `end_session_endpoint` — defaulting to the honest, hedged wording (never a promise it can't back up) until that check resolves. Not every IdP advertises RP-initiated logout, and this card must not repeat a remedy it cannot honour (the bug erun#1720 reported).
- The card also now renders the filled-in `erun platform user enroll --username … --issuer … --subject …` command with one-click copy, matching the desktop's `NotEnrolledState` hand-off, instead of showing only the raw identity values for an administrator to reassemble by hand.
- Extended `erun-console/playwright/tests/oidc-signin.spec.ts` (the real-Zitadel e2e) with the actual proof: sign out, land back on the console's signed-out landing page, then sign in again and confirm Zitadel prompts for credentials again rather than silently reusing the ended session. Also fixed a pre-existing locator ambiguity in that spec (`Tenant · OPERATIONS` now resolves in two places since the #1614 TenantSwitcher landed) that was blocking the suite from running at all.

## What I found in storage

The console only ever stores the `id_token` (`sessionStorage`, key `erun.console.idToken`) — it's the same value already used as the bearer token, per `auth.ts`'s existing comment ("the id_token is used as the bearer because it is always a JWT"). There is no separate access-token storage location the way #1680 found elsewhere, so `id_token_hint` is simply `storedToken()` read before it's cleared.

## No-end_session_endpoint decision

Default to the safe/hedged wording and only upgrade to the stronger claim once discovery confirms the endpoint exists (never the reverse, so the card never flashes a promise it then retracts). Confirmed-unsupported and still-checking render identically:

> Signing in again as this same account will not change that, and sign-out here only clears this browser's session — it cannot end your identity provider's session from here. To use a different account, sign out of your identity provider directly, then sign in here again.

Once confirmed supported:

> Signing in again as this same account will not change that. Sign out below — it also ends your identity provider session, so signing in again lets you choose a different one.

## The redirect URI that needs registering

`post_logout_redirect_uri` is `window.location.origin + '/'` — the exact same value already registered as the console's `redirect_uri` (e.g. `https://console.erunpaas.com/`).

**For erun's own hosted platforms (erunpaas.com and anything else deployed via the `erun-zitadel` chart), no manual action is needed.** `erun-oidc-bootstrap` (`erun-devops/docker/erun-devops/oidc-bootstrap.sh`, landed in #1149) already converges the Zitadel console app's `postLogoutRedirectUris` to the *same list* as `redirectUris` on every reconcile tick (a few minutes), not just at first creation. Once this change deploys, the next tick registers it with no client-config step.

For a Zitadel client registered outside that chart (hand-configured, or a BYO IdP), an administrator must add this same URI to the client's Post Logout Redirect URIs list — the same place `redirect_uri` is already registered.

## How an unregistered URI presents

If `post_logout_redirect_uri` isn't registered, Zitadel refuses the redirect back and shows its own error naming the invalid parameter — it does not read as a broken sign-out, because the local token is already cleared before that redirect is attempted. Navigating back to the console (new tab, back button, or re-typing the URL) lands on the ordinary signed-out landing page, not the stale not-enrolled screen — the local state was never left inconsistent.

## Verification

- `yarn test` (erun-console): 163/163 passed, including new coverage for `signOut`/`endSessionSupported` (redirect with both params present, no-token case, no-`end_session_endpoint` case, discovery-failure case, local-token-cleared-regardless-of-path) and the not-enrolled card's wording/enroll-command/copy behavior.
- `yarn typecheck && yarn lint && yarn format:check && yarn build` (erun-console): clean.
- `erun-console/playwright` real-Zitadel e2e (`./run.sh`, against a live Zitadel v4): **passed**, including the added assertions that sign-out reaches the landing page and that a subsequent sign-in requires re-entering credentials (proof the IdP session actually ended, not just the local token).
- `make check`: green — golangci-lint (erun-common/erun-cli/erun-mcp/erun-integration/erun-backend-api/erun-ui) 0 issues each, `go test erun-ui` ok, erun-kit + erun-console gates (typecheck/lint/format/build/test) all pass, all `erun-devops/k8s/*_test.sh` chart tests pass, `erun-integration` suite ok with coverage 75.6% (>= 75.6% threshold).

Closes #1720

🤖 Generated with [Claude Code](https://claude.com/claude-code)