### PR TITLE
Deny ScheduleWakeup in one-shot agent jobs; don't let exitCode read as success

### DIFF
--- a/erun-cli/cmd/job.go
+++ b/erun-cli/cmd/job.go
@@ -652,7 +652,7 @@ func jobAwaitExit(result common.AwaitEnvironmentJobResult) error {
 		return internal.WithExitCode(fmt.Errorf("job %q is still running after %ds", result.Job.ID, result.TimeoutSeconds), jobAwaitTimeoutExitCode)
 	case result.Job.State == common.EnvironmentJobStateUnknown:
 		return internal.WithExitCode(fmt.Errorf("job %q has no recorded outcome: %s", result.Job.ID, result.Job.Reason), jobAwaitUnknownExitCode)
-	case result.Job.Succeeded():
+	case result.Job.Succeeded:
 		return nil
 	case result.Job.State == common.EnvironmentJobStateAbandoned:
 		return fmt.Errorf("job %q abandoned background work: %s", result.Job.ID, result.Job.Reason)

--- a/erun-common/ai_launch_test.go
+++ b/erun-common/ai_launch_test.go
@@ -352,3 +352,16 @@ func TestAISessionLaunchLines(t *testing.T) {
 		}
 	})
 }
+
+// TestAISessionLaunchCommandKeepsScheduleWakeup guards the legitimate side of
+// erun#1731: the AI tab's persistent, resumable session is exactly the launch
+// mode that has a later invocation to wake into, unlike the one-shot agent job
+// AgentJobCommand builds (locked by the erun-integration dry-run golden
+// job/agent_start_dry_run_plans_the_streaming_invocation). It must never pick
+// up the one-shot job's --disallowedTools ScheduleWakeup restriction.
+func TestAISessionLaunchCommandKeepsScheduleWakeup(t *testing.T) {
+	got := AISessionLaunchCommand("", EnvironmentClaudeConfig{}, "team", "dev")
+	if strings.Contains(got, "disallowedTools") || strings.Contains(got, "ScheduleWakeup") {
+		t.Fatalf("the persistent AI session must keep ScheduleWakeup available, got %q", got)
+	}
+}

--- a/erun-common/job.go
+++ b/erun-common/job.go
@@ -149,6 +149,17 @@ type EnvironmentJob struct {
 	// the supervisor's liveness, so a record can never claim to be running after
 	// the process behind it is gone.
 	State string `json:"state"`
+	// Succeeded is the one field that answers "did this actually work",
+	// computed fresh on every read exactly like AliveAgeMs so it can never lag
+	// what State/ExitCode/WorktreeDirty actually say. It exists because those
+	// three fields do not, on their own, rule out false success: ExitCode can
+	// be a clean 0 while State is abandoned or gate-incomplete (the process
+	// that ended cleanly is not the same claim as the work it started
+	// reaching a real outcome), or while WorktreeDirty says the agent's own
+	// changes were never committed. A caller — especially a JSON/MCP one that
+	// cannot call the Go helper this mirrors — checks this field alone rather
+	// than re-deriving the combination itself.
+	Succeeded bool `json:"succeeded"`
 	// Kind is command or agent. An agent job runs an AI tool in its streaming
 	// mode, which is what lets it report progress rather than only a state.
 	Kind string `json:"kind,omitempty"`
@@ -294,18 +305,19 @@ func (j EnvironmentJob) Finished() bool {
 		j.State == EnvironmentJobStateAbandoned || j.State == EnvironmentJobStateGateIncomplete
 }
 
-// Succeeded is the only definition of success: an outcome was captured and it
-// was zero, with nothing left running behind it and nothing left uncommitted
-// in its own working tree. An unknown job is never a success, and neither is
-// an abandoned or gate-incomplete one — a zero exit code from the process
-// that started work it never waited for, whether that work is an unreaped
-// process in its own group or a sibling job record, is not the same claim as
-// a zero exit code from a job that finished cleanly. A dirty working tree is
-// the same shape of not-actually-clean finish: whatever the supervisor
-// managed to preserve on the agent's behalf (see job_worktree.go), the agent
-// itself did not commit its own work, and that is worth a caller's attention
-// even when everything else about the run looks fine.
-func (j EnvironmentJob) Succeeded() bool {
+// environmentJobSucceeded is the only definition of success: an outcome was
+// captured and it was zero, with nothing left running behind it and nothing
+// left uncommitted in its own working tree. An unknown job is never a
+// success, and neither is an abandoned or gate-incomplete one — a zero exit
+// code from the process that started work it never waited for, whether that
+// work is an unreaped process in its own group or a sibling job record, is
+// not the same claim as a zero exit code from a job that finished cleanly. A
+// dirty working tree is the same shape of not-actually-clean finish: whatever
+// the supervisor managed to preserve on the agent's behalf (see
+// job_worktree.go), the agent itself did not commit its own work, and that is
+// worth a caller's attention even when everything else about the run looks
+// fine. Backs the EnvironmentJob.Succeeded field.
+func environmentJobSucceeded(j EnvironmentJob) bool {
 	return j.State == EnvironmentJobStateExited && j.ExitCode != nil && *j.ExitCode == 0 && !j.WorktreeDirty
 }
 
@@ -382,10 +394,12 @@ func reconcileEnvironmentJob(dir string, job EnvironmentJob, now time.Time, aliv
 	// time that produced it, exactly like OutputBytes below.
 	job.AliveAgeMs = environmentJobAliveAgeMs(job.LastAliveAt, now)
 	if job.State != EnvironmentJobStateRunning {
+		job.Succeeded = environmentJobSucceeded(job)
 		return job
 	}
 	if job.PID > 0 && alive != nil && alive(job.PID) {
 		job.OutputBytes = environmentJobOutputSize(job.LogPath, job.OutputBytes)
+		job.Succeeded = environmentJobSucceeded(job)
 		return job
 	}
 	job.State = EnvironmentJobStateUnknown
@@ -407,6 +421,7 @@ func reconcileEnvironmentJob(dir string, job EnvironmentJob, now time.Time, aliv
 		job.Reason = fmt.Sprintf("job supervisor %d is gone without recording an exit status; the runtime pod was most likely replaced", job.PID)
 	}
 	job.OutputBytes = environmentJobOutputSize(job.LogPath, job.OutputBytes)
+	job.Succeeded = environmentJobSucceeded(job)
 	_ = writeEnvironmentJob(dir, job)
 	return job
 }

--- a/erun-common/job_abandoned_test.go
+++ b/erun-common/job_abandoned_test.go
@@ -52,7 +52,7 @@ func TestEnvironmentJobThatBackgroundsWorkAndExitsIsNotReportedAsSuccess(t *test
 		}
 	})
 
-	if job.Succeeded() {
+	if job.Succeeded {
 		t.Fatalf("job reported success (state=%q, exitCode=%v) even though it left a background process running: %+v", job.State, job.ExitCode, job)
 	}
 	if job.State != EnvironmentJobStateAbandoned {
@@ -84,7 +84,7 @@ func TestEnvironmentJobThatExitsCleanlyStillSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if !job.Succeeded() {
+	if !job.Succeeded {
 		t.Fatalf("job with no abandoned work did not report success: %+v", job)
 	}
 	if job.State != EnvironmentJobStateExited {
@@ -149,7 +149,7 @@ func TestEnvironmentJobThatEndsWhileAJobItStartedIsStillRunningIsNotReportedAsSu
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if parent.Succeeded() {
+	if parent.Succeeded {
 		t.Fatalf("job reported success (state=%q, exitCode=%v) even though a job it started was still running: %+v", parent.State, parent.ExitCode, parent)
 	}
 	if parent.State != EnvironmentJobStateGateIncomplete {

--- a/erun-common/job_agent.go
+++ b/erun-common/job_agent.go
@@ -60,7 +60,17 @@ func AgentJobCommand(tool, prompt string) ([]string, error) {
 	case agentToolClaude:
 		// --verbose is what makes stream-json emit per event instead of one
 		// closing envelope, which is the whole point of running it this way.
-		return []string{agentToolClaude, "-p", text, "--output-format", "stream-json", "--verbose"}, nil
+		//
+		// --disallowedTools ScheduleWakeup: this run is a one-shot supervised
+		// process with no later invocation to wake into, unlike the orchestrator's
+		// own persistent session (ai_launch.go), which keeps the tool. Offering it
+		// here let the agent "successfully" schedule a wakeup that will never
+		// fire and end its turn, while the supervisor still recorded a clean exit
+		// -- the run looked done and the work it was waiting on was still in
+		// flight (erun#1731). Denying the tool removes it from what the model is
+		// even offered, verified against a real `claude -p` run, rather than
+		// merely rejecting the call after the model has already committed to it.
+		return []string{agentToolClaude, "-p", text, "--output-format", "stream-json", "--verbose", "--disallowedTools", "ScheduleWakeup"}, nil
 	case agentToolCodex:
 		return []string{agentToolCodex, "exec", "--json", text}, nil
 	default:

--- a/erun-common/job_task_test.go
+++ b/erun-common/job_task_test.go
@@ -41,7 +41,7 @@ func TestStartTaskEnvironmentJobRecordsATypedResult(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if !finished.Succeeded() {
+	if !finished.Succeeded {
 		t.Fatalf("finished job = %+v, want succeeded", finished)
 	}
 	var decoded taskResult
@@ -74,7 +74,7 @@ func TestStartTaskEnvironmentJobRecordsAFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if finished.Succeeded() {
+	if finished.Succeeded {
 		t.Fatalf("finished job = %+v, want failed", finished)
 	}
 	if finished.ExitCode == nil || *finished.ExitCode == 0 {
@@ -109,7 +109,7 @@ func TestStartTaskEnvironmentJobRecoversAPanic(t *testing.T) {
 	if finished.State != EnvironmentJobStateExited {
 		t.Fatalf("state = %q, want exited (never left running)", finished.State)
 	}
-	if finished.Succeeded() {
+	if finished.Succeeded {
 		t.Fatalf("a panicking task must never read as succeeded")
 	}
 }

--- a/erun-common/job_worktree_test.go
+++ b/erun-common/job_worktree_test.go
@@ -87,7 +87,7 @@ func TestAgentJobWithADirtyWorkingTreeIsNotReportedAsSuccessAndIsCheckpointedAnd
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if job.Succeeded() {
+	if job.Succeeded {
 		t.Fatalf("job reported success even though it ended with an uncommitted working tree: %+v", job)
 	}
 	if !job.WorktreeDirty {
@@ -138,7 +138,7 @@ func TestAgentJobWithACleanWorkingTreeStillSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if !job.Succeeded() {
+	if !job.Succeeded {
 		t.Fatalf("job with a clean working tree did not report success: %+v", job)
 	}
 	if job.WorktreeDirty {
@@ -171,7 +171,7 @@ func TestAgentJobWithADirtyDetachedHeadIsReportedButNotCheckpointed(t *testing.T
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if job.Succeeded() {
+	if job.Succeeded {
 		t.Fatalf("job reported success even though it ended with an uncommitted, detached-HEAD working tree: %+v", job)
 	}
 	if !job.WorktreeDirty || !job.WorktreeDetached {
@@ -210,7 +210,7 @@ func TestAgentJobWithADirtyWorkingTreeOnAProtectedBranchIsReportedButNotCheckpoi
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if job.Succeeded() {
+	if job.Succeeded {
 		t.Fatalf("job reported success even though it left main dirty: %+v", job)
 	}
 	if job.WorktreeCommit != "" {
@@ -245,7 +245,7 @@ func TestCommandJobIgnoresItsWorkingTreeState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEnvironmentJob: %v", err)
 	}
-	if !job.Succeeded() {
+	if !job.Succeeded {
 		t.Fatalf("a plain command job must not have its own working tree checked: %+v", job)
 	}
 	if job.WorktreeDirty {

--- a/erun-integration/job_test.go
+++ b/erun-integration/job_test.go
@@ -710,6 +710,22 @@ func TestJob(t *testing.T) {
 		if await.ExitCode != 1 {
 			t.Fatalf("expected an abandoned job to report a failure outcome, got %d:\n%s", await.ExitCode, await.Combined)
 		}
+		// erun#1731: a raw exitCode of 0 sitting beside state "abandoned" is
+		// exactly the false-success shape a caller reading only exitCode would
+		// miss; succeeded must say so explicitly rather than leaving it to be
+		// re-derived from state.
+		statusJSON := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "gate", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		var payload struct {
+			State     string `json:"state"`
+			ExitCode  *int   `json:"exitCode"`
+			Succeeded bool   `json:"succeeded"`
+		}
+		if err := json.Unmarshal([]byte(statusJSON.Stdout), &payload); err != nil {
+			t.Fatalf("parse job status JSON: %v\n%s", err, statusJSON.Stdout)
+		}
+		if payload.State != "abandoned" || payload.ExitCode == nil || *payload.ExitCode != 0 || payload.Succeeded {
+			t.Fatalf("expected an abandoned job with exitCode 0 to report succeeded=false, got %+v", payload)
+		}
 		golden.Equal(t, "job/a_job_that_backgrounds_work_and_exits_reads_as_abandoned_not_success", normalize.Apply(status.Combined+await.Combined))
 	})
 
@@ -762,6 +778,23 @@ func TestJob(t *testing.T) {
 		await := erun.Run(t, []string{"job", "await", "--tenant", "team", "--environment", "dev", "--id", "outer", "--timeout", "1s"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
 		if await.ExitCode != 1 {
 			t.Fatalf("expected a gate-incomplete job to report a failure outcome, got %d:\n%s", await.ExitCode, await.Combined)
+		}
+		// erun#1731: this is the exact shape the issue reported -- exitCode 0
+		// sitting beside state gate-incomplete, with only state telling the
+		// truth. succeeded must say so explicitly, so exec_agent (and any other
+		// caller reading the job record over MCP or --output json) cannot read
+		// this as success from exitCode alone.
+		statusJSON := erun.Run(t, []string{"job", "status", "--tenant", "team", "--environment", "dev", "--id", "outer", "--output", "json"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		var payload struct {
+			State     string `json:"state"`
+			ExitCode  *int   `json:"exitCode"`
+			Succeeded bool   `json:"succeeded"`
+		}
+		if err := json.Unmarshal([]byte(statusJSON.Stdout), &payload); err != nil {
+			t.Fatalf("parse job status JSON: %v\n%s", err, statusJSON.Stdout)
+		}
+		if payload.State != "gate-incomplete" || payload.ExitCode == nil || *payload.ExitCode != 0 || payload.Succeeded {
+			t.Fatalf("expected a gate-incomplete job with exitCode 0 to report succeeded=false, got %+v", payload)
 		}
 		golden.Equal(t, "job/a_job_that_ends_while_a_job_it_started_is_still_running_reads_as_gate_incomplete", normalize.Apply(status.Combined+await.Combined))
 	})

--- a/erun-integration/testdata/job/agent_start_dry_run_plans_the_streaming_invocation.txt
+++ b/erun-integration/testdata/job/agent_start_dry_run_plans_the_streaming_invocation.txt
@@ -2,7 +2,7 @@ audit: erun job start --agent claude --dry-run --environment dev --name sweep --
 job: resolving agent tool "claude" in this environment
 job: detaching "sweep" as job sweep, output at <TMP>
 job: holding activity lease job-sweep for the job's lifetime
-<TMP> exec job supervise --tenant team --environment dev --id sweep --name sweep --max-output-bytes 16777216 --lease-ttl 15m0s --agent claude -- claude -p 'fix the failing tests' --output-format stream-json --verbose
+<TMP> exec job supervise --tenant team --environment dev --id sweep --name sweep --max-output-bytes 16777216 --lease-ttl 15m0s --agent claude -- claude -p 'fix the failing tests' --output-format stream-json --verbose --disallowedTools ScheduleWakeup
 audit: erun job start --agent codex --dry-run --environment dev --name sweep --tenant team fix the failing tests
 job: resolving agent tool "codex" in this environment
 job: detaching "sweep" as job sweep, output at <TMP>


### PR DESCRIPTION
## Summary

- `exec_agent`/`job start --agent claude` runs a one-shot supervised `claude -p` process with no later invocation, but it was still offered **ScheduleWakeup** — a tool whose entire premise is a resumed run. Four real sessions reached for it and ended their turn while work they'd started (a nested gate job) was still in flight, with the supervisor recording a clean exit alongside the unresolved state.
- Verified with a real `claude -p` run that `--disallowedTools ScheduleWakeup` actually removes the tool from what the model is offered ("Do you have ScheduleWakeup?" → "No.") rather than merely denying the call after the model has already committed to it — so this is the structural fix (issue's priority 1), not the fallback mitigation (priority 2). The orchestrator's persistent AI-tab session (`ai_launch.go`) is untouched and keeps the tool, since it genuinely has a later to wake into; a new test pins that it stays available there.
- Added `EnvironmentJob.Succeeded`, computed fresh on every read like `AliveAgeMs`, so a `gate-incomplete`/`abandoned` job's `exitCode: 0` (the supervised process really did exit cleanly) can no longer be misread as success by a JSON/MCP caller that doesn't independently combine `state`+`exitCode`+`worktreeDirty` the way the removed Go-only `Succeeded()` method did. `abandoned` needed the exact same treatment as `gate-incomplete`, since both already read `false` through the same underlying logic — no state-specific special-casing was needed. `erun exec job await`'s own process exit code was already correct for both states before this change.

## How tool-list assembly works (research)

The tool list for a `claude -p` job is assembled entirely by the Claude Code CLI at process start from its own defaults plus whatever `--allowedTools`/`--disallowedTools`/`--settings` flags erun passes on the invocation (`erun-common/job_agent.go`'s `AgentJobCommand`, mirrored by `erun-mcp`'s `exec_agent` tool and the CLI's `erun exec job start --agent`). erun fully controls this lever — the orchestrator's own launch (`erun-ui/orchestrator.go`) already uses `--disallowedTools AskUserQuestion` for the same reason (nobody answers questions in an unattended session). This PR adds `--disallowedTools ScheduleWakeup` to the one-shot claude invocation only.

## Test plan

- [x] `go test ./...` in `erun-common`, `erun-cli`, `erun-mcp`, `erun-ui`
- [x] `erun-integration`: full `go test ./...` green (regenerated the one affected dry-run golden), plus new assertions that a gate-incomplete/abandoned job's JSON record reports `succeeded: false` alongside `exitCode: 0`
- [x] New unit test pins that the orchestrator's persistent AI session keeps ScheduleWakeup available
- [x] `make check` green end to end (coverage 75.6%, threshold 75.6%)

Closes #1731