### PR TITLE
Distinguish user-create conflicts instead of reporting every one as a username collision

### DIFF
--- a/erun-backend/erun-backend-api/internal/repository/errors.go
+++ b/erun-backend/erun-backend-api/internal/repository/errors.go
@@ -30,6 +30,17 @@ var (
 	// other check_violations so a caller can be given the documented
 	// INVALID_BODY machine code instead of a generic one.
 	ErrCommentBodyInvalid = fmt.Errorf("comment body is empty or exceeds 8 KiB: %w", ErrInvalidInput)
+	// ErrUsernameConflict signals users_tenant_username_key specifically: a
+	// different identity already holds the requested username in the target
+	// tenant. Distinguished from ErrIdentityConflict so a caller is told which
+	// of the table's two uniqueness contracts actually fired, instead of a
+	// single conflict message guessing at the cause.
+	ErrUsernameConflict = fmt.Errorf("a user with this username already exists in the target tenant: %w", ErrConflict)
+	// ErrUnrecognizedConflict is UserRepository.Create's fallback for a
+	// uniqueness violation that matches neither users_tenant_username_key nor
+	// user_external_ids' primary key — reported as genuinely unknown rather
+	// than guessed at as the most likely-sounding cause.
+	ErrUnrecognizedConflict = fmt.Errorf("an unrecognized uniqueness constraint was violated: %w", ErrConflict)
 )
 
 func normalizeNoRows(err error) error {

--- a/erun-backend/erun-backend-api/internal/repository/identity.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity.go
@@ -173,6 +173,7 @@ func (r *IdentityRepository) refreshUserUsername(ctx context.Context, tenant mod
 		return user, nil
 	}
 
+	refreshed := user
 	err := r.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		if r.dialect == DialectPostgres {
 			if err := r.setPostgresSecurityContext(ctx, tx, security.Context{
@@ -189,14 +190,25 @@ func (r *IdentityRepository) refreshUserUsername(ctx context.Context, tenant mod
 			 WHERE tenant_id = ?
 			   AND user_id = ?
 			RETURNING user_id, tenant_id, username, created_at, updated_at
-		`, username, tenant.TenantID, user.UserID).Scan(ctx, &user)
+		`, username, tenant.TenantID, user.UserID).Scan(ctx, &refreshed)
 		return normalizeNoRows(err)
 	})
 	if err != nil {
+		if isUniqueViolation(err) {
+			// The token's claimed username now collides with a different user
+			// already enrolled under it in this tenant. That is a
+			// display-name refresh failing, not a reason to refuse
+			// authentication for an identity that already resolved — sign the
+			// caller in under the username already on record instead of
+			// surfacing the raw constraint violation as an auth rejection
+			// reason.
+			log.Printf("erun api identity username refresh skipped tenant=%q user=%q requestedUsername=%q reason=%q", tenant.TenantID, user.UserID, username, "username already in use by another user in this tenant")
+			return user, nil
+		}
 		return model.User{}, err
 	}
-	log.Printf("erun api identity refreshed username tenant=%q user=%q username=%q", tenant.TenantID, user.UserID, user.Username)
-	return user, nil
+	log.Printf("erun api identity refreshed username tenant=%q user=%q username=%q", tenant.TenantID, user.UserID, refreshed.Username)
+	return refreshed, nil
 }
 
 // ResolveTenantByIssuer maps a verified token to its tenant. The issuer's org-scoping

--- a/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/identity_e2e_test.go
@@ -1,10 +1,13 @@
 package repository
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
+	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -485,6 +488,55 @@ func TestResolveIdentityDistinguishesNotEnrolledFromUnresolved(t *testing.T) {
 	}
 	if !errors.Is(unresolvedErr, security.ErrTenantUnresolved) {
 		t.Fatalf("unresolved err = %v, want security.ErrTenantUnresolved even though this exact subject is enrolled", unresolvedErr)
+	}
+}
+
+// TestRefreshUserUsernameCollisionSignsInWithoutLeakingRawSQL proves the auth
+// path's own instance of this issue: a token's claimed username refresh
+// colliding with a different user already enrolled under it in the same
+// tenant must not fail authentication, and must never let the raw Postgres
+// unique-violation error (constraint name, SQLSTATE) reach the log as the
+// rejection reason -- an already-resolved identity signs in under its
+// existing username instead.
+func TestRefreshUserUsernameCollisionSignsInWithoutLeakingRawSQL(t *testing.T) {
+	db := identityBootstrapDatabase(t)
+	t.Cleanup(func() { clearIdentityBootstrap(t, db) })
+	repo := NewIdentityRepository(db, DialectPostgres, "")
+
+	const issuer = "https://issuer.example/refresh-collision"
+
+	tenant, alice, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:   issuer,
+		Subject:  "subject-alice",
+		Username: "alice",
+	})
+	mustNoErr(t, err, "bootstrap the first tenant and its first user")
+
+	mustNoErr(t, db.QueryRow(
+		`INSERT INTO users (tenant_id, username) VALUES ($1, $2) RETURNING user_id`,
+		tenant.TenantID, "bob",
+	).Err(), "seed a second user holding the username the refresh will collide on")
+
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	_, resolved, err := repo.ResolveIdentity(context.Background(), security.Claims{
+		Issuer:   issuer,
+		Subject:  "subject-alice",
+		Username: "bob", // already taken by the seeded second user
+	})
+	mustNoErr(t, err, "resolving an identity whose claimed username now collides must still authenticate")
+	if resolved.UserID != alice.UserID || resolved.Username != "alice" {
+		t.Fatalf("resolved = %+v, want alice's original user/username left unchanged", resolved)
+	}
+
+	logged := logBuf.String()
+	if strings.Contains(logged, "SQLSTATE") || strings.Contains(logged, "constraint") || strings.Contains(logged, "duplicate key") {
+		t.Fatalf("log output leaked a raw Postgres error: %q", logged)
+	}
+	if !strings.Contains(logged, "username refresh skipped") {
+		t.Fatalf("log output = %q, want a safe skipped-refresh reason", logged)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/repository/permissions_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/permissions_e2e_test.go
@@ -41,7 +41,11 @@ func permissionsDatabase(t *testing.T) (*sql.DB, string) {
 
 func clearPermissionsTenant(t *testing.T, db *sql.DB, tenantID string) {
 	t.Helper()
-	for _, table := range []string{"user_roles", "role_permissions", "roles", "users", "tenants"} {
+	// user_external_ids and tenant_issuers come before users/tenants: both
+	// foreign-key into them, so a test that seeds an external identity (e.g.
+	// UserRepository.Create's issuer/subject path) would otherwise leave the
+	// users/tenants delete below silently failing on the FK.
+	for _, table := range []string{"user_external_ids", "user_roles", "role_permissions", "roles", "users", "tenant_issuers", "tenants"} {
 		if _, err := db.Exec(`DELETE FROM `+table+` WHERE tenant_id = $1`, tenantID); err != nil {
 			t.Logf("clearing %s for tenant %s: %v", table, tenantID, err)
 		}

--- a/erun-backend/erun-backend-api/internal/repository/users.go
+++ b/erun-backend/erun-backend-api/internal/repository/users.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -36,17 +37,37 @@ type CreateUserParams struct {
 	RoleIDs  []string
 }
 
+// errIdentityAlreadyEnrolledRace is Create's internal-only signal that the
+// insertUserExternalID unique-violation branch fired: a concurrent enrollment
+// won the same (tenant, issuer, subject) between Create's up-front
+// findUserByExternalID check and this insert. It aborts the transaction (so
+// the just-inserted, now-orphaned users row rolls back) and never leaves this
+// file — Create catches it and re-resolves the winner the same way the
+// up-front check would have, so the caller sees the same no-op success either
+// way rather than a race-dependent error.
+var errIdentityAlreadyEnrolledRace = errors.New("identity already enrolled (race)")
+
 // Create enrolls a user and, when Issuer/Subject are given, links the external
 // identity that lets them actually sign in — otherwise the row exists but no
 // token can ever resolve to it.
+//
+// Re-enrolling an identity already mapped in this tenant is a no-op, not a
+// conflict: the operator's intent ("this identity usable in this tenant") is
+// already satisfied, so Create reports it back (alreadyEnrolled=true) with
+// the user that already holds it rather than erroring. The lookup is scoped
+// to tenantID exactly like every other query here, so it can only ever
+// surface a user within the caller's own resolved target tenant — never a
+// different tenant's enrollment of the same external identity.
 //
 // Role assignment: a caller-named RoleIDs list is granted as given.
 // Otherwise, the tenant's first user gets TenantAdmin — without a
 // grant-capable role nobody could ever grant a role at all, since granting is
 // itself permission-gated — and every later enrollment defaults to
 // TenantUser, so an invited colleague can use erun immediately rather than
-// sitting fully capability-less until someone grants a role by hand.
-func (r *UserRepository) Create(ctx context.Context, params CreateUserParams) (model.User, error) {
+// sitting fully capability-less until someone grants a role by hand. A no-op
+// re-enrollment does not re-run role assignment; it leaves the existing
+// user's roles untouched.
+func (r *UserRepository) Create(ctx context.Context, params CreateUserParams) (model.User, bool, error) {
 	username := strings.TrimSpace(params.Username)
 	issuer := strings.TrimSpace(params.Issuer)
 	subject := strings.TrimSpace(params.Subject)
@@ -55,6 +76,16 @@ func (r *UserRepository) Create(ctx context.Context, params CreateUserParams) (m
 	for _, roleID := range params.RoleIDs {
 		if roleID = strings.TrimSpace(roleID); roleID != "" {
 			roleIDs = append(roleIDs, roleID)
+		}
+	}
+
+	if issuer != "" && subject != "" {
+		existing, found, err := r.findUserByExternalID(ctx, tenantID, issuer, subject)
+		if err != nil {
+			return model.User{}, false, err
+		}
+		if found {
+			return existing, true, nil
 		}
 	}
 
@@ -76,9 +107,50 @@ func (r *UserRepository) Create(ctx context.Context, params CreateUserParams) (m
 		return assignEnrollmentRoles(ctx, tx, tenantID, user.UserID, roleIDs, isFirstUser)
 	})
 	if err != nil {
-		return model.User{}, err
+		if errors.Is(err, errIdentityAlreadyEnrolledRace) {
+			if existing, found, findErr := r.findUserByExternalID(ctx, tenantID, issuer, subject); findErr == nil && found {
+				return existing, true, nil
+			}
+			return model.User{}, false, ErrUnrecognizedConflict
+		}
+		return model.User{}, false, err
 	}
-	return user, nil
+	return user, false, nil
+}
+
+// findUserByExternalID looks up the user already holding tenantID's
+// (issuer, externalID) mapping, if any. Scoped by tenantID like every other
+// tenant-owned lookup here (falling back to RLS's own erun_current_tenant_id()
+// scoping when tenantID is empty), so it can never surface a different
+// tenant's enrollment.
+func (r *UserRepository) findUserByExternalID(ctx context.Context, tenantID string, issuer string, externalID string) (model.User, bool, error) {
+	var user model.User
+	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		var scanErr error
+		if tenantID != "" {
+			scanErr = tx.NewRaw(`
+				SELECT u.user_id, u.tenant_id, u.username, u.created_at, u.updated_at
+				  FROM user_external_ids uei
+				  JOIN users u ON u.tenant_id = uei.tenant_id AND u.user_id = uei.user_id
+				 WHERE uei.tenant_id = ? AND uei.issuer = ? AND uei.external_id = ?
+			`, tenantID, issuer, externalID).Scan(ctx, &user)
+		} else {
+			scanErr = tx.NewRaw(`
+				SELECT u.user_id, u.tenant_id, u.username, u.created_at, u.updated_at
+				  FROM user_external_ids uei
+				  JOIN users u ON u.tenant_id = uei.tenant_id AND u.user_id = uei.user_id
+				 WHERE uei.issuer = ? AND uei.external_id = ?
+			`, issuer, externalID).Scan(ctx, &user)
+		}
+		return normalizeNoRows(scanErr)
+	})
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return model.User{}, false, nil
+		}
+		return model.User{}, false, err
+	}
+	return user, true, nil
 }
 
 func insertUserRow(ctx context.Context, tx bun.Tx, tenantID string, username string) (model.User, error) {
@@ -99,13 +171,21 @@ func insertUserRow(ctx context.Context, tx bun.Tx, tenantID string, username str
 	}
 	if err != nil {
 		if isUniqueViolation(err) {
-			return model.User{}, ErrConflict
+			if name, ok := pgConstraintName(err); ok && name == "users_tenant_username_key" {
+				return model.User{}, ErrUsernameConflict
+			}
+			return model.User{}, ErrUnrecognizedConflict
 		}
 		return model.User{}, normalizeNoRows(err)
 	}
 	return user, nil
 }
 
+// insertUserExternalID's only unique constraint is user_external_ids' own
+// primary key (tenant_id, issuer, external_id), so any unique violation here
+// is unambiguously a concurrent enrollment winning the same identity mapping
+// Create's up-front findUserByExternalID check already looked for and did
+// not find — see errIdentityAlreadyEnrolledRace.
 func insertUserExternalID(ctx context.Context, tx bun.Tx, tenantID string, userID string, issuer string, subject string) error {
 	var err error
 	if tenantID != "" {
@@ -121,7 +201,7 @@ func insertUserExternalID(ctx context.Context, tx bun.Tx, tenantID string, userI
 	}
 	if err != nil {
 		if isUniqueViolation(err) {
-			return ErrConflict
+			return errIdentityAlreadyEnrolledRace
 		}
 		return err
 	}

--- a/erun-backend/erun-backend-api/internal/repository/users.go
+++ b/erun-backend/erun-backend-api/internal/repository/users.go
@@ -72,23 +72,38 @@ func (r *UserRepository) Create(ctx context.Context, params CreateUserParams) (m
 	issuer := strings.TrimSpace(params.Issuer)
 	subject := strings.TrimSpace(params.Subject)
 	tenantID := strings.TrimSpace(params.TenantID)
-	roleIDs := make([]string, 0, len(params.RoleIDs))
-	for _, roleID := range params.RoleIDs {
-		if roleID = strings.TrimSpace(roleID); roleID != "" {
-			roleIDs = append(roleIDs, roleID)
-		}
-	}
+	roleIDs := trimmedRoleIDs(params.RoleIDs)
 
 	if issuer != "" && subject != "" {
-		existing, found, err := r.findUserByExternalID(ctx, tenantID, issuer, subject)
-		if err != nil {
-			return model.User{}, false, err
-		}
-		if found {
-			return existing, true, nil
+		if existing, found, err := r.findUserByExternalID(ctx, tenantID, issuer, subject); err != nil || found {
+			return existing, found, err
 		}
 	}
 
+	user, err := r.insertUserAndRoles(ctx, tenantID, username, issuer, subject, roleIDs)
+	if err == nil {
+		return user, false, nil
+	}
+	if errors.Is(err, errIdentityAlreadyEnrolledRace) {
+		return r.resolveIdentityRaceWinner(ctx, tenantID, issuer, subject)
+	}
+	return model.User{}, false, err
+}
+
+// trimmedRoleIDs drops blank entries from a caller-supplied roleIds list.
+func trimmedRoleIDs(roleIDs []string) []string {
+	trimmed := make([]string, 0, len(roleIDs))
+	for _, roleID := range roleIDs {
+		if roleID = strings.TrimSpace(roleID); roleID != "" {
+			trimmed = append(trimmed, roleID)
+		}
+	}
+	return trimmed
+}
+
+// insertUserAndRoles is Create's actual insert path, run once
+// findUserByExternalID's up-front check has ruled out a no-op re-enrollment.
+func (r *UserRepository) insertUserAndRoles(ctx context.Context, tenantID string, username string, issuer string, subject string, roleIDs []string) (model.User, error) {
 	var user model.User
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		isFirstUser, err := tenantHasNoUsers(ctx, tx, tenantID)
@@ -106,16 +121,20 @@ func (r *UserRepository) Create(ctx context.Context, params CreateUserParams) (m
 		}
 		return assignEnrollmentRoles(ctx, tx, tenantID, user.UserID, roleIDs, isFirstUser)
 	})
-	if err != nil {
-		if errors.Is(err, errIdentityAlreadyEnrolledRace) {
-			if existing, found, findErr := r.findUserByExternalID(ctx, tenantID, issuer, subject); findErr == nil && found {
-				return existing, true, nil
-			}
-			return model.User{}, false, ErrUnrecognizedConflict
-		}
-		return model.User{}, false, err
+	return user, err
+}
+
+// resolveIdentityRaceWinner re-resolves the winner of errIdentityAlreadyEnrolledRace
+// the same way Create's up-front check would have, so the caller sees the same
+// no-op success either way. The lookup failing to find anything should not
+// happen (the unique violation that got here proves a winner exists), so it
+// falls back to reporting a genuinely unrecognized conflict rather than
+// guessing.
+func (r *UserRepository) resolveIdentityRaceWinner(ctx context.Context, tenantID string, issuer string, subject string) (model.User, bool, error) {
+	if existing, found, err := r.findUserByExternalID(ctx, tenantID, issuer, subject); err == nil && found {
+		return existing, true, nil
 	}
-	return user, false, nil
+	return model.User{}, false, ErrUnrecognizedConflict
 }
 
 // findUserByExternalID looks up the user already holding tenantID's

--- a/erun-backend/erun-backend-api/internal/repository/users_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/users_e2e_test.go
@@ -47,7 +47,7 @@ func TestUserRepositoryFirstUserGetsPredefinedRoles(t *testing.T) {
 	authorizer := &PermissionAuthorizer{txs: txs}
 	ctx := rolesContext(tenantID, "")
 
-	created, err := users.Create(ctx, CreateUserParams{Username: "first-admin"})
+	created, _, err := users.Create(ctx, CreateUserParams{Username: "first-admin"})
 	mustNoErr(t, err, "create first user")
 
 	names, err := users.RoleNames(rolesContext(tenantID, created.UserID), created.UserID)
@@ -84,7 +84,7 @@ func TestUserRepositoryLaterUserGetsTenantUserByDefault(t *testing.T) {
 		{methodPattern: "^(POST|PUT|PATCH|DELETE)$", pathPattern: "^/.*$"},
 	})
 
-	created, err := users.Create(rolesContext(tenantID, first), CreateUserParams{Username: "second-user"})
+	created, _, err := users.Create(rolesContext(tenantID, first), CreateUserParams{Username: "second-user"})
 	mustNoErr(t, err, "create second user")
 
 	names, err := users.RoleNames(rolesContext(tenantID, first), created.UserID)
@@ -127,7 +127,7 @@ func TestUserRepositoryExplicitRoleIDsAreGranted(t *testing.T) {
 	})
 	mustNoErr(t, err, "create narrow role")
 
-	created, err := users.Create(adminCtx, CreateUserParams{Username: "narrow-user", RoleIDs: []string{role.RoleID}})
+	created, _, err := users.Create(adminCtx, CreateUserParams{Username: "narrow-user", RoleIDs: []string{role.RoleID}})
 	mustNoErr(t, err, "create user with explicit roles")
 
 	names, err := users.RoleNames(adminCtx, created.UserID)
@@ -157,12 +157,85 @@ func TestUserRepositoryCreateRejectsUnknownRoleID(t *testing.T) {
 		{methodPattern: "^(POST|PUT|PATCH|DELETE)$", pathPattern: "^/.*$"},
 	})
 
-	_, err := users.Create(rolesContext(tenantID, first), CreateUserParams{
+	_, _, err := users.Create(rolesContext(tenantID, first), CreateUserParams{
 		Username: "someone",
 		RoleIDs:  []string{"00000000-0000-0000-0000-000000000000"},
 	})
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for an unknown role id, got %v", err)
+	}
+}
+
+// seedTenantIssuer registers issuer for tenantID so a user_external_ids row
+// can foreign-key it — the same registration bootstrap already performs, done
+// by hand here since these tests seed enrollment directly.
+func seedTenantIssuer(t *testing.T, db *sql.DB, tenantID, issuer string) {
+	t.Helper()
+	_, err := db.Exec(`INSERT INTO issuers (issuer) VALUES ($1) ON CONFLICT (issuer) DO NOTHING`, issuer)
+	mustNoErr(t, err, "seed issuers")
+	_, err = db.Exec(`INSERT INTO tenant_issuers (tenant_id, issuer, name) VALUES ($1, $2, $3)`, tenantID, issuer, issuer)
+	mustNoErr(t, err, "seed tenant_issuers")
+}
+
+// TestUserRepositoryCreateReportsUsernameConflictDistinctly proves a plain
+// username collision (no external identity involved) surfaces as
+// ErrUsernameConflict, not the bare ErrConflict a caller could not tell apart
+// from any other uniqueness violation.
+func TestUserRepositoryCreateReportsUsernameConflictDistinctly(t *testing.T) {
+	db, tenantID := usersDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	users := &UserRepository{txs: txs}
+	first := seedPermissionsUser(t, db, tenantID, "first-admin")
+
+	_, _, err := users.Create(rolesContext(tenantID, first), CreateUserParams{Username: "first-admin"})
+	if !errors.Is(err, ErrUsernameConflict) {
+		t.Fatalf("expected ErrUsernameConflict for a colliding username, got %v", err)
+	}
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected ErrUsernameConflict to still satisfy errors.Is(err, ErrConflict), got %v", err)
+	}
+}
+
+// TestUserRepositoryCreateTreatsReEnrollmentAsNoOp is the regression this fix
+// addresses: re-enrolling an identity already linked in the tenant, even
+// under a *different* requested username, reports the existing user back
+// (alreadyEnrolled=true) instead of the wrong-cause username-collision 409
+// that sent an operator hunting for a username that did not exist.
+func TestUserRepositoryCreateTreatsReEnrollmentAsNoOp(t *testing.T) {
+	db, tenantID := usersDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	users := &UserRepository{txs: txs}
+	first := seedPermissionsUser(t, db, tenantID, "first-admin")
+	issuer := "https://issuer.example"
+	seedTenantIssuer(t, db, tenantID, issuer)
+
+	created, alreadyEnrolled, err := users.Create(rolesContext(tenantID, first), CreateUserParams{
+		Username: "rihards-frs-lv",
+		Issuer:   issuer,
+		Subject:  "subject-1",
+	})
+	mustNoErr(t, err, "enroll identity first time")
+	if alreadyEnrolled {
+		t.Fatalf("expected the first enrollment to not be reported as already enrolled")
+	}
+
+	reEnrolled, alreadyEnrolled, err := users.Create(rolesContext(tenantID, first), CreateUserParams{
+		Username: "rihards", // a different username than the one already on file
+		Issuer:   issuer,
+		Subject:  "subject-1",
+	})
+	mustNoErr(t, err, "re-enroll the same identity")
+	if !alreadyEnrolled {
+		t.Fatalf("expected re-enrolling an already-linked identity to be reported as already enrolled")
+	}
+	if reEnrolled.UserID != created.UserID || reEnrolled.Username != created.Username {
+		t.Fatalf("re-enrollment = %+v, want the original user %+v untouched (no new row, no rename)", reEnrolled, created)
+	}
+
+	var count int
+	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND username = $2`, tenantID, "rihards").Scan(&count), "count rows for the requested username")
+	if count != 0 {
+		t.Fatalf("expected no user row for the requested (unused) username, got %d", count)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/routes/invite_requests_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/invite_requests_test.go
@@ -241,11 +241,11 @@ func (f *fakeApproveCreateTenantTenants) GetByName(_ context.Context, _ string) 
 
 type fakeApproveCreateTenantUsers struct{ gotTenantID string }
 
-func (f *fakeApproveCreateTenantUsers) Create(ctx context.Context, _ repository.CreateUserParams) (model.User, error) {
+func (f *fakeApproveCreateTenantUsers) Create(ctx context.Context, _ repository.CreateUserParams) (model.User, bool, error) {
 	if sc, ok := security.FromContext(ctx); ok {
 		f.gotTenantID = sc.TenantID
 	}
-	return model.User{UserID: "user-1"}, nil
+	return model.User{UserID: "user-1"}, false, nil
 }
 
 type fakeApproveCreateTenantInvites struct{}

--- a/erun-backend/erun-backend-api/internal/routes/users.go
+++ b/erun-backend/erun-backend-api/internal/routes/users.go
@@ -13,7 +13,7 @@ import (
 
 // UserEnrollmentRepository is the persistence dependency for POST/GET /v1/users.
 type UserEnrollmentRepository interface {
-	Create(ctx context.Context, params repository.CreateUserParams) (model.User, error)
+	Create(ctx context.Context, params repository.CreateUserParams) (model.User, bool, error)
 	List(ctx context.Context, filter repository.UserFilter) ([]model.User, error)
 }
 
@@ -35,6 +35,17 @@ type enrollUserRequest struct {
 	Subject  string   `json:"subject,omitempty"`
 	TenantID string   `json:"tenantId,omitempty"`
 	RoleIDs  []string `json:"roleIds,omitempty"`
+}
+
+// enrollUserResponse is createUser's response body: the enrolled (or
+// already-enrolled) user's model shape plus AlreadyEnrolled, which is true
+// only for the no-op re-enrollment case (see UserRepository.Create's doc) —
+// so a caller can tell "brand new, exactly as requested" apart from
+// "already existed, here is what's actually on file" instead of inferring it
+// from the HTTP status alone.
+type enrollUserResponse struct {
+	model.User
+	AlreadyEnrolled bool `json:"alreadyEnrolled,omitempty"`
 }
 
 func RegisterUserRoutes(register ProtectedRouteRegistrar, users UserEnrollmentRepository) {
@@ -93,7 +104,7 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 		overrideTenantID = targetTenantID
 	}
 
-	created, err := r.users.Create(req.Context(), repository.CreateUserParams{
+	created, alreadyEnrolled, err := r.users.Create(req.Context(), repository.CreateUserParams{
 		Username: username,
 		Issuer:   strings.TrimSpace(body.Issuer),
 		Subject:  strings.TrimSpace(body.Subject),
@@ -101,18 +112,27 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 		RoleIDs:  body.RoleIDs,
 	})
 	if err != nil {
-		if errors.Is(err, repository.ErrConflict) {
-			writeError(w, http.StatusConflict, "a user with this username already exists in the target tenant")
+		switch {
+		case errors.Is(err, repository.ErrUsernameConflict):
+			writeErrorCode(w, http.StatusConflict, "USERNAME_TAKEN", "a user with this username already exists in the target tenant")
 			return
-		}
-		if errors.Is(err, repository.ErrNotFound) {
+		case errors.Is(err, repository.ErrNotFound):
 			writeError(w, http.StatusNotFound, "one or more requested roles do not exist in this tenant")
 			return
+		default:
+			writeRepositoryError(w, req, err)
+			return
 		}
-		writeRepositoryError(w, req, err)
-		return
 	}
-	writeJSON(w, http.StatusCreated, created)
+	// Re-enrolling an identity already enrolled in the target tenant is a
+	// no-op success (200, the existing user), not a 201 — see
+	// UserRepository.Create's doc for why this is treated as satisfied
+	// intent rather than a conflict.
+	status := http.StatusCreated
+	if alreadyEnrolled {
+		status = http.StatusOK
+	}
+	writeJSON(w, status, enrollUserResponse{User: created, AlreadyEnrolled: alreadyEnrolled})
 }
 
 func (r UserRoutes) listUsers(w http.ResponseWriter, req *http.Request) {

--- a/erun-backend/erun-backend-api/internal/routes/users.go
+++ b/erun-backend/erun-backend-api/internal/routes/users.go
@@ -112,17 +112,8 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 		RoleIDs:  body.RoleIDs,
 	})
 	if err != nil {
-		switch {
-		case errors.Is(err, repository.ErrUsernameConflict):
-			writeErrorCode(w, http.StatusConflict, "USERNAME_TAKEN", "a user with this username already exists in the target tenant")
-			return
-		case errors.Is(err, repository.ErrNotFound):
-			writeError(w, http.StatusNotFound, "one or more requested roles do not exist in this tenant")
-			return
-		default:
-			writeRepositoryError(w, req, err)
-			return
-		}
+		writeCreateUserError(w, req, err)
+		return
 	}
 	// Re-enrolling an identity already enrolled in the target tenant is a
 	// no-op success (200, the existing user), not a 201 — see
@@ -133,6 +124,20 @@ func (r UserRoutes) createUser(w http.ResponseWriter, req *http.Request) {
 		status = http.StatusOK
 	}
 	writeJSON(w, status, enrollUserResponse{User: created, AlreadyEnrolled: alreadyEnrolled})
+}
+
+// writeCreateUserError maps Create's discriminated conflicts to their
+// documented codes/messages instead of letting the route fall through to the
+// generic conflict response for a cause it actually knows.
+func writeCreateUserError(w http.ResponseWriter, req *http.Request, err error) {
+	switch {
+	case errors.Is(err, repository.ErrUsernameConflict):
+		writeErrorCode(w, http.StatusConflict, "USERNAME_TAKEN", "a user with this username already exists in the target tenant")
+	case errors.Is(err, repository.ErrNotFound):
+		writeError(w, http.StatusNotFound, "one or more requested roles do not exist in this tenant")
+	default:
+		writeRepositoryError(w, req, err)
+	}
 }
 
 func (r UserRoutes) listUsers(w http.ResponseWriter, req *http.Request) {

--- a/erun-backend/erun-backend-api/internal/routes/users_test.go
+++ b/erun-backend/erun-backend-api/internal/routes/users_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/model"
@@ -13,9 +14,11 @@ import (
 )
 
 type stubUserEnrollmentRepository struct {
-	createCalls int
-	createErr   error
-	gotCreate   repository.CreateUserParams
+	createCalls     int
+	createErr       error
+	createAlreadyOn bool
+	createExisting  model.User
+	gotCreate       repository.CreateUserParams
 
 	listCalls int
 	listErr   error
@@ -23,17 +26,20 @@ type stubUserEnrollmentRepository struct {
 	users     []model.User
 }
 
-func (r *stubUserEnrollmentRepository) Create(_ context.Context, params repository.CreateUserParams) (model.User, error) {
+func (r *stubUserEnrollmentRepository) Create(_ context.Context, params repository.CreateUserParams) (model.User, bool, error) {
 	r.createCalls++
 	r.gotCreate = params
 	if r.createErr != nil {
-		return model.User{}, r.createErr
+		return model.User{}, false, r.createErr
+	}
+	if r.createAlreadyOn {
+		return r.createExisting, true, nil
 	}
 	tenantID := params.TenantID
 	if tenantID == "" {
 		tenantID = "caller-tenant"
 	}
-	return model.User{UserID: "user-new", TenantID: tenantID, Username: params.Username}, nil
+	return model.User{UserID: "user-new", TenantID: tenantID, Username: params.Username}, false, nil
 }
 
 func (r *stubUserEnrollmentRepository) List(_ context.Context, filter repository.UserFilter) ([]model.User, error) {
@@ -109,11 +115,58 @@ func TestCreateUserRejectsEmptyUsername(t *testing.T) {
 	}
 }
 
-func TestCreateUserMapsConflictToStatusConflict(t *testing.T) {
-	users := &stubUserEnrollmentRepository{createErr: repository.ErrConflict}
+// TestCreateUserMapsUnrecognizedConflictToGenericStatusConflict proves a
+// conflict Create cannot name a specific cause for still maps to 409, without
+// guessing at wording the way the pre-fix username-collision message did for
+// every conflict class.
+func TestCreateUserMapsUnrecognizedConflictToGenericStatusConflict(t *testing.T) {
+	users := &stubUserEnrollmentRepository{createErr: repository.ErrUnrecognizedConflict}
 	rec := postUsers(t, users, string(model.TenantTypeCompany), "tenant-a", `{"username":"alice"}`)
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "username") {
+		t.Fatalf("body = %q, an unrecognized conflict must not guess a username-collision cause", rec.Body.String())
+	}
+}
+
+// TestCreateUserMapsUsernameConflictToUsernameTakenCode proves a username
+// collision is reported with its own machine code and an accurate message,
+// rather than the same generic conflict response every conflict class used
+// to get regardless of which uniqueness constraint actually fired.
+func TestCreateUserMapsUsernameConflictToUsernameTakenCode(t *testing.T) {
+	users := &stubUserEnrollmentRepository{createErr: repository.ErrUsernameConflict}
+	rec := postUsers(t, users, string(model.TenantTypeCompany), "tenant-a", `{"username":"alice"}`)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"USERNAME_TAKEN"`) {
+		t.Fatalf("body = %q, want code USERNAME_TAKEN", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "username") {
+		t.Fatalf("body = %q, want a message naming the username cause", rec.Body.String())
+	}
+}
+
+// TestCreateUserReportsAlreadyEnrolledAsSuccessNotConflict proves re-enrolling
+// an identity already enrolled in the tenant is reported as the no-op it is —
+// 200 with alreadyEnrolled true and the real existing username — rather than
+// as any kind of conflict.
+func TestCreateUserReportsAlreadyEnrolledAsSuccessNotConflict(t *testing.T) {
+	users := &stubUserEnrollmentRepository{
+		createAlreadyOn: true,
+		createExisting:  model.User{UserID: "user-existing", TenantID: "tenant-a", Username: "rihards@frs.lv"},
+	}
+	rec := postUsers(t, users, string(model.TenantTypeCompany), "tenant-a", `{"username":"rihards","issuer":"https://issuer.example","subject":"sub-1"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"alreadyEnrolled":true`) {
+		t.Fatalf("body = %q, want alreadyEnrolled true", body)
+	}
+	if !strings.Contains(body, `"username":"rihards@frs.lv"`) {
+		t.Fatalf("body = %q, want the real existing username, not the requested one", body)
 	}
 }
 

--- a/erun-backend/erun-backend-api/internal/service/identity.go
+++ b/erun-backend/erun-backend-api/internal/service/identity.go
@@ -23,7 +23,7 @@ type IdentityAdmin interface {
 // user row and its external-identity mapping. repository.UserRepository
 // satisfies it.
 type IdentityUserCreator interface {
-	Create(ctx context.Context, params repository.CreateUserParams) (model.User, error)
+	Create(ctx context.Context, params repository.CreateUserParams) (model.User, bool, error)
 }
 
 // ErrIdentityMappingFailed marks an enrollment where the IdP half landed but
@@ -148,7 +148,7 @@ func (s *IdentityService) Enroll(ctx context.Context, params EnrollIdentityParam
 		}, nil
 	}
 
-	erunUser, err := s.users.Create(ctx, repository.CreateUserParams{
+	erunUser, _, err := s.users.Create(ctx, repository.CreateUserParams{
 		Username: params.Username,
 		Issuer:   params.Issuer,
 		Subject:  idpUser.ID,

--- a/erun-backend/erun-backend-api/internal/service/identity_test.go
+++ b/erun-backend/erun-backend-api/internal/service/identity_test.go
@@ -37,13 +37,13 @@ type stubIdentityUserCreator struct {
 	createCalls int
 }
 
-func (s *stubIdentityUserCreator) Create(_ context.Context, params repository.CreateUserParams) (model.User, error) {
+func (s *stubIdentityUserCreator) Create(_ context.Context, params repository.CreateUserParams) (model.User, bool, error) {
 	s.createCalls++
 	s.gotParams = params
 	if s.err != nil {
-		return model.User{}, s.err
+		return model.User{}, false, s.err
 	}
-	return s.created, nil
+	return s.created, false, nil
 }
 
 func TestIdentityServiceEnrollHappyPath(t *testing.T) {

--- a/erun-backend/erun-backend-api/internal/service/invite_requests.go
+++ b/erun-backend/erun-backend-api/internal/service/invite_requests.go
@@ -31,7 +31,7 @@ type InviteRequestTenantCreator interface {
 // InviteRequestUserEnroller enrols a user into the tenant ctx's own
 // security.Context names. *repository.UserRepository satisfies it.
 type InviteRequestUserEnroller interface {
-	Create(ctx context.Context, params repository.CreateUserParams) (model.User, error)
+	Create(ctx context.Context, params repository.CreateUserParams) (model.User, bool, error)
 }
 
 // InviteRequestInviteMinter mints an invite. *repository.InviteRepository satisfies it.
@@ -77,7 +77,7 @@ func (s *InviteRequestService) ApproveJoin(ctx context.Context, request model.In
 	if request.Kind != model.InviteRequestKindJoinTenant {
 		return model.InviteRequest{}, ErrInviteRequestWrongKind
 	}
-	if _, err := s.users.Create(ctx, repository.CreateUserParams{
+	if _, _, err := s.users.Create(ctx, repository.CreateUserParams{
 		Username: enrollmentUsername(request),
 		Issuer:   request.Issuer,
 		Subject:  request.Subject,
@@ -144,7 +144,7 @@ func (s *InviteRequestService) ApproveCreateTenant(ctx context.Context, request 
 		TenantID:   tenant.TenantID,
 		TenantType: string(tenant.Type),
 	})
-	if _, err := s.users.Create(tenantCtx, repository.CreateUserParams{
+	if _, _, err := s.users.Create(tenantCtx, repository.CreateUserParams{
 		Username: enrollmentUsername(request),
 		Issuer:   request.Issuer,
 		Subject:  request.Subject,

--- a/erun-backend/erun-backend-api/internal/service/invite_requests_test.go
+++ b/erun-backend/erun-backend-api/internal/service/invite_requests_test.go
@@ -42,13 +42,13 @@ type stubInviteRequestUserEnroller struct {
 	calls              int
 }
 
-func (s *stubInviteRequestUserEnroller) Create(ctx context.Context, params repository.CreateUserParams) (model.User, error) {
+func (s *stubInviteRequestUserEnroller) Create(ctx context.Context, params repository.CreateUserParams) (model.User, bool, error) {
 	s.got = params
 	s.calls++
 	if sc, ok := security.FromContext(ctx); ok {
 		s.gotSecurityContext = sc
 	}
-	return s.user, s.err
+	return s.user, false, s.err
 }
 
 type stubInviteRequestInviteMinter struct {

--- a/erun-backend/erun-backend-api/internal/service/invites.go
+++ b/erun-backend/erun-backend-api/internal/service/invites.go
@@ -114,7 +114,7 @@ func (s *InviteService) Accept(ctx context.Context, params AcceptInviteParams) (
 		TenantID:   invite.TenantID,
 		TenantType: consumed.TenantType,
 	})
-	erunUser, err := s.users.Create(tenantCtx, repository.CreateUserParams{
+	erunUser, _, err := s.users.Create(tenantCtx, repository.CreateUserParams{
 		Username: params.Username,
 		Issuer:   invite.Issuer,
 		Subject:  idpUser.ID,

--- a/erun-backend/erun-backend-api/internal/service/invites_test.go
+++ b/erun-backend/erun-backend-api/internal/service/invites_test.go
@@ -45,13 +45,13 @@ type stubInviteUserCreator struct {
 	calls              int
 }
 
-func (s *stubInviteUserCreator) Create(ctx context.Context, params repository.CreateUserParams) (model.User, error) {
+func (s *stubInviteUserCreator) Create(ctx context.Context, params repository.CreateUserParams) (model.User, bool, error) {
 	s.gotParams = params
 	s.calls++
 	if sc, ok := security.FromContext(ctx); ok {
 		s.gotSecurityContext = sc
 	}
-	return s.user, s.err
+	return s.user, false, s.err
 }
 
 func testConsumedInvite() repository.ConsumedInvite {

--- a/erun-backend/erun-backend-api/role_policy_e2e_test.go
+++ b/erun-backend/erun-backend-api/role_policy_e2e_test.go
@@ -86,7 +86,7 @@ func enrollUser(t *testing.T, txManager *repository.TxManager, tenantID string, 
 	t.Helper()
 	users := repository.NewUserRepository(txManager)
 	ctx := security.WithContext(context.Background(), security.Context{TenantID: tenantID, TenantType: string(tenantType)})
-	user, err := users.Create(ctx, params)
+	user, _, err := users.Create(ctx, params)
 	mustNoErr(t, err, "enroll user")
 	return user
 }

--- a/erun-cli/cmd/platform.go
+++ b/erun-cli/cmd/platform.go
@@ -165,8 +165,9 @@ func newPlatformUserEnrollCmd(store common.CloudReadStore, alias *string, deps c
 		Long: "Enroll a user in a tenant on the erun platform.\n\n" +
 			"Writes a new user row, immediately. Pass --issuer and --subject to link the external " +
 			"identity the user signs in with; without them the user cannot sign in until an identity " +
-			"is linked. --tenant-id targets another tenant and is honored only for an " +
-			"operations-tenant caller.",
+			"is linked. If that identity is already enrolled in the target tenant, this is a no-op: " +
+			"it reports the existing user rather than failing on a username collision. --tenant-id " +
+			"targets another tenant and is honored only for an operations-tenant caller.",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		Example:      "  erun platform user enroll --username jane --issuer https://acme.example.com --subject jane@acme.com",
@@ -181,7 +182,11 @@ func newPlatformUserEnrollCmd(store common.CloudReadStore, alias *string, deps c
 				return err
 			}
 			if ctx.Output != common.OutputJSON {
-				if _, err := fmt.Fprintf(ctx.Stdout, "enrolled user %s (%s) in tenant %s\n", user.Username, user.UserID, user.TenantID); err != nil {
+				message := fmt.Sprintf("enrolled user %s (%s) in tenant %s\n", user.Username, user.UserID, user.TenantID)
+				if user.AlreadyEnrolled {
+					message = fmt.Sprintf("this identity is already enrolled, as %s (%s) in tenant %s\n", user.Username, user.UserID, user.TenantID)
+				}
+				if _, err := fmt.Fprint(ctx.Stdout, message); err != nil {
 					return err
 				}
 			}

--- a/erun-common/platform_client.go
+++ b/erun-common/platform_client.go
@@ -109,15 +109,22 @@ type PlatformTenant struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
-// PlatformUser mirrors model.User's JSON shape.
+// PlatformUser mirrors model.User's JSON shape (plus AlreadyEnrolled, which
+// only POST /v1/users' response sets).
 type PlatformUser struct {
-	UserID    string    `json:"userId"`
-	TenantID  string    `json:"tenantId"`
-	Username  string    `json:"username"`
-	Issuer    string    `json:"issuer,omitempty"`
-	Subject   string    `json:"subject,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	UserID   string `json:"userId"`
+	TenantID string `json:"tenantId"`
+	Username string `json:"username"`
+	Issuer   string `json:"issuer,omitempty"`
+	Subject  string `json:"subject,omitempty"`
+	// AlreadyEnrolled is true when POST /v1/users found the requested external
+	// identity already enrolled in the target tenant and left it untouched
+	// (a no-op) instead of creating a new user — the caller asked to enroll an
+	// identity that was already usable, so this reports the existing user
+	// rather than a false username-collision conflict.
+	AlreadyEnrolled bool      `json:"alreadyEnrolled,omitempty"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
 }
 
 // PlatformEnvironment mirrors model.Environment's JSON shape.

--- a/erun-common/work_clone_reclaim_test.go
+++ b/erun-common/work_clone_reclaim_test.go
@@ -197,6 +197,8 @@ func TestDecideWorkCloneReclaimSquashMergedBranchWithADeletedRemoteBranchIsRecla
 	// repository lands.
 	merger := t.TempDir()
 	runGitForTest(t, filepath.Dir(merger), "clone", "-q", "--branch", "main", bare, merger)
+	runGitForTest(t, merger, "config", "user.email", "test@example.com")
+	runGitForTest(t, merger, "config", "user.name", "Test")
 	runGitForTest(t, merger, "fetch", "-q", "origin", "feature/lane")
 	runGitForTest(t, merger, "merge", "-q", "--squash", "origin/feature/lane")
 	runGitForTest(t, merger, "commit", "-q", "-m", "Squash merge feature/lane (#1)")
@@ -223,6 +225,8 @@ func TestDecideWorkCloneReclaimUnpushedBranchThatOnlyLooksLikeASquashMergeIsKept
 	// feature/lane's own changeset never gets merged anywhere.
 	other := t.TempDir()
 	runGitForTest(t, filepath.Dir(other), "clone", "-q", "--branch", "main", bare, other)
+	runGitForTest(t, other, "config", "user.email", "test@example.com")
+	runGitForTest(t, other, "config", "user.name", "Test")
 	writeAndCommit(t, other, "unrelated.txt", "unrelated\n", "unrelated main work")
 	runGitForTest(t, other, "push", "-q", "origin", "main")
 

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -863,6 +863,22 @@ Both act on the caller's own resolved tenant by default. An explicit `tenantId` 
 
 Omitting `issuer`/`subject` enrolls a username with **no external identity yet** — the row exists, but no token can resolve to it until one is linked, and there is no separate endpoint to link one after the fact in this build.
 
+**Re-enrolling an already-linked identity is a no-op, not a conflict.** When `issuer`/`subject` are given and that exact pair is already enrolled in the target tenant, the response is `200` (not `201`) with `alreadyEnrolled: true` and the user that already holds the mapping — its real `username`, which may differ from the one this request asked for. The operator's intent ("this identity usable in this tenant") was already satisfied, so nothing is created and existing roles are left untouched:
+
+```jsonc
+// 200 response — issuer/subject already enrolled as a different username
+{
+  "userId": "019a7fa5-c2c0-7c55-bc70-714873a71f60",
+  "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f10",
+  "username": "alice@idp.example",  // the username already on file, not the one requested
+  "issuer": "https://idp.example",
+  "subject": "alice@idp.example",
+  "alreadyEnrolled": true,
+  "createdAt": "2026-06-24T10:00:00Z",
+  "updatedAt": "2026-06-24T10:00:00Z"
+}
+```
+
 **Role assignment default.** An enrolled user gets exactly the roles named in `roleIds`. Omitting `roleIds` enrolls with **zero roles** — a user who can sign in but do nothing until someone with a grant-capable role grants one, the same "may do nothing" state [the capability set](#capability-set) already models. The one exception is the target tenant's **first** user: that enrollment still gets the predefined `ReadAll`/`WriteAll` roles regardless of `roleIds`, matching [empty-database bootstrap](#tenant-issuers) above — without it, a tenant whose first (and only) user held nothing could never grant anything, since granting a role is itself a permission-gated call. [`GET`/`POST /v1/roles`](#roles-endpoints) and [`/v1/users/{user_id}/roles`](#roles-endpoints) below are how an operator lists existing roles and grants/revokes them after enrollment.
 
 This endpoint requires the caller to already know the enrollee's `issuer`/`subject` from the identity provider. [`POST /v1/identity/users`](/agent-reference/identity-administration) is the higher-level alternative for a platform running its own IdP (Zitadel): it creates the IdP identity itself and calls this same mapping with the subject the IdP returns, in one action, restricted to an `OPERATIONS` tenant.
@@ -890,7 +906,8 @@ This endpoint requires the caller to already know the enrollee's `issuer`/`subje
 | `400` | `username` is empty, or the body is not valid JSON. | Send a non-empty `username`. |
 | `403` | `tenantId` (or `?tenantId=`) names a different tenant than the caller's own, and the caller's resolved tenant is not `OPERATIONS`. | Omit `tenantId` to act on your own tenant, or call from an operations-tenant token. |
 | `404` | `POST /v1/users`: a `roleIds` entry does not name a role in the target tenant. | Fix the role id, or create the role first via [`POST /v1/roles`](#roles-endpoints). |
-| `409` | `POST /v1/users`: a user with that `username` already exists in the target tenant (`users_tenant_username_key`). | Use a different username, or omit `tenantId` if you meant your own tenant. |
+| `409` `USERNAME_TAKEN` | `POST /v1/users`: a *different* identity already holds that `username` in the target tenant (`users_tenant_username_key`). Re-enrolling the *same* `issuer`/`subject` that already holds a username is never this — see the `200`/`alreadyEnrolled` response above. | Use a different username, or omit `tenantId` if you meant your own tenant. |
+| `409` `CONFLICT` | `POST /v1/users`: a uniqueness violation this endpoint does not recognize as either of the above. | Retry is unlikely to help without changing the request; treat as a server-side gap and report it. |
 
 ### Roles and role assignment {#roles-endpoints}
 


### PR DESCRIPTION
## Summary

- `UserRepository.Create` used to map every uniqueness violation into a bare `ErrConflict`, so `POST /v1/users` reported *any* conflict as "a user with this username already exists in the target tenant" — even when the real conflict was a re-enrolled external identity and no such username existed.
- `Create` now distinguishes `users_tenant_username_key` (a different identity holds the username — `ErrUsernameConflict`, `409 USERNAME_TAKEN`) from `user_external_ids`' own primary key (the same identity is already enrolled), and reports anything else as an explicit unrecognized conflict (`ErrUnrecognizedConflict`) rather than guessing.
- **Re-enrolling an identity already linked in the target tenant is now a no-op success** (`200` + `alreadyEnrolled: true`, returning the real existing user), not a conflict — the operator's intent ("this identity usable in this tenant") was already satisfied, and it can never leak another tenant's enrollment since the lookup is scoped to the same target tenant the write itself would use.
- Fixed a second instance of the same defect class on the **auth path**: `IdentityRepository.refreshUserUsername` let a raw Postgres unique-violation error (constraint name, SQLSTATE) reach the auth-rejected log line and the client response when a token's claimed username collided with a different enrolled user. It now skips the display-name refresh and signs the caller in under their existing username instead of failing authentication or leaking the raw driver error.
- Wired `alreadyEnrolled` through the shared `erun-common` platform client (`PlatformUser`) so `erun platform user enroll` prints "already enrolled" instead of "enrolled" for the no-op case; MCP inherits it for free via the embedded type.
- Documented the new `200`/`alreadyEnrolled` response and the split `409` codes in `agent-reference/api-protocol.md`.
- Fixed two pre-existing `erun-common` tests (`work_clone_reclaim_test.go`) that only passed with an ambient global git identity configured.

Closes #1723

## Test plan

- [x] `go test ./...` clean in `erun-backend-api`, `erun-common`, `erun-cli`, `erun-mcp`.
- [x] New unit tests in `internal/routes/users_test.go`: username conflict → `409 USERNAME_TAKEN`, unrecognized conflict → generic `409`, already-enrolled → `200` + `alreadyEnrolled` (not an error).
- [x] New e2e tests against a real migrated PostgreSQL (`internal/repository/users_e2e_test.go`, `internal/repository/identity_e2e_test.go`): username conflict distinctly reported, re-enrollment under a different requested username is a true no-op (no orphaned row, existing user/username preserved), and the auth-path username-refresh collision signs in without leaking the raw SQL error.
- [x] `erun-docs`: `yarn build` clean.
- [ ] `make check` (gating in this run).