### PR TITLE
Always resume the orchestrator's derived conversation, demote tracked to an attach

### DIFF
--- a/erun-ui/app_restart.go
+++ b/erun-ui/app_restart.go
@@ -71,14 +71,13 @@ type orchestratorRestoreState struct {
 }
 
 // orchestratorNoticeKind classifies how loudly an operator-facing notice about
-// a reopened orchestrator should read. Only two kinds are ever minted here:
-// resuming the tracked conversation is the mechanism working (info); every
-// other resolution this file reports — an unconfirmed record, a claimed
-// conversation, a refused hand-off, a changed scope, a hand-off left
-// mid-task — means something the operator asked for, or something a session
-// recorded, could not be honoured (warning). Mirrors
-// orchestratorConversationNoticeKind's rule for the notices that originate
-// there.
+// a reopened orchestrator should read. Only "warning" is minted today — an
+// unhonourable attachment, a refused hand-off, a changed scope, a hand-off left
+// mid-task — because every one of them means something the operator asked for,
+// or something a session recorded, could not be honoured. "info" is kept as a
+// distinct kind (see Sidebar.OrchestratorNotice.tsx's role="status" rendering)
+// for a future routine notice; ordinary resumption of the derived anchor has
+// nothing to report at all (erun#1696).
 type orchestratorNoticeKind string
 
 const (
@@ -342,24 +341,21 @@ func (a *App) ResolveOrchestratorToReopen() relaunchTarget {
 
 // resolveReopenSessionID decides which conversation a reopened orchestrator
 // resumes, and what has to be said about it: the conversation the operator
-// attached, else the one this orchestrator's own session last reported under the
-// launch the durable entry records, else the anchor derived from its id. See
-// orchestrator_live_conversation.go for why the tracked answer needs the launch
-// to vouch for it and why an unconfirmed one falls back loudly instead of
-// quietly. A transient orchestrator has no id to derive from and gets a fresh
-// conversation.
+// attached, else the anchor derived from its id — never the one this
+// orchestrator's own session last reported, which stays available only in the
+// Manage dialog (see orchestrator_live_conversation.go, erun#1696). A transient
+// orchestrator has no id to derive from and gets a fresh conversation.
 func (a *App) resolveReopenSessionID(entry orchestratorOpenEntry) (string, orchestratorNotice) {
 	if strings.TrimSpace(entry.OrchestratorID) == "" {
 		return uuid.NewString(), orchestratorNotice{}
 	}
 	choice := a.resolveOrchestratorConversation(entry)
-	a.markConversationChoiceReported(entry.OrchestratorID, choice)
 	if choice.Notice == "" {
 		return choice.ConversationID, orchestratorNotice{}
 	}
 	return choice.ConversationID, orchestratorNotice{
 		OrchestratorID: entry.OrchestratorID,
-		Kind:           orchestratorNoticeKind(orchestratorConversationNoticeKind(choice.Source)),
+		Kind:           orchestratorNoticeWarning,
 		Text:           choice.Notice,
 	}
 }

--- a/erun-ui/app_restart_test.go
+++ b/erun-ui/app_restart_test.go
@@ -446,10 +446,12 @@ func assertAllNoticesAreWarnings(t *testing.T, notices []orchestratorNotice) {
 }
 
 // The heart of the bug this fixes: several orchestrators resolving on the same
-// restore must each carry their own kind. A genuine warning sitting among
-// routine successes must stay distinguishable from them rather than being
-// flattened into one string that reads uniformly as either.
-func TestMixedRestoreCarriesDistinctKindsPerOrchestrator(t *testing.T) {
+// restore must each carry their own notice, attributed to the right one rather
+// than flattened into one string. Both causes here are warnings -- a launch
+// resumes the derived anchor with nothing to report unless something the
+// operator asked for could not be honoured (erun#1696), so a mixed restore's
+// two notices are two warnings, not a routine one beside a genuine one.
+func TestMixedRestoreAttributesEachWarningToItsOwnOrchestrator(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
 
@@ -460,48 +462,34 @@ func TestMixedRestoreCarriesDistinctKindsPerOrchestrator(t *testing.T) {
 	}
 
 	current := createAndStartNamedOrchestrator(t, app, "other", "laptop")
-	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	const gone = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
 	stageOrchestratorConversation(t, orchestratorSessionID(current))
-	stageOrchestratorConversation(t, live)
-	writeLiveConversationRecord(t, current, orchestratorLiveConversation{
-		ConversationID: live,
-		LaunchID:       recordedLaunchID(t, openPath, current),
-	})
+	if err := setAttachedOrchestratorConversation(openPath, current, gone); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
 
 	target := app.ResolveOrchestratorToReopen()
 	if target.OrchestratorID != current {
 		t.Fatalf("expected %q (started last) to own the pane, got %q", current, target.OrchestratorID)
 	}
-	assertExactlyOneInfoAndOneWarning(t, target.Notices, current, stale)
+	assertTwoWarningsEachAttributed(t, target.Notices, current, stale)
 }
 
-// assertExactlyOneInfoAndOneWarning fails unless notices carries exactly one
-// info notice (belonging to wantInfoID) and one warning notice (belonging to
-// wantWarningID) — the shape a mixed restore must produce, with each kind kept
-// distinct and attributed to the right orchestrator rather than merged.
-func assertExactlyOneInfoAndOneWarning(t *testing.T, notices []orchestratorNotice, wantInfoID, wantWarningID string) {
+// assertTwoWarningsEachAttributed fails unless notices carries exactly two
+// warning notices, one attributed to each of the given orchestrators, kept
+// distinct rather than merged into one.
+func assertTwoWarningsEachAttributed(t *testing.T, notices []orchestratorNotice, first, second string) {
 	t.Helper()
-	var infoCount, warningCount int
+	seen := map[string]bool{}
 	for _, notice := range notices {
-		if notice.Kind == orchestratorNoticeInfo {
-			infoCount++
-			if notice.OrchestratorID != wantInfoID {
-				t.Fatalf("expected the info notice to belong to %q, got %+v", wantInfoID, notice)
-			}
-			continue
+		if notice.Kind != orchestratorNoticeWarning {
+			t.Fatalf("expected every notice here to be a warning, got %+v", notice)
 		}
-		if notice.Kind == orchestratorNoticeWarning {
-			warningCount++
-			if notice.OrchestratorID != wantWarningID {
-				t.Fatalf("expected the warning notice to belong to %q, got %+v", wantWarningID, notice)
-			}
-			continue
-		}
-		t.Fatalf("unexpected notice kind %+v", notice)
+		seen[notice.OrchestratorID] = true
 	}
-	if infoCount != 1 || warningCount != 1 {
-		t.Fatalf("expected exactly one info notice (%s's resumed tracked conversation) and one warning "+
-			"notice (%s's changed scope), got %+v", wantInfoID, wantWarningID, notices)
+	if len(notices) != 2 || !seen[first] || !seen[second] {
+		t.Fatalf("expected one warning for %q (unhonourable attachment) and one for %q (changed scope), got %+v",
+			first, second, notices)
 	}
 }
 

--- a/erun-ui/frontend/src/app/orchestratorRestore.ts
+++ b/erun-ui/frontend/src/app/orchestratorRestore.ts
@@ -12,8 +12,10 @@ export interface OrchestratorReopenRef {
 }
 
 // OrchestratorNoticeKind mirrors the Go side's orchestratorNoticeKind: 'info'
-// is the mechanism working (a resumed tracked conversation), 'warning' is
-// every other resolution this restore reports. 'unknown' is a frontend-only
+// is reserved for a routine notice (none is minted today — a launch resumes
+// the derived anchor with nothing to report unless an explicit attachment
+// failed, erun#1696), 'warning' is every resolution this restore actually
+// reports. 'unknown' is a frontend-only
 // value for a notice whose kind this launch could not classify — a raw
 // payload missing the field, or naming something other than the two kinds the
 // backend ever mints. It exists so that case renders as its own visibly

--- a/erun-ui/frontend/src/components/app/OrchestratorDialog.Conversations.helpers.test.ts
+++ b/erun-ui/frontend/src/components/app/OrchestratorDialog.Conversations.helpers.test.ts
@@ -31,8 +31,10 @@ test('each role reads as its own situation, and stranded reads as a warning', ()
 
 test('the summary says which conversation is being resumed and why', () => {
   assert.match(resumingSummary('attached'), /attached/);
-  assert.match(resumingSummary('tracked'), /last live on/);
   assert.match(resumingSummary('derived'), /name resolves to/);
+  // A tracked conversation is never adopted on its own (erun#1696); any source
+  // other than an explicit attachment reads as the derived anchor.
+  assert.match(resumingSummary('tracked'), /name resolves to/);
 });
 
 // Size is one of the two facts that separate a conversation holding hours of

--- a/erun-ui/frontend/src/components/app/OrchestratorDialog.Conversations.helpers.ts
+++ b/erun-ui/frontend/src/components/app/OrchestratorDialog.Conversations.helpers.ts
@@ -38,13 +38,13 @@ export function roleLabel(role: string): ConversationRoleLabel {
 }
 
 // resumingSummary says, in one line, which conversation a launch resumes now and
-// why — the question the whole surface exists to answer.
+// why — the question the whole surface exists to answer. Only two sources ever
+// arrive here: an explicit attachment, or the derived anchor a launch resumes
+// by default (erun#1696) — a tracked conversation is never adopted on its own.
 export function resumingSummary(source: string): string {
   switch (source) {
     case 'attached':
       return 'Resuming the conversation you attached.';
-    case 'tracked':
-      return 'Resuming the conversation this orchestrator’s session was last live on.';
     default:
       return 'Resuming the conversation this orchestrator’s name resolves to.';
   }

--- a/erun-ui/frontend/src/components/app/OrchestratorDialog.Conversations.tsx
+++ b/erun-ui/frontend/src/components/app/OrchestratorDialog.Conversations.tsx
@@ -57,12 +57,11 @@ function useOrchestratorConversations(orchestratorId: string): {
 }
 
 // OrchestratorConversationsSection is how a wrong resume is corrected without
-// leaving the app. An orchestrator normally resumes the conversation its own
-// session was last live on, and when that cannot be confirmed it falls back to
-// the one its name resolves to — which is the case where the work sits in a
-// conversation nothing is attached to. This lists every conversation the
-// orchestrator could be pointed at, says which one it is on and why, and
-// attaches another.
+// leaving the app. An orchestrator resumes the conversation derived from its
+// id every launch, unless the operator explicitly attached something else — a
+// session that moved on (a `/clear`, a compaction) is never adopted on its own
+// say-so. This lists every conversation the orchestrator could be pointed at
+// instead, says which one it is on and why, and attaches another.
 //
 // Conversations belonging to other orchestrators are not offered: handing one
 // orchestrator another's history is the failure this whole area exists to

--- a/erun-ui/orchestrator.go
+++ b/erun-ui/orchestrator.go
@@ -1702,18 +1702,18 @@ func (a *App) wireOrchestratorMCP(id, name string, envs []eruncommon.Orchestrato
 // conversationToLaunch answers which conversation a spawn attaches to. A named
 // one (a restart hand-off, an operator attaching one deliberately) is taken as
 // given: it names the conversation that asked for this launch. Otherwise the
-// launch resolves what this orchestrator is on -- attached, tracked, or the
-// derived anchor -- and reports anything surprising about that answer, since a
-// resume that lands somewhere unexpected in silence is the whole defect.
+// launch resolves what this orchestrator is on -- attached, or the derived
+// anchor -- and reports anything surprising about that answer: today, only an
+// attachment that could not be honoured, since a resume that lands somewhere
+// unexpected in silence is the whole defect.
 func (a *App) conversationToLaunch(id, named string) string {
 	if conversationID := strings.TrimSpace(named); conversationID != "" {
 		return conversationID
 	}
 	choice := a.resolveOrchestratorConversation(orchestratorEntryOrEmpty(
 		readOpenOrchestrators(a.deps.orchestratorOpenPath), id))
-	a.markConversationChoiceReported(id, choice)
 	if choice.Notice != "" {
-		a.emitAppNotification(orchestratorConversationNoticeKind(choice.Source), choice.Notice)
+		a.emitAppNotification("warning", choice.Notice)
 	}
 	return choice.ConversationID
 }

--- a/erun-ui/orchestrator_conversations.go
+++ b/erun-ui/orchestrator_conversations.go
@@ -50,7 +50,10 @@ const (
 	// orchestratorConversationRoleAttached is the one the operator attached.
 	orchestratorConversationRoleAttached = "attached"
 	// orchestratorConversationRoleLive is the one this orchestrator's own session
-	// reported being on, under the launch that recorded it.
+	// reported being on, under the launch that recorded it. A launch never
+	// resumes this automatically (erun#1696) -- it is offered here for the
+	// operator to attach deliberately, most often after a `/clear` or a
+	// compaction started the session writing somewhere other than the anchor.
 	orchestratorConversationRoleLive = "live"
 	// orchestratorConversationRoleStranded is one recorded as live by a launch
 	// that cannot be confirmed. It is the case that needs a decision: the work
@@ -120,7 +123,7 @@ func (a *App) ListOrchestratorConversations(id string) (orchestratorConversation
 		TranscriptsRoot: orchestratorTranscriptsRoot(),
 	}
 	claims := a.otherOrchestratorConversationClaims(id)
-	roles := a.orchestratorConversationRoles(id, entry, choice)
+	roles := a.orchestratorConversationRoles(id, entry, claims)
 	files, err := orchestratorTranscriptFiles()
 	if err != nil {
 		return out, err
@@ -157,15 +160,22 @@ func (a *App) ListOrchestratorConversations(id string) (orchestratorConversation
 }
 
 // orchestratorConversationRoles maps the conversations this orchestrator has a
-// relationship with to what that relationship is.
-func (a *App) orchestratorConversationRoles(id string, entry orchestratorOpenEntry, choice orchestratorConversationChoice) map[string]string {
-	roles := map[string]string{orchestratorSessionID(id): orchestratorConversationRoleDerived}
-	if record, ok := readOrchestratorLiveConversation(id); ok {
-		// The same record reads as live or as stranded depending on whether the
-		// resolution could stand behind it, which is exactly the distinction an
-		// operator staring at two transcripts needs drawn for them.
+// relationship with to what that relationship is. A launch never adopts the
+// tracked conversation automatically any more (erun#1696), so a record's role
+// here is judged on its own confirmation -- the launch nonce, ownership, and
+// transcript checks orchestratorTrackedUnconfirmedReason runs -- never on
+// whether a launch happened to resume it.
+func (a *App) orchestratorConversationRoles(id string, entry orchestratorOpenEntry, claims map[string]string) map[string]string {
+	derived := orchestratorSessionID(id)
+	roles := map[string]string{derived: orchestratorConversationRoleDerived}
+	if record, ok := readOrchestratorLiveConversation(id); ok && record.ConversationID != derived {
+		// The same record reads as live or as stranded depending on whether it is
+		// confirmed, which is exactly the distinction an operator staring at two
+		// transcripts needs drawn for them: one is real, current work the anchor
+		// no longer surfaces on its own; the other is a record nothing can vouch
+		// for any more.
 		role := orchestratorConversationRoleStranded
-		if choice.Source == orchestratorConversationTracked && choice.ConversationID == record.ConversationID {
+		if orchestratorTrackedUnconfirmedReason(record, entry, claims) == "" {
 			role = orchestratorConversationRoleLive
 		}
 		roles[record.ConversationID] = role
@@ -222,8 +232,7 @@ func (a *App) AttachOrchestratorConversation(id, conversationID string, cols, ro
 }
 
 // DetachOrchestratorConversation drops an explicit attachment and restarts the
-// orchestrator on whatever it would resolve to on its own -- what it is tracked
-// as live on, or the derived anchor. An attachment the operator could set and
+// orchestrator on the derived anchor. An attachment the operator could set and
 // not clear would be a trap rather than a correction.
 func (a *App) DetachOrchestratorConversation(id string, cols, rows int) (orchestratorInfo, error) {
 	id = strings.TrimSpace(id)

--- a/erun-ui/orchestrator_conversations_test.go
+++ b/erun-ui/orchestrator_conversations_test.go
@@ -68,7 +68,10 @@ func listedConversationIDs(listing orchestratorConversations) map[string]struct{
 
 // The operator's question is "which of these is the work?", so a row has to
 // carry what answers it: when it was last written, how big it is, where it was
-// started, how it opens, and what relationship this orchestrator has to it.
+// started, how it opens, and what relationship this orchestrator has to it. A
+// launch never adopts the live one automatically (erun#1696) -- the derived
+// row is what it resumes, and the live row is offered confirmed for the
+// operator to attach.
 func TestConversationListingSaysWhichIsLiveAndWhatEachOneIs(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
@@ -88,27 +91,28 @@ func TestConversationListingSaysWhichIsLiveAndWhatEachOneIs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListOrchestratorConversations failed: %v", err)
 	}
-	if listing.Resuming != live || listing.ResumingSource != string(orchestratorConversationTracked) {
-		t.Fatalf("expected the listing to report the live conversation as what it resumes, got %+v", listing)
+	if listing.Resuming != derived || listing.ResumingSource != string(orchestratorConversationDerived) {
+		t.Fatalf("expected the listing to report the derived anchor as what it resumes, got %+v", listing)
 	}
 	// Newest first, because the operator scans for the one that was written last.
 	if listing.Conversations[0].ConversationID != live {
 		t.Fatalf("expected the most recently written conversation first, got %+v", listing.Conversations)
 	}
 	assertLiveRowDescribesTheWork(t, conversationRow(t, listing, live), now.Add(-14*time.Second))
-	if row := conversationRow(t, listing, derived); row.Role != orchestratorConversationRoleDerived || row.Resuming {
-		t.Fatalf("expected the derived row marked derived and not resuming, got %+v", row)
+	if row := conversationRow(t, listing, derived); row.Role != orchestratorConversationRoleDerived || !row.Resuming {
+		t.Fatalf("expected the derived row marked derived and resuming, got %+v", row)
 	}
 }
 
 // assertLiveRowDescribesTheWork checks the row for the tracked conversation
-// carries everything the choice is made on: that it is the live one, that it is
-// what a launch would resume, and the when/how-big/where/how-it-opens the
-// operator recognises it by.
+// carries everything the operator needs to recognise and attach it: that it is
+// confirmed live (not merely stranded), that a launch does NOT resume it on
+// its own (erun#1696), and the when/how-big/where/how-it-opens it is
+// recognised by.
 func assertLiveRowDescribesTheWork(t *testing.T, row orchestratorConversation, written time.Time) {
 	t.Helper()
-	if row.Role != orchestratorConversationRoleLive || !row.Resuming {
-		t.Fatalf("expected the live row marked live and resuming, got %+v", row)
+	if row.Role != orchestratorConversationRoleLive || row.Resuming {
+		t.Fatalf("expected the live row marked live and not resuming, got %+v", row)
 	}
 	if row.LastWrittenUnix != written.Unix() || row.SizeBytes == 0 {
 		t.Fatalf("expected last-written and size on the row, got %+v", row)

--- a/erun-ui/orchestrator_live_conversation.go
+++ b/erun-ui/orchestrator_live_conversation.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,16 +12,24 @@ import (
 // conversation is this orchestrator on right now" are two questions, and only
 // the first one can be derived. uuid5(namespace, orchestratorID) answers the
 // first perfectly: it is the same on every launch and on every machine, so it
-// cannot go stale and nothing can point it elsewhere. It answers the second
-// only while every live conversation happens to be the derived one, and it is
-// not: the harness does not always adopt the id erun asks it to resume, so a
-// launch that asks for the derived id can end up writing to a different
-// conversation entirely. A restart then resumes the derived transcript, which
-// stopped growing at the fork, while the conversation holding the work is left
-// with no session attached.
+// cannot go stale and nothing can point it elsewhere. It does not answer the
+// second -- the harness does not always adopt the id erun asks it to resume,
+// and an operator's own `/clear` or a compaction starts a new conversation
+// under a new id -- but a launch resumes the derived answer anyway, every
+// time, unless the operator has explicitly attached something else.
 //
-// So the live id is recorded, by the only thing that knows it -- the session --
-// and the derivation stays as the anchor a first launch starts from.
+// That is a deliberate trade, not an oversight (erun#1696). The alternative --
+// silently adopting whatever conversation a previous session happened to drift
+// onto -- has its own failure: nothing ever moves a drifted record back, so one
+// `/clear` used to rebind an orchestrator to that conversation permanently,
+// with every later launch reporting the same "surprising" rebinding forever
+// rather than the one-time event it actually was. Resuming the anchor bounds
+// that drift to the lifetime of the session that caused it: the next launch
+// starts clean, and the conversation it left behind is never lost -- it stays
+// recorded (see readOrchestratorLiveConversation) and offered in the Manage
+// dialog's Conversation section for the operator to attach deliberately (see
+// orchestratorConversationRoles in orchestrator_conversations.go). What it no
+// longer does is override the anchor without being asked.
 //
 // A record like this was removed once, and for a good reason: its writer keyed
 // purely on $ERUN_ORCHESTRATOR_ID, so any session that ever ran under the wrong
@@ -34,17 +41,18 @@ import (
 //
 // Every launch mints a nonce, hands it to the session in the environment, and
 // writes it into the durable open-set entry itself. The session's own hooks echo
-// it back beside the session id they see. A record is authoritative only when
-// its nonce matches the nonce of the launch that entry recorded, which makes
-// three things true by construction:
+// it back beside the session id they see. A record only counts as CONFIRMED --
+// worth showing as this orchestrator's real, current live conversation rather
+// than one nothing can vouch for -- when its nonce matches the nonce of the
+// launch that entry recorded, which makes three things true by construction:
 //
 //   - A record from an earlier launch, or from a session that never saw this
 //     launch's nonce, cannot be mistaken for the current answer.
 //   - A record nobody writes any more decays on its own: the next launch mints a
-//     nonce no record carries, so the store stops being authoritative the moment
-//     its writer stops -- and says so instead of going quiet.
+//     nonce no record carries, so the store stops being confirmable the moment
+//     its writer stops -- and the Manage dialog says so instead of going quiet.
 //   - Neither half is authoritative alone. The desktop writes the nonce, the
-//     session writes the conversation, and a resume needs both to agree.
+//     session writes the conversation, and confirmation needs both to agree.
 
 // orchestratorLiveConversationDirName holds one file per orchestrator naming
 // the conversation that orchestrator's own session last reported being on.
@@ -72,9 +80,6 @@ type orchestratorConversationSource string
 const (
 	// orchestratorConversationAttached is a conversation the operator chose.
 	orchestratorConversationAttached orchestratorConversationSource = "attached"
-	// orchestratorConversationTracked is the one this orchestrator's session
-	// reported being live on under the launch that recorded it.
-	orchestratorConversationTracked orchestratorConversationSource = "tracked"
 	// orchestratorConversationDerived is the anchor: uuid5 of the orchestrator id.
 	orchestratorConversationDerived orchestratorConversationSource = "derived"
 )
@@ -82,8 +87,7 @@ const (
 // orchestratorConversationChoice is a resolved resume decision: which
 // conversation, why, and what the operator has to be told about it. Notice is
 // non-empty exactly when the answer is not the plain, unsurprising one -- the
-// tracked conversation and the derived one disagreed, or something that should
-// have decided the answer could not be confirmed.
+// operator's own explicit attachment could not be honoured.
 type orchestratorConversationChoice struct {
 	ConversationID string
 	Source         orchestratorConversationSource
@@ -153,30 +157,22 @@ func orchestratorLiveConversationForLaunch(id, launchID, fallback string) string
 	return record.ConversationID
 }
 
-// orchestratorConversationNoticeKind picks how loudly a resolution reports
-// itself. Resuming the tracked conversation is the mechanism working, so it is
-// information; anything else means a resolution the operator asked for, or one
-// a session recorded, could not be honoured, and that is a warning.
-func orchestratorConversationNoticeKind(source orchestratorConversationSource) string {
-	if source == orchestratorConversationTracked {
-		return "info"
-	}
-	return "warning"
-}
-
 // resolveOrchestratorConversation decides which conversation a launch of this
 // orchestrator resumes, and what to say about it.
 //
-// Order of authority: the conversation the operator explicitly attached, then
-// the one this orchestrator's session reported under the launch this entry
-// records, then the derived anchor. Each candidate ahead of the anchor has to
-// clear the same two checks -- its transcript is still on disk, and no other
-// orchestrator claims it -- because the cost of resuming the wrong conversation
-// is somebody else's history presented as this orchestrator's own.
+// Order of authority: the conversation the operator explicitly attached, else
+// the anchor derived from the orchestrator id (erun#1696). The attachment has
+// to clear two checks the anchor never needs -- its transcript is still on
+// disk, and no other orchestrator claims it -- because the cost of resuming
+// the wrong conversation is somebody else's history presented as this
+// orchestrator's own. A conversation this orchestrator's own session reported
+// being on (see readOrchestratorLiveConversation) is not consulted here at
+// all: it is offered in the Manage dialog for the operator to attach
+// deliberately (see orchestratorConversationRoles), never adopted on its own.
 //
-// A candidate that fails falls through to the anchor WITH a notice. Falling
-// through silently is what let a stale record hand an orchestrator ten hours of
-// amnesia while it looked perfectly healthy.
+// An attachment that fails falls through to the anchor WITH a notice: an
+// operator's explicit instruction that silently stopped applying is the
+// failure this guards against.
 func (a *App) resolveOrchestratorConversation(entry orchestratorOpenEntry) orchestratorConversationChoice {
 	id := strings.TrimSpace(entry.OrchestratorID)
 	if id == "" {
@@ -185,8 +181,8 @@ func (a *App) resolveOrchestratorConversation(entry orchestratorOpenEntry) orche
 		return orchestratorConversationChoice{Source: orchestratorConversationDerived}
 	}
 	derived := orchestratorSessionID(id)
-	claims := a.otherOrchestratorConversationClaims(id)
 	if attached := strings.TrimSpace(entry.AttachedConversationID); attached != "" {
+		claims := a.otherOrchestratorConversationClaims(id)
 		if reason := orchestratorConversationUnusableReason(attached, claims); reason != "" {
 			return orchestratorConversationChoice{
 				ConversationID: derived,
@@ -196,58 +192,18 @@ func (a *App) resolveOrchestratorConversation(entry orchestratorOpenEntry) orche
 		}
 		return orchestratorConversationChoice{ConversationID: attached, Source: orchestratorConversationAttached}
 	}
-	record, ok := readOrchestratorLiveConversation(id)
-	if !ok || record.ConversationID == derived {
-		// Nothing tracked (a first launch), or tracked and already the anchor:
-		// the ordinary case, and nothing to report.
-		return orchestratorConversationChoice{ConversationID: derived, Source: orchestratorConversationDerived}
-	}
-	if reason := orchestratorTrackedUnconfirmedReason(record, entry, claims); reason != "" {
-		return orchestratorConversationChoice{
-			ConversationID: derived,
-			Source:         orchestratorConversationDerived,
-			Notice:         orchestratorTrackedConversationUnconfirmedNotice(id, record.ConversationID, derived, reason),
-		}
-	}
-	// The tracked conversation is confirmed and stands: report it only while it
-	// is new information. Once this exact tracked id has already been told to
-	// the operator, resolving to it again on every later launch has nothing new
-	// to say -- repeating a healthy steady state on every launch is what trains
-	// the operator to stop reading this notice family at all. A tracked id that
-	// changes from what was last reported is new information again and is
-	// reported.
-	notice := ""
-	if strings.TrimSpace(entry.LastReportedConversationID) != record.ConversationID {
-		notice = orchestratorResumedTrackedConversationNotice(id, record.ConversationID, derived)
-	}
-	return orchestratorConversationChoice{
-		ConversationID: record.ConversationID,
-		Source:         orchestratorConversationTracked,
-		Notice:         notice,
-	}
-}
-
-// markConversationChoiceReported persists that the operator has now been told
-// about a tracked-conversation resolution, so a later launch that resolves to
-// the SAME tracked conversation finds nothing new to say. Only the "info"
-// resolution is ever recorded here -- see orchestratorConversationNoticeKind --
-// because the three warning resolutions must keep reporting on every
-// occurrence. A no-op when there was nothing to report.
-func (a *App) markConversationChoiceReported(id string, choice orchestratorConversationChoice) {
-	if choice.Notice == "" || choice.Source != orchestratorConversationTracked {
-		return
-	}
-	if err := markOrchestratorConversationReported(a.deps.orchestratorOpenPath, id, choice.ConversationID); err != nil {
-		log.Printf("erun-app: mark orchestrator %s conversation reported: %v", id, err)
-	}
+	return orchestratorConversationChoice{ConversationID: derived, Source: orchestratorConversationDerived}
 }
 
 // orchestratorTrackedUnconfirmedReason reports why a tracked record cannot be
-// treated as this orchestrator's live conversation, or "" when it can. The
-// launch check is the load-bearing one: without a nonce that matches the launch
-// the durable entry recorded, a record is either from a run that has since been
-// replaced or from a writer that no longer exists, and neither may decide what a
-// resume attaches to.
+// shown as this orchestrator's CONFIRMED live conversation in the Manage
+// dialog, or "" when it can (see orchestratorConversationRoles in
+// orchestrator_conversations.go, the only caller). The launch check is the
+// load-bearing one: without a nonce that matches the launch the durable entry
+// recorded, a record is either from a run that has since been replaced or from
+// a writer that no longer exists, and neither may be presented as confirmed --
+// though either can still be attached by hand, since attaching only requires
+// the conversation to exist and belong to nobody else.
 func orchestratorTrackedUnconfirmedReason(record orchestratorLiveConversation, entry orchestratorOpenEntry, claims map[string]string) string {
 	launch := strings.TrimSpace(entry.LaunchID)
 	switch {
@@ -317,29 +273,6 @@ func orchestratorClaimedConversations(id string, entries []orchestratorOpenEntry
 		out = append(out, record.ConversationID)
 	}
 	return out
-}
-
-// orchestratorResumedTrackedConversationNotice reports that this orchestrator
-// came back on the conversation it was really live on rather than the one its id
-// derives to. It is the good outcome and still worth saying: the two ids
-// disagree, and the operator is the only one who can tell whether the one that
-// won is the work they expect to see.
-func orchestratorResumedTrackedConversationNotice(id, tracked, derived string) string {
-	return fmt.Sprintf("Reopened %s on the conversation its session was last live on (%s), "+
-		"not the one derived from its id (%s). "+
-		"Manage the orchestrator to see every conversation it can resume and attach a different one.",
-		id, tracked, derived)
-}
-
-// orchestratorTrackedConversationUnconfirmedNotice reports that a conversation
-// was recorded as this orchestrator's live one and could not be confirmed, so
-// the launch fell back to the derived anchor. It names the unconfirmed id
-// because that id is the operator's way back to the work: the conversation list
-// can attach it deliberately.
-func orchestratorTrackedConversationUnconfirmedNotice(id, tracked, derived, reason string) string {
-	return fmt.Sprintf("Reopened %s on the conversation derived from its id (%s), not the one last recorded as live (%s): %s. "+
-		"If that conversation holds the work, manage the orchestrator and attach it.",
-		id, derived, tracked, reason)
 }
 
 // orchestratorAttachmentUnusableNotice reports that the conversation the

--- a/erun-ui/orchestrator_live_conversation_test.go
+++ b/erun-ui/orchestrator_live_conversation_test.go
@@ -60,25 +60,29 @@ func writeLiveConversationRecord(t *testing.T, orchestratorID string, record orc
 	}
 }
 
-// The measured failure. An orchestrator was spawned to resume its derived
-// conversation; the harness did not adopt that id and kept writing to one of its
-// own. Ten hours later the derived transcript was untouched and the other had
-// been written seconds ago — and a restart resumed the dead one, coming back
-// apparently healthy with none of the work in it.
-func TestRestoreResumesTheConversationTheSessionIsLiveOnNotTheStaleDerivedOne(t *testing.T) {
+// The measured trade-off (erun#1696): an orchestrator's session diverged onto a
+// conversation of its own -- the derived transcript stopped growing ten hours
+// ago and the other has been written seconds ago -- and a launch resumes the
+// derived anchor anyway, every time, with nothing said about it. The tracked
+// conversation is not lost: it stays recorded and is offered in the Manage
+// dialog (erun-ui/orchestrator_conversations_test.go) for the operator to
+// attach deliberately. What it no longer does is override the anchor on its
+// own say-so, because nothing then moves a drifted record back and a launch
+// used to keep resuming it forever.
+func TestRestoreAlwaysResumesTheDerivedAnchorEvenWhenATrackedConversationDiverged(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
 
 	id := createAndStartOrchestrator(t, app)
 	derived := orchestratorSessionID(id)
 	// A v4 id, as the harness mints: the derivation could never produce it, which
-	// is exactly why the derivation cannot answer what is live.
-	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	// is exactly why a session can drift onto one.
+	const diverged = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
 	now := time.Now()
 	stageOrchestratorConversationAt(t, derived, now.Add(-10*time.Hour))
-	stageOrchestratorConversationAt(t, live, now.Add(-14*time.Second))
+	stageOrchestratorConversationAt(t, diverged, now.Add(-14*time.Second))
 	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
-		ConversationID: live,
+		ConversationID: diverged,
 		LaunchID:       recordedLaunchID(t, openPath, id),
 		AtUnix:         now.Unix(),
 	})
@@ -87,26 +91,18 @@ func TestRestoreResumesTheConversationTheSessionIsLiveOnNotTheStaleDerivedOne(t 
 	if target.OrchestratorID != id {
 		t.Fatalf("expected %q reopened, got %q", id, target.OrchestratorID)
 	}
-	if target.ConversationID == derived {
-		t.Fatalf("resumed the stale derived conversation %q while %q held the work", derived, live)
+	if target.ConversationID != derived {
+		t.Fatalf("expected the derived anchor %q resumed regardless of the divergence, got %q", derived, target.ConversationID)
 	}
-	if target.ConversationID != live {
-		t.Fatalf("expected the live conversation %q resumed, got %q", live, target.ConversationID)
-	}
-	// The two ids disagreed, and only the operator can tell whether the one that
-	// won is the work they expect: coming back on a different conversation with
-	// nothing said is the same defect wearing the opposite sign.
-	for _, want := range []string{id, live, derived} {
-		if !strings.Contains(noticeText(target.Notices), want) {
-			t.Fatalf("expected the notice to name %q, got %q", want, noticeText(target.Notices))
-		}
+	if noticeText(target.Notices) != "" {
+		t.Fatalf("expected an ordinary launch to say nothing about a tracked conversation it never adopts, got %q", noticeText(target.Notices))
 	}
 }
 
-// The ordinary click has to land where a restart lands. It resolved the derived
-// id straight from the orchestrator id, so opening an orchestrator by hand
-// stranded the very conversation a restart would have recovered.
-func TestStartingAnOrchestratorResumesTheConversationItIsLiveOn(t *testing.T) {
+// The ordinary click has to land where a restart lands. Both go through
+// resolveOrchestratorConversation, so both now resume the derived anchor
+// regardless of what the orchestrator's session last reported.
+func TestStartingAnOrchestratorResumesTheDerivedAnchorNotADivergedConversation(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
 
@@ -117,25 +113,26 @@ func TestStartingAnOrchestratorResumesTheConversationItIsLiveOn(t *testing.T) {
 	}
 
 	id := createAndStartOrchestrator(t, app)
-	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
-	stageOrchestratorConversation(t, orchestratorSessionID(id))
-	stageOrchestratorConversation(t, live)
+	derived := orchestratorSessionID(id)
+	const diverged = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	stageOrchestratorConversation(t, derived)
+	stageOrchestratorConversation(t, diverged)
 	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
-		ConversationID: live,
+		ConversationID: diverged,
 		LaunchID:       recordedLaunchID(t, openPath, id),
 	})
 
 	if err := app.StopOrchestrator(id); err != nil {
 		t.Fatalf("StopOrchestrator failed: %v", err)
 	}
-	// Stopping forgets the entry, so the attach that follows is the operator
+	// Stopping forgets the entry, so the start that follows is the operator
 	// starting this orchestrator again from the sidebar.
-	writeLiveConversationRecordEntry(t, app, id, live)
+	writeLiveConversationRecordEntry(t, app, id, diverged)
 	if _, err := app.StartOrchestrator(id, 80, 24); err != nil {
 		t.Fatalf("StartOrchestrator failed: %v", err)
 	}
-	if got := launched[len(launched)-1]; got != live {
-		t.Fatalf("expected the ordinary start to resume the live conversation %q, got %q", live, got)
+	if got := launched[len(launched)-1]; got != derived {
+		t.Fatalf("expected the ordinary start to resume the derived anchor %q, got %q", derived, got)
 	}
 }
 
@@ -154,10 +151,12 @@ func writeLiveConversationRecordEntry(t *testing.T, app *App, orchestratorID, co
 	})
 }
 
-// A conversation belongs to one orchestrator. A record that names another
-// orchestrator's conversation is the failure that made the previous recorder
-// worse than having none: it handed over somebody else's history and then
-// confirmed the mistake on every later launch.
+// A conversation belongs to one orchestrator. A tracked record that names
+// another orchestrator's conversation is never even consulted by an ordinary
+// resolve any more, so it cannot hand it over -- the ownership check still
+// matters for the Manage dialog's listing and for an explicit attach
+// (erun-ui/orchestrator_conversations_test.go), never for automatic
+// resolution.
 func TestRestoreNeverResumesAnotherOrchestratorsConversation(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
@@ -182,8 +181,8 @@ func TestRestoreNeverResumesAnotherOrchestratorsConversation(t *testing.T) {
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected its own derived conversation, got %q", target.ConversationID)
 	}
-	if !strings.Contains(noticeText(target.Notices), other.ID) {
-		t.Fatalf("expected the notice to name the orchestrator that owns it, got %q", noticeText(target.Notices))
+	if noticeText(target.Notices) != "" {
+		t.Fatalf("expected an ordinary launch to say nothing, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -206,129 +205,14 @@ func TestAFirstLaunchWithNothingTrackedResumesTheDerivedConversation(t *testing.
 }
 
 // A record from a launch that has been replaced — or from a writer that no
-// longer exists at all, which is how a deleted recorder's files went on deciding
-// resumes for days — is not this orchestrator's live conversation. It falls back
-// to the anchor and NAMES the unconfirmed id, because that id is the operator's
-// way back to the work.
-func TestATrackedConversationFromAnotherLaunchIsNotSilentlyAuthoritative(t *testing.T) {
-	app, _, _ := openStateTestApp(t)
-	defer app.shutdown(context.Background())
-
-	id := createAndStartOrchestrator(t, app)
-	const stranded = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
-	stageOrchestratorConversation(t, orchestratorSessionID(id))
-	stageOrchestratorConversation(t, stranded)
-	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
-		ConversationID: stranded,
-		LaunchID:       "a-launch-that-is-not-this-one",
-	})
-
-	target := app.ResolveOrchestratorToReopen()
-	if target.ConversationID != orchestratorSessionID(id) {
-		t.Fatalf("expected the derived conversation, got %q", target.ConversationID)
-	}
-	if !strings.Contains(noticeText(target.Notices), stranded) {
-		t.Fatalf("expected the notice to name the unconfirmed conversation, got %q", noticeText(target.Notices))
-	}
-}
-
-// The habituation failure this whole notice family exists to avoid: a launch
-// that resumes the SAME tracked conversation it already told the operator about
-// has nothing new to say, and must say nothing. A notice that fires on every
-// launch forever trains the operator to stop reading it -- including the three
-// warning notices that share its surface and still need to be believed every
-// time they fire.
-func TestRestoreReportsARepeatedTrackedConversationOnlyOnce(t *testing.T) {
-	app, openPath, _ := openStateTestApp(t)
-	defer app.shutdown(context.Background())
-
-	id := createAndStartOrchestrator(t, app)
-	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
-	stageOrchestratorConversation(t, orchestratorSessionID(id))
-	stageOrchestratorConversation(t, live)
-	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
-		ConversationID: live,
-		LaunchID:       recordedLaunchID(t, openPath, id),
-	})
-
-	first := app.ResolveOrchestratorToReopen()
-	if first.ConversationID != live {
-		t.Fatalf("expected the first launch to resume the live conversation %q, got %q", live, first.ConversationID)
-	}
-	if noticeText(first.Notices) == "" {
-		t.Fatal("expected the first divergence between tracked and derived to be reported")
-	}
-	// The mechanism working correctly is information, not a fault: a resumed
-	// tracked conversation must never be reported at the same severity as a
-	// refusal or an unconfirmed record.
-	if len(first.Notices) != 1 || first.Notices[0].Kind != orchestratorNoticeInfo {
-		t.Fatalf("expected exactly one info-kind notice for the resumed tracked conversation, got %+v", first.Notices)
-	}
-
-	second := app.ResolveOrchestratorToReopen()
-	if second.ConversationID != live {
-		t.Fatalf("expected the second launch to resume the same live conversation %q, got %q", live, second.ConversationID)
-	}
-	if noticeText(second.Notices) != "" {
-		t.Fatalf("expected a launch that resumes the conversation already reported to say nothing, got %q", noticeText(second.Notices))
-	}
-
-	// The record still resolves the same tracked conversation; only the notice
-	// about it is quiet the second time.
-	third := app.ResolveOrchestratorToReopen()
-	if noticeText(third.Notices) != "" {
-		t.Fatalf("expected a third repeat launch to stay silent too, got %q", noticeText(third.Notices))
-	}
-}
-
-// A tracked conversation that changes AFTER already being reported is new
-// information again and must be reported, even though the orchestrator has
-// already been told about a previous divergence.
-func TestRestoreReportsAChangeToADifferentTrackedConversation(t *testing.T) {
-	app, openPath, _ := openStateTestApp(t)
-	defer app.shutdown(context.Background())
-
-	id := createAndStartOrchestrator(t, app)
-	const firstLive = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
-	const secondLive = "22222222-3333-4444-8555-666666666666"
-	stageOrchestratorConversation(t, orchestratorSessionID(id))
-	stageOrchestratorConversation(t, firstLive)
-	stageOrchestratorConversation(t, secondLive)
-	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
-		ConversationID: firstLive,
-		LaunchID:       recordedLaunchID(t, openPath, id),
-	})
-
-	if target := app.ResolveOrchestratorToReopen(); noticeText(target.Notices) == "" || target.ConversationID != firstLive {
-		t.Fatalf("expected the first divergence reported and resumed, got conversation %q notice %q", target.ConversationID, noticeText(target.Notices))
-	}
-	if target := app.ResolveOrchestratorToReopen(); noticeText(target.Notices) != "" {
-		t.Fatalf("expected the repeat of the same tracked conversation to say nothing, got %q", noticeText(target.Notices))
-	}
-
-	// A new launch under the SAME entry's launch id, whose session now reports a
-	// different conversation than the one already reported.
-	writeLiveConversationRecord(t, id, orchestratorLiveConversation{
-		ConversationID: secondLive,
-		LaunchID:       recordedLaunchID(t, openPath, id),
-	})
-	target := app.ResolveOrchestratorToReopen()
-	if target.ConversationID != secondLive {
-		t.Fatalf("expected the changed tracked conversation %q resumed, got %q", secondLive, target.ConversationID)
-	}
-	if noticeText(target.Notices) == "" {
-		t.Fatal("expected a change to a different tracked conversation to be reported")
-	}
-	if target := app.ResolveOrchestratorToReopen(); noticeText(target.Notices) != "" {
-		t.Fatalf("expected the repeat of the newly reported conversation to say nothing, got %q", noticeText(target.Notices))
-	}
-}
-
-// A warning resolution is not a steady state to acclimatise to; it is
-// something that just went wrong, and it must say so on every occurrence, not
-// only the first. A record from an earlier, replaced launch stays wrong on
-// every later launch too.
-func TestAnUnconfirmedTrackedConversationIsReportedOnEveryLaunch(t *testing.T) {
+// longer exists at all, which is how a deleted recorder's files went on
+// deciding resumes for days — is just as silently ignored by an ordinary
+// resolve as a confirmed one: neither is consulted for automatic resumption
+// any more (erun#1696). Its confirmation status still matters to the Manage
+// dialog's listing (erun-ui/orchestrator_conversations_test.go), which is
+// where an unconfirmed record is distinguished from a confirmed one, but an
+// ordinary launch resumes the anchor either way with nothing to say.
+func TestAnUnconfirmedTrackedConversationIsNeverConsultedByAnOrdinaryResolve(t *testing.T) {
 	app, _, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
 
@@ -344,15 +228,19 @@ func TestAnUnconfirmedTrackedConversationIsReportedOnEveryLaunch(t *testing.T) {
 	first := app.ResolveOrchestratorToReopen()
 	second := app.ResolveOrchestratorToReopen()
 	for _, target := range []relaunchTarget{first, second} {
-		if !strings.Contains(noticeText(target.Notices), stranded) {
-			t.Fatalf("expected every launch to report the unconfirmed conversation, got %q", noticeText(target.Notices))
+		if target.ConversationID != orchestratorSessionID(id) {
+			t.Fatalf("expected the derived conversation, got %q", target.ConversationID)
+		}
+		if noticeText(target.Notices) != "" {
+			t.Fatalf("expected every ordinary launch to say nothing, got %q", noticeText(target.Notices))
 		}
 	}
 }
 
-// The same refusal for a record whose conversation is gone: resuming nothing is
-// safer than resuming the wrong thing, and either way the operator hears it.
-func TestATrackedConversationWithNoTranscriptFallsBackAndSaysSo(t *testing.T) {
+// The same silence for a tracked record whose conversation is gone: an
+// ordinary resolve never looks at the tracked record at all, so it neither
+// resumes it nor reports on its absence.
+func TestATrackedConversationWithNoTranscriptIsAlsoIgnoredByAnOrdinaryResolve(t *testing.T) {
 	app, openPath, _ := openStateTestApp(t)
 	defer app.shutdown(context.Background())
 
@@ -367,8 +255,8 @@ func TestATrackedConversationWithNoTranscriptFallsBackAndSaysSo(t *testing.T) {
 	if target.ConversationID != orchestratorSessionID(id) {
 		t.Fatalf("expected the derived conversation, got %q", target.ConversationID)
 	}
-	if !strings.Contains(noticeText(target.Notices), "no longer on disk") {
-		t.Fatalf("expected the notice to say the transcript is gone, got %q", noticeText(target.Notices))
+	if noticeText(target.Notices) != "" {
+		t.Fatalf("expected an ordinary launch to say nothing, got %q", noticeText(target.Notices))
 	}
 }
 
@@ -415,10 +303,13 @@ func TestRestartHandoffNamesTheConversationTheSessionIsLiveOn(t *testing.T) {
 
 // The structural gate, and the reason this record is not the deleted one coming
 // back: the writer is exercised, not asserted about. The hook erun installs is
-// RUN, and what the resolver then resolves is what that run left behind. A
-// reader whose writer disappears fails here rather than in a month of quietly
-// resuming the wrong conversation.
-func TestTheLiveConversationRecorderWritesWhatTheResolverReads(t *testing.T) {
+// RUN, and what the Manage dialog's listing then shows confirmed is what that
+// run left behind. A reader whose writer disappears fails here rather than in
+// a month of a stranded conversation nobody could find. Reading through
+// ListOrchestratorConversations rather than ResolveOrchestratorToReopen is
+// itself the point of erun#1696: the tracked record is confirmable, but no
+// longer resumed automatically.
+func TestTheLiveConversationRecorderWritesWhatTheListingReadsConfirmed(t *testing.T) {
 	shell, err := exec.LookPath("sh")
 	if err != nil {
 		t.Skip("no POSIX shell on this host")
@@ -427,14 +318,15 @@ func TestTheLiveConversationRecorderWritesWhatTheResolverReads(t *testing.T) {
 	defer app.shutdown(context.Background())
 
 	id := createAndStartOrchestrator(t, app)
-	const live = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
-	stageOrchestratorConversation(t, orchestratorSessionID(id))
-	stageOrchestratorConversation(t, live)
+	derived := orchestratorSessionID(id)
+	const diverged = "0c01340d-65bd-4ed9-bb9e-91bdff59a6ec"
+	stageOrchestratorConversation(t, derived)
+	stageOrchestratorConversation(t, diverged)
 
 	// Exactly what a hook invocation carries on stdin, and exactly the two
 	// environment values the launch hands the session.
 	payload, err := json.Marshal(map[string]any{
-		"session_id":      live,
+		"session_id":      diverged,
 		"transcript_path": "/does/not/matter.jsonl",
 		"hook_event_name": "SessionStart",
 	})
@@ -450,8 +342,27 @@ func TestTheLiveConversationRecorderWritesWhatTheResolverReads(t *testing.T) {
 		t.Fatalf("run recorder hook: %v\n%s", runErr, out)
 	}
 
-	if target := app.ResolveOrchestratorToReopen(); target.ConversationID != live {
-		t.Fatalf("the recorder wrote %q but the resolver resumed %q", live, target.ConversationID)
+	listing, err := app.ListOrchestratorConversations(id)
+	if err != nil {
+		t.Fatalf("ListOrchestratorConversations failed: %v", err)
+	}
+	found := false
+	for _, row := range listing.Conversations {
+		if row.ConversationID != diverged {
+			continue
+		}
+		found = true
+		if row.Role != orchestratorConversationRoleLive {
+			t.Fatalf("the recorder wrote %q under a confirmed launch, expected it listed as confirmed, got %+v", diverged, row)
+		}
+	}
+	if !found {
+		t.Fatalf("the recorder wrote %q but the listing never surfaced it: %+v", diverged, listing.Conversations)
+	}
+
+	// Confirmable, but still not what an ordinary launch resumes.
+	if target := app.ResolveOrchestratorToReopen(); target.ConversationID != derived {
+		t.Fatalf("expected the derived anchor resumed regardless of the recorded conversation, got %q", target.ConversationID)
 	}
 }
 

--- a/erun-ui/orchestrator_open_state.go
+++ b/erun-ui/orchestrator_open_state.go
@@ -55,10 +55,9 @@ type orchestratorOpenEntry struct {
 	// all -- from deciding what a resume attaches to.
 	LaunchID string `json:"launchId,omitempty"`
 	// AttachedConversationID is the conversation the operator chose for this
-	// orchestrator, and it outranks both the tracked and the derived answer. An
-	// explicit choice that a later launch quietly recomputed away would be no
-	// choice at all, so it is durable and cleared only by asking for the
-	// default back.
+	// orchestrator, and it outranks the derived answer. An explicit choice that a
+	// later launch quietly recomputed away would be no choice at all, so it is
+	// durable and cleared only by asking for the default back.
 	AttachedConversationID string `json:"attachedConversationId,omitempty"`
 	// Environments is the scope (sorted tenant/environment pairs, see
 	// orchestratorScopeOf) the recorded session was actually wired to when this
@@ -69,16 +68,6 @@ type orchestratorOpenEntry struct {
 	// release wrote, which restore treats as unknown rather than a guaranteed
 	// match.
 	Environments []string `json:"environments,omitempty"`
-	// LastReportedConversationID is the tracked conversation id this
-	// orchestrator's operator was last told about (see
-	// orchestratorResumedTrackedConversationNotice). Resolving to the SAME
-	// tracked conversation again has nothing new to say and stays silent;
-	// resolving to a different one is new information and is reported, which is
-	// what stops the notice from repeating forever once a divergence has already
-	// been explained. It only tracks the "info" resolution -- a warning
-	// (unconfirmed record, refused attachment) reports on every occurrence by
-	// design and never updates this.
-	LastReportedConversationID string `json:"lastReportedConversationId,omitempty"`
 }
 
 type orchestratorOpenState struct {
@@ -124,7 +113,6 @@ func recordOpenOrchestrator(path, orchestratorID, launchID string, scope []strin
 	entries := readOpenOrchestrators(path)
 	existing := orchestratorEntryOrEmpty(entries, orchestratorID)
 	attached := strings.TrimSpace(existing.AttachedConversationID)
-	lastReported := strings.TrimSpace(existing.LastReportedConversationID)
 	out := make([]orchestratorOpenEntry, 0, len(entries)+1)
 	for _, entry := range entries {
 		if entry.OrchestratorID == orchestratorID {
@@ -133,11 +121,10 @@ func recordOpenOrchestrator(path, orchestratorID, launchID string, scope []strin
 		out = append(out, entry)
 	}
 	out = append(out, orchestratorOpenEntry{
-		OrchestratorID:             orchestratorID,
-		LaunchID:                   strings.TrimSpace(launchID),
-		AttachedConversationID:     attached,
-		Environments:               scope,
-		LastReportedConversationID: lastReported,
+		OrchestratorID:         orchestratorID,
+		LaunchID:               strings.TrimSpace(launchID),
+		AttachedConversationID: attached,
+		Environments:           scope,
 	})
 	return writeOpenOrchestrators(path, out)
 }
@@ -165,39 +152,6 @@ func setAttachedOrchestratorConversation(path, orchestratorID, conversationID st
 		entries = append(entries, orchestratorOpenEntry{
 			OrchestratorID:         orchestratorID,
 			AttachedConversationID: strings.TrimSpace(conversationID),
-		})
-	}
-	return writeOpenOrchestrators(path, entries)
-}
-
-// markOrchestratorConversationReported records the tracked conversation id an
-// orchestrator's operator was just told about, so a later launch that resolves
-// the SAME tracked conversation again finds nothing new to say. Called only for
-// the "info" resolution (see orchestratorConversationNoticeKind); a warning
-// resolution reports every occurrence and never calls this. Creates the entry
-// when none exists yet, mirroring setAttachedOrchestratorConversation.
-func markOrchestratorConversationReported(path, orchestratorID, conversationID string) error {
-	orchestratorID = strings.TrimSpace(orchestratorID)
-	if path == "" || orchestratorID == "" {
-		return nil
-	}
-	conversationID = strings.TrimSpace(conversationID)
-	entries := readOpenOrchestrators(path)
-	found := false
-	for i, entry := range entries {
-		if entry.OrchestratorID != orchestratorID {
-			continue
-		}
-		if entry.LastReportedConversationID == conversationID {
-			return nil
-		}
-		entries[i].LastReportedConversationID = conversationID
-		found = true
-	}
-	if !found {
-		entries = append(entries, orchestratorOpenEntry{
-			OrchestratorID:             orchestratorID,
-			LastReportedConversationID: conversationID,
 		})
 	}
 	return writeOpenOrchestrators(path, entries)
@@ -277,11 +231,10 @@ func dedupOrchestratorEntries(entries []orchestratorOpenEntry) []orchestratorOpe
 		}
 		seen[id] = struct{}{}
 		out = append(out, orchestratorOpenEntry{
-			OrchestratorID:             id,
-			LaunchID:                   strings.TrimSpace(entry.LaunchID),
-			AttachedConversationID:     strings.TrimSpace(entry.AttachedConversationID),
-			Environments:               entry.Environments,
-			LastReportedConversationID: strings.TrimSpace(entry.LastReportedConversationID),
+			OrchestratorID:         id,
+			LaunchID:               strings.TrimSpace(entry.LaunchID),
+			AttachedConversationID: strings.TrimSpace(entry.AttachedConversationID),
+			Environments:           entry.Environments,
 		})
 	}
 	if len(out) == 0 {

--- a/erun-ui/playwright/tests/orchestrator-conversation-attach.spec.ts
+++ b/erun-ui/playwright/tests/orchestrator-conversation-attach.spec.ts
@@ -100,6 +100,102 @@ test.describe('choosing which conversation an orchestrator resumes', () => {
     await app.page.keyboard.press('Escape');
   });
 
+  // erun#1696: a launch never adopts a diverged conversation on its own any
+  // more, so the only way back to it is this surface. What the headless
+  // harness cannot produce is a REAL confirmed "Live" row -- that needs a
+  // session that ran and reported itself through its hooks, which this
+  // harness deliberately has no real Claude to run (see the file comment
+  // above). The backend answer is stubbed so this spec can prove the row a
+  // real one would render: distinct from "nothing diverged", never marked as
+  // what the launch resumes, and reachable with one click. The Go side proves
+  // the record itself is written and confirmed correctly
+  // (erun-ui/orchestrator_live_conversation_test.go's
+  // TestTheLiveConversationRecorderWritesWhatTheListingReadsConfirmed) and
+  // that a launch never adopts it (erun-ui/orchestrator_conversations_test.go).
+  test('a conversation the session diverged onto is listed distinctly from the anchor, and attachable', async ({
+    app,
+    page,
+  }) => {
+    const derived = '11111111-2222-4333-8444-555555555555';
+    const diverged = '22222222-3333-4444-8555-666666666666';
+    const attached: unknown[] = [];
+    await page.route('**/__erun_invoke', async (route, request) => {
+      const body = JSON.parse(request.postData() ?? '{}') as { method: string; args?: unknown[] };
+      if (body.method === 'ListOrchestratorConversations') {
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              orchestratorId: SEED_ORCHESTRATOR,
+              resuming: derived,
+              resumingSource: 'derived',
+              conversations: [
+                {
+                  conversationId: diverged,
+                  folder: '/Users/pw/orchestrators',
+                  lastWrittenUnix: Math.floor(Date.now() / 1000),
+                  sizeBytes: 4096,
+                  excerpt: 'picking up after a /clear',
+                  role: 'live',
+                  resuming: false,
+                },
+                {
+                  conversationId: derived,
+                  folder: '',
+                  lastWrittenUnix: 0,
+                  sizeBytes: 0,
+                  role: 'derived',
+                  resuming: true,
+                },
+              ],
+              transcriptsRoot: '/tmp/does-not-matter',
+            },
+          }),
+        });
+      }
+      if (body.method === 'AttachOrchestratorConversation') {
+        attached.push(body.args);
+        return route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              id: SEED_ORCHESTRATOR,
+              name: SEED_ORCHESTRATOR,
+              environments: [],
+              tenants: [],
+              directories: [],
+              sessionId: 8888,
+              status: 'running',
+              transient: false,
+            },
+          }),
+        });
+      }
+      await route.continue();
+    });
+
+    await app.sidebar.openOrchestratorDialog(SEED_ORCHESTRATOR);
+    await app.orchestratorDialog.waitForOpen('Edit orchestrator');
+
+    // The anchor is what a launch resumes now...
+    const anchorRow = app.orchestratorDialog.conversationRow(derived);
+    await expect(anchorRow).toContainText('Resumes now');
+    await expect(anchorRow).toContainText('Default');
+
+    // ...and the diverged conversation is still right there, labelled as real
+    // confirmed work rather than folded into "nothing diverged" or hidden
+    // behind the anchor that now resumes instead of it.
+    const divergedRow = app.orchestratorDialog.conversationRow(diverged);
+    await expect(divergedRow).toBeVisible();
+    await expect(divergedRow).toContainText('Live');
+    await expect(divergedRow).not.toContainText('Resumes now');
+    await expect(divergedRow).toContainText('picking up after a /clear');
+
+    await app.orchestratorDialog.conversationAttachButton(diverged).click();
+    await app.orchestratorDialog.waitForClosed('Edit orchestrator');
+    expect(attached).toEqual([[SEED_ORCHESTRATOR, diverged, 80, 24]]);
+  });
+
   test('attaching a conversation restarts the orchestrator on it and closes the dialog', async ({
     app,
     page,


### PR DESCRIPTION
## Summary

`resolveOrchestratorConversation` now resolves **attached → anchor**, dropping the automatic **tracked** override (erun#1696). An orchestrator's session diverging onto a conversation of its own — a `/clear`, a compaction — no longer permanently rebinds the orchestrator to that conversation; the next launch resumes the derived anchor with nothing to report, and the diverged conversation stays available in the Manage dialog's Conversation section for the operator to attach deliberately.

- `resolveOrchestratorConversation` (`orchestrator_live_conversation.go`): attached → anchor only. An unhonourable attachment still falls back to the anchor with a warning notice.
- The routine "resumed the tracked conversation" info notice, and its repeat-suppression machinery (`LastReportedConversationID`, `markOrchestratorConversationReported`), are removed — there is no longer a mismatch to report on an ordinary launch. The #1695 notice machinery (per-kind rendering, `InlineAlert` for warnings) is untouched; the genuine warnings (unhonourable attachment, another orchestrator's claim) still fire and keep their alert treatment.
- The Manage dialog's Conversation section (`ListOrchestratorConversations`, already existed) now classifies a tracked record's role (`live` vs `stranded`) on its own launch-nonce confirmation rather than on whether a launch happened to adopt it — the same information, no longer inverted by the resolution outcome.
- `orchestratorLiveConversationForLaunch` and the `SessionStart`/turn-boundary hook that feeds it are unchanged: they still answer "what is the *currently running* session on" for restart hand-off, crash respawn, and the heartbeat, which is a different question from "what does the next launch resume."

## UX Impact Review Checklist

1. **Affected paths.** Ordinary orchestrator launch/restore (`ResolveOrchestratorToReopen`, `StartOrchestrator`), and the Manage dialog's Conversation section (`ListOrchestratorConversations`, `AttachOrchestratorConversation`).
2. **User-visible sequence.** An ordinary launch resumes the derived conversation silently (no notice) whether or not a tracked record diverged. Opening Manage on that orchestrator still lists the diverged conversation, labelled "Live" (confirmed) or "Stranded" (unconfirmed), attachable with one click — unchanged surface, corrected classification.
3. **State-without-affordance.** N/A — no new state introduced; `LastReportedConversationID` removed since its role/notice pairing is now dead.
4. **Visibility of system status.** The Manage dialog already surfaces the tracked conversation's status; this PR only removes a notice that had become permanently repetitive (see the issue's "the tracked record wins on every launch from then on" comment).
5. **Success/failure feedback.** Unaffected: explicit attachment still reports failure the same way.
6. **Consistency with comparable flows.** Matches the existing attached-conversation-gone notice treatment (warning, `InlineAlert`).
7. **Heuristic pass.** Visibility of system status: improved — the notice that fired on every launch forever (per the issue's own diagnosis) is gone, and the Manage dialog remains the one place to see and correct a divergence.
8. **Playwright coverage.** `erun-ui/playwright/tests/orchestrator-conversation-attach.spec.ts` — new spec proves a diverged conversation renders distinctly from the anchor and is attachable; existing `orchestrator-reopen-on-launch.spec.ts` specs (stubbed, kind-rendering) untouched and still green.

## Answers to the mandated report

- **Does the Manage dialog already surface a diverged conversation?** Yes — `ListOrchestratorConversations`/`OrchestratorConversationsSection` already existed and lists it. What was fixed: its role classification (`live`/`stranded`) was keyed off whether *the current resolution adopted it* (`choice.Source == tracked`), which can never be true any more; it now judges the record's own launch-nonce confirmation directly, so a confirmed diverged conversation still reads "Live" rather than falling into "Stranded".
- **First launch of a new orchestrator?** Unaffected — `orchestratorResumeAndFallback` (`--resume`/`--session-id`) and the "nothing tracked" early return in `resolveOrchestratorConversation` are untouched; no notice.
- **Does the `SessionStart` hook still earn its keep?** Yes. It is the sole writer of `readOrchestratorLiveConversation`, which now feeds two things: the Manage dialog's confirmed/unconfirmed classification, and (unchanged) `orchestratorLiveConversationForLaunch`, used by restart hand-off, crash respawn, and the session heartbeat to answer "what is the currently-running session on" — a different question from what a launch resumes.
- **"Nothing diverged" vs "diverged and waiting"?** Distinguished in the Manage dialog by role: no tracked record at all → only the `derived` row exists; a tracked record differing from the anchor → a second row, `live` or `stranded`, always present regardless of automatic resolution.
- **Gate totals (verbatim):**
  - `make check`: `golangci-lint` 0 issues (all modules); `go test erun-ui` `ok 20.881s`; `erun-integration` suite `ok 96.085s`, `coverage 75.6% (>= 75.6%)`.
  - `erun-ui/playwright/run.sh --build`: `458 passed (18.0m)`.

Closes #1696