### PR TITLE
Resolve CREATE_TENANT approval to an existing tenant instead of 500ing

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/errors.go
+++ b/erun-backend/erun-backend-api/internal/repository/errors.go
@@ -15,6 +15,12 @@ var (
 	ErrNotFound               = errors.New("not found")
 	ErrMissingSecurityContext = errors.New("missing security context")
 	ErrConflict               = errors.New("conflict")
+	// ErrTenantNameConflict signals tenants.name's own UNIQUE constraint
+	// specifically, distinguished from the tenant_issuers conflict TenantRepository.Create
+	// also guards against: a tenant this call did not create already holds the
+	// requested name, so a caller resolving one (e.g. ApproveCreateTenant) can
+	// look the existing tenant up instead of treating this as a generic 409.
+	ErrTenantNameConflict = errors.New("tenant name already exists")
 	// ErrLastGrantCapableRole guards against a tenant locking itself out of its
 	// own role management: revoking it would leave no user able to grant roles,
 	// and there would be no recovery lever left inside the product.

--- a/erun-backend/erun-backend-api/internal/repository/tenants.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants.go
@@ -53,7 +53,7 @@ func (r *TenantRepository) Create(ctx context.Context, params CreateTenantParams
 			Column("name", "type").
 			Returning("*").
 			Scan(ctx); err != nil {
-			return normalizeNoRows(err)
+			return classifyTenantCreateError(err)
 		}
 
 		// ON CONFLICT DO NOTHING lets a shared issuer already in the registry map
@@ -84,6 +84,22 @@ func (r *TenantRepository) Create(ctx context.Context, params CreateTenantParams
 		return model.Tenant{}, err
 	}
 	return tenant, nil
+}
+
+// classifyTenantCreateError maps a failure inserting the tenants row itself
+// to the sentinel a caller needs. name's own UNIQUE constraint
+// (tenants_name_key, the column's inline UNIQUE) means a tenant this call
+// did not create already holds the name — an expected, resolvable race
+// (erun#1722), not a fault, and named specifically so it is never confused
+// with the tenant_issuers conflict Create's caller checks separately, which
+// is a real "this issuer is already spoken for" refusal with no equivalent
+// resolution. Any other error (including a different unique/check violation)
+// passes through normalizeNoRows unclassified rather than being guessed at.
+func classifyTenantCreateError(err error) error {
+	if constraint, ok := pgConstraintName(err); ok && constraint == "tenants_name_key" {
+		return ErrTenantNameConflict
+	}
+	return normalizeNoRows(err)
 }
 
 // nullIfEmpty stores NULL — the single-tenant marker — for empty issuer columns;
@@ -174,6 +190,24 @@ func (r *TenantRepository) Current(ctx context.Context) (model.Tenant, error) {
 			  FROM tenants
 			 WHERE tenant_id = ?
 		`, securityContext.TenantID).Scan(ctx, &tenant)
+		return normalizeNoRows(err)
+	})
+	return tenant, err
+}
+
+// GetByName returns the tenant currently holding name, or ErrNotFound. Its
+// one caller is Create's ErrTenantNameConflict path: resolving the tenant a
+// name race lost to, not a general lookup, so unlike Current it applies no
+// tenant-scoping — the caller (an operations-only workflow) is allowed to
+// resolve any tenant by name.
+func (r *TenantRepository) GetByName(ctx context.Context, name string) (model.Tenant, error) {
+	var tenant model.Tenant
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewRaw(`
+			SELECT tenant_id, name, type, created_at, updated_at
+			  FROM tenants
+			 WHERE name = ?
+		`, strings.TrimSpace(name)).Scan(ctx, &tenant)
 		return normalizeNoRows(err)
 	})
 	return tenant, err

--- a/erun-backend/erun-backend-api/internal/repository/tenants_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants_e2e_test.go
@@ -3,10 +3,12 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -154,5 +156,41 @@ func TestReachableReturnsSingleTenantForSingleTenantCaller(t *testing.T) {
 	mustNoErr(t, err, "Reachable")
 	if len(reachable) != 1 || reachable[0].TenantID != tenantID {
 		t.Fatalf("expected exactly [%s], got %+v", tenantID, reachable)
+	}
+}
+
+// TestCreateReportsTenantNameConflictAndGetByNameResolvesIt is erun#1722's
+// reproduction: a tenant with the requested name was registered out-of-band
+// (a different issuer, standing in for "someone else got there first"), so
+// Create's own name-taken write must come back as the specific,
+// resolvable ErrTenantNameConflict rather than a generic 500, and GetByName
+// must resolve to the tenant that actually holds the name.
+func TestCreateReportsTenantNameConflictAndGetByNameResolvesIt(t *testing.T) {
+	db := tenantsDatabase(t)
+	repo := NewTenantRepository(NewTxManager(db, DialectPostgres))
+	ctx := security.WithContext(context.Background(), security.Context{TenantType: string(model.TenantTypeOperations)})
+
+	name := "name-conflict-e2e-" + time.Now().Format("20060102150405.000000")
+	first, err := repo.Create(ctx, CreateTenantParams{
+		Name:   name,
+		Type:   model.TenantTypeCompany,
+		Issuer: "https://idp.name-conflict-e2e.example/first",
+	})
+	mustNoErr(t, err, "register the first tenant to hold the name")
+	t.Cleanup(func() { clearReachableTenants(t, db, first.TenantID) })
+
+	_, err = repo.Create(ctx, CreateTenantParams{
+		Name:   name,
+		Type:   model.TenantTypeCompany,
+		Issuer: "https://idp.name-conflict-e2e.example/second",
+	})
+	if !errors.Is(err, ErrTenantNameConflict) {
+		t.Fatalf("second Create with the same name: err = %v, want ErrTenantNameConflict", err)
+	}
+
+	resolved, err := repo.GetByName(ctx, name)
+	mustNoErr(t, err, "GetByName")
+	if resolved.TenantID != first.TenantID {
+		t.Fatalf("GetByName returned tenant %s, want the first tenant %s that actually holds the name", resolved.TenantID, first.TenantID)
 	}
 }

--- a/erun-backend/erun-backend-api/internal/repository/tenants_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants_test.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// TestClassifyTenantCreateErrorMapsNameUniqueViolation locks the fix for
+// erun#1722: a tenant name that already exists must be distinguished from
+// every other insert failure, not surfaced as a generic 500.
+func TestClassifyTenantCreateErrorMapsNameUniqueViolation(t *testing.T) {
+	err := classifyTenantCreateError(&pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "tenants_name_key"})
+
+	if !errors.Is(err, ErrTenantNameConflict) {
+		t.Fatalf("err = %v, want ErrTenantNameConflict", err)
+	}
+}
+
+// TestClassifyTenantCreateErrorLeavesOtherViolationsAlone proves the mapping
+// is scoped to the name's own constraint: a unique violation on a different
+// constraint (or no constraint name at all) must not be misclassified as a
+// resolvable name race.
+func TestClassifyTenantCreateErrorLeavesOtherViolationsAlone(t *testing.T) {
+	err := classifyTenantCreateError(&pgconn.PgError{Code: pgerrcode.UniqueViolation, ConstraintName: "tenants_pkey"})
+
+	if errors.Is(err, ErrTenantNameConflict) {
+		t.Fatalf("err = %v, want anything but ErrTenantNameConflict for a different constraint", err)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/routes/audit_events.go
+++ b/erun-backend/erun-backend-api/internal/routes/audit_events.go
@@ -41,7 +41,7 @@ func (r AuditEventRoutes) listAuditEvents(w http.ResponseWriter, req *http.Reque
 	}
 	page, err := r.events.List(req.Context(), filter)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, auditEventsResponse{Events: page.Events, NextCursor: page.NextCursor})

--- a/erun-backend/erun-backend-api/internal/routes/builds.go
+++ b/erun-backend/erun-backend-api/internal/routes/builds.go
@@ -34,7 +34,7 @@ func RegisterBuildRoutes(register ProtectedRouteRegistrar, builds BuildRepositor
 func (r BuildRoutes) listBuilds(w http.ResponseWriter, req *http.Request) {
 	builds, err := r.builds.List(req.Context(), apirepository.BuildFilter{ReviewID: req.PathValue("review_id")})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, builds)
@@ -59,7 +59,7 @@ func (r BuildRoutes) createBuild(w http.ResponseWriter, req *http.Request) {
 	}
 	build, err := r.service.Create(req.Context(), build)
 	if err != nil {
-		writeBuildError(w, err)
+		writeBuildError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, build)
@@ -68,7 +68,7 @@ func (r BuildRoutes) createBuild(w http.ResponseWriter, req *http.Request) {
 // writeBuildError gives builds.md's documented business codes their exact
 // machine code; every other failure falls through to the generic
 // status-derived code.
-func writeBuildError(w http.ResponseWriter, err error) {
+func writeBuildError(w http.ResponseWriter, req *http.Request, err error) {
 	var invalidCommitID *service.InvalidCommitIDError
 	if errors.As(err, &invalidCommitID) {
 		writeErrorCode(w, http.StatusBadRequest, "INVALID_COMMIT_ID", invalidCommitID.Error())
@@ -84,13 +84,13 @@ func writeBuildError(w http.ResponseWriter, err error) {
 		writeErrorDetails(w, http.StatusBadRequest, "INVALID_BODY", missingFailureDetail.Error(), map[string]any{"field": "failureDetail"})
 		return
 	}
-	writeRepositoryError(w, err)
+	writeRepositoryError(w, req, err)
 }
 
 func (r BuildRoutes) getBuild(w http.ResponseWriter, req *http.Request) {
 	build, err := r.builds.Get(req.Context(), req.PathValue("build_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, build)

--- a/erun-backend/erun-backend-api/internal/routes/cloud_provider_aliases.go
+++ b/erun-backend/erun-backend-api/internal/routes/cloud_provider_aliases.go
@@ -54,7 +54,7 @@ func (r CloudProviderAliasRoutes) setAlias(w http.ResponseWriter, req *http.Requ
 		return
 	}
 	if err := r.aliases.Set(req.Context(), alias, provider, body.Credentials); err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/erun-backend/erun-backend-api/internal/routes/comments.go
+++ b/erun-backend/erun-backend-api/internal/routes/comments.go
@@ -39,7 +39,7 @@ type updateCommentStatusRequest struct {
 func (r CommentRoutes) listComments(w http.ResponseWriter, req *http.Request) {
 	comments, err := r.comments.List(req.Context(), apirepository.CommentFilter{ReviewID: req.PathValue("review_id")})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, comments)
@@ -54,12 +54,12 @@ func (r CommentRoutes) createComment(w http.ResponseWriter, req *http.Request) {
 	comment.ReviewID = req.PathValue("review_id")
 	comment, err := r.service.PrepareCreate(req.Context(), comment)
 	if err != nil {
-		writeCommentError(w, err)
+		writeCommentError(w, req, err)
 		return
 	}
 	comment, err = r.comments.Create(req.Context(), comment)
 	if err != nil {
-		writeCommentError(w, err)
+		writeCommentError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, comment)
@@ -73,7 +73,7 @@ func (r CommentRoutes) updateCommentStatus(w http.ResponseWriter, req *http.Requ
 	}
 	comment, err := r.service.UpdateStatus(req.Context(), req.PathValue("comment_id"), input.Status)
 	if err != nil {
-		writeCommentError(w, err)
+		writeCommentError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, comment)
@@ -82,7 +82,7 @@ func (r CommentRoutes) updateCommentStatus(w http.ResponseWriter, req *http.Requ
 // writeCommentError gives comments.md's documented business codes their
 // exact machine code; every other failure falls through to the generic
 // status-derived code.
-func writeCommentError(w http.ResponseWriter, err error) {
+func writeCommentError(w http.ResponseWriter, req *http.Request, err error) {
 	var invalidCommitID *service.InvalidCommitIDError
 	if errors.As(err, &invalidCommitID) {
 		writeErrorCode(w, http.StatusBadRequest, "INVALID_COMMIT_ID", invalidCommitID.Error())
@@ -97,5 +97,5 @@ func writeCommentError(w http.ResponseWriter, err error) {
 		writeErrorCode(w, http.StatusBadRequest, "INVALID_BODY", err.Error())
 		return
 	}
-	writeRepositoryError(w, err)
+	writeRepositoryError(w, req, err)
 }

--- a/erun-backend/erun-backend-api/internal/routes/config.go
+++ b/erun-backend/erun-backend-api/internal/routes/config.go
@@ -47,22 +47,22 @@ func (r ConfigRoutes) getConfig(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	tenant, err := r.tenants.Current(ctx)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	environments, err := r.environments.List(ctx)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	contexts, err := r.contexts.List(ctx)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	rateLimit, err := r.rateLimits.Get(ctx)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, configResponse{

--- a/erun-backend/erun-backend-api/internal/routes/contexts.go
+++ b/erun-backend/erun-backend-api/internal/routes/contexts.go
@@ -115,7 +115,7 @@ func RegisterContextRoutes(register ProtectedRouteRegistrar, contexts ContextRep
 func (r ContextRoutes) listContexts(w http.ResponseWriter, req *http.Request) {
 	contexts, err := r.contexts.List(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, contexts)
@@ -124,7 +124,7 @@ func (r ContextRoutes) listContexts(w http.ResponseWriter, req *http.Request) {
 func (r ContextRoutes) getContext(w http.ResponseWriter, req *http.Request) {
 	cloudContext, err := r.contexts.Get(req.Context(), req.PathValue("context_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, cloudContext)
@@ -162,7 +162,7 @@ func (r ContextRoutes) createContext(w http.ResponseWriter, req *http.Request) {
 		MaxEnvironments:    input.maxEnvironments,
 	})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (r ContextRoutes) createContext(w http.ResponseWriter, req *http.Request) {
 
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	if err := r.provisioner.Start(provision.ProvisionInput{
@@ -191,7 +191,7 @@ func (r ContextRoutes) createContext(w http.ResponseWriter, req *http.Request) {
 		DiskType:           input.diskType,
 		DiskSizeGB:         input.diskSizeGB,
 	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to start provisioning")
+		writeInternalError(w, req, "failed to start provisioning", err)
 		return
 	}
 	writeJSON(w, http.StatusAccepted, createContextResponse{Context: &created, Plan: plan})

--- a/erun-backend/erun-backend-api/internal/routes/dns01_token.go
+++ b/erun-backend/erun-backend-api/internal/routes/dns01_token.go
@@ -40,17 +40,17 @@ func (r DNS01TokenRoutes) mintDNS01Token(w http.ResponseWriter, req *http.Reques
 	// endpoint can only mint for the caller's own environment.
 	environment, err := r.environments.Get(ctx, req.PathValue("environment_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	tenant, err := r.tenants.Current(ctx)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	token, audience, err := r.signer.SignDNS01(tenant.Name, environment.Name, time.Now())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), err)
 		return
 	}
 	writeJSON(w, http.StatusOK, dns01TokenResponse{Token: token, Audience: audience})

--- a/erun-backend/erun-backend-api/internal/routes/environments.go
+++ b/erun-backend/erun-backend-api/internal/routes/environments.go
@@ -145,7 +145,7 @@ func (r EnvironmentRoutes) stopEnvironment(w http.ResponseWriter, req *http.Requ
 	ctx := req.Context()
 	environment, err := r.environments.Get(ctx, req.PathValue("environment_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	if environment.Type != model.EnvironmentTypeRuntime {
@@ -154,7 +154,7 @@ func (r EnvironmentRoutes) stopEnvironment(w http.ResponseWriter, req *http.Requ
 	}
 	input, err := r.lifecycleInput(ctx, environment)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to resolve environment placement")
+		writeInternalError(w, req, "failed to resolve environment placement", err)
 		return
 	}
 	input.StopID = uuid.NewString()
@@ -187,7 +187,7 @@ func (r EnvironmentRoutes) deleteEnvironment(w http.ResponseWriter, req *http.Re
 	ctx := req.Context()
 	environment, err := r.environments.Get(ctx, req.PathValue("environment_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	// Claiming before starting the workflow is what keeps a double-submit
@@ -196,7 +196,7 @@ func (r EnvironmentRoutes) deleteEnvironment(w http.ResponseWriter, req *http.Re
 	// to notice and wait it out by hand.
 	claimed, err := r.environments.ClaimDelete(ctx, environment.EnvironmentID, deleteClaimStaleAfter)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	if !claimed {
@@ -281,6 +281,7 @@ func deleteClaimRefusal(status model.EnvironmentStatus) string {
 // strand the environment there with no workflow run left to move it out.
 func (r EnvironmentRoutes) writeStartDeleteError(w http.ResponseWriter, ctx context.Context, environmentID string, err error) {
 	_ = r.environments.MarkDeleteBlocked(ctx, environmentID, err.Error())
+	logServerErrorForRoute(ctx, "DELETE /v1/environments/{environment_id}", err)
 	writeError(w, http.StatusInternalServerError, "failed to start delete")
 }
 
@@ -350,7 +351,7 @@ func (r EnvironmentRoutes) deployEnvironment(w http.ResponseWriter, req *http.Re
 	ctx := req.Context()
 	environment, err := r.environments.Get(ctx, req.PathValue("environment_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	version, err := resolveDeployVersion(req, environment)
@@ -369,14 +370,14 @@ func (r EnvironmentRoutes) deployEnvironment(w http.ResponseWriter, req *http.Re
 			writeError(w, http.StatusConflict, exceeded.Error())
 			return
 		}
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	// Claiming before starting the workflow is what keeps a double-submit from
 	// running two rollouts into the same release.
 	claimed, err := r.environments.ClaimDeploy(ctx, environment.EnvironmentID, deployClaimStaleAfter)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	if !claimed {
@@ -543,7 +544,7 @@ func (r EnvironmentRoutes) validatePlacementCapacity(ctx context.Context, cloudC
 // candidate having room (an explicit context at capacity, or the whole
 // auto-select inventory exhausted) is a 409, matching the existing
 // quota-exceeded shape; anything else is a repository-layer failure.
-func writePlacementError(w http.ResponseWriter, err error) {
+func writePlacementError(w http.ResponseWriter, req *http.Request, err error) {
 	var capacityErr *placementCapacityError
 	switch {
 	case errors.As(err, &capacityErr):
@@ -551,7 +552,7 @@ func writePlacementError(w http.ResponseWriter, err error) {
 	case errors.Is(err, errPlacementContextNotFound), errors.Is(err, errCrossClusterPlacementUnsupported):
 		writeError(w, http.StatusBadRequest, err.Error())
 	default:
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 	}
 }
 
@@ -613,7 +614,7 @@ func resolveDeployVersion(req *http.Request, environment model.Environment) (str
 func (r EnvironmentRoutes) listEnvironments(w http.ResponseWriter, req *http.Request) {
 	environments, err := r.environments.List(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, environments)
@@ -622,7 +623,7 @@ func (r EnvironmentRoutes) listEnvironments(w http.ResponseWriter, req *http.Req
 func (r EnvironmentRoutes) getEnvironment(w http.ResponseWriter, req *http.Request) {
 	environment, err := r.environments.Get(req.Context(), req.PathValue("environment_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, environment)
@@ -762,14 +763,14 @@ func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Re
 	// what the caller sent — is what gets persisted and deployed.
 	placement, err := r.resolvePlacement(req.Context(), environment)
 	if err != nil {
-		writePlacementError(w, err)
+		writePlacementError(w, req, err)
 		return
 	}
 	environment.ContextID = placement.ContextID
 
 	count, quota, err := environmentQuotaUsage(req.Context(), r.environments, r.quotas)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	if preview {
@@ -787,7 +788,7 @@ func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Re
 		}
 		runtimeCount, err := r.environments.CountByType(req.Context(), model.EnvironmentTypeRuntime)
 		if err != nil {
-			writeRepositoryError(w, err)
+			writeRepositoryError(w, req, err)
 			return
 		}
 		if err := validateAggregateResourceBudget(runtimeCount+1, quota); err != nil {
@@ -807,7 +808,7 @@ func (r EnvironmentRoutes) createEnvironment(w http.ResponseWriter, req *http.Re
 func (r EnvironmentRoutes) persistAndMaybeProvision(w http.ResponseWriter, req *http.Request, environment model.Environment, placement resolvedPlacement) {
 	created, err := r.environments.Create(req.Context(), environment)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 
@@ -821,7 +822,7 @@ func (r EnvironmentRoutes) persistAndMaybeProvision(w http.ResponseWriter, req *
 		return
 	}
 	if err := r.startProvisioning(req.Context(), created, placement); err != nil {
-		writeStartProvisioningError(w, err)
+		writeStartProvisioningError(w, req.Context(), err)
 		return
 	}
 	writeJSON(w, http.StatusAccepted, created)
@@ -832,7 +833,8 @@ func (r EnvironmentRoutes) persistAndMaybeProvision(w http.ResponseWriter, req *
 // already left it (registered, not provisioning) — nothing was attempted, so
 // nothing needs unwinding. A missing tenant runtime image is no longer this
 // path: it now selects the canonical-image bootstrap instead of failing here.
-func writeStartProvisioningError(w http.ResponseWriter, _ error) {
+func writeStartProvisioningError(w http.ResponseWriter, ctx context.Context, err error) {
+	logServerErrorForRoute(ctx, "POST /v1/environments", err)
 	writeError(w, http.StatusInternalServerError, "failed to start provisioning")
 }
 
@@ -842,6 +844,7 @@ func writeStartProvisioningError(w http.ResponseWriter, _ error) {
 // environment there with no workflow run left to move it out.
 func (r EnvironmentRoutes) writeStartDeployError(w http.ResponseWriter, ctx context.Context, environmentID string, err error) {
 	_ = r.environments.MarkDeployFailed(ctx, environmentID, err.Error())
+	logServerErrorForRoute(ctx, "POST /v1/environments/{environment_id}/deploy", err)
 	writeError(w, http.StatusInternalServerError, "failed to start deploy")
 }
 
@@ -855,12 +858,12 @@ func (r EnvironmentRoutes) writeStartDeployError(w http.ResponseWriter, ctx cont
 func (r EnvironmentRoutes) previewCreateEnvironment(w http.ResponseWriter, req *http.Request, environment model.Environment, count int, quota model.TenantQuota) {
 	tenant, err := r.tenants.Current(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	runtimeCount, err := r.environments.CountByType(req.Context(), model.EnvironmentTypeRuntime)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	plan := provisionPlanInput{

--- a/erun-backend/erun-backend-api/internal/routes/errors.go
+++ b/erun-backend/erun-backend-api/internal/routes/errors.go
@@ -1,12 +1,15 @@
 package routes
 
 import (
+	"context"
 	"errors"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
 
 // errorEnvelope is the {code, message, details} JSON body every error
@@ -52,7 +55,7 @@ func writeErrorDetails(w http.ResponseWriter, status int, code, message string, 
 	writeJSON(w, status, errorEnvelope{Code: code, Message: message, Details: details})
 }
 
-func writeRepositoryError(w http.ResponseWriter, err error) {
+func writeRepositoryError(w http.ResponseWriter, req *http.Request, err error) {
 	switch {
 	case errors.Is(err, repository.ErrNotFound):
 		writeError(w, http.StatusNotFound, http.StatusText(http.StatusNotFound))
@@ -61,10 +64,46 @@ func writeRepositoryError(w http.ResponseWriter, err error) {
 	case errors.Is(err, repository.ErrInvalidInput):
 		writeError(w, http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
 	case errors.Is(err, repository.ErrMissingSecurityContext):
+		logServerError(req, err)
 		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
 	case errors.Is(err, repository.ErrConflict):
 		writeError(w, http.StatusConflict, http.StatusText(http.StatusConflict))
 	default:
+		logServerError(req, err)
 		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
 	}
+}
+
+// logServerError is the one log line every 5xx from an authenticated route
+// must leave behind (erun#1722): which route, which actor, and the real
+// underlying error — never shown to the caller, whose response body stays
+// the generic status text. An unauthenticated route (no security context
+// yet resolved) still logs, just without an actor to name.
+func logServerError(req *http.Request, err error) {
+	tenantID, userID := "", ""
+	if securityContext, ok := security.FromContext(req.Context()); ok {
+		tenantID, userID = securityContext.TenantID, securityContext.ErunUserID
+	}
+	log.Printf("erun api server error method=%s path=%s tenant=%q user=%q error=%q", req.Method, req.URL.Path, tenantID, userID, err.Error())
+}
+
+// writeInternalError is writeRepositoryError's counterpart for a 500 that
+// did not come from a repository call — e.g. a security context the
+// authentication middleware should have already stamped, or a downstream
+// signer failure. err is logged in full and never reaches the response
+// body; message is the client-facing text the call site already used.
+func writeInternalError(w http.ResponseWriter, req *http.Request, message string, err error) {
+	logServerError(req, err)
+	writeError(w, http.StatusInternalServerError, message)
+}
+
+// logServerErrorForRoute is logServerError's counterpart for the few call
+// sites (environments.go's start-delete/deploy/provisioning failure paths)
+// that only carry a context, not the original *http.Request.
+func logServerErrorForRoute(ctx context.Context, route string, err error) {
+	tenantID, userID := "", ""
+	if securityContext, ok := security.FromContext(ctx); ok {
+		tenantID, userID = securityContext.TenantID, securityContext.ErunUserID
+	}
+	log.Printf("erun api server error route=%q tenant=%q user=%q error=%q", route, tenantID, userID, err.Error())
 }

--- a/erun-backend/erun-backend-api/internal/routes/errors_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/errors_test.go
@@ -1,15 +1,31 @@
 package routes
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 )
+
+// captureLog redirects the standard logger for the duration of fn and
+// returns what it wrote, so a test can assert on the one place an operator
+// would see why a request 500'd (erun#1722).
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	original := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(original)
+	fn()
+	return buf.String()
+}
 
 // TestWriteErrorAlwaysCarriesACode is the property the whole envelope exists
 // for: a client branching on `code` must never see it absent, even when the
@@ -48,9 +64,10 @@ func TestWriteRepositoryErrorMapsEverySentinelToACode(t *testing.T) {
 		{repository.ErrConflict, http.StatusConflict, "CONFLICT"},
 		{errors.New("unrecognized"), http.StatusInternalServerError, "INTERNAL_SERVER_ERROR"},
 	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/whatever", nil)
 	for _, c := range cases {
 		rec := httptest.NewRecorder()
-		writeRepositoryError(rec, c.err)
+		writeRepositoryError(rec, req, c.err)
 
 		if rec.Code != c.wantStatus {
 			t.Fatalf("err=%v: status = %d, want %d", c.err, rec.Code, c.wantStatus)
@@ -62,6 +79,43 @@ func TestWriteRepositoryErrorMapsEverySentinelToACode(t *testing.T) {
 		if body.Code != c.wantCode {
 			t.Fatalf("err=%v: code = %q, want %q", c.err, body.Code, c.wantCode)
 		}
+	}
+}
+
+// TestWriteRepositoryErrorLogsRouteActorAndErrorOn500 is erun#1722's
+// observability requirement: a 500 on an authenticated route must leave a
+// server-side trace naming the route, the actor, and the real underlying
+// error — none of which reaches the client-facing response body.
+func TestWriteRepositoryErrorLogsRouteActorAndErrorOn500(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/invite-requests/req-1/approve", nil)
+	ctx := security.WithContext(req.Context(), security.Context{TenantID: "tenant-ops", ErunUserID: "user-42"})
+	req = req.WithContext(ctx)
+	underlying := errors.New("tenants_name_key already claimed by a different row")
+
+	output := captureLog(t, func() {
+		rec := httptest.NewRecorder()
+		writeRepositoryError(rec, req, underlying)
+	})
+
+	for _, want := range []string{"POST", "/v1/invite-requests/req-1/approve", "tenant-ops", "user-42", underlying.Error()} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("log output = %q, want it to contain %q", output, want)
+		}
+	}
+}
+
+// TestWriteRepositoryErrorDoesNotLogClientFaults keeps the log free of
+// routine 4xx noise: only a 500 needs an operator's attention.
+func TestWriteRepositoryErrorDoesNotLogClientFaults(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/whatever", nil)
+
+	output := captureLog(t, func() {
+		rec := httptest.NewRecorder()
+		writeRepositoryError(rec, req, repository.ErrNotFound)
+	})
+
+	if output != "" {
+		t.Fatalf("log output = %q, want nothing logged for a client-fault 404", output)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/routes/identity.go
+++ b/erun-backend/erun-backend-api/internal/routes/identity.go
@@ -98,7 +98,7 @@ func requireOperationsTenant(securityContext security.Context) error {
 func (r IdentityRoutes) securityContext(w http.ResponseWriter, req *http.Request) (security.Context, bool) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return security.Context{}, false
 	}
 	if err := requireOperationsTenant(securityContext); err != nil {
@@ -133,7 +133,7 @@ func (r IdentityRoutes) listUsers(w http.ResponseWriter, req *http.Request) {
 	}
 	erunUsers, err := r.erunUsers.List(req.Context(), repository.UserFilter{TenantID: securityContext.TenantID})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	views := mergeIdentityUsers(idpUsers, erunUsers)

--- a/erun-backend/erun-backend-api/internal/routes/invite_requests.go
+++ b/erun-backend/erun-backend-api/internal/routes/invite_requests.go
@@ -2,6 +2,8 @@ package routes
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"strconv"
@@ -60,7 +62,7 @@ func RegisterInviteRequestRoutes(register ProtectedRouteRegistrar, requests Invi
 func (r inviteRequestRoutes) list(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	filter := repository.InviteRequestFilter{
@@ -71,7 +73,7 @@ func (r inviteRequestRoutes) list(w http.ResponseWriter, req *http.Request) {
 	} else {
 		tenant, err := r.tenants.Current(req.Context())
 		if err != nil {
-			writeRepositoryError(w, err)
+			writeRepositoryError(w, req, err)
 			return
 		}
 		filter.Kind = model.InviteRequestKindJoinTenant
@@ -79,7 +81,7 @@ func (r inviteRequestRoutes) list(w http.ResponseWriter, req *http.Request) {
 	}
 	requests, err := r.requests.List(req.Context(), filter)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, requests)
@@ -94,7 +96,7 @@ func (r inviteRequestRoutes) list(w http.ResponseWriter, req *http.Request) {
 func (r inviteRequestRoutes) approve(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	request, ok := r.loadPendingRequest(w, req)
@@ -117,11 +119,11 @@ func (r inviteRequestRoutes) approve(w http.ResponseWriter, req *http.Request) {
 		}
 		decided, err = r.decisions.ApproveCreateTenant(req.Context(), request, securityContext.ErunUserID)
 	default:
-		writeError(w, http.StatusInternalServerError, "unknown invite request kind")
+		writeInternalError(w, req, "unknown invite request kind", fmt.Errorf("invite request %s has unrecognized kind %q", request.InviteRequestID, request.Kind))
 		return
 	}
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, decided)
@@ -138,7 +140,7 @@ type declineInviteRequestBody struct {
 func (r inviteRequestRoutes) decline(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	var body declineInviteRequestBody
@@ -170,7 +172,7 @@ func (r inviteRequestRoutes) decline(w http.ResponseWriter, req *http.Request) {
 
 	declined, err := r.decisions.Decline(req.Context(), request, securityContext.ErunUserID, reason)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, declined)
@@ -182,7 +184,7 @@ func (r inviteRequestRoutes) decline(w http.ResponseWriter, req *http.Request) {
 func (r inviteRequestRoutes) loadPendingRequest(w http.ResponseWriter, req *http.Request) (model.InviteRequest, bool) {
 	request, err := r.requests.Get(req.Context(), req.PathValue("invite_request_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return model.InviteRequest{}, false
 	}
 	if request.Status != model.InviteRequestStatusPending {
@@ -198,7 +200,7 @@ func (r inviteRequestRoutes) loadPendingRequest(w http.ResponseWriter, req *http
 func (r inviteRequestRoutes) callerOwnsTenantName(w http.ResponseWriter, req *http.Request, tenantName string) bool {
 	tenant, err := r.tenants.Current(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return false
 	}
 	if !strings.EqualFold(tenant.Name, tenantName) {
@@ -322,7 +324,7 @@ func (r inviteRequestPublicRoutes) submit(w http.ResponseWriter, req *http.Reque
 
 	result, err := r.limiter.allowIdentity(req.Context(), claims.Issuer, claims.Subject)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), err)
 		return
 	}
 	if !result.Allowed {
@@ -338,7 +340,7 @@ func (r inviteRequestPublicRoutes) submit(w http.ResponseWriter, req *http.Reque
 
 	request, err := r.requests.Submit(req.Context(), params)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusAccepted, request)
@@ -389,7 +391,7 @@ func (r inviteRequestPublicRoutes) mine(w http.ResponseWriter, req *http.Request
 	}
 	request, err := r.requests.GetByIdentity(req.Context(), claims.Issuer, claims.Subject)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, request)

--- a/erun-backend/erun-backend-api/internal/routes/invite_requests_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/invite_requests_test.go
@@ -3,6 +3,8 @@ package routes
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,6 +12,7 @@ import (
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/repository"
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/service"
 )
 
 type stubInviteRequestSubmitter struct {
@@ -215,5 +218,92 @@ func TestApproveCreateTenantRequiresOperationsTenant(t *testing.T) {
 	}
 	if approver.approveCalls != 1 {
 		t.Fatalf("approve workflow was called %d times, want 1 for an operations caller", approver.approveCalls)
+	}
+}
+
+// fakeApproveCreateTenantRepositories wires the real service.InviteRequestService
+// used below, rather than the stubInviteRequestApprover the tests above use,
+// so this test exercises the actual erun#1722 fix end to end through the
+// HTTP route: routes.approve -> service.ApproveCreateTenant -> the tenant
+// repository's own name-conflict resolution.
+type fakeApproveCreateTenantTenants struct {
+	createErr    error
+	byNameTenant model.Tenant
+}
+
+func (f *fakeApproveCreateTenantTenants) Create(_ context.Context, _ repository.CreateTenantParams) (model.Tenant, error) {
+	return model.Tenant{}, f.createErr
+}
+
+func (f *fakeApproveCreateTenantTenants) GetByName(_ context.Context, _ string) (model.Tenant, error) {
+	return f.byNameTenant, nil
+}
+
+type fakeApproveCreateTenantUsers struct{ gotTenantID string }
+
+func (f *fakeApproveCreateTenantUsers) Create(ctx context.Context, _ repository.CreateUserParams) (model.User, error) {
+	if sc, ok := security.FromContext(ctx); ok {
+		f.gotTenantID = sc.TenantID
+	}
+	return model.User{UserID: "user-1"}, nil
+}
+
+type fakeApproveCreateTenantInvites struct{}
+
+func (fakeApproveCreateTenantInvites) Create(_ context.Context, _ repository.CreateInviteParams) (model.Invite, error) {
+	return model.Invite{InviteID: "invite-1", Token: "tok"}, nil
+}
+
+type fakeApproveCreateTenantDecisions struct{ approved model.InviteRequest }
+
+func (f *fakeApproveCreateTenantDecisions) MarkApproved(_ context.Context, id string, decidedByUserID string, mintedInviteID string) (model.InviteRequest, error) {
+	f.approved = model.InviteRequest{InviteRequestID: id, Status: model.InviteRequestStatusApproved, DecidedByUserID: decidedByUserID, MintedInviteID: mintedInviteID}
+	return f.approved, nil
+}
+
+func (f *fakeApproveCreateTenantDecisions) MarkDeclined(_ context.Context, id string, decidedByUserID string, reason string) (model.InviteRequest, error) {
+	return model.InviteRequest{}, errors.New("not exercised by this test")
+}
+
+// TestApproveCreateTenantWhenTenantAlreadyExistsRespondsOKNotStuckPending
+// drives the real fix end to end through the HTTP layer: approving a
+// CREATE_TENANT request whose tenant name now belongs to a tenant this call
+// did not create must not 500, and must land the request on APPROVED — a
+// state the operator can see resolved — rather than leaving it PENDING.
+func TestApproveCreateTenantWhenTenantAlreadyExistsRespondsOKNotStuckPending(t *testing.T) {
+	store := &stubInviteRequestStore{got: model.InviteRequest{
+		InviteRequestID: "req-1",
+		Status:          model.InviteRequestStatusPending,
+		Kind:            model.InviteRequestKindCreateTenant,
+		TenantName:      "newco",
+		Issuer:          "https://newco-issuer.example.com",
+		Subject:         "verified-subject",
+	}}
+	tenants := &fakeApproveCreateTenantTenants{
+		createErr:    repository.ErrTenantNameConflict,
+		byNameTenant: model.Tenant{TenantID: "tenant-existing", Name: "newco", Type: model.TenantTypeCompany},
+	}
+	users := &fakeApproveCreateTenantUsers{}
+	decisions := &fakeApproveCreateTenantDecisions{}
+	svc := service.NewInviteRequestService(decisions, tenants, users, fakeApproveCreateTenantInvites{})
+	routes := inviteRequestRoutes{requests: store, tenants: &stubTenantRepository{}, decisions: svc}
+
+	req := inviteRequest(http.MethodPost, "/v1/invite-requests/req-1/approve", `{}`, "ops-tenant", string(model.TenantTypeOperations), "https://auth.example.com")
+	req.SetPathValue("invite_request_id", "req-1")
+	rec := httptest.NewRecorder()
+	routes.approve(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (not a 500 on the name collision); body=%s", rec.Code, rec.Body.String())
+	}
+	var decided model.InviteRequest
+	if err := json.Unmarshal(rec.Body.Bytes(), &decided); err != nil {
+		t.Fatalf("response body is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	if decided.Status != model.InviteRequestStatusApproved {
+		t.Fatalf("request status = %q, want APPROVED — it must not stay PENDING with no reachable outcome", decided.Status)
+	}
+	if users.gotTenantID != "tenant-existing" {
+		t.Fatalf("requester was enrolled under tenant %q, want the existing tenant %q", users.gotTenantID, "tenant-existing")
 	}
 }

--- a/erun-backend/erun-backend-api/internal/routes/invites.go
+++ b/erun-backend/erun-backend-api/internal/routes/invites.go
@@ -57,7 +57,7 @@ type createInviteRequest struct {
 func (r InviteRoutes) createInvite(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	var body createInviteRequest
@@ -84,7 +84,7 @@ func (r InviteRoutes) createInvite(w http.ResponseWriter, req *http.Request) {
 		TTL:      inviteTTL,
 	})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, invite)
@@ -93,7 +93,7 @@ func (r InviteRoutes) createInvite(w http.ResponseWriter, req *http.Request) {
 func (r InviteRoutes) listInvites(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	targetTenantID, err := resolveTargetTenant(securityContext, req.URL.Query().Get("tenantId"))
@@ -103,7 +103,7 @@ func (r InviteRoutes) listInvites(w http.ResponseWriter, req *http.Request) {
 	}
 	invites, err := r.invites.List(req.Context(), repository.InviteFilter{TenantID: targetTenantID})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, invites)
@@ -111,7 +111,7 @@ func (r InviteRoutes) listInvites(w http.ResponseWriter, req *http.Request) {
 
 func (r InviteRoutes) revokeInvite(w http.ResponseWriter, req *http.Request) {
 	if err := r.invites.Revoke(req.Context(), req.PathValue("invite_id")); err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/erun-backend/erun-backend-api/internal/routes/mcp_token.go
+++ b/erun-backend/erun-backend-api/internal/routes/mcp_token.go
@@ -38,22 +38,22 @@ func (r MCPTokenRoutes) mintMCPToken(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	environment, err := r.environments.Get(ctx, req.PathValue("environment_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	tenant, err := r.tenants.Current(ctx)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	securityContext, err := security.RequiredFromContext(ctx)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), err)
 		return
 	}
 	token, audience, err := r.signer.Sign(tenant.Name, environment.Name, securityContext.ErunUserID, time.Now())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), err)
 		return
 	}
 	writeJSON(w, http.StatusOK, mcpTokenResponse{Token: token, Audience: audience})

--- a/erun-backend/erun-backend-api/internal/routes/platform_rate_limits.go
+++ b/erun-backend/erun-backend-api/internal/routes/platform_rate_limits.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -41,7 +42,7 @@ type setInviteRequestRateLimitBody struct {
 func (r platformRateLimitRoutes) setInviteRequestRateLimit(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	if securityContext.TenantType != string(model.TenantTypeOperations) {
@@ -59,7 +60,7 @@ func (r platformRateLimitRoutes) setInviteRequestRateLimit(w http.ResponseWriter
 	}
 	limit, err := r.limits.SetInviteRequestWindow(req.Context(), body.WindowSeconds)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, limit)

--- a/erun-backend/erun-backend-api/internal/routes/provision.go
+++ b/erun-backend/erun-backend-api/internal/routes/provision.go
@@ -102,18 +102,18 @@ func (r ProvisionRoutes) provision(w http.ResponseWriter, req *http.Request) {
 	// to the caller's tenant.
 	tenant, err := r.tenants.Current(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 
 	count, quota, err := environmentQuotaUsage(req.Context(), r.environments, r.quotas)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	runtimeCount, err := r.environments.CountByType(req.Context(), model.EnvironmentTypeRuntime)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 

--- a/erun-backend/erun-backend-api/internal/routes/releases.go
+++ b/erun-backend/erun-backend-api/internal/routes/releases.go
@@ -60,7 +60,7 @@ func (r ReleaseRoutes) createRelease(w http.ResponseWriter, req *http.Request) {
 		CommitID:     strings.TrimSpace(body.CommitID),
 	})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	if result.Created {
@@ -87,7 +87,7 @@ func (r ReleaseRoutes) listReleases(w http.ResponseWriter, req *http.Request) {
 		Status:       model.ReleaseStatus(query.Get("status")),
 	})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, releases)
@@ -98,7 +98,7 @@ func (r ReleaseRoutes) listReleases(w http.ResponseWriter, req *http.Request) {
 func (r ReleaseRoutes) listReviewReleases(w http.ResponseWriter, req *http.Request) {
 	releases, err := r.releases.List(req.Context(), apirepository.ReleaseFilter{ReviewID: req.PathValue("review_id")})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, releases)
@@ -107,7 +107,7 @@ func (r ReleaseRoutes) listReviewReleases(w http.ResponseWriter, req *http.Reque
 func (r ReleaseRoutes) getRelease(w http.ResponseWriter, req *http.Request) {
 	release, err := r.releases.Get(req.Context(), req.PathValue("release_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, release)

--- a/erun-backend/erun-backend-api/internal/routes/reviews.go
+++ b/erun-backend/erun-backend-api/internal/routes/reviews.go
@@ -105,7 +105,7 @@ func (r ReviewRoutes) listReviews(w http.ResponseWriter, req *http.Request) {
 	}
 	reviews, err := r.reviews.List(req.Context(), filter)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, reviews)
@@ -114,7 +114,7 @@ func (r ReviewRoutes) listReviews(w http.ResponseWriter, req *http.Request) {
 func (r ReviewRoutes) listReviewers(w http.ResponseWriter, req *http.Request) {
 	reviewers, err := r.reviewers.List(req.Context(), apirepository.ReviewReviewerFilter{ReviewID: req.PathValue("review_id")})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, reviewers)
@@ -131,7 +131,7 @@ func (r ReviewRoutes) addReviewer(w http.ResponseWriter, req *http.Request) {
 		UserID:   input.UserID,
 	})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, reviewer)
@@ -139,7 +139,7 @@ func (r ReviewRoutes) addReviewer(w http.ResponseWriter, req *http.Request) {
 
 func (r ReviewRoutes) removeReviewer(w http.ResponseWriter, req *http.Request) {
 	if err := r.reviewers.Delete(req.Context(), req.PathValue("review_id"), req.PathValue("user_id")); err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -154,7 +154,7 @@ func (r ReviewRoutes) createReview(w http.ResponseWriter, req *http.Request) {
 	review = r.service.PrepareCreate(review)
 	review, err := r.reviews.Create(req.Context(), review)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, review)
@@ -163,7 +163,7 @@ func (r ReviewRoutes) createReview(w http.ResponseWriter, req *http.Request) {
 func (r ReviewRoutes) listMergeQueue(w http.ResponseWriter, req *http.Request) {
 	reviews, err := r.reviews.ListMergeQueue(req.Context(), req.URL.Query().Get("targetBranch"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, reviews)
@@ -177,7 +177,7 @@ func (r ReviewRoutes) advanceMergeQueue(w http.ResponseWriter, req *http.Request
 	}
 	review, err := r.service.AdvanceMergeQueue(req.Context(), input.TargetBranch)
 	if err != nil {
-		writeAdvanceMergeQueueError(w, err)
+		writeAdvanceMergeQueueError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, review)
@@ -191,7 +191,7 @@ func (r ReviewRoutes) overrideAdvanceMergeQueue(w http.ResponseWriter, req *http
 	}
 	review, err := r.service.OverrideAdvanceMergeQueue(req.Context(), input.TargetBranch, input.Reason)
 	if err != nil {
-		writeAdvanceMergeQueueError(w, err)
+		writeAdvanceMergeQueueError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, review)
@@ -201,7 +201,7 @@ func (r ReviewRoutes) overrideAdvanceMergeQueue(w http.ResponseWriter, req *http
 // the count and the review to route the operator to, rather than the bare
 // status text writeRepositoryError gives every other conflict, and gives the
 // merge-queue-specific machine codes documented in collaboration/reviews.md.
-func writeAdvanceMergeQueueError(w http.ResponseWriter, err error) {
+func writeAdvanceMergeQueueError(w http.ResponseWriter, req *http.Request, err error) {
 	var blocked *service.UnresolvedThreadsError
 	if errors.As(err, &blocked) {
 		writeJSON(w, http.StatusConflict, unresolvedThreadsResponse{
@@ -221,13 +221,13 @@ func writeAdvanceMergeQueueError(w http.ResponseWriter, err error) {
 		writeErrorCode(w, http.StatusNotFound, "EMPTY_QUEUE", empty.Error())
 		return
 	}
-	writeRepositoryError(w, err)
+	writeRepositoryError(w, req, err)
 }
 
 func (r ReviewRoutes) getReview(w http.ResponseWriter, req *http.Request) {
 	review, err := r.reviews.Get(req.Context(), req.PathValue("review_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, review)
@@ -241,7 +241,7 @@ func (r ReviewRoutes) updateReviewStatus(w http.ResponseWriter, req *http.Reques
 	}
 	review, err := r.service.UpdateStatus(req.Context(), req.PathValue("review_id"), input.Status, input.BuildID, input.RemoteURL)
 	if err != nil {
-		writeUpdateStatusError(w, err)
+		writeUpdateStatusError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, review)
@@ -251,7 +251,7 @@ func (r ReviewRoutes) updateReviewStatus(w http.ResponseWriter, req *http.Reques
 // their exact machine code and details shape; every other failure (not
 // found, missing security context, ...) falls through to the generic
 // status-derived code.
-func writeUpdateStatusError(w http.ResponseWriter, err error) {
+func writeUpdateStatusError(w http.ResponseWriter, req *http.Request, err error) {
 	var invalidTransition *service.InvalidTransitionError
 	if errors.As(err, &invalidTransition) {
 		writeErrorDetails(w, http.StatusBadRequest, "INVALID_TRANSITION", invalidTransition.Error(), map[string]any{
@@ -271,5 +271,5 @@ func writeUpdateStatusError(w http.ResponseWriter, err error) {
 		writeErrorCode(w, http.StatusConflict, "MERGE_NOT_VERIFIED", notVerified.Error())
 		return
 	}
-	writeRepositoryError(w, err)
+	writeRepositoryError(w, req, err)
 }

--- a/erun-backend/erun-backend-api/internal/routes/roles.go
+++ b/erun-backend/erun-backend-api/internal/routes/roles.go
@@ -48,7 +48,7 @@ type createRoleRequest struct {
 func (routes RoleRoutes) listRoles(w http.ResponseWriter, req *http.Request) {
 	roles, err := routes.roles.List(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, roles)
@@ -89,7 +89,7 @@ func (routes RoleRoutes) createRole(w http.ResponseWriter, req *http.Request) {
 			writeError(w, http.StatusConflict, "a role with this name, or a permission on it, already exists in this tenant")
 			return
 		}
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, role)
@@ -98,7 +98,7 @@ func (routes RoleRoutes) createRole(w http.ResponseWriter, req *http.Request) {
 func (routes RoleRoutes) listUserRoles(w http.ResponseWriter, req *http.Request) {
 	roles, err := routes.roles.ForUser(req.Context(), req.PathValue("user_id"))
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, roles)
@@ -130,7 +130,7 @@ func (routes RoleRoutes) grantUserRole(w http.ResponseWriter, req *http.Request)
 			writeError(w, http.StatusNotFound, "the user or role does not exist in this tenant")
 			return
 		}
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, grant)
@@ -143,7 +143,7 @@ func (routes RoleRoutes) revokeUserRole(w http.ResponseWriter, req *http.Request
 			writeError(w, http.StatusConflict, err.Error())
 			return
 		}
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/erun-backend/erun-backend-api/internal/routes/tenant_issuers.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenant_issuers.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -38,7 +39,7 @@ func RegisterTenantIssuerRoutes(register ProtectedRouteRegistrar, issuers Tenant
 func (r TenantIssuerRoutes) listTenantIssuers(w http.ResponseWriter, req *http.Request) {
 	issuers, err := r.issuers.List(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, issuers)
@@ -56,7 +57,7 @@ func (r TenantIssuerRoutes) updateTenantIssuerName(w http.ResponseWriter, req *h
 	}
 	issuer, err := r.issuers.UpdateName(req.Context(), input.Issuer, input.Name)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, issuer)
@@ -70,7 +71,7 @@ func (r TenantIssuerRoutes) updateTenantIssuerName(w http.ResponseWriter, req *h
 func (r TenantIssuerRoutes) updateTenantIssuerOrgScope(w http.ResponseWriter, req *http.Request, input updateTenantIssuerRequest) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	if securityContext.TenantType != string(model.TenantTypeOperations) {
@@ -83,7 +84,7 @@ func (r TenantIssuerRoutes) updateTenantIssuerOrgScope(w http.ResponseWriter, re
 	}
 	issuer, err := r.issuers.UpdateOrgScope(req.Context(), input.Issuer, input.OrgFieldKey, input.OrgFieldValue)
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, issuer)

--- a/erun-backend/erun-backend-api/internal/routes/tenant_quotas.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenant_quotas.go
@@ -66,7 +66,7 @@ func RegisterTenantQuotaRoute(register ProtectedRouteRegistrar, quotas TenantQuo
 func (r TenantQuotaRoutes) getQuota(w http.ResponseWriter, req *http.Request) {
 	quota, err := r.reader.Get(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, quota)
@@ -77,7 +77,7 @@ func (r TenantQuotaRoutes) getQuota(w http.ResponseWriter, req *http.Request) {
 func (r TenantQuotaRoutes) setQuota(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, "missing security context")
+		writeInternalError(w, req, "missing security context", errors.New("security context not found in request"))
 		return
 	}
 	if securityContext.TenantType != string(model.TenantTypeOperations) {
@@ -108,7 +108,7 @@ func (r TenantQuotaRoutes) setQuota(w http.ResponseWriter, req *http.Request) {
 		MaxTotalStorageGB:     body.MaxTotalStorageGB,
 	})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, quota)

--- a/erun-backend/erun-backend-api/internal/routes/tenants.go
+++ b/erun-backend/erun-backend-api/internal/routes/tenants.go
@@ -58,7 +58,7 @@ func RegisterTenantRoutes(register ProtectedRouteRegistrar, tenants TenantReposi
 func (r TenantRoutes) listTenants(w http.ResponseWriter, req *http.Request) {
 	tenants, err := r.tenants.List(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, tenants)
@@ -71,7 +71,7 @@ func (r TenantRoutes) listTenants(w http.ResponseWriter, req *http.Request) {
 func (r TenantRoutes) reachableTenants(w http.ResponseWriter, req *http.Request) {
 	tenants, err := r.tenants.Reachable(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, tenants)
@@ -86,7 +86,7 @@ func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
 		// Protected routes always run behind authentication middleware that stamps
 		// the security context, so a missing context is an internal wiring error,
 		// not a client fault.
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	if securityContext.TenantType != string(model.TenantTypeOperations) {
@@ -106,7 +106,7 @@ func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
 			writeError(w, http.StatusConflict, duplicateIssuerMessage(params.Issuer, params.OrgFieldValue))
 			return
 		}
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 
@@ -125,7 +125,7 @@ func (r TenantRoutes) createTenant(w http.ResponseWriter, req *http.Request) {
 func (r TenantRoutes) reconcileBootstrapName(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 	if securityContext.TenantType != string(model.TenantTypeOperations) {
@@ -139,7 +139,7 @@ func (r TenantRoutes) reconcileBootstrapName(w http.ResponseWriter, req *http.Re
 
 	current, err := r.tenants.Current(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (r TenantRoutes) reconcileBootstrapName(w http.ResponseWriter, req *http.Re
 		case errors.Is(err, service.ErrBootstrapNameConflict):
 			writeError(w, http.StatusConflict, err.Error())
 		default:
-			writeRepositoryError(w, err)
+			writeRepositoryError(w, req, err)
 		}
 		return
 	}

--- a/erun-backend/erun-backend-api/internal/routes/usage_events.go
+++ b/erun-backend/erun-backend-api/internal/routes/usage_events.go
@@ -25,7 +25,7 @@ func RegisterUsageEventRoutes(register ProtectedRouteRegistrar, events UsageEven
 func (r UsageEventRoutes) listUsageEvents(w http.ResponseWriter, req *http.Request) {
 	events, err := r.events.List(req.Context())
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, events)

--- a/erun-backend/erun-backend-api/internal/routes/users.go
+++ b/erun-backend/erun-backend-api/internal/routes/users.go
@@ -65,7 +65,7 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 		// Protected routes always run behind authentication middleware that stamps
 		// the security context, so a missing context is an internal wiring error,
 		// not a client fault.
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 
@@ -109,7 +109,7 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 			writeError(w, http.StatusNotFound, "one or more requested roles do not exist in this tenant")
 			return
 		}
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusCreated, created)
@@ -118,7 +118,7 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 func (r UserRoutes) listUsers(w http.ResponseWriter, req *http.Request) {
 	securityContext, ok := security.FromContext(req.Context())
 	if !ok {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, req, http.StatusText(http.StatusInternalServerError), errors.New("security context not found in request"))
 		return
 	}
 
@@ -130,7 +130,7 @@ func (r UserRoutes) listUsers(w http.ResponseWriter, req *http.Request) {
 
 	users, err := r.users.List(req.Context(), repository.UserFilter{TenantID: targetTenantID})
 	if err != nil {
-		writeRepositoryError(w, err)
+		writeRepositoryError(w, req, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, users)

--- a/erun-backend/erun-backend-api/internal/routes/whoami.go
+++ b/erun-backend/erun-backend-api/internal/routes/whoami.go
@@ -56,7 +56,7 @@ type whoamiResponse struct {
 func (routes WhoamiRoutes) handleWhoami(w http.ResponseWriter, r *http.Request) {
 	securityContext, err := security.RequiredFromContext(r.Context())
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		writeInternalError(w, r, http.StatusText(http.StatusInternalServerError), err)
 		return
 	}
 
@@ -69,13 +69,13 @@ func (routes WhoamiRoutes) handleWhoami(w http.ResponseWriter, r *http.Request) 
 	if routes.users != nil {
 		user, err := routes.users.Get(r.Context(), securityContext.ErunUserID)
 		if err != nil {
-			writeRepositoryError(w, err)
+			writeRepositoryError(w, r, err)
 			return
 		}
 		response.Username = user.Username
 		roles, err := routes.users.RoleNames(r.Context(), securityContext.ErunUserID)
 		if err != nil {
-			writeRepositoryError(w, err)
+			writeRepositoryError(w, r, err)
 			return
 		}
 		response.Roles = roles
@@ -87,7 +87,7 @@ func (routes WhoamiRoutes) handleWhoami(w http.ResponseWriter, r *http.Request) 
 	if routes.capabilities != nil && routes.catalog != nil {
 		capabilities, err := routes.capabilities.PermittedRoutes(r.Context(), routes.catalog())
 		if err != nil {
-			writeRepositoryError(w, err)
+			writeRepositoryError(w, r, err)
 			return
 		}
 		response.Capabilities = capabilities

--- a/erun-backend/erun-backend-api/internal/service/invite_requests.go
+++ b/erun-backend/erun-backend-api/internal/service/invite_requests.go
@@ -19,9 +19,13 @@ import (
 const inviteRequestInviteTTL = 7 * 24 * time.Hour
 
 // InviteRequestTenantCreator registers a new tenant and its OIDC issuer
-// mapping. *repository.TenantRepository satisfies it.
+// mapping, or resolves the tenant a name race lost to. *repository.TenantRepository
+// satisfies it.
 type InviteRequestTenantCreator interface {
 	Create(ctx context.Context, params repository.CreateTenantParams) (model.Tenant, error)
+	// GetByName resolves Create's ErrTenantNameConflict: the tenant this call
+	// did not create but that now holds the requested name.
+	GetByName(ctx context.Context, name string) (model.Tenant, error)
 }
 
 // InviteRequestUserEnroller enrols a user into the tenant ctx's own
@@ -96,6 +100,19 @@ func (s *InviteRequestService) ApproveJoin(ctx context.Context, request model.In
 // invite for that tenant. The caller (a route) must already have verified
 // the caller is an OPERATIONS tenant before calling this — registering a
 // tenant is operations-only regardless of who asks for it.
+//
+// A CREATE_TENANT request can be overtaken by its own chosen name between
+// being raised and being decided — someone else registers the same name
+// first, or (per the "does not remain PENDING" requirement below) an earlier
+// approve attempt on this very request created the tenant and then failed a
+// later step. Either way the tenant existing is a race, not a mistake
+// (erun#1722): enrolling the requester into it is what CREATE_TENANT actually
+// asks for, so Create's ErrTenantNameConflict resolves to that tenant instead
+// of failing the approval. This is also what makes the overall workflow
+// retry-safe without a spanning database transaction (see the package doc
+// comment): resolving-or-creating the tenant is now idempotent, so retrying a
+// partially-failed approve (e.g. tenant registered, enrollment then failed)
+// converges to success instead of repeating the same fatal error.
 func (s *InviteRequestService) ApproveCreateTenant(ctx context.Context, request model.InviteRequest, decidedByUserID string) (model.InviteRequest, error) {
 	if request.Kind != model.InviteRequestKindCreateTenant {
 		return model.InviteRequest{}, ErrInviteRequestWrongKind
@@ -105,7 +122,15 @@ func (s *InviteRequestService) ApproveCreateTenant(ctx context.Context, request 
 		Type:   model.TenantTypeCompany,
 		Issuer: request.Issuer,
 	})
-	if err != nil {
+	switch {
+	case err == nil:
+		// registered fresh; fall through to enrollment below.
+	case errors.Is(err, repository.ErrTenantNameConflict):
+		tenant, err = s.tenants.GetByName(ctx, request.TenantName)
+		if err != nil {
+			return model.InviteRequest{}, fmt.Errorf("resolve existing tenant %q: %w", request.TenantName, err)
+		}
+	default:
 		return model.InviteRequest{}, fmt.Errorf("register tenant: %w", err)
 	}
 
@@ -113,10 +138,11 @@ func (s *InviteRequestService) ApproveCreateTenant(ctx context.Context, request 
 	// user is enrolled under a synthetic security context bound to it — the
 	// same "resolve tenant, then bind its own security context" shape
 	// IdentityRepository's per-tenant first-user bootstrap already uses for
-	// an equally caller-less enrollment.
+	// an equally caller-less enrollment. tenant.Type (not a hardcoded
+	// COMPANY) matters once tenant may be one Create didn't just mint.
 	tenantCtx := security.WithContext(ctx, security.Context{
 		TenantID:   tenant.TenantID,
-		TenantType: string(model.TenantTypeCompany),
+		TenantType: string(tenant.Type),
 	})
 	if _, err := s.users.Create(tenantCtx, repository.CreateUserParams{
 		Username: enrollmentUsername(request),

--- a/erun-backend/erun-backend-api/internal/service/invite_requests_test.go
+++ b/erun-backend/erun-backend-api/internal/service/invite_requests_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -14,12 +15,23 @@ type stubInviteRequestTenantCreator struct {
 	err    error
 	got    repository.CreateTenantParams
 	calls  int
+
+	byNameTenant model.Tenant
+	byNameErr    error
+	gotByName    string
+	byNameCalls  int
 }
 
 func (s *stubInviteRequestTenantCreator) Create(_ context.Context, params repository.CreateTenantParams) (model.Tenant, error) {
 	s.got = params
 	s.calls++
 	return s.tenant, s.err
+}
+
+func (s *stubInviteRequestTenantCreator) GetByName(_ context.Context, name string) (model.Tenant, error) {
+	s.gotByName = name
+	s.byNameCalls++
+	return s.byNameTenant, s.byNameErr
 }
 
 type stubInviteRequestUserEnroller struct {
@@ -171,5 +183,87 @@ func TestApproveCreateTenantRegistersTenantEnrolsFirstUserAndMintsInvite(t *test
 	}
 	if invites.got.TenantID != "tenant-new" {
 		t.Fatalf("minted invite tenant = %q, want the newly registered tenant", invites.got.TenantID)
+	}
+}
+
+// TestApproveCreateTenantEnrolsIntoExistingTenantWhenNameConflicts is
+// erun#1722's reproduction: the requested tenant name was registered
+// out-of-band between the request being raised and decided (a race, not a
+// mistake). Approving must not 500 on the resulting unique violation and
+// must not leave the request PENDING with no reachable outcome — it enrols
+// the requester into the tenant that already holds the name and completes
+// the approval, landing on APPROVED, a state the operator can act on.
+func TestApproveCreateTenantEnrolsIntoExistingTenantWhenNameConflicts(t *testing.T) {
+	requests := &stubInviteRequestDecisionStore{approved: model.InviteRequest{InviteRequestID: "req-1", Status: model.InviteRequestStatusApproved}}
+	tenants := &stubInviteRequestTenantCreator{
+		err:          repository.ErrTenantNameConflict,
+		byNameTenant: model.Tenant{TenantID: "tenant-existing", Name: "newco", Type: model.TenantTypeCompany},
+	}
+	users := &stubInviteRequestUserEnroller{user: model.User{UserID: "user-1"}}
+	invites := &stubInviteRequestInviteMinter{invite: model.Invite{InviteID: "invite-1", Token: "tok"}}
+	svc := NewInviteRequestService(requests, tenants, users, invites)
+
+	request := model.InviteRequest{
+		InviteRequestID: "req-1",
+		Issuer:          "https://newco-issuer.example.com",
+		Subject:         "verified-subject",
+		Kind:            model.InviteRequestKindCreateTenant,
+		TenantName:      "newco",
+		Status:          model.InviteRequestStatusPending,
+	}
+	ctx := security.WithContext(context.Background(), security.Context{TenantID: "ops-tenant", TenantType: string(model.TenantTypeOperations)})
+	decided, err := svc.ApproveCreateTenant(ctx, request, "ops-user")
+	if err != nil {
+		t.Fatalf("ApproveCreateTenant: %v", err)
+	}
+
+	if tenants.byNameCalls != 1 || tenants.gotByName != "newco" {
+		t.Fatalf("GetByName called %d times with %q, want 1 call with %q", tenants.byNameCalls, tenants.gotByName, "newco")
+	}
+	if users.gotSecurityContext.TenantID != "tenant-existing" {
+		t.Fatalf("enrollment ran under tenant %q, want the existing tenant %q", users.gotSecurityContext.TenantID, "tenant-existing")
+	}
+	if invites.got.TenantID != "tenant-existing" {
+		t.Fatalf("minted invite tenant = %q, want the existing tenant", invites.got.TenantID)
+	}
+	if requests.approveCalls != 1 {
+		t.Fatalf("MarkApproved called %d times, want 1 — the request must not stay PENDING", requests.approveCalls)
+	}
+	if decided.Status != model.InviteRequestStatusApproved {
+		t.Fatalf("decided.Status = %q, want APPROVED", decided.Status)
+	}
+}
+
+// TestApproveCreateTenantSurfacesUnrelatedTenantCreateFailure is the
+// catch-all guard: only the specific name-conflict sentinel resolves to the
+// existing tenant. Any other failure registering the tenant (a genuine
+// database fault) must still fail the approval outright, leaving the
+// request PENDING rather than silently marking it decided.
+func TestApproveCreateTenantSurfacesUnrelatedTenantCreateFailure(t *testing.T) {
+	requests := &stubInviteRequestDecisionStore{approved: model.InviteRequest{InviteRequestID: "req-1", Status: model.InviteRequestStatusApproved}}
+	tenants := &stubInviteRequestTenantCreator{err: errors.New("connection reset by peer")}
+	users := &stubInviteRequestUserEnroller{}
+	invites := &stubInviteRequestInviteMinter{}
+	svc := NewInviteRequestService(requests, tenants, users, invites)
+
+	request := model.InviteRequest{
+		InviteRequestID: "req-1",
+		Issuer:          "https://newco-issuer.example.com",
+		Subject:         "verified-subject",
+		Kind:            model.InviteRequestKindCreateTenant,
+		TenantName:      "newco",
+		Status:          model.InviteRequestStatusPending,
+	}
+	ctx := security.WithContext(context.Background(), security.Context{TenantID: "ops-tenant", TenantType: string(model.TenantTypeOperations)})
+	_, err := svc.ApproveCreateTenant(ctx, request, "ops-user")
+
+	if err == nil {
+		t.Fatal("ApproveCreateTenant: want an error for an unrelated tenant-create failure, got nil")
+	}
+	if tenants.byNameCalls != 0 {
+		t.Fatalf("GetByName called %d times, want 0 — only ErrTenantNameConflict resolves this way", tenants.byNameCalls)
+	}
+	if users.calls != 0 || invites.calls != 0 || requests.approveCalls != 0 {
+		t.Fatalf("enrollment/invite/approve ran (%d/%d/%d calls), want none once tenant registration fails for an unrelated reason", users.calls, invites.calls, requests.approveCalls)
 	}
 }


### PR DESCRIPTION
## Summary

Approving a `CREATE_TENANT` invite request whose tenant name a different flow already claimed hit `tenants.name`'s UNIQUE constraint as a raw 500, left the request stuck `PENDING` with no reachable outcome, and logged nothing an operator could correlate. This fixes all three:

- `TenantRepository.Create` now classifies that specific unique violation (`tenants_name_key`, distinguished by constraint name from the unrelated `tenant_issuers` conflict it already guards) as a new `ErrTenantNameConflict` sentinel instead of a raw 500.
- `InviteRequestService.ApproveCreateTenant` resolves that sentinel by looking the existing tenant up (`TenantRepository.GetByName`) and enrolling the requester into it — the reading taken: the tenant existing is a race ("someone else got there first"), not a mistake, and enrolling the requester is what a `CREATE_TENANT` request actually asks for. `UserRepository.Create`'s own first-user check means this still grants `TenantAdmin` if that tenant genuinely has nobody enrolled yet, `TenantUser` otherwise. The approval then completes normally (invite minted, request marked `APPROVED`), so the request lands on a state the operator can act on instead of a limbo indistinguishable from "nobody has looked at it yet". This also makes the whole workflow retry-safe without a spanning database transaction: resolving-or-creating the tenant is now idempotent, so retrying a partially-failed approve (e.g. tenant registered, a later step then failed) converges to success instead of repeating the same fatal error.
- Every 5xx from an authenticated route now logs the route, the actor (tenant/user), and the real underlying error via a new `writeRepositoryError`/`writeInternalError` logging path in `internal/routes/errors.go` — applied uniformly across the API, not just this endpoint, since the client-facing response body must never carry that detail.

## Test plan

- [x] `TestClassifyTenantCreateErrorMapsNameUniqueViolation` / `...LeavesOtherViolationsAlone` — unit tests pinning the constraint-name classification (`internal/repository/tenants_test.go`)
- [x] `TestCreateReportsTenantNameConflictAndGetByNameResolvesIt` — opt-in e2e test against real Postgres (`internal/repository/tenants_e2e_test.go`, requires `ERUN_E2E_TENANTS_DATABASE_URL`)
- [x] `TestApproveCreateTenantEnrolsIntoExistingTenantWhenNameConflicts` — service-level proof the requester ends up enrolled into the existing tenant and the request reaches `APPROVED` (`internal/service/invite_requests_test.go`)
- [x] `TestApproveCreateTenantSurfacesUnrelatedTenantCreateFailure` — catch-all guard: an unrelated tenant-create failure still fails the approval and leaves the request `PENDING`, not silently approved
- [x] `TestApproveCreateTenantWhenTenantAlreadyExistsRespondsOKNotStuckPending` — HTTP-level test through the real service proving the route responds 200, not 500, and the response body shows `APPROVED`
- [x] `TestWriteRepositoryErrorLogsRouteActorAndErrorOn500` / `...DoesNotLogClientFaults` — the 5xx logging/correlation requirement, and that 4xx stays quiet
- [x] `make check` green (lint, all Go/TS suites, integration suite, chart tests)

Closes #1722