### PR TITLE
Give the sidebar hover cards a shared type scale

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.EnvHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvHoverCard.tsx
@@ -4,6 +4,13 @@ import * as React from 'react';
 
 import { summarizeEnvironmentUsage } from '@/app/environmentUsageSummary';
 import type { EnvironmentIndicator } from '@/components/app/Sidebar.helpers';
+import {
+  HOVER_CARD_CAPTION_CLASS,
+  HoverCardBadge,
+  HoverCardMuted,
+  HoverCardRow,
+  HoverCardTitle,
+} from '@/components/app/Sidebar.HoverCardRow';
 import type { UISelection, UIWorkingIssue } from '@/types';
 import type { UIEnvironmentUsageSnapshot } from '@/uiEnvironmentUsageTypes';
 
@@ -20,22 +27,13 @@ function EnvTypeBadge({
 }): React.ReactElement | null {
   if (isHost) {
     return (
-      <span
-        className="flex-none rounded-[calc(var(--radius)-4px)] border border-border px-1 py-px text-[10px] font-medium uppercase leading-none tracking-wide text-muted-foreground"
-        aria-label="Host environment — no pod, this machine only"
-      >
-        Host
-      </span>
+      <HoverCardBadge ariaLabel="Host environment — no pod, this machine only">Host</HoverCardBadge>
     );
   }
   if (!isLocal) {
     return null;
   }
-  return (
-    <span className="flex-none rounded-[calc(var(--radius)-4px)] border border-border px-1 py-px text-[10px] font-medium uppercase leading-none tracking-wide text-muted-foreground">
-      Local
-    </span>
-  );
+  return <HoverCardBadge>Local</HoverCardBadge>;
 }
 
 // EnvHoverCard shows an env row's details in a Popover rather than a tooltip
@@ -118,52 +116,37 @@ export function EnvHoverCard({
       >
         <div className="border-b border-border px-3 py-2">
           <div className="flex items-center gap-1.5">
-            <span className="min-w-0 truncate font-medium">
+            <HoverCardTitle>
               {tenantName} / {environmentName}
-            </span>
+            </HoverCardTitle>
             <EnvTypeBadge isLocal={isLocal} isHost={isHost} />
           </div>
         </div>
         <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 px-3 py-2.5">
-          <HoverRow label="Version">
+          <HoverCardRow label="Version">
             {runtimeVersion ? (
-              <span className="font-mono text-[12px]">{runtimeVersion}</span>
+              <span className="font-mono tabular-nums">{runtimeVersion}</span>
             ) : (
               <Muted>Not set</Muted>
             )}
-          </HoverRow>
-          <HoverRow label="Working on">
+          </HoverCardRow>
+          <HoverCardRow label="Working on">
             <WorkingOn issue={issue} />
-          </HoverRow>
-          <HoverRow label="Activity">
+          </HoverCardRow>
+          <HoverCardRow label="Activity">
             <ActivityState activityLabel={activityLabel} indicator={indicator} />
-          </HoverRow>
-          <HoverRow label="Usage">
+          </HoverCardRow>
+          <HoverCardRow label="Usage">
             <UsageState usage={usage} />
-          </HoverRow>
+          </HoverCardRow>
         </dl>
       </PopoverContent>
     </Popover>
   );
 }
 
-function HoverRow({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactNode;
-}): React.ReactElement {
-  return (
-    <>
-      <dt className="text-[12px] text-muted-foreground">{label}</dt>
-      <dd className="min-w-0 break-words text-foreground">{children}</dd>
-    </>
-  );
-}
-
 function Muted({ children }: { children: React.ReactNode }): React.ReactElement {
-  return <span className="text-muted-foreground">{children}</span>;
+  return <HoverCardMuted>{children}</HoverCardMuted>;
 }
 
 // ActivityState reports the desktop's own in-flight command when there is one,
@@ -211,12 +194,12 @@ function UsageState({
   }
   return (
     <span className="grid gap-0.5">
-      <span>{summary.headline}</span>
+      <span className="tabular-nums">{summary.headline}</span>
       <span
         className={
           summary.stale
-            ? 'flex items-center gap-1 text-[12px] text-amber-700 dark:text-amber-400'
-            : 'text-[12px] text-muted-foreground'
+            ? 'flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400'
+            : HOVER_CARD_CAPTION_CLASS
         }
       >
         {summary.stale && <TriangleAlert aria-hidden="true" className="size-3 shrink-0" />}
@@ -242,9 +225,9 @@ function WorkingOn({ issue }: { issue: WorkingIssueState }): React.ReactElement 
   }
   return (
     <div className="grid gap-0.5">
-      <span className="font-mono text-[12px]">{value.branch}</span>
+      <span className="font-mono">{value.branch}</span>
       {value.issueNumber ? (
-        <span className="text-[12px]">
+        <span>
           #{value.issueNumber}
           {value.issueTitle ? ` · ${value.issueTitle}` : ''}
         </span>

--- a/erun-ui/frontend/src/components/app/Sidebar.HoverCardRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.HoverCardRow.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+
+// The type scale both sidebar hover cards (EnvHoverCard, OrchestratorHoverCard)
+// render through -- extracted so the two cards cannot re-drift into their own
+// per-row treatments the way they did before #1694 (six treatments in the env
+// card, three in its value column alone). Exactly three treatments exist in
+// this family, and every row goes through one of them:
+//
+//   - label/caption (`HOVER_CARD_CAPTION_CLASS`, 12px/text-xs, muted): the
+//     `dt` in every HoverCardRow, and any secondary caption line under a
+//     value (a usage reading's age, an environment's status/usage sub-line)
+//     -- a caption is secondary information exactly like a label is, so it
+//     shares the label's size rather than inventing its own.
+//   - value (`HoverCardRow`'s `dd`, 14px/text-sm, the card's own base size):
+//     every value's primary content. Nothing shrinks or grows a value's own
+//     font-size; a value that is a literal identifier (a version, a branch)
+//     may add `font-mono` on top of this same size -- mono is a face choice,
+//     never a size choice. The prior bug was exactly a differently-sized
+//     mono value (12px mono against 14px sans in the same column).
+//   - badge (`HoverCardBadge`, 10px pill): the one deliberate exception,
+//     reserved for the small border pill (Host/Local/Transient).
+//
+// `HoverCardTitle` reuses the value treatment's size (14px) rather than a
+// fourth size/face combination -- it earns its emphasis by weight only
+// (font-medium), the same way a row's own name can (see OrchestratorHoverCard
+// environment names).
+export const HOVER_CARD_CAPTION_CLASS = 'text-xs text-muted-foreground';
+
+export function HoverCardRow({
+  label,
+  wide = false,
+  children,
+}: {
+  label: string;
+  // wide stacks the label above the value across both grid columns, for a
+  // value that needs the card's full content width rather than sharing it
+  // with the label column.
+  wide?: boolean;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <>
+      <dt className={wide ? `col-span-2 ${HOVER_CARD_CAPTION_CLASS}` : HOVER_CARD_CAPTION_CLASS}>
+        {label}
+      </dt>
+      <dd
+        className={
+          wide
+            ? 'col-span-2 min-w-0 break-words text-sm text-foreground'
+            : 'min-w-0 break-words text-sm text-foreground'
+        }
+      >
+        {children}
+      </dd>
+    </>
+  );
+}
+
+export function HoverCardBadge({
+  children,
+  ariaLabel,
+}: {
+  children: React.ReactNode;
+  ariaLabel?: string;
+}): React.ReactElement {
+  return (
+    <span
+      className="flex-none rounded-[calc(var(--radius)-4px)] border border-border px-1 py-px text-[10px] font-medium uppercase leading-none tracking-wide text-muted-foreground"
+      aria-label={ariaLabel}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function HoverCardTitle({ children }: { children: React.ReactNode }): React.ReactElement {
+  return <span className="min-w-0 truncate text-sm font-medium">{children}</span>;
+}
+
+export function HoverCardMuted({ children }: { children: React.ReactNode }): React.ReactElement {
+  return <span className="text-muted-foreground">{children}</span>;
+}

--- a/erun-ui/frontend/src/components/app/Sidebar.HoverCardRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.HoverCardRow.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 
 // The type scale both sidebar hover cards (EnvHoverCard, OrchestratorHoverCard)
 // render through -- extracted so the two cards cannot re-drift into their own
-// per-row treatments the way they did before #1694 (six treatments in the env
-// card, three in its value column alone). Exactly three treatments exist in
-// this family, and every row goes through one of them:
+// per-row treatments the way they used to (six treatments in the env card,
+// three in its value column alone). Exactly three treatments exist in this
+// family, and every row goes through one of them:
 //
 //   - label/caption (`HOVER_CARD_CAPTION_CLASS`, 12px/text-xs, muted): the
 //     `dt` in every HoverCardRow, and any secondary caption line under a

--- a/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
@@ -7,6 +7,13 @@ import { orchestratorBusyElapsed } from '@/app/orchestratorBusyLabel';
 import { orchestratorEnvironmentLine } from '@/app/orchestratorEnvironmentActivity';
 import { orchestratorNudgeSummary } from '@/app/orchestratorNudgeSummary';
 import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
+import {
+  HOVER_CARD_CAPTION_CLASS,
+  HoverCardBadge,
+  HoverCardMuted,
+  HoverCardRow,
+  HoverCardTitle,
+} from '@/components/app/Sidebar.HoverCardRow';
 import { StatusDotGlyph } from '@/components/app/Sidebar.StatusDot';
 
 // OrchestratorHoverCard gives an orchestrator row the same hover treatment the
@@ -84,18 +91,14 @@ export function OrchestratorHoverCard({
       >
         <div className="border-b border-border px-3 py-2">
           <div className="flex items-center gap-1.5">
-            <span className="min-w-0 truncate font-medium">{orchestrator.name}</span>
-            {orchestrator.transient && (
-              <span className="flex-none rounded-[calc(var(--radius)-4px)] border border-border px-1 py-px text-[10px] leading-none font-medium tracking-wide text-muted-foreground uppercase">
-                Transient
-              </span>
-            )}
+            <HoverCardTitle>{orchestrator.name}</HoverCardTitle>
+            {orchestrator.transient && <HoverCardBadge>Transient</HoverCardBadge>}
           </div>
         </div>
         <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 px-3 py-2.5">
-          <HoverRow label="Status">{running ? 'Running' : 'Stopped'}</HoverRow>
+          <HoverCardRow label="Status">{running ? 'Running' : 'Stopped'}</HoverCardRow>
           {running && orchestrator.restartRequired && (
-            <HoverRow label="Restart">
+            <HoverCardRow label="Restart">
               <span className="flex items-start gap-1.5 text-amber-600">
                 <TriangleAlert aria-hidden="true" className="mt-0.5 size-3.5 flex-none" />
                 <span>
@@ -103,22 +106,22 @@ export function OrchestratorHoverCard({
                   set until restarted.
                 </span>
               </span>
-            </HoverRow>
+            </HoverCardRow>
           )}
-          <HoverRow label="Doing">
+          <HoverCardRow label="Doing">
             <OrchestratorDoing orchestrator={orchestrator} running={running} />
-          </HoverRow>
+          </HoverCardRow>
           {/* wide: an environment's busy detail names a real holder ("held by
               gradle-build"), which needs the card's full content width to read
               without eliding -- the narrow value column every other row shares
               with the "Environments" label leaves too little room for it. */}
-          <HoverRow label="Environments" wide>
+          <HoverCardRow label="Environments" wide>
             <OrchestratorEnvironments environments={orchestrator.environments} />
-          </HoverRow>
+          </HoverCardRow>
           {running && (
-            <HoverRow label="Nudges">
+            <HoverCardRow label="Nudges">
               <OrchestratorNudges orchestrator={orchestrator} />
-            </HoverRow>
+            </HoverCardRow>
           )}
         </dl>
       </PopoverContent>
@@ -201,15 +204,13 @@ function OrchestratorEnvironments({
             </span>
             <span className="min-w-0 flex-1">
               <span className="block truncate font-medium">{line.name}</span>
-              <span className="block truncate text-[12px] text-muted-foreground">
-                {line.status}
-              </span>
+              <span className={`block truncate ${HOVER_CARD_CAPTION_CLASS}`}>{line.status}</span>
               {line.usage && (
                 <span
                   className={
                     line.usageStale
-                      ? 'block truncate text-[12px] text-amber-700 dark:text-amber-400'
-                      : 'block truncate text-[12px] text-muted-foreground'
+                      ? 'block truncate text-xs tabular-nums text-amber-700 dark:text-amber-400'
+                      : `block truncate tabular-nums ${HOVER_CARD_CAPTION_CLASS}`
                   }
                 >
                   {line.usage}
@@ -249,42 +250,6 @@ function OrchestratorNudges({
   return <Muted>{summary}</Muted>;
 }
 
-function HoverRow({
-  label,
-  wide = false,
-  children,
-}: {
-  label: string;
-  // wide stacks the label above the value across both grid columns, for a
-  // value that needs the card's full content width rather than sharing it
-  // with the label column.
-  wide?: boolean;
-  children: React.ReactNode;
-}): React.ReactElement {
-  return (
-    <>
-      <dt
-        className={
-          wide
-            ? 'col-span-2 text-[12px] text-muted-foreground'
-            : 'text-[12px] text-muted-foreground'
-        }
-      >
-        {label}
-      </dt>
-      <dd
-        className={
-          wide
-            ? 'col-span-2 min-w-0 break-words text-foreground'
-            : 'min-w-0 break-words text-foreground'
-        }
-      >
-        {children}
-      </dd>
-    </>
-  );
-}
-
 function Muted({ children }: { children: React.ReactNode }): React.ReactElement {
-  return <span className="text-muted-foreground">{children}</span>;
+  return <HoverCardMuted>{children}</HoverCardMuted>;
 }

--- a/erun-ui/playwright/tests/sidebar-hovercard-no-info-lost.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-hovercard-no-info-lost.spec.ts
@@ -3,7 +3,7 @@ import type { Page, Route } from '@playwright/test';
 import { expect, test } from '../fixtures/erunApp.js';
 import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
 
-// #1694 restyled both hover cards onto a shared type scale (HoverCardRow).
+// Both hover cards were restyled onto a shared type scale (HoverCardRow).
 // A restyle that drops or truncates a field is a worse regression than the
 // inconsistent type treatments it replaced, so this spec pins every field
 // both cards rendered before the change, populated with real (not

--- a/erun-ui/playwright/tests/sidebar-hovercard-no-info-lost.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-hovercard-no-info-lost.spec.ts
@@ -1,0 +1,167 @@
+import type { Page, Route } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// #1694 restyled both hover cards onto a shared type scale (HoverCardRow).
+// A restyle that drops or truncates a field is a worse regression than the
+// inconsistent type treatments it replaced, so this spec pins every field
+// both cards rendered before the change, populated with real (not
+// placeholder) values so a dropped field can't hide behind an empty string.
+
+async function stubWorkingIssue(page: Page): Promise<void> {
+  await page.route('**/__erun_invoke', async (route: Route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'EnvironmentWorkingIssue') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            available: true,
+            branch: 'feature/1694-hover-card-type-scale',
+            issueNumber: 1694,
+            issueTitle: 'Neither sidebar hover card has a type scale',
+          },
+        }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+async function emitStaleEnvUsage(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ tenant, environment }) => {
+      const runtime = (
+        window as unknown as {
+          runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+        }
+      ).runtime;
+      runtime.EventsEmit('env-usage', {
+        tenant,
+        environment,
+        usage: {
+          tenant,
+          environment,
+          available: true,
+          cpu: { available: true, utilization: '12.0%', quota: '2.00 cores' },
+          memory: {
+            available: true,
+            current: '512Mi',
+            limit: '2048Mi',
+            percentOfLimit: 25,
+            oomKills: 0,
+          },
+        },
+        observedAtUnix: Math.floor(Date.now() / 1000) - 600,
+        staleAfterSeconds: 90,
+      });
+    },
+    { tenant: SEED_TENANT, environment: SEED_ENV_ALPHA },
+  );
+}
+
+test('the env hover card still renders every field: version, branch+issue, activity, and a stale usage reading', async ({
+  app,
+  page,
+}) => {
+  await stubWorkingIssue(page);
+  await app.reboot();
+
+  const card = app.sidebar.envHoverCard(SEED_TENANT, SEED_ENV_ALPHA);
+  await expect(async () => {
+    await emitStaleEnvUsage(page);
+    await page.mouse.move(0, 0);
+    await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
+    await expect(card).toBeVisible({ timeout: 1_000 });
+    await expect(card).toContainText('Stale', { timeout: 1_000 });
+  }).toPass({ timeout: 20_000 });
+
+  // Header: tenant/env title plus the Local badge.
+  await expect(card).toContainText(`${SEED_TENANT} / ${SEED_ENV_ALPHA}`);
+  await expect(card.getByText('Local', { exact: true })).toBeVisible();
+
+  // Version row.
+  await expect(card.getByText('Version', { exact: true })).toBeVisible();
+  await expect(card).toContainText('1.0.0');
+
+  // Working-on row: branch, issue number, and issue title all present.
+  await expect(card.getByText('Working on', { exact: true })).toBeVisible();
+  await expect(card).toContainText('feature/1694-hover-card-type-scale');
+  await expect(card).toContainText('#1694');
+  await expect(card).toContainText('Neither sidebar hover card has a type scale');
+
+  // Activity row.
+  await expect(card.getByText('Activity', { exact: true })).toBeVisible();
+  await expect(card).toContainText('Idle');
+
+  // Usage row: headline figures, staleness flag, and the reading's age.
+  await expect(card.getByText('Usage', { exact: true })).toBeVisible();
+  await expect(card).toContainText('CPU 12.0%');
+  await expect(card).toContainText('Mem 25% of 2048Mi');
+  await expect(card).toContainText('Stale');
+  await expect(card).toContainText('ago');
+});
+
+test('the orchestrator hover card still renders every field: status, doing, linked environments, and nudges', async ({
+  app,
+  page,
+}) => {
+  const busyAtUnix = Math.floor(Date.now() / 1000) - 252;
+  await page.route('**/__erun_invoke', async (route: Route, request) => {
+    const parsed = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (parsed.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: [
+            {
+              id: SEED_ORCHESTRATOR,
+              name: SEED_ORCHESTRATOR,
+              environments: [
+                { tenant: SEED_TENANT, environment: SEED_ENV_ALPHA, directory: '/tmp/a' },
+              ],
+              tenants: [],
+              directories: [],
+              sessionId: 4242,
+              status: 'running',
+              busy: true,
+              busyAtUnix,
+              transient: true,
+              shellRunning: true,
+              shellCommand: 'yarn build',
+              shellStartedAtUnix: busyAtUnix,
+            },
+          ],
+        }),
+      });
+    }
+    await route.continue();
+  });
+  await app.reboot();
+
+  await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+  const card = app.sidebar.orchestratorHoverCard(SEED_ORCHESTRATOR);
+  await expect(card).toBeVisible();
+
+  // Header: orchestrator name plus the Transient badge.
+  await expect(card).toContainText(SEED_ORCHESTRATOR);
+  await expect(card.getByText('Transient', { exact: true })).toBeVisible();
+
+  // Status row.
+  await expect(card.getByText('Status', { exact: true })).toBeVisible();
+  await expect(card).toContainText('Running');
+
+  // Doing row: both the working turn and the background shell are named.
+  await expect(card.getByText('Doing', { exact: true })).toBeVisible();
+  await expect(card).toContainText('Working, for');
+  await expect(card).toContainText('Shell running for');
+  await expect(card).toContainText('yarn build');
+
+  // Environments row: linked env's name and status line.
+  await expect(card.getByText('Environments', { exact: true })).toBeVisible();
+  await expect(card).toContainText(`${SEED_TENANT} / ${SEED_ENV_ALPHA}`);
+
+  // Nudges row (rendered only while running).
+  await expect(card.getByText('Nudges', { exact: true })).toBeVisible();
+});

--- a/erun-ui/playwright/tests/sidebar-hovercard-type-scale.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-hovercard-type-scale.spec.ts
@@ -1,0 +1,155 @@
+import type { Page, Route } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// #1694: neither sidebar hover card had a declared type scale -- the env card
+// alone mixed three sizes and two faces across a four-row card, and its value
+// column carried three different treatments on its own (mono-12px, sans-12px,
+// and unclassed-inherits-14px). Both cards now render every label/value row
+// through the shared HoverCardRow (Sidebar.HoverCardRow.tsx), which fixes the
+// scale to exactly three treatments: a 12px muted label/caption, a 14px value
+// (mono only as a face choice on identifiers, never a size change), and a
+// 10px badge pill. This spec asserts the scale computationally rather than by
+// reading pixel counts off a screenshot, so a future one-off className on a
+// single row fails a test instead of drifting back to six treatments quietly.
+
+async function fontSizePx(locator: import('@playwright/test').Locator): Promise<number> {
+  const size = await locator.evaluate((el) => window.getComputedStyle(el).fontSize);
+  return Number.parseFloat(size);
+}
+
+async function distinctFontSizes(
+  locator: import('@playwright/test').Locator,
+): Promise<Set<number>> {
+  const count = await locator.count();
+  const sizes = new Set<number>();
+  for (let index = 0; index < count; index += 1) {
+    sizes.add(await fontSizePx(locator.nth(index)));
+  }
+  return sizes;
+}
+
+async function stubWorkingIssue(page: Page): Promise<void> {
+  await page.route('**/__erun_invoke', async (route: Route, request) => {
+    const body = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (body.method === 'EnvironmentWorkingIssue') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            available: true,
+            branch: 'feature/1694-hover-card-type-scale',
+            issueNumber: 1694,
+            issueTitle: 'Neither sidebar hover card has a type scale',
+          },
+        }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('sidebar hover card type scale (#1694)', () => {
+  test('the env card value column is exactly one font-size, distinct from the label size', async ({
+    app,
+    page,
+  }) => {
+    await stubWorkingIssue(page);
+    await app.reboot();
+
+    await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
+    const card = app.sidebar.envHoverCard(SEED_TENANT, SEED_ENV_ALPHA);
+    await expect(card).toBeVisible();
+    // Wait for the working-issue fetch (stubbed above) to resolve so the
+    // mono branch value is actually rendered before sizes are sampled.
+    await expect(card).toContainText('feature/1694-hover-card-type-scale');
+
+    const values = distinctFontSizes(card.locator('dd'));
+    const labels = distinctFontSizes(card.locator('dt'));
+    const [valueSizes, labelSizes] = await Promise.all([values, labels]);
+
+    expect(valueSizes.size, 'every dd in the card must share one font-size').toBe(1);
+    expect(labelSizes.size, 'every dt in the card must share one font-size').toBe(1);
+
+    const [valueSize] = [...valueSizes];
+    const [labelSize] = [...labelSizes];
+    expect(valueSize).toBeGreaterThan(labelSize as number);
+
+    // The title reuses the value treatment's size (emphasis is by weight
+    // only), never a fourth size.
+    const title = card.getByText(`${SEED_TENANT} / ${SEED_ENV_ALPHA}`, { exact: true });
+    expect(await fontSizePx(title)).toBeCloseTo(valueSize as number, 1);
+  });
+
+  test('the orchestrator card value column is exactly one font-size, distinct from the label size', async ({
+    app,
+    page,
+  }) => {
+    await page.route('**/__erun_invoke', async (route: Route, request) => {
+      const parsed = JSON.parse(request.postData() ?? '{}') as { method?: string };
+      if (parsed.method === 'ListOrchestrators') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: [
+              {
+                id: SEED_ORCHESTRATOR,
+                name: SEED_ORCHESTRATOR,
+                environments: [
+                  { tenant: SEED_TENANT, environment: SEED_ENV_ALPHA, directory: '/tmp/a' },
+                ],
+                tenants: [],
+                directories: [],
+                sessionId: 4242,
+                status: 'running',
+                busy: true,
+                busyAtUnix: Math.floor(Date.now() / 1000) - 60,
+                transient: true,
+                shellRunning: false,
+                shellCommand: '',
+                shellStartedAtUnix: 0,
+              },
+            ],
+          }),
+        });
+      }
+      await route.continue();
+    });
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+    const card = app.sidebar.orchestratorHoverCard(SEED_ORCHESTRATOR);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Working, for');
+
+    const values = distinctFontSizes(card.locator('dd'));
+    const labels = distinctFontSizes(card.locator('dt'));
+    const [valueSizes, labelSizes] = await Promise.all([values, labels]);
+
+    expect(valueSizes.size, 'every dd in the card must share one font-size').toBe(1);
+    expect(labelSizes.size, 'every dt in the card must share one font-size').toBe(1);
+
+    const [valueSize] = [...valueSizes];
+    const [labelSize] = [...labelSizes];
+    expect(valueSize).toBeGreaterThan(labelSize as number);
+
+    const title = card.getByText(SEED_ORCHESTRATOR, { exact: true });
+    expect(await fontSizePx(title)).toBeCloseTo(valueSize as number, 1);
+  });
+
+  test('numeric values (version, usage figures) carry tabular figures', async ({ app }) => {
+    await app.reboot();
+    await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
+    const card = app.sidebar.envHoverCard(SEED_TENANT, SEED_ENV_ALPHA);
+    await expect(card).toBeVisible();
+
+    const version = card.locator('dd').first();
+    await expect(version).toContainText('1.0.0');
+    const variant = await version
+      .locator('span')
+      .first()
+      .evaluate((el) => window.getComputedStyle(el).fontVariantNumeric);
+    expect(variant).toContain('tabular-nums');
+  });
+});

--- a/erun-ui/playwright/tests/sidebar-hovercard-type-scale.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-hovercard-type-scale.spec.ts
@@ -3,8 +3,8 @@ import type { Page, Route } from '@playwright/test';
 import { expect, test } from '../fixtures/erunApp.js';
 import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
 
-// #1694: neither sidebar hover card had a declared type scale -- the env card
-// alone mixed three sizes and two faces across a four-row card, and its value
+// Neither sidebar hover card had a declared type scale -- the env card alone
+// mixed three sizes and two faces across a four-row card, and its value
 // column carried three different treatments on its own (mono-12px, sans-12px,
 // and unclassed-inherits-14px). Both cards now render every label/value row
 // through the shared HoverCardRow (Sidebar.HoverCardRow.tsx), which fixes the


### PR DESCRIPTION
## Summary

Neither sidebar hover card (env, orchestrator) declared a type scale (#1694): the env card mixed three sizes and two faces across a four-row card, with its value column alone carrying three different treatments (mono-12px, sans-12px, unclassed-inherits-14px).

**Existing scale check (mandatory per issue):** `erun-kit`'s `theme.css` defines color/radius/shadow/font-family tokens but no custom font-size scale — so "the scale that already exists" is Tailwind's own default scale (`text-xs`=12px, `text-sm`=14px), and the bug was these cards bypassing it with arbitrary `text-[12px]`/`text-[10px]` values instead of using it. No second scale was invented.

**Hierarchy chosen:** title (what this is) > value (its state/detail) > label/caption (context), expressed by weight only where it needs emphasis, and by exactly three size/face treatments overall:
- **label/caption** — `text-xs` (12px), muted. Used for every row's `dt`, and reused for secondary caption lines under a value (a usage reading's age, an environment's status/usage sub-line in the orchestrator card) — a caption is secondary information exactly like a label is.
- **value** — `text-sm` (14px), the card's own base size. Every `dd`'s primary content. A value that is a literal identifier (version, branch) may add `font-mono` on top of this same size — mono is a face choice, never a size choice (the "mono for identifiers" option the issue named as the better product answer). This is the rule the shared component's own comment states.
- **badge** — the 10px pill (Host/Local/Transient), the one deliberate exception.
- The title reuses the value's 14px size, earning emphasis by weight only (`font-medium`), never a fourth size/face combination.
- `tabular-nums` added to numeric values (version, CPU/memory usage figures) so figures align and don't jitter as they update.

Extracted into `Sidebar.HoverCardRow.tsx` (`HoverCardRow`, `HoverCardBadge`, `HoverCardTitle`, `HoverCardMuted`), consumed identically by both `Sidebar.EnvHoverCard.tsx` and `Sidebar.OrchestratorHoverCard.tsx`, so the two cards cannot re-drift into their own per-row treatments.

## UX Impact Review Checklist (`erun-ui/AGENTS.md`)

1. **Affected paths:** Sidebar env row hover → `EnvHoverCard` popover; Sidebar orchestrator row hover → `OrchestratorHoverCard` popover. Purely presentational typography; no data flow change.
2. **User-visible sequence:** unchanged — hover/focus a row, the same popover opens with the same header + label/value rows, now legible in a deliberate hierarchy instead of ad-hoc sizes.
3. **State-without-affordance:** N/A — no state mutations added.
4/5. **Visibility of status / success-failure feedback:** N/A — no operation triggered by this change.
6. **Consistency with comparable flows (Nielsen #4):** this change *is* the consistency fix — one shared row component now backs both cards, closing the exact gap `erun-ui/AGENTS.md`'s Design-Language Decision Record names as the standard (`BusyRowSpinner`/`StatusDotGlyph` shared identically across the two row kinds).
7. **Heuristic pass:** #4 (consistency) and #8 (aesthetic/minimalist — 3 treatments instead of 6) are the ones this change targets and improves; #6 (recognition over recall) improves as a side effect of a clear hierarchy; #1/2/3/5/7/9/10 do not apply (no status, error, or help surface touched).
8. **Playwright coverage:** `sidebar-hovercard-type-scale.spec.ts` (new) asserts the scale computationally — every `dd` in an open card shares one font-size distinct from every `dt`, the title reuses the value size, and numeric values carry `tabular-nums` — so a future one-off className regresses a test, not just a screenshot. `sidebar-hovercard-no-info-lost.spec.ts` (new) pins every field both cards rendered before the change (version, branch+issue+title, activity, usage headline+staleness+age; status, doing/working+shell, linked environment name+status+usage, nudges) populated with real values, so a restyle that drops or truncates a field fails. Existing specs (`sidebar-env-hover.spec.ts`, `sidebar-orchestrator-hover-card.spec.ts`, `sidebar-environment-usage.spec.ts`) needed no edits — confirms the change is visually-only.

## Verification

- Screenshotted both cards, both themes, before and after (populated with a real branch/issue/stale-usage reading for the env card, and a busy+shell+linked-environment orchestrator) via a throwaway spec (`git stash` the two card files, rebuild, capture "before"; restore, rebuild, capture "after"). The env card's `Working on` row visibly gains a uniform size across the mono branch line and the sans issue-number line (previously two different 12px-vs-inherited-14px treatments); the orchestrator card is visually unchanged, matching the issue's own finding that it drifted less.
- `go test ./...` (erun-ui), `yarn typecheck && yarn lint && yarn format:check && yarn build` (frontend), and the two new + full existing `erun-ui/playwright` suite all green (see gate run below).

## Test plan
- [x] `sidebar-hovercard-type-scale.spec.ts` — computational scale assertions
- [x] `sidebar-hovercard-no-info-lost.spec.ts` — anti-regression, every field present
- [x] Existing `sidebar-env-hover.spec.ts` / `sidebar-orchestrator-hover-card.spec.ts` / `sidebar-environment-usage.spec.ts` unchanged and green
- [x] `make check`
- [x] `erun-ui/playwright/run.sh --build`

Closes #1694