### PR TITLE
Let an OPERATIONS operator enrol a user into another tenant from the console

### DIFF
--- a/erun-backend/erun-backend-api/internal/model/tenant.go
+++ b/erun-backend/erun-backend-api/internal/model/tenant.go
@@ -20,6 +20,11 @@ type Tenant struct {
 	Type          TenantType `json:"type" bun:"type"`
 	CreatedAt     time.Time  `json:"createdAt" bun:"created_at,scanonly"`
 	UpdatedAt     time.Time  `json:"updatedAt" bun:"updated_at,scanonly"`
+	// UserCount is read-only, UX-derived data populated only by queries that
+	// join against users (TenantRepository.List) — nil, not zero, wherever a
+	// query does not compute it, so a caller can tell "this tenant genuinely
+	// has zero users" apart from "this read path never counted".
+	UserCount *int `json:"userCount,omitempty" bun:"user_count,scanonly"`
 }
 
 type TenantIssuer struct {

--- a/erun-backend/erun-backend-api/internal/repository/tenants.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants.go
@@ -117,6 +117,10 @@ func nullIfEmpty(value string) any {
 // tenants is a root resolution table (not RLS-scoped), so a non-operations
 // caller must be filtered in application code rather than relying on the
 // database to scope the query.
+//
+// The operations branch computes UserCount with a single LEFT JOIN/GROUP BY
+// rather than one query per tenant, so a platform with many tenants costs
+// this endpoint one round trip, not N.
 func (r *TenantRepository) List(ctx context.Context) ([]model.Tenant, error) {
 	securityContext, ok := security.FromContext(ctx)
 	if !ok {
@@ -132,9 +136,12 @@ func (r *TenantRepository) List(ctx context.Context) ([]model.Tenant, error) {
 	var tenants []model.Tenant
 	err := r.txs.WithinTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 		return tx.NewRaw(`
-			SELECT tenant_id, name, type, created_at, updated_at
-			  FROM tenants
-			 ORDER BY created_at ASC
+			SELECT t.tenant_id, t.name, t.type, t.created_at, t.updated_at,
+			       COUNT(u.user_id) AS user_count
+			  FROM tenants t
+			  LEFT JOIN users u ON u.tenant_id = t.tenant_id
+			 GROUP BY t.tenant_id, t.name, t.type, t.created_at, t.updated_at
+			 ORDER BY t.created_at ASC
 		`).Scan(ctx, &tenants)
 	})
 	return tenants, err

--- a/erun-backend/erun-backend-api/internal/repository/tenants_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/tenants_e2e_test.go
@@ -194,3 +194,47 @@ func TestCreateReportsTenantNameConflictAndGetByNameResolvesIt(t *testing.T) {
 		t.Fatalf("GetByName returned tenant %s, want the first tenant %s that actually holds the name", resolved.TenantID, first.TenantID)
 	}
 }
+
+// TestListReportsUserCountPerTenant proves List's UserCount is a real
+// per-tenant read, not a value that defaults to zero when nothing was
+// counted: a tenant seeded with a user reports 1, and a tenant registered
+// with none reports an explicit 0 (a non-nil pointer), the distinction the
+// console's inert-tenant flag (erun#1744) depends on to tell "genuinely
+// empty" apart from "not computed".
+func TestListReportsUserCountPerTenant(t *testing.T) {
+	db := tenantsDatabase(t)
+	stamp := time.Now().Format("20060102150405.000000")
+
+	withUser := seedReachableTenant(t, db, "list-usercount-with-user-"+stamp,
+		"https://idp.list-usercount-e2e.example/with-user", "", "list-usercount-e2e-user")
+
+	ctx := security.WithContext(context.Background(), security.Context{TenantType: string(model.TenantTypeOperations)})
+	repo := NewTenantRepository(NewTxManager(db, DialectPostgres))
+	empty, err := repo.Create(ctx, CreateTenantParams{
+		Name:   "list-usercount-empty-" + stamp,
+		Type:   model.TenantTypeCompany,
+		Issuer: "https://idp.list-usercount-e2e.example/empty",
+	})
+	mustNoErr(t, err, "register the zero-user tenant")
+	t.Cleanup(func() { clearReachableTenants(t, db, withUser, empty.TenantID) })
+
+	tenants, err := repo.List(ctx)
+	mustNoErr(t, err, "List")
+
+	counts := make(map[string]*int, len(tenants))
+	for i := range tenants {
+		counts[tenants[i].TenantID] = tenants[i].UserCount
+	}
+
+	withUserCount := counts[withUser]
+	if withUserCount == nil || *withUserCount != 1 {
+		t.Fatalf("tenant with a seeded user: UserCount = %v, want a pointer to 1", withUserCount)
+	}
+	emptyCount := counts[empty.TenantID]
+	if emptyCount == nil {
+		t.Fatalf("tenant with zero users: UserCount = nil, want an explicit pointer to 0, not an unresolved count")
+	}
+	if *emptyCount != 0 {
+		t.Fatalf("tenant with zero users: UserCount = %d, want 0", *emptyCount)
+	}
+}

--- a/erun-backend/erun-backend-api/internal/repository/users_e2e_test.go
+++ b/erun-backend/erun-backend-api/internal/repository/users_e2e_test.go
@@ -1,11 +1,16 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/sophium/erun/erun-backend/erun-backend-api/internal/security"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
@@ -236,6 +241,87 @@ func TestUserRepositoryCreateTreatsReEnrollmentAsNoOp(t *testing.T) {
 	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND username = $2`, tenantID, "rihards").Scan(&count), "count rows for the requested username")
 	if count != 0 {
 		t.Fatalf("expected no user row for the requested (unused) username, got %d", count)
+	}
+}
+
+// seedTenant registers a second tenant beyond usersDatabase's own, so a test
+// can act as one tenant while targeting another.
+func seedTenant(t *testing.T, db *sql.DB, tenantType, namePrefix string) string {
+	t.Helper()
+	var tenantID string
+	err := db.QueryRow(
+		`INSERT INTO tenants (name, type) VALUES ($1, $2) RETURNING tenant_id`,
+		namePrefix+"-"+time.Now().Format("20060102150405.000000"), tenantType,
+	).Scan(&tenantID)
+	mustNoErr(t, err, "seed "+tenantType+" tenant")
+	t.Cleanup(func() { clearPermissionsTenant(t, db, tenantID) })
+	return tenantID
+}
+
+// TestUserRepositoryOperationsCallerEnrollsIntoTargetTenant is the
+// authorization boundary POST /v1/users' resolveTargetTenant exists for,
+// proven end to end rather than against a stub: an operations-scoped
+// caller's transaction runs as erun_operations (TxManager's
+// setPostgresSecurityContext), which schema/rls/users.sql's
+// users_operations_access policy lets write any tenant_id, so the enrolled
+// user must actually land in the requested target tenant, not the caller's
+// own operations tenant.
+func TestUserRepositoryOperationsCallerEnrollsIntoTargetTenant(t *testing.T) {
+	db, targetTenantID := usersDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	users := &UserRepository{txs: txs}
+	opsTenantID := seedTenant(t, db, "OPERATIONS", "users-e2e-ops")
+	opsCtx := security.WithContext(context.Background(), security.Context{
+		TenantID: opsTenantID, TenantType: "OPERATIONS", ErunUserID: "ops-caller",
+	})
+
+	created, _, err := users.Create(opsCtx, CreateUserParams{Username: "cross-tenant-user", TenantID: targetTenantID})
+	mustNoErr(t, err, "operations caller enrolls into the target tenant")
+	if created.TenantID != targetTenantID {
+		t.Fatalf("created.TenantID = %q, want the target tenant %q, not the operations caller's own", created.TenantID, targetTenantID)
+	}
+
+	var count int
+	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM users WHERE tenant_id = $1 AND username = $2`, targetTenantID, "cross-tenant-user").Scan(&count), "count rows in the target tenant")
+	if count != 1 {
+		t.Fatalf("expected exactly one row landed in the target tenant, got %d", count)
+	}
+	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM users WHERE tenant_id = $1`, opsTenantID).Scan(&count), "count rows in the operations caller's own tenant")
+	if count != 0 {
+		t.Fatalf("expected no row landed in the operations caller's own tenant, got %d", count)
+	}
+}
+
+// TestUserRepositoryNonOperationsCallerCannotOverrideTenant proves the
+// authorization boundary holds even below the route's resolveTargetTenant
+// gate: a non-operations caller's transaction runs as erun_tenant, whose
+// users_tenant_isolation policy (schema/rls/users.sql) has WITH CHECK
+// (tenant_id = erun_current_tenant_id()), so an insert explicitly naming a
+// different tenant_id is refused by PostgreSQL itself — not merely by the
+// route's own check — if this method is ever reached with an override from
+// a non-operations caller.
+func TestUserRepositoryNonOperationsCallerCannotOverrideTenant(t *testing.T) {
+	db, callerTenantID := usersDatabase(t)
+	txs := NewTxManager(db, DialectPostgres)
+	users := &UserRepository{txs: txs}
+	targetTenantID := seedTenant(t, db, "COMPANY", "users-e2e-target")
+	callerCtx := security.WithContext(context.Background(), security.Context{
+		TenantID: callerTenantID, TenantType: "COMPANY", ErunUserID: "caller",
+	})
+
+	_, _, err := users.Create(callerCtx, CreateUserParams{Username: "should-not-exist", TenantID: targetTenantID})
+	if err == nil {
+		t.Fatalf("expected a non-operations caller's cross-tenant override to be refused, got success")
+	}
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != pgerrcode.InsufficientPrivilege {
+		t.Fatalf("expected a row-level-security insufficient-privilege error, got %v", err)
+	}
+
+	var count int
+	mustNoErr(t, db.QueryRow(`SELECT COUNT(*) FROM users WHERE username = $1`, "should-not-exist").Scan(&count), "count rows for the refused username")
+	if count != 0 {
+		t.Fatalf("expected no row was written anywhere, got %d", count)
 	}
 }
 

--- a/erun-console/src/app/api/platformApi.ts
+++ b/erun-console/src/app/api/platformApi.ts
@@ -20,6 +20,7 @@ export const platformApi = createApi({
     'Environment',
     'Context',
     'IdentityUsers',
+    'PlatformUsers',
     'OrgSettings',
     'SmtpSettings',
     'Invites',

--- a/erun-console/src/app/api/platformUsersApi.ts
+++ b/erun-console/src/app/api/platformUsersApi.ts
@@ -1,0 +1,102 @@
+// RTK Query endpoints for /v1/users: the raw erun-side enrollment surface
+// (erun-backend-api/internal/routes/users.go) that writes a user row
+// directly, optionally linking an external (issuer, subject) identity —
+// the same capability `erun platform user enroll` exposes on the CLI.
+// Distinct from identityApi's /v1/identity/users, which also creates the IdP
+// account itself; this one assumes the identity already exists (or will be
+// linked later) and is the only enrollment path that can target a tenant
+// other than the caller's own.
+import { asOptionalString, asString, isRecord } from 'erun-kit';
+
+import { platformApi } from './platformApi';
+
+export interface PlatformUser {
+  userId: string;
+  tenantId: string;
+  username: string;
+  issuer?: string;
+  subject?: string;
+}
+
+function parsePlatformUser(raw: Record<string, unknown>): PlatformUser {
+  return {
+    userId: asString(raw.userId),
+    tenantId: asString(raw.tenantId),
+    username: asString(raw.username),
+    issuer: asOptionalString(raw.issuer),
+    subject: asOptionalString(raw.subject),
+  };
+}
+
+function parsePlatformUserList(value: unknown): PlatformUser[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord).map(parsePlatformUser);
+}
+
+// EnrollPlatformUserInput mirrors POST /v1/users' body. tenantId targets a
+// tenant other than the caller's own and is honored only for an
+// operations-tenant caller (erun-backend-api's resolveTargetTenant); the
+// backend refuses it outright for anyone else, so the console's own
+// tenant-selector gating is presentation only, never the real boundary.
+export interface EnrollPlatformUserInput {
+  username: string;
+  issuer?: string;
+  subject?: string;
+  tenantId?: string;
+}
+
+// alreadyEnrolled distinguishes the no-op "this identity is already enrolled
+// in the target tenant" success (200) from a genuine username collision,
+// which the backend reports as a USERNAME_TAKEN error instead (see
+// httpBaseQuery's parsedError / queryError's describeQueryError for how that
+// surfaces to a caller of enrollPlatformUser).
+export interface EnrollPlatformUserResult {
+  user: PlatformUser;
+  alreadyEnrolled: boolean;
+}
+
+function parseEnrollPlatformUserResult(raw: unknown): EnrollPlatformUserResult {
+  if (!isRecord(raw)) {
+    throw new Error('enroll user response was not in the expected shape');
+  }
+  return { user: parsePlatformUser(raw), alreadyEnrolled: raw.alreadyEnrolled === true };
+}
+
+export const platformUsersApi = platformApi.injectEndpoints({
+  endpoints: (builder) => ({
+    listPlatformUsers: builder.query<PlatformUser[], { token: string; tenantId?: string }>({
+      query: ({ token, tenantId }) => ({
+        url:
+          tenantId !== undefined && tenantId.length > 0
+            ? `/v1/users?tenantId=${encodeURIComponent(tenantId)}`
+            : '/v1/users',
+        token,
+        label: 'list platform users',
+      }),
+      transformResponse: parsePlatformUserList,
+      providesTags: ['PlatformUsers'],
+    }),
+
+    // enrollPlatformUser invalidates 'Tenants' as well as 'PlatformUsers':
+    // it is the one write that can change a tenant's user count, which the
+    // Tenants view's inert-tenant flag (erun#1744) reads from listTenants.
+    enrollPlatformUser: builder.mutation<
+      EnrollPlatformUserResult,
+      { token: string; input: EnrollPlatformUserInput }
+    >({
+      query: ({ token, input }) => ({
+        url: '/v1/users',
+        method: 'POST',
+        body: input,
+        token,
+        label: 'enroll user',
+      }),
+      transformResponse: parseEnrollPlatformUserResult,
+      invalidatesTags: ['PlatformUsers', 'Tenants'],
+    }),
+  }),
+});
+
+export const { useListPlatformUsersQuery, useEnrollPlatformUserMutation } = platformUsersApi;

--- a/erun-console/src/app/api/tenantsApi.ts
+++ b/erun-console/src/app/api/tenantsApi.ts
@@ -7,12 +7,22 @@ import { asString, isRecord } from 'erun-kit';
 
 import { platformApi } from './platformApi';
 
+// userCount is populated only by listTenants (the operations-only listing
+// erun-backend-api's TenantRepository.List computes it for); it is
+// `undefined` — not 0 — for the createTenant/getReachableTenants responses,
+// which never count. Collapsing "not computed" into 0 would flag a healthy
+// tenant as inert the moment its count simply hadn't loaded yet.
 export interface PlatformTenant {
   tenantId: string;
   name: string;
   type: string;
   createdAt: string;
   updatedAt: string;
+  userCount?: number;
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
 }
 
 function parsePlatformTenant(raw: Record<string, unknown>): PlatformTenant {
@@ -22,6 +32,7 @@ function parsePlatformTenant(raw: Record<string, unknown>): PlatformTenant {
     type: asString(raw.type),
     createdAt: asString(raw.createdAt),
     updatedAt: asString(raw.updatedAt),
+    userCount: asOptionalNumber(raw.userCount),
   };
 }
 

--- a/erun-console/src/identity/EnrollUserForm.test.tsx
+++ b/erun-console/src/identity/EnrollUserForm.test.tsx
@@ -1,0 +1,179 @@
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithStore } from '../test/renderWithStore';
+import { EnrollUserForm } from './EnrollUserForm';
+
+interface MockReq {
+  method: string;
+  url: string;
+  body?: unknown;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function requestUrl(input: string | URL): string {
+  return input instanceof URL ? input.href : input;
+}
+
+function mockFetch(handler: (req: MockReq) => Response): MockReq[] {
+  const calls: MockReq[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL, init?: RequestInit) => {
+      const req: MockReq = {
+        method: init?.method ?? 'GET',
+        url: requestUrl(input),
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      };
+      calls.push(req);
+      return Promise.resolve(handler(req));
+    }),
+  );
+  return calls;
+}
+
+const TENANTS = [
+  {
+    tenantId: 'own-tenant',
+    name: 'operations-hq',
+    type: 'OPERATIONS',
+    createdAt: '2026-06-24T10:00:00Z',
+    updatedAt: '2026-06-24T10:00:00Z',
+    userCount: 4,
+  },
+  {
+    tenantId: 'other-tenant',
+    name: 'validationagent',
+    type: 'COMPANY',
+    createdAt: '2026-06-24T10:00:00Z',
+    updatedAt: '2026-06-24T10:00:00Z',
+    userCount: 0,
+  },
+];
+
+function mockTenantsAndUsers(onEnroll: (req: MockReq) => Response | undefined): void {
+  mockFetch((req) => {
+    if (req.url === '/v1/tenants' && req.method === 'GET') {
+      return jsonResponse(TENANTS);
+    }
+    if (req.url === '/v1/users' && req.method === 'POST') {
+      return onEnroll(req) ?? jsonResponse({}, 500);
+    }
+    return jsonResponse({}, 404);
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('EnrollUserForm', () => {
+  it('does not show a tenant selector for a non-OPERATIONS caller', async () => {
+    mockTenantsAndUsers(() => undefined);
+    renderWithStore(
+      <EnrollUserForm token="dev-token" ownTenantId="own-tenant" tenantType="COMPANY" />,
+    );
+    await screen.findByText('Enroll a user directly');
+
+    expect(screen.queryByLabelText('Tenant')).not.toBeInTheDocument();
+  });
+
+  it('shows the tenant selector for an OPERATIONS caller', async () => {
+    mockTenantsAndUsers(() => undefined);
+    renderWithStore(
+      <EnrollUserForm token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
+
+    expect(await screen.findByLabelText('Tenant')).toBeInTheDocument();
+  });
+
+  it('defaults the target to the signed-in tenant and omits tenantId when unchanged', async () => {
+    let enrollBody: unknown;
+    mockTenantsAndUsers((req) => {
+      enrollBody = req.body;
+      return jsonResponse(
+        { userId: 'u-1', tenantId: 'own-tenant', username: 'alice', alreadyEnrolled: false },
+        201,
+      );
+    });
+    renderWithStore(
+      <EnrollUserForm token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
+    await screen.findByLabelText('Tenant');
+
+    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+      target: { value: 'alice' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll directly' }));
+
+    expect(await screen.findByText(/Enrolled alice/)).toBeInTheDocument();
+    expect(enrollBody).toEqual({ username: 'alice' });
+  });
+
+  it('states the first user of a tenant with no users will receive TenantAdmin, before submitting', async () => {
+    mockTenantsAndUsers(() => undefined);
+    // The target defaults to ownTenantId, and 'other-tenant' is seeded with
+    // userCount: 0 above -- exercising the default-target path (rather than
+    // driving the Radix Select popover, which jsdom does not render
+    // interactively) is enough to prove the notice reacts to the resolved
+    // target tenant's own count.
+    renderWithStore(
+      <EnrollUserForm token="dev-token" ownTenantId="other-tenant" tenantType="OPERATIONS" />,
+    );
+
+    expect(await screen.findByText(/will be granted TenantAdmin/)).toBeInTheDocument();
+  });
+
+  it('reports a no-op re-enrollment as already enrolled, distinctly from a username collision', async () => {
+    mockTenantsAndUsers(() =>
+      jsonResponse(
+        { userId: 'u-1', tenantId: 'own-tenant', username: 'alice', alreadyEnrolled: true },
+        200,
+      ),
+    );
+    renderWithStore(
+      <EnrollUserForm token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
+    await screen.findByLabelText('Tenant');
+
+    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+      target: { value: 'alice' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll directly' }));
+
+    expect(await screen.findByText(/already enrolled/)).toBeInTheDocument();
+    expect(screen.queryByText(/username already exists/)).not.toBeInTheDocument();
+  });
+
+  it('reports a genuine username collision distinctly from an already-enrolled no-op', async () => {
+    mockTenantsAndUsers(() =>
+      jsonResponse(
+        {
+          code: 'USERNAME_TAKEN',
+          message: 'a user with this username already exists in the target tenant',
+        },
+        409,
+      ),
+    );
+    renderWithStore(
+      <EnrollUserForm token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
+    await screen.findByLabelText('Tenant');
+
+    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+      target: { value: 'alice' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll directly' }));
+
+    expect(await screen.findByText(/username already exists/)).toBeInTheDocument();
+    expect(screen.queryByText(/already enrolled/)).not.toBeInTheDocument();
+  });
+});

--- a/erun-console/src/identity/EnrollUserForm.tsx
+++ b/erun-console/src/identity/EnrollUserForm.tsx
@@ -1,0 +1,85 @@
+import { Button } from 'erun-kit';
+import * as React from 'react';
+
+import { useListTenantsQuery } from '../app/api/tenantsApi';
+import { usePlatformEnrollController } from './platformEnrollController';
+import {
+  FirstUserNotice,
+  PlatformEnrollFeedback,
+  PlatformEnrollUsernameFields,
+  TenantTargetSelect,
+} from './PlatformEnrollFields';
+
+// EnrollUserForm is the console's parity for `erun platform user enroll`
+// (erun#1744): it writes a user row directly via POST /v1/users, optionally
+// targeting a tenant other than the caller's own. The tenant selector only
+// ever renders for an OPERATIONS caller (TenantTargetSelect); every other
+// caller enrolls into their own tenant with no selector shown at all.
+export function EnrollUserForm({
+  token,
+  ownTenantId,
+  tenantType,
+}: {
+  token: string;
+  ownTenantId: string;
+  tenantType: string;
+}): React.ReactElement {
+  const tenantsQuery = useListTenantsQuery(token);
+  const tenants = React.useMemo(() => tenantsQuery.data ?? [], [tenantsQuery.data]);
+  const [targetTenantId, setTargetTenantId] = React.useState(ownTenantId);
+  const [username, setUsername] = React.useState('');
+  const [issuer, setIssuer] = React.useState('');
+  const [subject, setSubject] = React.useState('');
+  const [becameFirstUser, setBecameFirstUser] = React.useState(false);
+  const { state, enroll, reset } = usePlatformEnrollController(token);
+
+  const targetTenant = tenants.find((tenant) => tenant.tenantId === targetTenantId);
+  const busy = state.status === 'enrolling';
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    reset();
+    setBecameFirstUser(targetTenant?.userCount === 0);
+    enroll({
+      username: username.trim(),
+      issuer: issuer.trim() || undefined,
+      subject: subject.trim() || undefined,
+      tenantId: targetTenantId !== ownTenantId ? targetTenantId : undefined,
+    });
+  };
+
+  return (
+    <form
+      className="grid max-w-md gap-3"
+      onSubmit={submit}
+      aria-labelledby="enroll-platform-user-heading"
+    >
+      <h3 id="enroll-platform-user-heading" className="text-sm font-semibold text-foreground">
+        Enroll a user directly
+      </h3>
+      <p className="text-xs text-muted-foreground">
+        Writes a user row immediately, linking the (issuer, subject) identity if given. Leave both
+        blank to enroll a username that cannot sign in until an identity is linked later.
+      </p>
+      <TenantTargetSelect
+        tenantType={tenantType}
+        tenants={tenants}
+        value={targetTenantId}
+        onChange={setTargetTenantId}
+      />
+      <PlatformEnrollUsernameFields
+        username={username}
+        setUsername={setUsername}
+        issuer={issuer}
+        setIssuer={setIssuer}
+        subject={subject}
+        setSubject={setSubject}
+      />
+      <FirstUserNotice tenant={targetTenant} />
+      <Button type="submit" disabled={busy} className="justify-self-start">
+        {busy ? 'Enrolling…' : 'Enroll directly'}
+      </Button>
+      <PlatformEnrollFeedback state={state} tenants={tenants} becameFirstUser={becameFirstUser} />
+    </form>
+  );
+}

--- a/erun-console/src/identity/PlatformEnrollFields.tsx
+++ b/erun-console/src/identity/PlatformEnrollFields.tsx
@@ -1,0 +1,162 @@
+import { FieldLabel, Input, SelectField } from 'erun-kit';
+import * as React from 'react';
+
+import type { PlatformTenant } from '../app/api/tenantsApi';
+import type { PlatformEnrollState } from './platformEnrollController';
+
+// TenantTargetSelect is shown only to an OPERATIONS caller — the same
+// tenant.type check `shell/sections.ts` already gates the Users/Tenants nav
+// entries on, reused here rather than a new permission mechanism. A
+// non-OPERATIONS caller never reaches a component that renders this (the nav
+// gate already keeps them out), but the check stays local too so the control
+// itself never depends only on the surrounding panel for that guarantee.
+export function TenantTargetSelect({
+  tenantType,
+  tenants,
+  value,
+  onChange,
+}: {
+  tenantType: string;
+  tenants: PlatformTenant[];
+  value: string;
+  onChange: (tenantId: string) => void;
+}): React.ReactElement | null {
+  if (tenantType !== 'OPERATIONS') {
+    return null;
+  }
+  return (
+    <SelectField
+      id="enroll-target-tenant"
+      label="Tenant"
+      value={value}
+      options={tenants.map((tenant) => ({ value: tenant.tenantId, label: tenant.name }))}
+      onChange={onChange}
+    />
+  );
+}
+
+// FirstUserNotice fires only on an exact, resolved 0 — never on an
+// undefined/unresolved userCount — so a tenant whose count hasn't loaded yet
+// never gets told it is about to receive its first user.
+export function FirstUserNotice({
+  tenant,
+}: {
+  tenant: PlatformTenant | undefined;
+}): React.ReactElement | null {
+  if (tenant?.userCount !== 0) {
+    return null;
+  }
+  return (
+    <p className="text-sm text-muted-foreground" role="status">
+      {tenant.name} has no users yet — enrolling here makes this person its first user, and they
+      will be granted TenantAdmin.
+    </p>
+  );
+}
+
+export function PlatformEnrollUsernameFields({
+  username,
+  setUsername,
+  issuer,
+  setIssuer,
+  subject,
+  setSubject,
+}: {
+  username: string;
+  setUsername: (value: string) => void;
+  issuer: string;
+  setIssuer: (value: string) => void;
+  subject: string;
+  setSubject: (value: string) => void;
+}): React.ReactElement {
+  return (
+    <>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="enroll-platform-username" required>
+          Username
+        </FieldLabel>
+        <Input
+          id="enroll-platform-username"
+          value={username}
+          onChange={(e) => {
+            setUsername(e.target.value);
+          }}
+          required
+        />
+      </div>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="enroll-platform-issuer">Issuer (optional)</FieldLabel>
+        <Input
+          id="enroll-platform-issuer"
+          value={issuer}
+          onChange={(e) => {
+            setIssuer(e.target.value);
+          }}
+          placeholder="https://idp.example.com"
+        />
+      </div>
+      <div className="grid gap-2">
+        <FieldLabel htmlFor="enroll-platform-subject">Subject (optional)</FieldLabel>
+        <Input
+          id="enroll-platform-subject"
+          value={subject}
+          onChange={(e) => {
+            setSubject(e.target.value);
+          }}
+        />
+      </div>
+    </>
+  );
+}
+
+function tenantLabel(tenants: PlatformTenant[], tenantId: string): string {
+  return tenants.find((tenant) => tenant.tenantId === tenantId)?.name ?? tenantId;
+}
+
+// PlatformEnrollFeedback renders alreadyEnrolled and a genuine username
+// collision as two distinct messages (erun#1744's acceptance criterion) —
+// the backend already discriminates them (200+alreadyEnrolled vs 409
+// USERNAME_TAKEN); this is where the console stops collapsing them into one.
+export function PlatformEnrollFeedback({
+  state,
+  tenants,
+  becameFirstUser,
+}: {
+  state: PlatformEnrollState;
+  tenants: PlatformTenant[];
+  becameFirstUser: boolean;
+}): React.ReactElement | null {
+  if (state.status === 'enrolled') {
+    if (state.alreadyEnrolled) {
+      return (
+        <p className="text-sm text-muted-foreground" role="status">
+          This identity is already enrolled, as {state.user.username} in{' '}
+          {tenantLabel(tenants, state.user.tenantId)}.
+        </p>
+      );
+    }
+    return (
+      <p className="text-sm text-muted-foreground" role="status">
+        Enrolled {state.user.username} in {tenantLabel(tenants, state.user.tenantId)}.
+        {becameFirstUser
+          ? ' They are this tenant’s first user and have been granted TenantAdmin.'
+          : ''}
+      </p>
+    );
+  }
+  if (state.status === 'conflict') {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        A different user already holds that username in the target tenant: {state.message}
+      </p>
+    );
+  }
+  if (state.status === 'error') {
+    return (
+      <p className="text-sm text-destructive" role="alert">
+        Could not enroll user: {state.message}
+      </p>
+    );
+  }
+  return null;
+}

--- a/erun-console/src/identity/UsersPanel.test.tsx
+++ b/erun-console/src/identity/UsersPanel.test.tsx
@@ -47,7 +47,9 @@ afterEach(() => {
 describe('UsersPanel', () => {
   it('lists identities and renders an empty state when there are none', async () => {
     mockFetch(() => jsonResponse([]));
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     expect(await screen.findByText('No users enrolled yet.')).toBeInTheDocument();
   });
 
@@ -65,7 +67,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     expect(await screen.findByText('alice')).toBeInTheDocument();
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
     expect(screen.getByText('USER_STATE_ACTIVE')).toBeInTheDocument();
@@ -87,16 +91,19 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('No users enrolled yet.');
 
-    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+    const form = within(screen.getByRole('form', { name: 'Enroll a user' }));
+    fireEvent.change(form.getByLabelText('Username', { exact: false }), {
       target: { value: 'bob' },
     });
-    fireEvent.change(screen.getByLabelText('Email', { exact: false }), {
+    fireEvent.change(form.getByLabelText('Email', { exact: false }), {
       target: { value: 'bob@example.com' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Enroll user' }));
+    fireEvent.click(form.getByRole('button', { name: 'Enroll user' }));
 
     expect(await screen.findByText(/Enrolled bob/)).toBeInTheDocument();
     expect(screen.getByText(/An invite email is on its way/)).toBeInTheDocument();
@@ -120,16 +127,19 @@ describe('UsersPanel', () => {
       }
       return jsonResponse([]);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('No users enrolled yet.');
 
-    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+    const form = within(screen.getByRole('form', { name: 'Enroll a user' }));
+    fireEvent.change(form.getByLabelText('Username', { exact: false }), {
       target: { value: 'dana' },
     });
-    fireEvent.change(screen.getByLabelText('Email', { exact: false }), {
+    fireEvent.change(form.getByLabelText('Email', { exact: false }), {
       target: { value: 'dana@example.com' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Enroll user' }));
+    fireEvent.click(form.getByRole('button', { name: 'Enroll user' }));
 
     expect(await screen.findByText(/Outbound mail is not configured/)).toBeInTheDocument();
     expect(screen.getByText('Temporary password for dana')).toBeInTheDocument();
@@ -158,16 +168,19 @@ describe('UsersPanel', () => {
       }
       return jsonResponse([]);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('No users enrolled yet.');
 
-    fireEvent.change(screen.getByLabelText('Username', { exact: false }), {
+    const form = within(screen.getByRole('form', { name: 'Enroll a user' }));
+    fireEvent.change(form.getByLabelText('Username', { exact: false }), {
       target: { value: 'carol' },
     });
-    fireEvent.change(screen.getByLabelText('Email', { exact: false }), {
+    fireEvent.change(form.getByLabelText('Email', { exact: false }), {
       target: { value: 'carol@example.com' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Enroll user' }));
+    fireEvent.click(form.getByRole('button', { name: 'Enroll user' }));
 
     expect(await screen.findByText(/could not be enrolled as an erun user/)).toBeInTheDocument();
   });
@@ -182,7 +195,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('alice');
 
     expect(screen.getByText('Tenant member')).toBeInTheDocument();
@@ -198,7 +213,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('admin-sa');
 
     expect(screen.getByText('Machine account')).toBeInTheDocument();
@@ -217,7 +234,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('USER_STATE_ACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
@@ -233,7 +252,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('USER_STATE_ACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
@@ -255,7 +276,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('USER_STATE_ACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
@@ -292,7 +315,9 @@ describe('UsersPanel', () => {
       }),
     );
 
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('USER_STATE_ACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
@@ -323,7 +348,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('USER_STATE_ACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Deactivate' }));
@@ -351,7 +378,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('alice');
 
     expect(screen.getAllByRole('button', { name: 'Manage roles' })).toHaveLength(1);
@@ -386,7 +415,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('alice');
 
     fireEvent.click(screen.getByRole('button', { name: 'Manage roles' }));
@@ -431,7 +462,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('alice');
 
     fireEvent.click(screen.getByRole('button', { name: 'Manage roles' }));
@@ -460,7 +493,9 @@ describe('UsersPanel', () => {
       }
       return jsonResponse({}, 404);
     });
-    renderWithStore(<UsersPanel token="dev-token" />);
+    renderWithStore(
+      <UsersPanel token="dev-token" ownTenantId="own-tenant" tenantType="OPERATIONS" />,
+    );
     await screen.findByText('USER_STATE_INACTIVE');
 
     fireEvent.click(screen.getByRole('button', { name: 'Reactivate' }));

--- a/erun-console/src/identity/UsersPanel.tsx
+++ b/erun-console/src/identity/UsersPanel.tsx
@@ -26,6 +26,7 @@ import * as React from 'react';
 import type { EnrollIdentityUserInput, IdentityUser } from '../app/api/identityApi';
 import type { EnrollState, UsersState } from './controller';
 import { useUsersController } from './controller';
+import { EnrollUserForm } from './EnrollUserForm';
 import { UserRolesDialog } from './UserRolesDialog';
 
 // EnrollFeedback tells the operator which of the two enrollment paths the
@@ -429,7 +430,19 @@ function UsersBody({
 // colleague (creates the IdP identity and the erun user mapping in one
 // action), deactivate/reactivate an existing one, and manage which roles an
 // enrolled user holds. Only rendered for an OPERATIONS tenant — see App.tsx.
-export function UsersPanel({ token }: { token: string }): React.ReactElement {
+// EnrollUserForm below is the separate, tenant-targetable enrollment path
+// (POST /v1/users, erun#1744) that can put a first user into a tenant other
+// than the caller's own — the one thing the IdP-creating form above cannot
+// do, since it always creates the identity in the caller's own org.
+export function UsersPanel({
+  token,
+  ownTenantId,
+  tenantType,
+}: {
+  token: string;
+  ownTenantId: string;
+  tenantType: string;
+}): React.ReactElement {
   const { usersState, enrollState, enroll, setActive, dismissTemporaryPassword } =
     useUsersController(token);
   const temporaryPassword =
@@ -451,6 +464,7 @@ export function UsersPanel({ token }: { token: string }): React.ReactElement {
           onManageRoles={setManagingRoles}
         />
         <EnrollForm enroll={enrollState} onEnroll={enroll} />
+        <EnrollUserForm token={token} ownTenantId={ownTenantId} tenantType={tenantType} />
       </CardContent>
       {temporaryPassword !== undefined && enrollState.status === 'enrolled' && (
         <TemporaryPasswordDialog

--- a/erun-console/src/identity/platformEnrollController.ts
+++ b/erun-console/src/identity/platformEnrollController.ts
@@ -1,0 +1,80 @@
+import * as React from 'react';
+
+import type { EnrollPlatformUserInput, PlatformUser } from '../app/api/platformUsersApi';
+import { useEnrollPlatformUserMutation } from '../app/api/platformUsersApi';
+import { describeQueryError } from '../app/queryError';
+
+// PlatformEnrollState discriminates the three outcomes POST /v1/users can
+// report: a no-op re-enrollment (alreadyEnrolled true on the 'enrolled'
+// branch), a genuine username collision (its own USERNAME_TAKEN code, kept
+// apart as 'conflict' rather than falling into the generic 'error' bucket),
+// and every other failure. Collapsing the first two into one message is
+// exactly the gap erun#1744 asks to close.
+export type PlatformEnrollState =
+  | { status: 'idle' }
+  | { status: 'enrolling' }
+  | { status: 'enrolled'; user: PlatformUser; alreadyEnrolled: boolean }
+  | { status: 'conflict'; message: string }
+  | { status: 'error'; message: string };
+
+export interface PlatformEnrollController {
+  state: PlatformEnrollState;
+  enroll: (input: EnrollPlatformUserInput) => void;
+  reset: () => void;
+}
+
+function useActiveRef(): React.RefObject<boolean> {
+  const activeRef = React.useRef(true);
+  React.useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+  return activeRef;
+}
+
+// usePlatformEnrollController wraps POST /v1/users' mutation and classifies
+// its rejection by the backend's own machine code, rather than rendering
+// every non-2xx response as the same generic failure text.
+export function usePlatformEnrollController(token: string): PlatformEnrollController {
+  const [enrollPlatformUser] = useEnrollPlatformUserMutation();
+  const [state, setState] = React.useState<PlatformEnrollState>({ status: 'idle' });
+  const activeRef = useActiveRef();
+
+  const enroll = React.useCallback(
+    (input: EnrollPlatformUserInput) => {
+      setState({ status: 'enrolling' });
+      enrollPlatformUser({ token, input })
+        .unwrap()
+        .then((result) => {
+          if (!activeRef.current) {
+            return;
+          }
+          setState({
+            status: 'enrolled',
+            user: result.user,
+            alreadyEnrolled: result.alreadyEnrolled,
+          });
+        })
+        .catch((error: unknown) => {
+          if (!activeRef.current) {
+            return;
+          }
+          const described = describeQueryError(error);
+          setState(
+            described.code === 'USERNAME_TAKEN'
+              ? { status: 'conflict', message: described.message }
+              : { status: 'error', message: described.message },
+          );
+        });
+    },
+    [token, activeRef, enrollPlatformUser],
+  );
+
+  const reset = React.useCallback(() => {
+    setState({ status: 'idle' });
+  }, []);
+
+  return { state, enroll, reset };
+}

--- a/erun-console/src/shell/AppShell.tsx
+++ b/erun-console/src/shell/AppShell.tsx
@@ -32,16 +32,18 @@ function OperationsSectionContent({
   active,
   token,
   docsUrl,
+  tenant,
 }: {
   active: 'tenants' | 'users' | 'org-settings' | 'smtp-settings';
   token: string;
   docsUrl: string | undefined;
+  tenant: TenantConfigView['tenant'];
 }): React.ReactElement {
   switch (active) {
     case 'tenants':
       return <TenantsPanel token={token} docsUrl={docsUrl} />;
     case 'users':
-      return <UsersPanel token={token} />;
+      return <UsersPanel token={token} ownTenantId={tenant.tenantId} tenantType={tenant.type} />;
     case 'org-settings':
       return <OrgSettingsPanel token={token} />;
     case 'smtp-settings':
@@ -98,7 +100,14 @@ function SectionContent({
         />
       );
     default:
-      return <OperationsSectionContent active={active} token={token} docsUrl={docsUrl} />;
+      return (
+        <OperationsSectionContent
+          active={active}
+          token={token}
+          docsUrl={docsUrl}
+          tenant={config.tenant}
+        />
+      );
   }
 }
 

--- a/erun-console/src/tenants/EnrollTenantUserDialog.tsx
+++ b/erun-console/src/tenants/EnrollTenantUserDialog.tsx
@@ -1,0 +1,100 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'erun-kit';
+import { LoaderCircle } from 'lucide-react';
+import * as React from 'react';
+
+import type { PlatformTenant } from '../app/api/tenantsApi';
+import { usePlatformEnrollController } from '../identity/platformEnrollController';
+import {
+  FirstUserNotice,
+  PlatformEnrollFeedback,
+  PlatformEnrollUsernameFields,
+} from '../identity/PlatformEnrollFields';
+
+// EnrollTenantUserDialog is the Tenants view's own way to put a user into a
+// tenant (erun#1744) — offered where the empty tenant is actually visible,
+// rather than only from the Users view with a tenant picker. The target
+// tenant is fixed to the row it was opened from, so there is no selector
+// here at all, only the same username/issuer/subject fields and first-user
+// notice EnrollUserForm uses.
+export function EnrollTenantUserDialog({
+  tenant,
+  token,
+  onClose,
+}: {
+  tenant: PlatformTenant;
+  token: string;
+  onClose: () => void;
+}): React.ReactElement {
+  const [username, setUsername] = React.useState('');
+  const [issuer, setIssuer] = React.useState('');
+  const [subject, setSubject] = React.useState('');
+  const { state, enroll } = usePlatformEnrollController(token);
+  const busy = state.status === 'enrolling';
+  const becameFirstUser = tenant.userCount === 0;
+
+  const submit = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    enroll({
+      username: username.trim(),
+      issuer: issuer.trim() || undefined,
+      subject: subject.trim() || undefined,
+      tenantId: tenant.tenantId,
+    });
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && !busy) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent aria-labelledby="enroll-tenant-user-heading">
+        <DialogHeader>
+          <DialogTitle id="enroll-tenant-user-heading">
+            Enroll a user into {tenant.name}
+          </DialogTitle>
+          <DialogDescription>
+            Writes a user row directly into this tenant, the same way `erun platform user enroll
+            --tenant-id` does.
+          </DialogDescription>
+        </DialogHeader>
+        <form className="grid gap-3" onSubmit={submit}>
+          <PlatformEnrollUsernameFields
+            username={username}
+            setUsername={setUsername}
+            issuer={issuer}
+            setIssuer={setIssuer}
+            subject={subject}
+            setSubject={setSubject}
+          />
+          <FirstUserNotice tenant={tenant} />
+          <PlatformEnrollFeedback
+            state={state}
+            tenants={[tenant]}
+            becameFirstUser={becameFirstUser}
+          />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Close
+            </Button>
+            <Button type="submit" disabled={busy}>
+              {busy && <LoaderCircle className="animate-spin" aria-hidden="true" />}
+              Enroll user
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/erun-console/src/tenants/TenantsPanel.test.tsx
+++ b/erun-console/src/tenants/TenantsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithStore } from '../test/renderWithStore';
@@ -78,6 +78,43 @@ describe('TenantsPanel', () => {
     // Scoped to a table cell: the create form's own Type select also defaults
     // to displaying "COMPANY", so a bare getByText would be ambiguous.
     expect(screen.getByRole('cell', { name: 'COMPANY' })).toBeInTheDocument();
+    // The response carried no userCount at all (a read path that never
+    // counts) -- this must render as "unresolved", never as the same "0
+    // users" badge a genuinely empty tenant gets.
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.queryByText('No users')).not.toBeInTheDocument();
+  });
+
+  it('flags a tenant with zero users as inert, distinctly from one with an unresolved count', async () => {
+    mockFetch((req) => {
+      if (req.url === '/v1/tenants' && req.method === 'GET') {
+        return jsonResponse([
+          {
+            tenantId: 'tn-empty',
+            name: 'validationagent',
+            type: 'COMPANY',
+            createdAt: '2026-06-24T10:00:00Z',
+            updatedAt: '2026-06-24T10:00:00Z',
+            userCount: 0,
+          },
+          {
+            tenantId: 'tn-populated',
+            name: 'acme',
+            type: 'COMPANY',
+            createdAt: '2026-06-24T10:00:00Z',
+            updatedAt: '2026-06-24T10:00:00Z',
+            userCount: 3,
+          },
+        ]);
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<TenantsPanel token="dev-token" docsUrl={undefined} />);
+    await screen.findByText('validationagent');
+
+    expect(screen.getByText('No users')).toBeInTheDocument();
+    expect(screen.getByText('3 users')).toBeInTheDocument();
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
   });
 
   it('registers a tenant and reports the no-first-user note, then refreshes the list', async () => {
@@ -247,6 +284,50 @@ describe('TenantsPanel', () => {
       maxTotalMemoryMb: 4096,
       maxTotalStorageGb: 100,
     });
+  });
+
+  it('enrolls the first user of an empty tenant from the Tenants view and names the TenantAdmin grant', async () => {
+    let enrollBody: unknown;
+    mockFetch((req) => {
+      if (req.url === '/v1/tenants' && req.method === 'GET') {
+        return jsonResponse([
+          {
+            tenantId: 'tn-empty',
+            name: 'validationagent',
+            type: 'COMPANY',
+            createdAt: '2026-06-24T10:00:00Z',
+            updatedAt: '2026-06-24T10:00:00Z',
+            userCount: 0,
+          },
+        ]);
+      }
+      if (req.url === '/v1/users' && req.method === 'POST') {
+        enrollBody = req.body;
+        return jsonResponse(
+          { userId: 'u-1', tenantId: 'tn-empty', username: 'jane', alreadyEnrolled: false },
+          201,
+        );
+      }
+      return jsonResponse({}, 404);
+    });
+    renderWithStore(<TenantsPanel token="dev-token" docsUrl={undefined} />);
+    await screen.findByText('validationagent');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enroll user' }));
+    const dialog = await screen.findByRole('dialog');
+    // Told before confirming, not discovered after (erun#1744 acceptance
+    // criterion): the notice is visible as soon as the dialog opens.
+    expect(within(dialog).getByText(/will be granted TenantAdmin/)).toBeInTheDocument();
+
+    fireEvent.change(within(dialog).getByLabelText('Username', { exact: false }), {
+      target: { value: 'jane' },
+    });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Enroll user' }));
+
+    expect(
+      await screen.findByText(/first user and have been granted TenantAdmin/),
+    ).toBeInTheDocument();
+    expect(enrollBody).toEqual({ username: 'jane', tenantId: 'tn-empty' });
   });
 
   it('links the org-scoped-issuer explanation using the instance docs URL when provided', async () => {

--- a/erun-console/src/tenants/TenantsPanel.tsx
+++ b/erun-console/src/tenants/TenantsPanel.tsx
@@ -8,6 +8,7 @@ import {
   FieldLabel,
   Input,
   SelectField,
+  StatusBadge,
   Table,
   TableBody,
   TableCell,
@@ -22,6 +23,7 @@ import type { CreateTenantInput, PlatformTenant } from '../app/api/tenantsApi';
 import { PUBLIC_DOCS_URL } from '../shell/landingContent';
 import type { CreateTenantState, TenantFieldError, TenantsState } from './controller';
 import { useTenantsController } from './controller';
+import { EnrollTenantUserDialog } from './EnrollTenantUserDialog';
 import { TenantQuotaDialog } from './TenantQuotaDialog';
 
 // The identity model's own explanation of org-scoped (shared) issuers — see
@@ -275,12 +277,40 @@ function formatCreatedAt(createdAt: string): string {
   return Number.isNaN(parsed.getTime()) ? createdAt : parsed.toLocaleDateString();
 }
 
+// TenantUserCountBadge is the Tenants view's own noticing point for an inert
+// tenant (erun#1744): a tenant registered through the product but with no
+// console-reachable way to add a user reads identically to a healthy one
+// unless the zero itself is flagged here, where it was created. `undefined`
+// (the count did not load, rather than genuinely being zero) renders as
+// "Unknown" so a fetch hiccup never gets mistaken for the inert state.
+function TenantUserCountBadge({
+  userCount,
+}: {
+  userCount: number | undefined;
+}): React.ReactElement {
+  if (userCount === undefined) {
+    return <StatusBadge tone="muted" label="Unknown" showIcon={false} />;
+  }
+  if (userCount === 0) {
+    return <StatusBadge tone="warning" label="No users" />;
+  }
+  return (
+    <StatusBadge
+      tone="muted"
+      label={`${String(userCount)} ${userCount === 1 ? 'user' : 'users'}`}
+      showIcon={false}
+    />
+  );
+}
+
 function TenantRow({
   tenant,
   onManageQuota,
+  onEnrollUser,
 }: {
   tenant: PlatformTenant;
   onManageQuota: (tenant: PlatformTenant) => void;
+  onEnrollUser: (tenant: PlatformTenant) => void;
 }): React.ReactElement {
   return (
     <TableRow>
@@ -288,6 +318,19 @@ function TenantRow({
       <TableCell>{tenant.type}</TableCell>
       <TableCell>{formatCreatedAt(tenant.createdAt)}</TableCell>
       <TableCell>
+        <TenantUserCountBadge userCount={tenant.userCount} />
+      </TableCell>
+      <TableCell className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            onEnrollUser(tenant);
+          }}
+        >
+          Enroll user
+        </Button>
         <Button
           type="button"
           variant="outline"
@@ -306,9 +349,11 @@ function TenantRow({
 function TenantsTable({
   tenants,
   onManageQuota,
+  onEnrollUser,
 }: {
   tenants: PlatformTenant[];
   onManageQuota: (tenant: PlatformTenant) => void;
+  onEnrollUser: (tenant: PlatformTenant) => void;
 }): React.ReactElement {
   if (tenants.length === 0) {
     return <EmptyState icon={<Building2 />} heading="No tenants registered yet." />;
@@ -320,12 +365,18 @@ function TenantsTable({
           <TableHead>Name</TableHead>
           <TableHead>Type</TableHead>
           <TableHead>Created</TableHead>
-          <TableHead>Quota</TableHead>
+          <TableHead>Users</TableHead>
+          <TableHead />
         </TableRow>
       </TableHeader>
       <TableBody>
         {tenants.map((tenant) => (
-          <TenantRow key={tenant.tenantId} tenant={tenant} onManageQuota={onManageQuota} />
+          <TenantRow
+            key={tenant.tenantId}
+            tenant={tenant}
+            onManageQuota={onManageQuota}
+            onEnrollUser={onEnrollUser}
+          />
         ))}
       </TableBody>
     </Table>
@@ -335,9 +386,11 @@ function TenantsTable({
 function TenantsBody({
   tenantsState,
   onManageQuota,
+  onEnrollUser,
 }: {
   tenantsState: TenantsState;
   onManageQuota: (tenant: PlatformTenant) => void;
+  onEnrollUser: (tenant: PlatformTenant) => void;
 }): React.ReactElement {
   if (tenantsState.status === 'loading') {
     return (
@@ -353,7 +406,13 @@ function TenantsBody({
       </p>
     );
   }
-  return <TenantsTable tenants={tenantsState.tenants} onManageQuota={onManageQuota} />;
+  return (
+    <TenantsTable
+      tenants={tenantsState.tenants}
+      onManageQuota={onManageQuota}
+      onEnrollUser={onEnrollUser}
+    />
+  );
 }
 
 // TenantsPanel is the console's tenant-registration surface: the one action
@@ -370,13 +429,20 @@ export function TenantsPanel({
   const [managingQuotaFor, setManagingQuotaFor] = React.useState<PlatformTenant | undefined>(
     undefined,
   );
+  const [enrollingUserFor, setEnrollingUserFor] = React.useState<PlatformTenant | undefined>(
+    undefined,
+  );
   return (
     <Card aria-labelledby="tenants-heading">
       <CardHeader>
         <CardTitle id="tenants-heading">Tenants</CardTitle>
       </CardHeader>
       <CardContent className="grid gap-6">
-        <TenantsBody tenantsState={tenantsState} onManageQuota={setManagingQuotaFor} />
+        <TenantsBody
+          tenantsState={tenantsState}
+          onManageQuota={setManagingQuotaFor}
+          onEnrollUser={setEnrollingUserFor}
+        />
         <CreateTenantForm createState={createState} docsUrl={docsUrl} onCreate={create} />
       </CardContent>
       {managingQuotaFor !== undefined && (
@@ -386,6 +452,15 @@ export function TenantsPanel({
           token={token}
           onClose={() => {
             setManagingQuotaFor(undefined);
+          }}
+        />
+      )}
+      {enrollingUserFor !== undefined && (
+        <EnrollTenantUserDialog
+          tenant={enrollingUserFor}
+          token={token}
+          onClose={() => {
+            setEnrollingUserFor(undefined);
           }}
         />
       )}

--- a/erun-docs/docs/agent-reference/api-protocol.md
+++ b/erun-docs/docs/agent-reference/api-protocol.md
@@ -744,6 +744,36 @@ Provide **either** a `context` block (provision a new cluster — its bootstrap 
 
 Note that being **at or over quota is not an error** here — it returns `200` with `quotaOk: false` and the full plan (see `quotaOk` above), unlike `POST /v1/environments`, which rejects the actual write with `409`.
 
+### `GET /v1/tenants` {#get-v1tenants}
+
+Lists tenants. An **operations-tenant** caller sees **every** tenant this platform hosts; any other caller sees a single-item list containing only their own resolved tenant — `tenants` is a root resolution table with no RLS, so this scoping happens in application code rather than the database.
+
+```jsonc
+// 200 response (operations-tenant caller)
+[
+  {
+    "tenantId": "019a7fa5-c2c0-7c55-bc70-714873a71f50",
+    "name": "acme",
+    "type": "COMPANY",
+    "createdAt": "2026-06-24T10:00:00Z",
+    "updatedAt": "2026-06-24T10:00:00Z",
+    "userCount": 3
+  },
+  {
+    "tenantId": "019a8012-...-000",
+    "name": "validationagent",
+    "type": "COMPANY",
+    "createdAt": "2026-08-30T09:00:00Z",
+    "updatedAt": "2026-08-30T09:00:00Z",
+    "userCount": 0
+  }
+]
+```
+
+`userCount` is populated **only** for the operations-tenant branch above, in a single query (a `LEFT JOIN`/`GROUP BY` over `users`, not one query per tenant) — a tenant with genuinely zero users reports the explicit number `0`, never `null` and never an omitted field. Every other tenant-returning shape in this API (this endpoint's own single-tenant branch, `POST /v1/tenants`'s create response, `GET /v1/tenants/reachable`, `PATCH /v1/tenants/reconcile-bootstrap-name`) never computes it and omits the field entirely. A caller must treat "field absent" and "field present with value `0`" as different facts — the first means "not counted here", the second means "counted, and it is zero" — never coalesce a missing `userCount` to `0`.
+
+**Error behaviour.** Bare HTTP status with the generic JSON `{code, message}` envelope (see [Errors](#errors)); no endpoint-specific codes.
+
 ### `POST /v1/tenants`
 
 Registers a **new tenant** plus the OIDC issuer mapping that resolves its tokens. This is an **operations-only** endpoint: beyond the broad `WriteAll` permission that authorization enforces for any write, the handler adds an explicit gate — the caller's resolved tenant must be an `OPERATIONS` tenant, because `tenants`, `issuers`, and `tenant_issuers` are root resolution tables writable only by the operations role. A non-operations caller is rejected with `403` before any write is attempted.

--- a/erun-docs/docs/collaboration/identity-administration.md
+++ b/erun-docs/docs/collaboration/identity-administration.md
@@ -19,6 +19,7 @@ Signed in as an Operator on an **OPERATIONS** tenant, the console's **Users** vi
 - **Deactivate** a user, which blocks their next sign-in immediately. The console asks you to confirm before it takes effect, naming the person and the consequence.
 - **Reactivate** a deactivated user.
 - **Manage a user's roles.** A newly enrolled user starts with **no access at all** — they can sign in and do nothing until someone grants them a role. Click **Manage roles** on their row to see what they hold today, grant one of the tenant's defined roles, or revoke one. The tenant's first user is the one exception: they still get full access automatically, since a brand-new tenant with nobody able to grant anything would otherwise be stuck. For the full role/permission model, see [Agent reference · erun API protocol](/agent-reference/api-protocol#roles-endpoints).
+- **Enroll a user directly, into any tenant.** A second, separate form writes a user row straight into a tenant — the same action `erun platform user enroll` runs from the CLI — without creating a new identity-provider account. This is the one enrollment path that can target a tenant other than your own: a **Tenant** selector appears above the form, defaulting to your own tenant, so nothing changes for the common case unless you pick a different one. If the tenant you pick has no users yet, the form tells you before you submit that this enrollment makes them its first user and grants them **TenantAdmin**. Re-enrolling an identity already enrolled there reports back plainly that it already existed, distinct from a genuine username clash in that tenant.
 
 The **Org settings** view lets you read and change:
 
@@ -48,11 +49,13 @@ Every other view in this console operates inside your own tenant. Registering a 
 
 Signed in as an Operator on an OPERATIONS tenant, this view lets you:
 
-- **See every tenant this platform hosts** — name, type, and when it was registered.
+- **See every tenant this platform hosts** — name, type, when it was registered, and how many users it has.
 - **Register a new tenant.** Give it a **name** (lowercase letters and digits only, no hyphens — the console tells you this rule up front, since the `<tenant>-<env>` namespace needs it to stay unambiguous), a **type** (`COMPANY` or `OPERATIONS`), and the **issuer** whose tokens should resolve to it. A rejected name, issuer, or type renders next to the field it's actually about, not as a bare status code.
 - **Point a new tenant at a shared (org-scoped) issuer** — one identity provider serving several tenants — using the optional org field key/value pair. The view links to [the identity model's own explanation](/agent-reference/api-protocol#tenant-issuers) of how `(issuer, org)` resolves to a tenant, so those two values aren't guesswork.
 
 Registering a tenant creates **no first user**. The tenant's first admin is whoever presents the first valid token that resolves to it — the same per-tenant first-user bootstrap every tenant already relies on (see [Agent reference · erun API protocol](/agent-reference/api-protocol#tenant-issuers)). The console says this plainly right after registration, since it's easy to expect an enrollment step that doesn't exist here.
+
+That leaves a tenant reachable only once some token can actually resolve to it. **A tenant showing "No users" is flagged right in this list** — distinct from a count that hasn't loaded yet, which reads "Unknown" rather than a false zero — so an inert tenant is noticed here, where it was created, not discovered later as a support report. **Enroll user** on that row opens the same direct-enrollment action described under [What the console offers](#what-the-console-offers) above, already targeting this tenant, with the same first-user/TenantAdmin notice before you submit.
 
 For the full endpoint spec, see [Agent reference · erun API protocol](/agent-reference/api-protocol#post-v1tenants).
 


### PR DESCRIPTION
## Summary

A newly registered tenant can have zero users, and the console offered no way to put the first one there even though `POST /v1/users` already accepts a target tenant for an OPERATIONS caller. This closes the gap end to end:

- `EnrollUserForm` (Users view) gets a tenant-targeted enrollment path, with the tenant selector shown only to an OPERATIONS caller (the same `tenant.type` gate the nav already uses) and defaulting to the signed-in tenant.
- `EnrollTenantUserDialog` wires the same action into the Tenants view, where an inert (zero-user) tenant is actually visible.
- Enrolling into a tenant with zero users states up front that the new user becomes its first and receives `TenantAdmin`.
- `alreadyEnrolled` (no-op re-enrollment) and a genuine `USERNAME_TAKEN` collision now render as two distinct messages instead of one.
- `TenantsPanel` adds a per-tenant user count (`GET /v1/tenants`'s new field, via a single `LEFT JOIN`/`GROUP BY`, `nil` when unresolved rather than a false zero), distinguishing "Unknown" from a genuinely empty "No users" tenant.
- `erun-docs` documents `GET /v1/tenants` and the console's cross-tenant enrollment.
- The authorization boundary the whole feature leans on (`resolveTargetTenant`: only an OPERATIONS caller may target another tenant) is now proven against a real migrated Postgres, not just an HTTP-layer stub: an operations caller's override actually lands the user in the target tenant (RLS role `erun_operations`), and a non-operations caller's override is refused by PostgreSQL's own `WITH CHECK` policy, not merely by the route.

Closes #1744

## Acceptance criteria

- [x] An OPERATIONS operator can enrol a user into a tenant other than their own, from the console.
- [x] The selector is not shown to a non-OPERATIONS caller, matching how the rest of the console degrades by permission.
- [x] Enrolling the first user of a tenant states that they will receive `TenantAdmin`.
- [x] A tenant with no users is visibly distinguishable in the Tenants view, so the inert state is noticed rather than discovered later.
- [x] `alreadyEnrolled` and a username collision produce different messages.

## Test plan

- [x] `make check` green: 6 lint packages 0 issues, `erun-ui` Go tests, console vitest (26 files / 180 tests), 8 helm chart tests, integration suite ok, coverage 75.6% (>= 75.6% floor).
- [x] Backend Go e2e suite (`internal/repository`, `internal/routes`) run against a real migrated PostgreSQL 18.3 (docker + `atlas migrate apply --env default`) — not wired into `make check`, so run directly: `ERUN_E2E_USERS_DATABASE_URL=... ERUN_E2E_TENANTS_DATABASE_URL=... ERUN_E2E_PERMISSIONS_DATABASE_URL=... ERUN_E2E_ROLES_DATABASE_URL=... go test ./internal/repository/... ./internal/routes/... -run 'TestUserRepository|TestListTenants|TestListReportsUserCountPerTenant|TestCreateUser|TestListUsers' -v`. All green, including `TestListReportsUserCountPerTenant` (the per-tenant user-count test, run for the first time) and the two new authorization-boundary tests.