### PR TITLE
Port aws sts get-web-identity-token onto the switchable execution mode

### DIFF
--- a/erun-common/cloud.go
+++ b/erun-common/cloud.go
@@ -963,7 +963,7 @@ func normalizeAWSCloudDependencies(deps CloudDependencies) CloudDependencies {
 		deps.RunAWSLogout = defaultRunAWSLogout
 	}
 	if deps.RunAWSBearerToken == nil {
-		deps.RunAWSBearerToken = defaultRunAWSBearerToken
+		deps.RunAWSBearerToken = runAWSBearerTokenForExecutionMode()
 	}
 	if deps.RunAWSEnableOIDC == nil {
 		deps.RunAWSEnableOIDC = defaultRunAWSEnableOIDC
@@ -989,6 +989,13 @@ func resolveAWSIdentityForExecutionMode() func(Context, string) (AWSIdentity, er
 		return libraryResolveAWSIdentity
 	}
 	return defaultResolveAWSIdentity
+}
+
+func runAWSBearerTokenForExecutionMode() func(Context, string, string) (string, error) {
+	if currentExecutionMode(awsSTSWebIdentityTokenExecutionOperation) == ExecutionModeLibrary {
+		return libraryRunAWSBearerToken
+	}
+	return defaultRunAWSBearerToken
 }
 
 func checkAWSStatusForExecutionMode() func(Context, CloudProviderConfig) CloudProviderStatus {
@@ -1110,17 +1117,7 @@ func defaultRunAWSLogout(ctx Context, profile string) error {
 
 func defaultRunAWSBearerToken(ctx Context, profile, audience string) (string, error) {
 	audience = normalizeCloudBearerAudience(audience)
-	args := []string{
-		"sts", "get-web-identity-token",
-		"--audience", audience,
-		"--signing-algorithm", "RS256",
-		"--duration-seconds", "900",
-		"--query", "WebIdentityToken",
-		"--output", "text",
-	}
-	if strings.TrimSpace(profile) != "" {
-		args = append(args, "--profile", strings.TrimSpace(profile))
-	}
+	args := awsGetWebIdentityTokenArgs(profile, audience)
 	ctx.TraceCommand("", "aws", args...)
 	if ctx.DryRun {
 		return "", nil

--- a/erun-common/cloud_aws_sdk.go
+++ b/erun-common/cloud_aws_sdk.go
@@ -3,8 +3,10 @@ package eruncommon
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
@@ -17,6 +19,15 @@ import (
 // subprocess-only: they either drive a real browser SSO flow or write the
 // shared ~/.aws/config ini file, neither of which aws-sdk-go-v2 replaces.
 const awsSTSIdentityExecutionOperation = "aws-sts"
+
+// awsSTSWebIdentityTokenExecutionOperation is the ExecutionModeFor/
+// ExecutionModeReport key for the `aws sts get-web-identity-token` call site
+// (defaultRunAWSBearerToken below), the OIDC bearer-token mint
+// awsCloudProviderBearerToken uses to federate an AWS-provider alias with
+// erun. Kept distinct from awsSTSIdentityExecutionOperation per
+// execution_mode.go's convention of one key per ported call site, even though
+// both hang off the same aws-sdk-go-v2 STS client.
+const awsSTSWebIdentityTokenExecutionOperation = "aws-sts-web-identity-token"
 
 // libraryResolveAWSIdentity is the library-backed alternative to
 // defaultResolveAWSIdentity. It renders the exact same `aws sts
@@ -49,6 +60,26 @@ func libraryCheckAWSStatus(_ Context, provider CloudProviderConfig) CloudProvide
 	return CloudProviderStatus{CloudProviderConfig: provider, Status: status, Message: awsSDKErrorMessage(err)}
 }
 
+// libraryRunAWSBearerToken is the library-backed alternative to
+// defaultRunAWSBearerToken. It renders the exact same `aws sts
+// get-web-identity-token` trace line for dry-run/audit parity — including the
+// unconditional dry-run trace awsBearerTokenWithOIDCRetry issues a second time
+// to preview its federation-enable recovery — then mints the token via
+// aws-sdk-go-v2 instead of shelling out to the aws CLI.
+func libraryRunAWSBearerToken(ctx Context, profile, audience string) (string, error) {
+	profile = strings.TrimSpace(profile)
+	audience = normalizeCloudBearerAudience(audience)
+	traceAWSGetWebIdentityToken(ctx, profile, audience)
+	if ctx.DryRun {
+		return "", nil
+	}
+	token, err := awsSDKWebIdentityToken(context.Background(), profile, audience)
+	if err != nil {
+		return "", fmt.Errorf("get AWS web identity token: %s", awsSDKErrorMessage(err))
+	}
+	return token, nil
+}
+
 // awsGetCallerIdentityArgs is the single source of the `aws sts
 // get-caller-identity` argv, shared by defaultResolveAWSIdentity (which also
 // executes it as a subprocess) and traceAWSGetCallerIdentity (which only
@@ -64,6 +95,30 @@ func awsGetCallerIdentityArgs(profile string) []string {
 
 func traceAWSGetCallerIdentity(ctx Context, profile string) {
 	ctx.TraceCommand("", "aws", awsGetCallerIdentityArgs(profile)...)
+}
+
+// awsGetWebIdentityTokenArgs is the single source of the `aws sts
+// get-web-identity-token` argv, shared by defaultRunAWSBearerToken (which also
+// executes it as a subprocess) and traceAWSGetWebIdentityToken (which only
+// renders it), so the dry-run/audit trace can never drift from either
+// execution path.
+func awsGetWebIdentityTokenArgs(profile, audience string) []string {
+	args := []string{
+		"sts", "get-web-identity-token",
+		"--audience", audience,
+		"--signing-algorithm", "RS256",
+		"--duration-seconds", "900",
+		"--query", "WebIdentityToken",
+		"--output", "text",
+	}
+	if profile = strings.TrimSpace(profile); profile != "" {
+		args = append(args, "--profile", profile)
+	}
+	return args
+}
+
+func traceAWSGetWebIdentityToken(ctx Context, profile, audience string) {
+	ctx.TraceCommand("", "aws", awsGetWebIdentityTokenArgs(profile, audience)...)
 }
 
 func awsSDKCallerIdentity(ctx context.Context, profile string) (AWSIdentity, error) {
@@ -84,6 +139,26 @@ func awsSDKCallerIdentity(ctx context.Context, profile string) (AWSIdentity, err
 		Arn:     stringFromPtr(out.Arn),
 		UserID:  stringFromPtr(out.UserId),
 	}, nil
+}
+
+func awsSDKWebIdentityToken(ctx context.Context, profile, audience string) (string, error) {
+	var opts []func(*awsconfig.LoadOptions) error
+	if profile = strings.TrimSpace(profile); profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return "", err
+	}
+	out, err := sts.NewFromConfig(cfg).GetWebIdentityToken(ctx, &sts.GetWebIdentityTokenInput{
+		Audience:         []string{audience},
+		SigningAlgorithm: awssdk.String("RS256"),
+		DurationSeconds:  awssdk.Int32(900),
+	})
+	if err != nil {
+		return "", err
+	}
+	return stringFromPtr(out.WebIdentityToken), nil
 }
 
 func stringFromPtr(v *string) string {

--- a/erun-common/cloud_aws_sdk_test.go
+++ b/erun-common/cloud_aws_sdk_test.go
@@ -40,6 +40,29 @@ func traceCapturingContext() (Context, *bytes.Buffer) {
 	return Context{Logger: logger}, &trace
 }
 
+// stsWebIdentityTokenFixture starts a fake STS endpoint that answers
+// GetWebIdentityToken with a fixed token, honored via the SDK's own
+// AWS_ENDPOINT_URL env var (no daemon, no real AWS account needed).
+func stsWebIdentityTokenFixture(t *testing.T) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = fmt.Fprint(w, `<?xml version="1.0"?>
+<GetWebIdentityTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetWebIdentityTokenResult>
+    <WebIdentityToken>header.payload.sig</WebIdentityToken>
+    <Expiration>2026-01-01T00:00:00Z</Expiration>
+  </GetWebIdentityTokenResult>
+  <ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata>
+</GetWebIdentityTokenResponse>`)
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("AWS_ENDPOINT_URL", server.URL)
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAFAKE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fakesecret")
+	t.Setenv("AWS_REGION", "us-east-1")
+}
+
 func TestLibraryResolveAWSIdentityMatchesSubprocessObservableResult(t *testing.T) {
 	stsCallerIdentityFixture(t)
 	ctx, trace := traceCapturingContext()
@@ -104,6 +127,77 @@ func TestLibraryCheckAWSStatusNotConfiguredForMissingProfile(t *testing.T) {
 	}
 	if status.Message == "" {
 		t.Fatal("expected a non-empty status message")
+	}
+}
+
+func TestLibraryRunAWSBearerTokenMatchesSubprocessObservableResult(t *testing.T) {
+	stsWebIdentityTokenFixture(t)
+	ctx, trace := traceCapturingContext()
+
+	token, err := libraryRunAWSBearerToken(ctx, "", "https://api.example")
+	if err != nil {
+		t.Fatalf("libraryRunAWSBearerToken: %v", err)
+	}
+
+	// This is exactly what defaultRunAWSBearerToken parses out of `aws sts
+	// get-web-identity-token ... --output text` stdout — the two paths must
+	// agree on the observable result for the same underlying token.
+	want := "header.payload.sig"
+	if token != want {
+		t.Fatalf("token = %q, want %q", token, want)
+	}
+
+	// The trace line must be byte-identical to what defaultRunAWSBearerToken
+	// renders for the subprocess path (root AGENTS.md's dry-run/audit
+	// contract: the equivalent CLI invocation, regardless of execution mode).
+	wantTrace := formatShellCommand("", "aws", awsGetWebIdentityTokenArgs("", "https://api.example")...)
+	if got := strings.TrimSpace(trace.String()); got != wantTrace {
+		t.Fatalf("trace = %q, want %q", got, wantTrace)
+	}
+}
+
+func TestLibraryRunAWSBearerTokenDryRunTracesWithoutCallingAWS(t *testing.T) {
+	// No fixture set up: a dry run must never touch the network, so an
+	// unstubbed AWS_ENDPOINT_URL would fail the test if it were reached.
+	ctx, trace := traceCapturingContext()
+	ctx.DryRun = true
+
+	token, err := libraryRunAWSBearerToken(ctx, "my-profile", "https://api.example")
+	if err != nil {
+		t.Fatalf("libraryRunAWSBearerToken: %v", err)
+	}
+	if token != "" {
+		t.Fatalf("token = %q, want empty on dry run", token)
+	}
+
+	wantTrace := formatShellCommand("", "aws", awsGetWebIdentityTokenArgs("my-profile", "https://api.example")...)
+	if got := strings.TrimSpace(trace.String()); got != wantTrace {
+		t.Fatalf("trace = %q, want %q", got, wantTrace)
+	}
+}
+
+// TestAWSGetWebIdentityTokenArgsSharedByBothPaths locks the one argv builder
+// defaultRunAWSBearerToken (subprocess) and traceAWSGetWebIdentityToken
+// (library) both call, so a profile can never render differently between
+// execution modes.
+func TestAWSGetWebIdentityTokenArgsSharedByBothPaths(t *testing.T) {
+	got := awsGetWebIdentityTokenArgs("my-profile", "https://api.example")
+	want := []string{
+		"sts", "get-web-identity-token",
+		"--audience", "https://api.example",
+		"--signing-algorithm", "RS256",
+		"--duration-seconds", "900",
+		"--query", "WebIdentityToken",
+		"--output", "text",
+		"--profile", "my-profile",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/erun-common/execution_mode.go
+++ b/erun-common/execution_mode.go
@@ -26,6 +26,7 @@ type ExecutionConfig struct {
 // depending on config.yaml already naming them explicitly.
 var knownExecutionOperations = []string{
 	"aws-sts",
+	"aws-sts-web-identity-token",
 }
 
 // ExecutionModeFor resolves which path a promoted operation should take.

--- a/erun-common/execution_mode_test.go
+++ b/erun-common/execution_mode_test.go
@@ -56,3 +56,13 @@ func TestExecutionModeReportListsKnownOperations(t *testing.T) {
 		t.Fatal("expected \"aws-sts\" in the execution mode report")
 	}
 }
+
+func TestExecutionModeReportListsAWSWebIdentityTokenOperation(t *testing.T) {
+	statuses := ExecutionModeReport(ERunConfig{})
+	for _, status := range statuses {
+		if status.Operation == "aws-sts-web-identity-token" {
+			return
+		}
+	}
+	t.Fatal("expected \"aws-sts-web-identity-token\" in the execution mode report")
+}

--- a/erun-common/go.mod
+++ b/erun-common/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/adrg/xdg v0.5.3
+	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.6
 	github.com/coreos/go-oidc/v3 v3.18.0
@@ -12,7 +13,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.43.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.36 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.37 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.37 // indirect

--- a/erun-docs/docs/cli/doctor.md
+++ b/erun-docs/docs/cli/doctor.md
@@ -34,11 +34,12 @@ See [Troubleshooting](/reference/troubleshooting#runtime-image-registry-mismatch
 
 When any item is `missing`, `doctor` offers to run the corresponding recovery step.
 
-`doctor` also reports the **execution mode** of every operation that can run through either a CLI subprocess or an equivalent Go library — today just `aws-sts` (`aws sts get-caller-identity`), with more to follow — so whether an install opted an operation into the library path, or left it on the default subprocess path, can be confirmed rather than guessed at:
+`doctor` also reports the **execution mode** of every operation that can run through either a CLI subprocess or an equivalent Go library — today `aws-sts` (`aws sts get-caller-identity`) and `aws-sts-web-identity-token` (`aws sts get-web-identity-token`), with more to follow — so whether an install opted an operation into the library path, or left it on the default subprocess path, can be confirmed rather than guessed at:
 
 ```
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 ```
 
 See [Configuration reference · Execution modes](/reference/configuration#execution-modes) for the config key that controls it.

--- a/erun-docs/docs/reference/configuration.md
+++ b/erun-docs/docs/reference/configuration.md
@@ -398,6 +398,7 @@ execution:
   | Operation | What it covers | What stays on subprocess |
   |---|---|---|
   | `aws-sts` | `aws sts get-caller-identity`, used to resolve the caller's AWS identity and check whether a stored AWS session is still active. | Every other `aws` operation (`sso login`/`logout`, `configure set`, `configure export-credentials`) — these drive a real browser SSO flow or write the shared `~/.aws` ini files, neither of which the switch touches. |
+  | `aws-sts-web-identity-token` | `aws sts get-web-identity-token`, used by `cloud oidc` to mint the OIDC bearer token that federates an AWS-provider alias with erun. | The federation-enable recovery (`aws iam enable-outbound-web-identity-federation`) this operation retries through on failure — still subprocess-only. |
 
 ---
 

--- a/erun-integration/cloud_test.go
+++ b/erun-integration/cloud_test.go
@@ -746,6 +746,60 @@ func TestCloud(t *testing.T) {
 		golden.Equal(t, "cloud/oidc_dry_run_traces_bearer_token_command", normalize.Apply(result.Combined))
 	})
 
+	t.Run("oidc_dry_run_unaffected_by_library_execution_mode", func(t *testing.T) {
+		// Locks the dry-run/audit contract for the second aws-sts operation:
+		// awsCloudProviderBearerToken's status check + bearer-token trace must
+		// stay byte-identical to the subprocess-mode golden even when
+		// execution.modes.aws-sts-web-identity-token opts into the library
+		// path, since both defaultRunAWSBearerToken and libraryRunAWSBearerToken
+		// trace through the same awsGetWebIdentityTokenArgs and return before
+		// ever calling AWS on a dry run.
+		setup := env.New(t)
+		seedCloudProviderAlias(t, setup, "rihards+123456789012@aws", "test-profile")
+		seedExecutionMode(t, setup, "aws-sts-web-identity-token", "library")
+		args := []string{"cloud", "oidc", "--alias", "rihards+123456789012@aws", "--audience", "https://api.example", "--dry-run"}
+		result := erun.Run(t, args, erun.RunOptions{Cwd: setup.Cwd, Env: setup.Env()})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "cloud/oidc_dry_run_traces_bearer_token_command", normalize.Apply(result.Combined))
+	})
+
+	t.Run("oidc_real_run_library_execution_mode_needs_no_aws_binary", func(t *testing.T) {
+		// Proves the library path produces the same observable result as the
+		// subprocess path: with both execution.modes.aws-sts and
+		// execution.modes.aws-sts-web-identity-token set to "library", and a
+		// real static-credential AWS profile on disk, both the status check
+		// (CheckAWSStatus) and the bearer-token mint (RunAWSBearerToken)
+		// resolve via aws-sdk-go-v2 against a fake STS endpoint
+		// (AWS_ENDPOINT_URL) instead of shelling out, so the scenario declares
+		// no "aws" stub at all — the PATH scrub in internal/env would fail the
+		// run with "executable file not found" if production code fell
+		// through to a subprocess for either call.
+		setup := env.New(t)
+		seedCloudProviderAlias(t, setup, "test-user@aws", "test-profile")
+		seedExecutionMode(t, setup, "aws-sts", "library")
+		seedExecutionMode(t, setup, "aws-sts-web-identity-token", "library")
+		seedAWSStaticCredentialProfile(t, setup, "test-profile")
+		issuer := "https://oidc.eu-west-2.amazonaws.com/test-issuer"
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"iss":"` + issuer + `"}`))
+		jwt := header + "." + payload + ".sig"
+		envVars := append(setup.Env(), "AWS_ENDPOINT_URL="+awsSTSActionStubServer(t, jwt).URL)
+		result := erun.Run(t, []string{"cloud", "oidc", "--alias", "test-user@aws"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "cloud/oidc_real_run_library_execution_mode_needs_no_aws_binary", normalize.Apply(result.Combined))
+		raw, err := os.ReadFile(filepath.Join(setup.ConfigHome, "erun", "config.yaml"))
+		if err != nil {
+			t.Fatalf("read root config: %v", err)
+		}
+		if !strings.Contains(string(raw), "oidcissuerurl: "+issuer) {
+			t.Errorf("expected persisted OIDC issuer %q, got:\n%s", issuer, raw)
+		}
+	})
+
 	t.Run("login_select_prompt_resolves_active_alias", func(t *testing.T) {
 		// Without --alias, `cloud login` shows a Select of configured aliases;
 		// "\r" confirms the single highlighted entry (the run's one interactive
@@ -1481,8 +1535,11 @@ func seedCloudProviderAlias(t testing.TB, setup env.Setup, alias, profile string
 // seedExecutionMode appends an execution.modes override to the root
 // config.yaml, preserving whatever seedCloudProviderAlias or another fixture
 // already wrote — config.yaml is plain YAML, so appending a distinct
-// top-level key is enough, without needing to parse and re-merge the
-// existing document.
+// top-level key is enough, without needing to parse and re-merge the existing
+// document. A second call (a scenario opting two operations into library mode
+// at once) inserts its line into the existing "modes:" map instead of adding
+// a second "execution:" top-level key, which yaml.Unmarshal rejects as a
+// duplicate key.
 func seedExecutionMode(t testing.TB, setup env.Setup, operation, mode string) {
 	t.Helper()
 	root := filepath.Join(setup.ConfigHome, "erun")
@@ -1491,7 +1548,15 @@ func seedExecutionMode(t testing.TB, setup env.Setup, operation, mode string) {
 	}
 	path := filepath.Join(root, "config.yaml")
 	existing, _ := os.ReadFile(path)
-	body := string(existing) + "execution:\n  modes:\n    " + operation + ": " + mode + "\n"
+	body := string(existing)
+	line := "    " + operation + ": " + mode + "\n"
+	const modesHeader = "execution:\n  modes:\n"
+	if idx := strings.Index(body, modesHeader); idx >= 0 {
+		insertAt := idx + len(modesHeader)
+		body = body[:insertAt] + line + body[insertAt:]
+	} else {
+		body += modesHeader + line
+	}
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write erun config: %v", err)
 	}
@@ -1534,6 +1599,47 @@ func stsCallerIdentityStubServer(t testing.TB) *httptest.Server {
   </GetCallerIdentityResult>
   <ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata>
 </GetCallerIdentityResponse>`)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// awsSTSActionStubServer discriminates by the AWS Query protocol's Action
+// form field, so one fake STS endpoint can back both GetCallerIdentity
+// (CheckAWSStatus) and GetWebIdentityToken (RunAWSBearerToken) in the same
+// real-run scenario — a scenario that flips both operations to library mode
+// exercises both against a single AWS_ENDPOINT_URL.
+func awsSTSActionStubServer(t testing.TB, webIdentityToken string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		switch r.PostForm.Get("Action") {
+		case "GetCallerIdentity":
+			_, _ = fmt.Fprint(w, `<?xml version="1.0"?>
+<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+    <Arn>arn:aws:iam::123456789012:user/test-user</Arn>
+    <UserId>AIDAEXAMPLE</UserId>
+    <Account>123456789012</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata>
+</GetCallerIdentityResponse>`)
+		case "GetWebIdentityToken":
+			_, _ = fmt.Fprintf(w, `<?xml version="1.0"?>
+<GetWebIdentityTokenResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetWebIdentityTokenResult>
+    <WebIdentityToken>%s</WebIdentityToken>
+    <Expiration>2026-01-01T00:00:00Z</Expiration>
+  </GetWebIdentityTokenResult>
+  <ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata>
+</GetWebIdentityTokenResponse>`, webIdentityToken)
+		default:
+			http.Error(w, "unexpected STS action "+r.PostForm.Get("Action"), http.StatusBadRequest)
+		}
 	}))
 	t.Cleanup(server.Close)
 	return server

--- a/erun-integration/testdata/cloud/oidc_real_run_library_execution_mode_needs_no_aws_binary.txt
+++ b/erun-integration/testdata/cloud/oidc_real_run_library_execution_mode_needs_no_aws_binary.txt
@@ -1,0 +1,4 @@
+Saved OIDC issuer https://oidc.eu-west-2.amazonaws.com/test-issuer for test-user@aws
+audit: erun cloud oidc --alias test-user@aws
+cloud oidc: refresh issuer for alias=test-user@aws
+cloud oidc: derived issuer = https://oidc.eu-west-2.amazonaws.com/test-issuer

--- a/erun-integration/testdata/doctor/dry_run_aws_alias_env_plans_host_credential_check.txt
+++ b/erun-integration/testdata/doctor/dry_run_aws_alias_env_plans_host_credential_check.txt
@@ -9,6 +9,7 @@ Run `erun doctor --repair-config` to walk through restoring the root config or r
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 Running: Remove unused Docker images
 audit: erun doctor --dry-run --prune-images team dev

--- a/erun-integration/testdata/doctor/dry_run_clear_pending_helm_traces_kubectl_delete.txt
+++ b/erun-integration/testdata/doctor/dry_run_clear_pending_helm_traces_kubectl_delete.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 Running: Clear pending helm release
 No cleanup actions selected.

--- a/erun-integration/testdata/doctor/dry_run_prune_images_traces_dind_exec.txt
+++ b/erun-integration/testdata/doctor/dry_run_prune_images_traces_dind_exec.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 Running: Remove unused Docker images
 audit: erun doctor --dry-run --prune-images team dev

--- a/erun-integration/testdata/doctor/dry_run_reports_library_execution_mode.txt
+++ b/erun-integration/testdata/doctor/dry_run_reports_library_execution_mode.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: library
+aws-sts-web-identity-token: subprocess
 
 Running: Remove unused Docker images
 audit: erun doctor --dry-run --prune-images team dev

--- a/erun-integration/testdata/doctor/dry_run_reports_runtime_image_registry_mismatch.txt
+++ b/erun-integration/testdata/doctor/dry_run_reports_runtime_image_registry_mismatch.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Runtime image registry ==
 runtimeimage resolves to registry 123456789012.dkr.ecr.eu-west-2.amazonaws.com, but runtimeregistry is ghcr.io/sophium.

--- a/erun-integration/testdata/doctor/dry_run_rollback_traces_helm_rollback.txt
+++ b/erun-integration/testdata/doctor/dry_run_rollback_traces_helm_rollback.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 Running: Roll back to the last successful revision
 No cleanup actions selected.

--- a/erun-integration/testdata/doctor/real_run_clear_pending_helm_via_prompt_then_prune_containers.txt
+++ b/erun-integration/testdata/doctor/real_run_clear_pending_helm_via_prompt_then_prune_containers.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_namespace_listed_but_api_failing_error.txt
+++ b/erun-integration/testdata/doctor/real_run_namespace_listed_but_api_failing_error.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_pod_down_degrades_host_credentials_instead_of_aborting.txt
+++ b/erun-integration/testdata/doctor/real_run_pod_down_degrades_host_credentials_instead_of_aborting.txt
@@ -9,6 +9,7 @@ Skipping context "test-context": name does not match the erun-<seq>-<account>-<r
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_prune_images_and_build_cache_via_stubs.txt
+++ b/erun-integration/testdata/doctor/real_run_prune_images_and_build_cache_via_stubs.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_reports_absent_host_credentials.txt
+++ b/erun-integration/testdata/doctor/real_run_reports_absent_host_credentials.txt
@@ -9,6 +9,7 @@ Skipping context "test-context": name does not match the erun-<seq>-<account>-<r
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_reports_expired_host_credentials.txt
+++ b/erun-integration/testdata/doctor/real_run_reports_expired_host_credentials.txt
@@ -9,6 +9,7 @@ Skipping context "test-context": name does not match the erun-<seq>-<account>-<r
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_reports_unrecorded_expiry_and_unresolved_region.txt
+++ b/erun-integration/testdata/doctor/real_run_reports_unrecorded_expiry_and_unresolved_region.txt
@@ -9,6 +9,7 @@ Skipping context "test-context": name does not match the erun-<seq>-<account>-<r
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_reports_valid_host_credentials.txt
+++ b/erun-integration/testdata/doctor/real_run_reports_valid_host_credentials.txt
@@ -9,6 +9,7 @@ Skipping context "test-context": name does not match the erun-<seq>-<account>-<r
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/real_run_storage_unhealthy_diagnostic_error.txt
+++ b/erun-integration/testdata/doctor/real_run_storage_unhealthy_diagnostic_error.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Helm release status ==
 NAME: team-devops

--- a/erun-integration/testdata/doctor/repair_jetbrains_gateway_dry_run.txt
+++ b/erun-integration/testdata/doctor/repair_jetbrains_gateway_dry_run.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 Running: Clear cached JetBrains Gateway backend metadata
 Cached backend path: <TMP>

--- a/erun-integration/testdata/doctor/repair_jetbrains_gateway_no_metadata.txt
+++ b/erun-integration/testdata/doctor/repair_jetbrains_gateway_no_metadata.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 If the release is stuck pending or an image failed to pull, re-run `erun deploy --force` to rebuild and redeploy, or clear the pending release.
 No cached JetBrains Gateway backend metadata found for this environment.

--- a/erun-integration/testdata/doctor/repair_jetbrains_gateway_real_run.txt
+++ b/erun-integration/testdata/doctor/repair_jetbrains_gateway_real_run.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 If the release is stuck pending or an image failed to pull, re-run `erun deploy --force` to rebuild and redeploy, or clear the pending release.
 Running: Clear cached JetBrains Gateway backend metadata

--- a/erun-integration/testdata/doctor/repair_workspace_sync_dry_run.txt
+++ b/erun-integration/testdata/doctor/repair_workspace_sync_dry_run.txt
@@ -1,6 +1,7 @@
 Target: team/dev
 == Execution modes ==
 aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
 
 == Workspace sync (host mirror) ==
   host alias: erun-team-dev


### PR DESCRIPTION
## Summary

Continues #1691, picking up where #1743 left off. #1743's own closing note gave the order: helm's non-deploy read-only calls first, then aws's remaining operations, then kubectl `get`/`apply`/`wait`. This PR investigated helm first, found it not safely portable in one pass (see below), and ported the next tractable item instead: a second `aws-sts` operation.

## What's ported

`aws sts get-web-identity-token` (`defaultRunAWSBearerToken` in `erun-common/cloud.go`), the OIDC bearer-token mint `awsCloudProviderBearerToken` uses to federate an AWS-provider alias with erun (the `cloud oidc` command). New execution-mode key `aws-sts-web-identity-token`, following #1743's exact shape:

- `awsGetWebIdentityTokenArgs(profile, audience)` (`erun-common/cloud_aws_sdk.go`) is the single argv builder both `defaultRunAWSBearerToken` (subprocess) and `traceAWSGetWebIdentityToken`/`libraryRunAWSBearerToken` (library) call, so the two paths structurally cannot drift.
- `libraryRunAWSBearerToken` mints the token via `aws-sdk-go-v2`'s already-vendored STS client's `GetWebIdentityToken` operation — **no new Go dependency added**, since `aws-sts` already pulled in `service/sts`.
- `erun doctor`'s `== Execution modes ==` block now lists `aws-sts-web-identity-token` alongside `aws-sts` automatically (it iterates `knownExecutionOperations`, no doctor code changed).
- `execution.modes.aws-sts-web-identity-token: library` in `config.yaml` flips it, same as `aws-sts`.

## Verification

- `erun-common`: `TestLibraryRunAWSBearerTokenMatchesSubprocessObservableResult` (httptest STS fixture, asserts both the returned token and the byte-identical trace line), `TestLibraryRunAWSBearerTokenDryRunTracesWithoutCallingAWS`, `TestAWSGetWebIdentityTokenArgsSharedByBothPaths`.
- `erun-integration`:
  - `cloud/oidc_dry_run_unaffected_by_library_execution_mode` reuses the existing `oidc_dry_run_traces_bearer_token_command` golden byte-for-byte with the new mode set to `library`.
  - `cloud/oidc_real_run_library_execution_mode_needs_no_aws_binary`: both `aws-sts` and `aws-sts-web-identity-token` set to `library`, a single fake STS endpoint (discriminating on the AWS Query protocol's `Action` field) backs both `GetCallerIdentity` and `GetWebIdentityToken`, and the scenario declares **no `aws` stub at all** — the PATH scrub would fail the run with "executable file not found" if production code fell through to a subprocess.
  - Every `doctor` golden with the `== Execution modes ==` block picked up the new line (19 files, one-line diff each, reviewed).
  - Fixed a latent bug in the shared `seedExecutionMode` test helper: seeding two operations wrote two top-level `execution:` keys, which `yaml.Unmarshal` rejects as a duplicate key. It now inserts into the existing `modes:` map on a second call.
- Docs: `erun-docs/docs/reference/configuration.md` and `erun-docs/docs/cli/doctor.md` updated with the new operation; `yarn build` clean.
- `make check`: green. `golangci-lint`: 0 issues in every module. Integration coverage held at 75.6% (>= 75.6%), no threshold change needed.

## Why helm's non-deploy read-only calls were not attempted this pass

Investigated first, per #1743's ordering. The candidates are `helm status`/`helm list` (used by `doctor`'s `RunDeployDiagnosis` and `observe`'s `fetchObservedHelmRelease`) — genuinely read-only against a live cluster, not the deploy/upgrade path #1743 already ruled out.

Porting even these turns out to need more than a mechanical repeat of the aws-sts pattern:

1. **A materially larger dependency graph.** `helm.sh/helm/v3/pkg/action` pulls in the full `k8s.io/client-go` + `k8s.io/apimachinery` graph, which the issue itself flags as a real binary-size/build-time cost — much larger than the single `service/sts` package this PR adds nothing of.
2. **No existing seam to fake the cluster for equivalence testing.** The aws-sts port could rely on `aws-sdk-go-v2` honoring `AWS_ENDPOINT_URL`, so a plain `httptest.Server` stood in for STS with no new infrastructure. Helm's storage backend talks to the Kubernetes API via `client-go`'s REST client (secrets, list/get, protobuf-vs-JSON content negotiation, kubeconfig/context resolution matching `kubectl`'s own defaults) — there is no equivalent one-line env-var seam, and this repo's integration harness has never faked a Kubernetes API server (every existing scenario stubs the `kubectl`/`helm` *binary*, not the API underneath it). Building that fake server correctly (request shape, response encoding, content-type negotiation) is real, novel harness work, not a rerun of the aws-sts recipe.
3. **Correctness risk on live-cluster reads.** Getting `client-go`'s kubeconfig/context resolution to exactly match `kubectl`/`helm`'s own default-loading semantics needs careful validation — a subtle divergence here would silently point a read at the wrong cluster.

This is the same shape of finding #1743 made about the helm *deploy* path (a real design problem, not a mechanical port) — except the blocker here is test infrastructure rather than a missing streaming API. kubectl (`get`/`apply`/`wait`) inherits the identical blocker (same `client-go` dependency, same missing fake-API-server harness), so it wasn't attempted either.

## What's left, and the order I'd tackle it in

1. **Helm read-only (`status`/`list`)** — needs the `client-go`/fake-API-server investment above before it can start.
2. **kubectl `get`/`apply`/`wait`** — same investment, larger surface (122 call sites).
3. Smaller remaining `aws` operations were checked and are **not currently portable**: `aws iam enable-outbound-web-identity-federation` (the federation-enable retry `awsBearerTokenWithOIDCRetry` calls) has no matching operation in the vendored `aws-sdk-go-v2/service/iam` at the pinned version — confirmed by `go doc`, not merely unattempted. `aws configure export-credentials` (`ExportCloudProviderCredentials`) is desktop-only and unreachable from the compiled `erun` binary the integration suite drives, so it can't get the same dry-run-parity/no-stub-needed proof this PR and #1743 both rely on.
4. Whichever future PR stands up a fake Kubernetes API server for the harness should also reconsider both (1) and (2) together, since they'd share the same infrastructure investment.

Deliberately untouched, confirmed by review of the diff: the helm deploy path (`runHelmDeployWithPodWatch`, `runHelmUpgradeWithSelectorRecovery`), the dtach/AI-session-lifecycle contract (`ai_launch.go`, `open.go`'s reattach, `whip*.go`, `session_heartbeat.go`), and `git merge --squash`/conflict handling.

Refs #1691