### PR TITLE
Forward the resolved tenant/environment into every MCP tool call

### DIFF
--- a/erun-cli/cmd/environment_call.go
+++ b/erun-cli/cmd/environment_call.go
@@ -41,6 +41,13 @@ func callEnvironmentTool[T any](ctx context.Context, commandCtx common.Context, 
 	if err != nil {
 		return decoded, false, err
 	}
+	// This host already resolved the target to pick target.endpoint above --
+	// restating it in the call itself, rather than leaving the tool to infer it
+	// from the server's own bound context, is what turns a stale edge pointed at
+	// the wrong environment into a named refusal instead of a silent act on the
+	// wrong one (resolveLocalTarget, erun-mcp/runtime.go).
+	arguments["tenant"] = target.tenant
+	arguments["environment"] = target.environment
 	commandCtx.TraceCommand("", "mcp", "tools/call", target.endpoint, tool, compactMCPArguments(arguments))
 	if commandCtx.DryRun {
 		return decoded, false, nil

--- a/erun-cli/cmd/whip.go
+++ b/erun-cli/cmd/whip.go
@@ -150,21 +150,41 @@ func whipOneEnvironment(ctx context.Context, commandCtx common.Context, resolveO
 		notAlive.Error = err.Error()
 		return notAlive
 	}
-	commandCtx.TraceCommand("", "mcp", "tools/call", target.endpoint, "whip", fmt.Sprintf("preview=%v", commandCtx.DryRun))
+	// Restate the tenant/environment this host already resolved rather than
+	// leaving the tool to infer them from the server's own bound context: it is
+	// the stronger assertion the issue this fixes asked for, and it is what lets
+	// a stale edge pointed at the wrong environment surface as a named mismatch
+	// instead of a silent act on the wrong one (resolveLocalTarget,
+	// erun-mcp/runtime.go).
+	arguments := map[string]any{"preview": commandCtx.DryRun, "tenant": target.tenant, "environment": target.environment}
+	commandCtx.TraceCommand("", "mcp", "tools/call", target.endpoint, "whip", compactMCPArguments(arguments))
 
-	result, err := callMCPToolWithReattach(ctx, commandCtx, target, "whip", map[string]any{"preview": commandCtx.DryRun}, false)
+	// A failed attempt (network error, target refusal, malformed response) is
+	// reported as failed(), not folded into notAlive: the whip tool itself
+	// already reports a dead session as a *successful* result carrying
+	// WhipReasonNotAlive, so an error here never means "no live session" --
+	// it means the call itself did not work, which is a different problem
+	// asking for different operator action (root AGENTS.md's "Smooth,
+	// Seamless, No Dead Ends" -- distinguish causes before writing copy).
+	failed := func(detail string) common.WhipResult {
+		return common.WhipResult{
+			Candidate: common.WhipCandidate{Kind: common.WhipTargetEnvironment, ID: id, Name: id, Reachable: true, Alive: false},
+			Decision:  common.WhipDecisionNone,
+			Reason:    common.WhipReasonCallFailed,
+			Error:     detail,
+		}
+	}
+
+	result, err := callMCPToolWithReattach(ctx, commandCtx, target, "whip", arguments, false)
 	if err != nil {
-		notAlive.Error = err.Error()
-		return notAlive
+		return failed(err.Error())
 	}
 	var decoded common.WhipResult
 	if len(result.Structured) == 0 {
-		notAlive.Error = fmt.Sprintf("%s/%s returned no result for whip", tenant, environment)
-		return notAlive
+		return failed(fmt.Sprintf("%s/%s returned no result for whip", tenant, environment))
 	}
 	if err := json.Unmarshal(result.Structured, &decoded); err != nil {
-		notAlive.Error = fmt.Sprintf("decode the whip result from %s/%s: %v", tenant, environment, err)
-		return notAlive
+		return failed(fmt.Sprintf("decode the whip result from %s/%s: %v", tenant, environment, err))
 	}
 	return decoded
 }
@@ -204,6 +224,9 @@ func whipResultValue(result common.WhipResult) string {
 	case common.WhipDecisionCap:
 		return "capped: stopped nudging after repeated silence"
 	default:
+		if result.Reason == common.WhipReasonCallFailed {
+			return "call failed: " + result.Error
+		}
 		value := "skipped — " + string(result.Reason)
 		if result.Error != "" {
 			value += ": " + result.Error

--- a/erun-common/whip.go
+++ b/erun-common/whip.go
@@ -71,6 +71,14 @@ const (
 	WhipReasonAlreadyCapped WhipReason = "already-capped"
 	WhipReasonCapCrossed    WhipReason = "cap-crossed"
 	WhipReasonNudge         WhipReason = "nudge"
+	// WhipReasonCallFailed marks a whip tool call that was actually attempted
+	// against a reachable edge and failed there (a target-resolution refusal, a
+	// transport error, a malformed response) -- never the tool reporting a dead
+	// session, which comes back as WhipReasonNotAlive in a successful result.
+	// Callers must not fold this into WhipReasonNotAlive: "no live session to
+	// push" and "the call itself failed" describe different problems and call
+	// for different operator action.
+	WhipReasonCallFailed WhipReason = "call-failed"
 )
 
 // DefaultWhipMessage restates the pacing contract verbatim, plus the one

--- a/erun-integration/environment_half_scenarios_test.go
+++ b/erun-integration/environment_half_scenarios_test.go
@@ -137,6 +137,14 @@ func TestJobOffEnvironment(t *testing.T) {
 		if calls[1].Tool != "exec_job_status" {
 			t.Fatalf("the environment was asked for %q second, want exec_job_status", calls[1].Tool)
 		}
+		// erun#1709: this host already resolved team/dev to reach this edge, and
+		// must restate it in the call itself rather than leaving the tool to
+		// infer it from the server's own bound context -- the plumbing gap that
+		// let a bare "tenant and environment are required" reach an operator
+		// even though the flags were parsed correctly.
+		for _, call := range calls {
+			assertToolArgumentsNameTarget(t, call, "team", "dev")
+		}
 	})
 
 	t.Run("start_dry_run_traces_the_environment_call", func(t *testing.T) {
@@ -217,6 +225,7 @@ func TestJobOffEnvironment(t *testing.T) {
 		if !call.IdleProbe {
 			t.Errorf("expected job_status to carry the idle-probe header so polling it does not reset the environment's idle timer")
 		}
+		assertToolArgumentsNameTarget(t, call, "team", "dev")
 	})
 
 	t.Run("output_reads_the_environments_captured_output", func(t *testing.T) {
@@ -242,6 +251,39 @@ func TestJobOffEnvironment(t *testing.T) {
 		}
 		if !call.IdleProbe {
 			t.Errorf("expected job_output to carry the idle-probe header so polling it does not reset the environment's idle timer")
+		}
+		assertToolArgumentsNameTarget(t, call, "team", "dev")
+	})
+
+	// A genuinely unresolved target (the edge's own runtime image predates the
+	// tenant/environment plumbing fix, or the pod was started with no bound
+	// context of its own) must still error -- and the message an operator
+	// actually sees has to name which tool refused and what would satisfy it,
+	// not the bare "tenant and environment are required" dead end erun#1709
+	// reported (that phrasing named no tool, no caller, and no recovery).
+	t.Run("status_reports_the_tool_and_the_remedy_when_the_target_is_unresolved", func(t *testing.T) {
+		skipIfPortsBusy(t, jobEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", jobEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{ToolResults: map[string]string{
+			"exec_job_status": `{"content":[{"type":"text","text":"tenant/environment not resolved: this MCP server was not started bound to a tenant/environment, and the call did not supply tenant/environment either -- pass tenant and environment explicitly in the call, or run this edge for an environment that has it configured"}],"isError":true}`,
+		}}
+		edge.start(t, jobEdgeLocalPort)
+
+		result := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "suite"},
+			erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a non-zero exit for an unresolved target, got 0:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "exec_job_status") {
+			t.Errorf("error must name the refusing tool (exec_job_status), got:\n%s", result.Combined)
+		}
+		if !strings.Contains(result.Combined, "pass tenant and environment explicitly") {
+			t.Errorf("error must name the remedy, got:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "tenant and environment are required") {
+			t.Errorf("error regressed to the bare required-input dead end, got:\n%s", result.Combined)
 		}
 	})
 }

--- a/erun-integration/mcp_test.go
+++ b/erun-integration/mcp_test.go
@@ -105,6 +105,11 @@ type fakeMCPRequest struct {
 	// Tool is the tool a tools/call named, which is what proves a caller reached
 	// the intended surface rather than some other one.
 	Tool string
+	// Arguments is the tools/call arguments object the caller actually sent, so
+	// a scenario can assert what a host-side command forwarded into the payload
+	// (e.g. that it restated the tenant/environment it already resolved) rather
+	// than only that a call reached the edge at all.
+	Arguments map[string]any
 	// IdleProbe reports whether the request carried the header that exempts it
 	// from the environment's activity accounting — set by a diagnostic read, and
 	// never by a call that can mutate the environment.
@@ -138,7 +143,8 @@ func (e *fakeMCPEdge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ID     json.RawMessage `json:"id"`
 		Method string          `json:"method"`
 		Params struct {
-			Name string `json:"name"`
+			Name      string         `json:"name"`
+			Arguments map[string]any `json:"arguments"`
 		} `json:"params"`
 	}
 	_ = json.Unmarshal(body, &request)
@@ -149,6 +155,7 @@ func (e *fakeMCPEdge) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Authbearer: strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "),
 		SessionID:  r.Header.Get("Mcp-Session-Id"),
 		Tool:       request.Params.Name,
+		Arguments:  request.Params.Arguments,
 		IdleProbe:  r.Header.Get(common.MCPIdleProbeHeader) == "true",
 	})
 	e.mu.Unlock()
@@ -269,6 +276,21 @@ func (e *fakeMCPEdge) requestFor(t *testing.T, method string) fakeMCPRequest {
 	}
 	t.Fatalf("edge never received %s; got %+v", method, e.recorded())
 	return fakeMCPRequest{}
+}
+
+// assertToolArgumentsNameTarget asserts a tools/call request restated the
+// tenant/environment the host already resolved to reach this edge, rather
+// than leaving the tool to infer them from the server's own bound context
+// (erun#1709). Every off-environment idle/job/activity-lease call must carry
+// its own tenant/environment on the wire.
+func assertToolArgumentsNameTarget(t *testing.T, request fakeMCPRequest, tenant, environment string) {
+	t.Helper()
+	if got, _ := request.Arguments["tenant"].(string); got != tenant {
+		t.Errorf("%s call: got tenant argument %q, want %q -- arguments: %+v", request.Tool, got, tenant, request.Arguments)
+	}
+	if got, _ := request.Arguments["environment"].(string); got != environment {
+		t.Errorf("%s call: got environment argument %q, want %q -- arguments: %+v", request.Tool, got, environment, request.Arguments)
+	}
 }
 
 type mcpTokenClaims struct {

--- a/erun-integration/testdata/idle/off_environment_dry_run_traces_the_environment_call.txt
+++ b/erun-integration/testdata/idle/off_environment_dry_run_traces_the_environment_call.txt
@@ -1,3 +1,3 @@
 audit: erun idle --dry-run team dev
 mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
-mcp tools/call http://<LOOPBACK>:17000/mcp idle '{}'
+mcp tools/call http://<LOOPBACK>:17000/mcp idle '{"environment":"dev","tenant":"team"}'

--- a/erun-integration/testdata/job/off_environment_start_dry_run_traces_the_environment_call.txt
+++ b/erun-integration/testdata/job/off_environment_start_dry_run_traces_the_environment_call.txt
@@ -1,3 +1,3 @@
 audit: erun job start --dry-run --environment dev --name suite --tenant team work --all
 mcp: team/dev edge resolved to http://<LOOPBACK>:17000/mcp
-mcp tools/call http://<LOOPBACK>:17000/mcp exec_raw '{"command":["work","--all"],"leaseTtlSeconds":900,"maxOutputBytes":16777216,"name":"suite","wait":false}'
+mcp tools/call http://<LOOPBACK>:17000/mcp exec_raw '{"command":["work","--all"],"environment":"dev","leaseTtlSeconds":900,"maxOutputBytes":16777216,"name":"suite","tenant":"team","wait":false}'

--- a/erun-integration/testdata/whip/dry_run_json_output.txt
+++ b/erun-integration/testdata/whip/dry_run_json_output.txt
@@ -13,7 +13,7 @@
         "Capped": false
       },
       "decision": 0,
-      "reason": "not-alive",
+      "reason": "call-failed",
       "pushed": false,
       "error": "no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it"
     },
@@ -36,4 +36,4 @@
 }
 audit: erun whip --dry-run --json
 mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
-mcp tools/call http://<LOOPBACK>:26100/mcp whip preview=true
+mcp tools/call http://<LOOPBACK>:26100/mcp whip '{"environment":"dev","preview":true,"tenant":"team"}'

--- a/erun-integration/testdata/whip/dry_run_one_named_environment_not_open_reports_call_failed.txt
+++ b/erun-integration/testdata/whip/dry_run_one_named_environment_not_open_reports_call_failed.txt
@@ -1,0 +1,4 @@
+  team/dev: call failed: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
+audit: erun whip --dry-run --environment dev --tenant team
+mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
+mcp tools/call http://<LOOPBACK>:26100/mcp whip '{"environment":"dev","preview":true,"tenant":"team"}'

--- a/erun-integration/testdata/whip/dry_run_one_named_environment_not_open_reports_not_alive.txt
+++ b/erun-integration/testdata/whip/dry_run_one_named_environment_not_open_reports_not_alive.txt
@@ -1,4 +1,0 @@
-  team/dev: skipped — not-alive: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
-audit: erun whip --dry-run --environment dev --tenant team
-mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
-mcp tools/call http://<LOOPBACK>:26100/mcp whip preview=true

--- a/erun-integration/testdata/whip/dry_run_whips_every_configured_environment_and_orchestrator.txt
+++ b/erun-integration/testdata/whip/dry_run_whips_every_configured_environment_and_orchestrator.txt
@@ -1,8 +1,8 @@
-  other/staging: skipped — not-alive: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
-  team/dev: skipped — not-alive: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
+  other/staging: call failed: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
+  team/dev: call failed: no desktop identity at <DESKTOP_IDENTITY>; open an environment from the ERun desktop app once so the identity exists and deployed runtimes trust it
   orchestrator Eng One: skipped — unreachable-from-transport
 audit: erun whip --dry-run
 mcp: other/staging edge resolved to http://<LOOPBACK>:26200/mcp
-mcp tools/call http://<LOOPBACK>:26200/mcp whip preview=true
+mcp tools/call http://<LOOPBACK>:26200/mcp whip '{"environment":"staging","preview":true,"tenant":"other"}'
 mcp: team/dev edge resolved to http://<LOOPBACK>:26100/mcp
-mcp tools/call http://<LOOPBACK>:26100/mcp whip preview=true
+mcp tools/call http://<LOOPBACK>:26100/mcp whip '{"environment":"dev","preview":true,"tenant":"team"}'

--- a/erun-integration/whip_test.go
+++ b/erun-integration/whip_test.go
@@ -33,12 +33,19 @@ func TestWhip(t *testing.T) {
 		golden.Equal(t, "whip/dry_run_no_targets_configured", normalize.Apply(result.Combined))
 	})
 
-	t.Run("dry_run_one_named_environment_not_open_reports_not_alive", func(t *testing.T) {
+	t.Run("dry_run_one_named_environment_not_open_reports_call_failed", func(t *testing.T) {
 		// Pinned to the 26100 range (erun-integration/AGENTS.md's "pin a high
 		// port range") rather than the plain SeedTenantEnv default, or the probe
 		// below can land on whatever a developer's live erun session already
 		// holds on the default 17000 range and read as a stale port-forward
 		// instead of the "nobody has this open" case the scenario means to test.
+		//
+		// This harness has no desktop identity to mint a bearer with, so the
+		// whip tool call itself fails before it ever reaches a pod -- reported
+		// as a call failure (erun-common's WhipReasonCallFailed), never folded
+		// into "not alive" the way it used to be (erun#1709): the tool call
+		// erroring out is never the same claim as the tool reporting a dead
+		// session, which comes back as a *successful* result.
 		skipIfPortsBusy(t, 26100)
 		setup := env.New(t)
 		fixture.SeedTenantEnvWithLocalPortRangeStart(t, setup, "team", "dev", 26100)
@@ -46,7 +53,7 @@ func TestWhip(t *testing.T) {
 		if result.ExitCode != 0 {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
-		golden.Equal(t, "whip/dry_run_one_named_environment_not_open_reports_not_alive", normalize.Apply(result.Combined))
+		golden.Equal(t, "whip/dry_run_one_named_environment_not_open_reports_call_failed", normalize.Apply(result.Combined))
 	})
 
 	t.Run("dry_run_whips_every_configured_environment_and_orchestrator", func(t *testing.T) {
@@ -79,6 +86,34 @@ func TestWhip(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "whip/dry_run_json_output", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_forwards_the_resolved_target", func(t *testing.T) {
+		// erun#1709: `erun whip` used to call the "whip" MCP tool with only
+		// {"preview": ...}, relying entirely on the pod defaulting to its own
+		// bound context. This proves the call now restates the tenant/
+		// environment this host already resolved to reach the edge, through a
+		// real (fake) edge rather than the dry-run path above, which never
+		// reaches a live tool result to decode.
+		whipEdgeLocalPort := 26500
+		skipIfPortsBusy(t, whipEdgeLocalPort)
+		setup := env.New(t)
+		fixture.SeedRemoteTenantEnvWithSSHDPortRange(t, setup, "team", "dev", whipEdgeLocalPort)
+		fixture.SeedDesktopIdentity(t, setup)
+		edge := &fakeMCPEdge{Results: map[string]string{"tools/call": `{"content":[{"type":"text","text":"whip"}],` +
+			`"structuredContent":{"candidate":{"Kind":"environment","ID":"team/dev","Name":"team/dev","Reachable":true,"Alive":true},"decision":1,"reason":"nudge","pushed":true}}`}}
+		edge.start(t, whipEdgeLocalPort)
+
+		result := erun.Run(t, []string{"whip", "--tenant", "team", "--environment", "dev"}, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+
+		call := edge.requestFor(t, "tools/call")
+		if call.Tool != "whip" {
+			t.Fatalf("the environment was asked for %q, want whip", call.Tool)
+		}
+		assertToolArgumentsNameTarget(t, call, "team", "dev")
 	})
 
 	t.Run("dry_run_only_tenant_given_refuses", func(t *testing.T) {

--- a/erun-ui/app.go
+++ b/erun-ui/app.go
@@ -87,7 +87,7 @@ type erunUIDeps struct {
 	loadEnvironmentJobs       func(context.Context, string, string) ([]eruncommon.EnvironmentJob, error)
 	readEnvironmentJobOutput  func(context.Context, string, string, eruncommon.ReadEnvironmentJobOutputParams) (eruncommon.EnvironmentJobOutput, error)
 	cancelEnvironmentJob      func(context.Context, string, string, eruncommon.CancelEnvironmentJobParams) (eruncommon.CancelEnvironmentJobResult, error)
-	whipEnvironment           func(context.Context, string, string) (eruncommon.WhipResult, error)
+	whipEnvironment           func(context.Context, string, string, string, string) (eruncommon.WhipResult, error)
 	loadAPILog                func(context.Context, uiTenantDashboardInput) (string, error)
 	workspaceSyncReady        func(context.Context, string) error
 	syncWorkspace             func(context.Context, eruncommon.WorkspaceSyncParams) (eruncommon.WorkspaceSyncResult, error)

--- a/erun-ui/ui_model_whip.go
+++ b/erun-ui/ui_model_whip.go
@@ -130,6 +130,16 @@ func whipResultToUI(result eruncommon.WhipResult) uiWhipResult {
 		ui.Reason = "stopped nudging after repeated silence — reply in its pane or restart it"
 		return ui
 	default:
+		if result.Reason == eruncommon.WhipReasonCallFailed {
+			// A call that was actually attempted and failed is a write that was
+			// refused, not a benign skip -- same InlineAlert-territory distinction
+			// the decided-but-refused-nudge case above already draws, so it must
+			// not collapse into whipSkipReasonText's "not alive" wording.
+			ui.Outcome = "failed"
+			ui.Reason = "call failed"
+			ui.Error = result.Error
+			return ui
+		}
 		ui.Outcome = "skipped"
 		ui.Reason = whipSkipReasonText(result.Reason)
 		ui.Error = result.Error

--- a/erun-ui/whip.go
+++ b/erun-ui/whip.go
@@ -149,12 +149,19 @@ func (a *App) whipOneEnvironmentNow(ctx context.Context, tenant, environment str
 		}
 	}
 
-	decoded, err := a.deps.whipEnvironment(ctx, mcpEndpointForOpenResult(result), a.mcpBearer(tenant, environment))
+	decoded, err := a.deps.whipEnvironment(ctx, tenant, environment, mcpEndpointForOpenResult(result), a.mcpBearer(tenant, environment))
 	if err != nil {
+		// A failed call is not the same claim as WhipReasonNotAlive: the whip
+		// tool itself already reports a dead session as a *successful* result
+		// carrying that reason, so an error here always means the call itself
+		// did not work (a target mismatch, a stale runtime image, a transport
+		// failure) -- a different problem asking for different operator action
+		// than "go start the session" (root AGENTS.md's "Smooth, Seamless, No
+		// Dead Ends" -- distinguish causes before writing copy).
 		return eruncommon.WhipResult{
 			Candidate: eruncommon.WhipCandidate{Kind: eruncommon.WhipTargetEnvironment, ID: id, Name: id, Reachable: true, Alive: false},
 			Decision:  eruncommon.WhipDecisionNone,
-			Reason:    eruncommon.WhipReasonNotAlive,
+			Reason:    eruncommon.WhipReasonCallFailed,
 			Error:     err.Error(),
 		}
 	}

--- a/erun-ui/whip_mcp.go
+++ b/erun-ui/whip_mcp.go
@@ -15,7 +15,14 @@ import (
 // and pushes exactly as it would for any other transport; the desktop never
 // re-derives that decision locally. Not idle-probed: pushing a nudge is a
 // real write, not a diagnostic read.
-func whipEnvironmentViaMCP(ctx context.Context, endpoint, bearer string) (eruncommon.WhipResult, error) {
+//
+// tenant/environment are the target whipOneEnvironmentNow already resolved
+// and used to pick endpoint -- restating them in the call itself, rather than
+// leaving the tool to infer them from the server's own bound context, is the
+// stronger assertion the resolveLocalTarget contract (erun-mcp/runtime.go)
+// asks callers to make: a stale edge pointed at the wrong environment then
+// surfaces as a named mismatch instead of a silent act on the wrong one.
+func whipEnvironmentViaMCP(ctx context.Context, tenant, environment, endpoint, bearer string) (eruncommon.WhipResult, error) {
 	client := mcp.NewClient(&mcp.Implementation{Name: "erun-app", Version: currentBuildInfo().Version}, nil)
 	session, err := client.Connect(ctx, mcpClientTransport(endpoint, bearer, false), nil)
 	if err != nil {
@@ -27,7 +34,7 @@ func whipEnvironmentViaMCP(ctx context.Context, endpoint, bearer string) (erunco
 
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "whip",
-		Arguments: map[string]any{"preview": false},
+		Arguments: map[string]any{"preview": false, "tenant": tenant, "environment": environment},
 	})
 	if err != nil {
 		return eruncommon.WhipResult{}, formatWhipMCPError(err)

--- a/erun-ui/whip_test.go
+++ b/erun-ui/whip_test.go
@@ -479,7 +479,15 @@ func TestWhipResultToUIRendersEveryOutcome(t *testing.T) {
 	if failedPush.Outcome != "failed" || failedPush.Error == "" {
 		t.Fatalf("got %+v, want a decided-but-failed push reported failed with its error", failedPush)
 	}
+}
 
+// TestWhipResultToUIRendersACallFailureAsFailed is the erun#1709 regression
+// test for the UI facade: a WhipReasonCallFailed result (the tool call itself
+// erroring out, never the tool reporting a dead session) must render as
+// "failed", not fold into whipSkipReasonText's "not alive" wording the way a
+// genuine skip does. Split out from TestWhipResultToUIRendersEveryOutcome to
+// keep that test's cyclomatic complexity under the repo's lint threshold.
+func TestWhipResultToUIRendersACallFailureAsFailed(t *testing.T) {
 	failedCall := whipResultToUI(eruncommon.WhipResult{
 		Candidate: eruncommon.WhipCandidate{Kind: eruncommon.WhipTargetEnvironment, ID: "erun/dev", Name: "erun/dev"},
 		Decision:  eruncommon.WhipDecisionNone,

--- a/erun-ui/whip_test.go
+++ b/erun-ui/whip_test.go
@@ -45,7 +45,7 @@ func TestWhipOneEnvironmentNowNotOpenReportsNotAlive(t *testing.T) {
 		canConnectLocalPort: func(int) bool {
 			return false
 		},
-		whipEnvironment: func(context.Context, string, string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(context.Context, string, string, string, string) (eruncommon.WhipResult, error) {
 			called = true
 			return eruncommon.WhipResult{}, nil
 		},
@@ -100,7 +100,7 @@ func TestWhipOneEnvironmentNowPushesThroughAReachableEdge(t *testing.T) {
 		canReachMCPEndpoint: func(int) bool {
 			return true
 		},
-		whipEnvironment: func(_ context.Context, endpoint, _ string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(_ context.Context, _, _, endpoint, _ string) (eruncommon.WhipResult, error) {
 			gotEndpoint = endpoint
 			return eruncommon.WhipResult{
 				Candidate: eruncommon.WhipCandidate{Kind: eruncommon.WhipTargetEnvironment, ID: "erun/ux", Name: "erun/ux", Reachable: true, Alive: true},
@@ -133,7 +133,7 @@ func TestWhipOneEnvironmentNowStampsIdentityOnSuccessEvenIfThePodDidNot(t *testi
 		canReachMCPEndpoint: func(int) bool {
 			return true
 		},
-		whipEnvironment: func(context.Context, string, string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(context.Context, string, string, string, string) (eruncommon.WhipResult, error) {
 			return eruncommon.WhipResult{
 				Decision: eruncommon.WhipDecisionNudge,
 				Reason:   eruncommon.WhipReasonNudge,
@@ -151,24 +151,59 @@ func TestWhipOneEnvironmentNowStampsIdentityOnSuccessEvenIfThePodDidNot(t *testi
 	}
 }
 
-// TestWhipOneEnvironmentNowSurfacesACallFailureAsNotAlive covers the MCP call
-// itself failing (e.g. an old runtime image without the "whip" tool): the
-// environment is reported not-alive with the failure attached, rather than
-// the report silently omitting this target.
-func TestWhipOneEnvironmentNowSurfacesACallFailureAsNotAlive(t *testing.T) {
+// TestWhipOneEnvironmentNowSurfacesACallFailureAsFailedNotNotAlive covers the
+// MCP call itself failing (e.g. an old runtime image without the "whip" tool,
+// or -- since the fix below now forwards a real target -- a tenant/
+// environment mismatch the pod's own resolveLocalTarget refused): the
+// environment must be reported as a genuine failure, never folded into
+// WhipReasonNotAlive. The whip tool itself already reports a dead session as
+// a *successful* result carrying that reason, so an error at this call site
+// can only mean the call itself did not work -- erun#1709's "a reason that
+// contradicts the error" defect (a not-alive skip citing an unrelated
+// call-level error, e.g. a missing target) is exactly what this guards.
+func TestWhipOneEnvironmentNowSurfacesACallFailureAsFailedNotNotAlive(t *testing.T) {
 	app := NewApp(erunUIDeps{
 		store: whipTestStore(t),
 		canReachMCPEndpoint: func(int) bool {
 			return true
 		},
-		whipEnvironment: func(context.Context, string, string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(context.Context, string, string, string, string) (eruncommon.WhipResult, error) {
 			return eruncommon.WhipResult{}, errors.New("tool not found")
 		},
 	})
 
 	result := app.whipOneEnvironmentNow(context.Background(), "erun", "ux")
-	if result.Reason != eruncommon.WhipReasonNotAlive || result.Error == "" {
-		t.Fatalf("expected a not-alive result naming the failure, got %+v", result)
+	if result.Reason != eruncommon.WhipReasonCallFailed || result.Error == "" {
+		t.Fatalf("expected a call-failed result naming the failure, got %+v", result)
+	}
+	if result.Reason == eruncommon.WhipReasonNotAlive {
+		t.Fatal("a call-level failure must never be reported as not-alive")
+	}
+}
+
+// TestWhipOneEnvironmentNowForwardsTheResolvedTarget is the plumbing
+// regression test for erun#1709: the desktop used to call the "whip" MCP tool
+// with only {"preview": false}, relying entirely on the pod defaulting to its
+// own bound context. whipOneEnvironmentNow already resolved tenant/environment
+// to reach this edge in the first place, so it must restate them in the call
+// -- the stronger assertion that turns a stale edge pointed at the wrong
+// environment into a named mismatch instead of a silent act on the wrong one.
+func TestWhipOneEnvironmentNowForwardsTheResolvedTarget(t *testing.T) {
+	var gotTenant, gotEnvironment string
+	app := NewApp(erunUIDeps{
+		store: whipTestStore(t),
+		canReachMCPEndpoint: func(int) bool {
+			return true
+		},
+		whipEnvironment: func(_ context.Context, tenant, environment, _, _ string) (eruncommon.WhipResult, error) {
+			gotTenant, gotEnvironment = tenant, environment
+			return eruncommon.WhipResult{Decision: eruncommon.WhipDecisionNudge, Pushed: true}, nil
+		},
+	})
+
+	app.whipOneEnvironmentNow(context.Background(), "erun", "ux")
+	if gotTenant != "erun" || gotEnvironment != "ux" {
+		t.Fatalf("expected the resolved target to be forwarded, got tenant=%q environment=%q", gotTenant, gotEnvironment)
 	}
 }
 
@@ -185,7 +220,7 @@ func TestWhipNowFoldsEnvironmentsAndOrchestratorsIntoOneReport(t *testing.T) {
 		canReachMCPEndpoint: func(int) bool {
 			return true
 		},
-		whipEnvironment: func(context.Context, string, string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(context.Context, string, string, string, string) (eruncommon.WhipResult, error) {
 			return eruncommon.WhipResult{
 				Candidate: eruncommon.WhipCandidate{Kind: eruncommon.WhipTargetEnvironment, ID: "erun/ux", Name: "erun/ux", Reachable: true, Alive: true},
 				Decision:  eruncommon.WhipDecisionNudge,
@@ -242,7 +277,7 @@ func TestWhipEnvironmentsNowSkipsHostEnvs(t *testing.T) {
 		canReachMCPEndpoint: func(int) bool {
 			return true
 		},
-		whipEnvironment: func(context.Context, string, string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(context.Context, string, string, string, string) (eruncommon.WhipResult, error) {
 			return eruncommon.WhipResult{
 				Candidate: eruncommon.WhipCandidate{Kind: eruncommon.WhipTargetEnvironment, ID: "erun/ux", Name: "erun/ux", Reachable: true, Alive: true},
 				Decision:  eruncommon.WhipDecisionNudge,
@@ -282,7 +317,7 @@ func TestWhipEnvironmentsNowOnlyPushesRequestedEnvironments(t *testing.T) {
 		canReachMCPEndpoint: func(int) bool {
 			return true
 		},
-		whipEnvironment: func(_ context.Context, endpoint, _ string) (eruncommon.WhipResult, error) {
+		whipEnvironment: func(_ context.Context, _, _, endpoint, _ string) (eruncommon.WhipResult, error) {
 			pushedEndpoints = append(pushedEndpoints, endpoint)
 			return eruncommon.WhipResult{Decision: eruncommon.WhipDecisionNudge, Pushed: true}, nil
 		},
@@ -443,5 +478,15 @@ func TestWhipResultToUIRendersEveryOutcome(t *testing.T) {
 	})
 	if failedPush.Outcome != "failed" || failedPush.Error == "" {
 		t.Fatalf("got %+v, want a decided-but-failed push reported failed with its error", failedPush)
+	}
+
+	failedCall := whipResultToUI(eruncommon.WhipResult{
+		Candidate: eruncommon.WhipCandidate{Kind: eruncommon.WhipTargetEnvironment, ID: "erun/dev", Name: "erun/dev"},
+		Decision:  eruncommon.WhipDecisionNone,
+		Reason:    eruncommon.WhipReasonCallFailed,
+		Error:     "tenant/environment not resolved",
+	})
+	if failedCall.Outcome != "failed" || failedCall.Error == "" {
+		t.Fatalf("got %+v, want a call failure reported failed with its error, never folded into skipped", failedCall)
 	}
 }


### PR DESCRIPTION
## Summary

`whip` from the desktop was the reported symptom, but the same defect pattern
turned out to be the shared root cause behind two other failures reported the
same day: `exec_raw` with `wait:false`, and the `exec job` CLI family
(`status`/`start`/`output`). This is **one defect, one shared root cause**,
with a **second, related defect** specific to whip's skip-reason reporting.

### The shared root cause

Every host-side caller that talks to an environment's MCP edge resolves the
tenant/environment it needs locally (to pick which edge to call), but never
restated that target in the tool call's own arguments — relying entirely on
the remote server defaulting to its own bound context:

- `erun-cli`'s `callEnvironmentTool` (the shared choke point behind every
  `exec job *`, `idle`, and `activity_lease *` off-environment verb) —
  the audit line showed the flags were parsed correctly (`mcp: frs/build edge
  resolved to ...`), but the payload sent to the tool carried none of it.
- `erun-cli`'s `whip` command (`whipOneEnvironment`).
- The desktop's `whipEnvironmentViaMCP` (`erun-ui/whip_mcp.go`) — the original
  #1709 report, `Arguments: map[string]any{"preview": false}`, no tenant, no
  environment, even though the caller had just used both to resolve the MCP
  endpoint.

The server-side half of this contract (`resolveLocalTarget`,
`erun-mcp/runtime.go`) was already fixed in earlier PRs (#1202, #1493, #1507)
to refuse a foreign target with a named, actionable message instead of the
bare `tenant and environment are required`. What was still missing was the
client-side plumbing that actually supplies a target in the first place — so
a server with no bound context of its own (or, worse, a stale edge bound to a
*different* environment) had no way to tell a caller apart from one that
simply forgot.

Fixed once, at the three call sites above: they now put the tenant/environment
they already resolved into the outgoing `arguments`. This is also the
stronger assertion the tools' own `resolveLocalTarget` documentation already
asks callers to make — a stale edge pointed at the wrong environment now
surfaces as a named mismatch instead of a silent act on the wrong one.

### The second, related defect: whip's skip-reason misuse

Both whip callers (erun-cli and the desktop) folded a genuine call failure
(network error, target refusal, malformed response) into
`WhipReasonNotAlive` — producing exactly the reported contradiction:

```
frs/build   Skipped   not alive — no live session to push: whip: tenant and environment are required
```

The whip tool itself already reports a dead session as a **successful**
result carrying `WhipReasonNotAlive`; an error at the call site can therefore
only mean the call itself didn't work, never "no live session." A new
`eruncommon.WhipReasonCallFailed` distinguishes the two, and both the CLI's
`whipResultValue` and the desktop's `whipResultToUI` now report it as a
failure, not a benign skip.

### Not fixed by defaulting

`resolveLocalTarget` still refuses when neither side names a target — this PR
only supplies the target a caller already resolved, never substitutes the
server's own context for one the caller left unset.

## Test plan

- [x] `erun-integration/environment_half_scenarios_test.go`: new
      `assertToolArgumentsNameTarget` helper + assertions on `job start`
      (`exec_raw` wait:false), `job status`, `job output` proving the CLI now
      forwards tenant/environment on the wire (red-then-green verified by
      temporarily reverting `callEnvironmentTool`).
- [x] `erun-integration/whip_test.go`: new `real_run_forwards_the_resolved_target`
      scenario against a fake MCP edge, proving `erun whip` now forwards the
      target too (red-then-green verified against `whip.go`).
- [x] `erun-integration/environment_half_scenarios_test.go`:
      `status_reports_the_tool_and_the_remedy_when_the_target_is_unresolved`
      proves a genuinely unresolved target still errors, and the message names
      the refusing tool (`exec_job_status`) and the remedy (`pass tenant and
      environment explicitly`) rather than regressing to the bare
      `tenant and environment are required` dead end.
- [x] `erun-ui/whip_test.go`: `TestWhipOneEnvironmentNowForwardsTheResolvedTarget`
      (desktop forwards tenant/environment), and
      `TestWhipOneEnvironmentNowSurfacesACallFailureAsFailedNotNotAlive` /
      `TestWhipResultToUIRendersACallFailureAsFailed` (a call failure renders
      as failed, never not-alive).
- [x] Existing goldens updated for the new trace/argument shape (`idle`,
      `job start`, `whip` dry-run scenarios) — reviewed by hand, each diff adds
      the forwarded `tenant`/`environment` and, for whip, reclassifies a
      previously-mislabeled "not alive" case (missing desktop identity — a
      real call failure) as `call-failed`.
- [x] Full `make check` green: golangci-lint clean across all Go modules, all
      Go/JS suites green, `erun-integration` coverage 75.6% (>= 75.6%
      threshold, unchanged).

## UX Impact Review (erun-ui/AGENTS.md checklist)

1. **Affected paths**: titlebar Whip control → `WhipNow` → the `whip` MCP call.
2. **User-visible sequence**: unchanged — the whip report renders the same way
   it always has; only the classification of one failure mode changes (a call
   failure now renders under the existing "failed" outcome instead of
   "skipped").
3. No new state-without-affordance: no new fields, just a corrected
   classification of an existing one.
4/5. Visibility of system status improves: an operator who previously read
   "not alive — no live session to push: ...tenant and environment are
   required" (a call to start the session that would never fix anything) now
   sees "failed: ..." naming an actual call problem.
6. Consistency: reuses the existing "failed" outcome/rendering already used
   for a decided-but-refused push — no new UI vocabulary.
7. Nielsen heuristics: match between system and real world (#2) is the one
   this change fixes — the report previously named a condition ("not alive")
   that wasn't true.
8. Playwright: the existing `titlebar-whip-action.spec.ts` mocks `WhipNow`'s
   response directly and already exercises rendering of arbitrary
   outcome/reason/error combinations (including `outcome: 'failed'`), so the
   frontend rendering path needs no new coverage — this PR only changes which
   internal Go condition maps to that already-tested `failed` outcome. Covered
   by the new Go unit tests above instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)