### PR TITLE
Move the whip action to the popover header, keep it reachable at scale

### DIFF
--- a/erun-ui/frontend/src/components/app/Titlebar.WhipAction.TargetPicker.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.WhipAction.TargetPicker.tsx
@@ -49,22 +49,15 @@ function environmentRows(
   }));
 }
 
-function whipButtonLabel(pending: boolean, count: number): string {
-  if (pending) {
-    return 'Whipping…';
-  }
-  return `Whip ${String(count)} target${count === 1 ? '' : 's'}`;
-}
-
 // TitlebarWhipTargetPicker is the selection surface issue erun#1700 asks for:
 // individual environments and orchestrators, checkable, plus the three group
-// shortcuts, with the primary action stating how many targets it will whip
-// before it acts (Nielsen #1, visibility of system status) rather than
-// leaving the operator to guess from an unlabeled button. Plain checkboxes
-// and buttons rather than a Command/cmdk list: the population here is short
-// and never needs type-to-filter, and every row is reachable with a plain Tab
-// (WCAG 2.1.1 keyboard) the same way the existing deploy-components and
-// orchestrator-environments checklists already are.
+// shortcuts. Plain checkboxes and buttons rather than a Command/cmdk list:
+// the population here is short and never needs type-to-filter, and every row
+// is reachable with a plain Tab (WCAG 2.1.1 keyboard) the same way the
+// existing deploy-components and orchestrator-environments checklists
+// already are. The primary whip action lives in the popover header
+// (Titlebar.WhipAction.tsx) rather than here, so it stays reachable without
+// scrolling this list (erun#1748).
 export function TitlebarWhipTargetPicker({
   targets,
   targetsLoading,
@@ -74,9 +67,6 @@ export function TitlebarWhipTargetPicker({
   onSelectAllEnvironments,
   onSelectAllOrchestrators,
   onSelectAll,
-  count,
-  pending,
-  onWhip,
 }: {
   targets: main.uiWhipTargetList | null;
   targetsLoading: boolean;
@@ -86,9 +76,6 @@ export function TitlebarWhipTargetPicker({
   onSelectAllEnvironments: () => void;
   onSelectAllOrchestrators: () => void;
   onSelectAll: () => void;
-  count: number;
-  pending: boolean;
-  onWhip: () => void;
 }): React.ReactElement {
   return (
     <div className="flex flex-col gap-3">
@@ -126,14 +113,6 @@ export function TitlebarWhipTargetPicker({
           />
         </div>
       )}
-      <Button
-        type="button"
-        variant="default"
-        disabled={pending || targetsLoading || count === 0}
-        onClick={onWhip}
-      >
-        {whipButtonLabel(pending, count)}
-      </Button>
     </div>
   );
 }

--- a/erun-ui/frontend/src/components/app/Titlebar.WhipAction.TargetPicker.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.WhipAction.TargetPicker.tsx
@@ -1,4 +1,5 @@
-import { Button, Checkbox } from 'erun-kit';
+import { Button, Checkbox, IconTooltip } from 'erun-kit';
+import { Bot, ListChecks, Server } from 'lucide-react';
 import * as React from 'react';
 
 import type { WhipTargetSelection } from '@/app/model';
@@ -84,16 +85,40 @@ export function TitlebarWhipTargetPicker({
           Nothing is focused right now. Choose one or more targets below.
         </p>
       )}
-      <div className="flex flex-wrap gap-1.5">
-        <Button type="button" variant="outline" size="sm" onClick={onSelectAllOrchestrators}>
-          Select all orchestrators
-        </Button>
-        <Button type="button" variant="outline" size="sm" onClick={onSelectAllEnvironments}>
-          Select all environments
-        </Button>
-        <Button type="button" variant="outline" size="sm" onClick={onSelectAll}>
-          Select all
-        </Button>
+      <div className="flex items-center gap-1.5">
+        <IconTooltip label="Select all orchestrators">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            aria-label="Select all orchestrators"
+            onClick={onSelectAllOrchestrators}
+          >
+            <Bot aria-hidden="true" className="size-4" />
+          </Button>
+        </IconTooltip>
+        <IconTooltip label="Select all environments">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            aria-label="Select all environments"
+            onClick={onSelectAllEnvironments}
+          >
+            <Server aria-hidden="true" className="size-4" />
+          </Button>
+        </IconTooltip>
+        <IconTooltip label="Select all orchestrators and environments">
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            aria-label="Select all"
+            onClick={onSelectAll}
+          >
+            <ListChecks aria-hidden="true" className="size-4" />
+          </Button>
+        </IconTooltip>
       </div>
       {targetsLoading || !targets ? (
         <p className="text-xs text-muted-foreground">Loading targets…</p>

--- a/erun-ui/frontend/src/components/app/Titlebar.WhipAction.tsx
+++ b/erun-ui/frontend/src/components/app/Titlebar.WhipAction.tsx
@@ -27,6 +27,10 @@ const whipButtonClassName =
 
 const whipLabel = 'Whip: push the focused target, or choose which ones to push';
 
+function whipButtonLabel(count: number): string {
+  return `Whip ${String(count)} target${count === 1 ? '' : 's'}`;
+}
+
 // TitlebarWhipAction is the operator-triggered whip control. Whipping is a
 // write into a live AI session, not a read, so a click never fans out to
 // every configured environment and orchestrator on its own (erun#1700):
@@ -164,20 +168,31 @@ function WhipPopoverBody({
   onWhip: () => void;
   onClose: () => void;
 }): React.ReactElement {
+  // The report view replaces the picker (and its own selection controls)
+  // below, so the header's whip action follows the same gate: it only makes
+  // sense to show while there is a selection left to act on.
+  const showPicker = !outcome && !pending;
   return (
     <div role="region" aria-label="Whip" className="flex max-h-[70vh] flex-col">
-      <div className="flex items-center justify-between border-b px-3 py-2">
-        <h2 className="text-sm font-semibold">Whip</h2>
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+        <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">Whip</h2>
+        {showPicker && (
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            disabled={targetsLoading || count === 0}
+            onClick={onWhip}
+          >
+            {whipButtonLabel(count)}
+          </Button>
+        )}
         <Button type="button" variant="ghost" size="icon" aria-label="Close whip" onClick={onClose}>
           <X aria-hidden="true" className="size-3.5" />
         </Button>
       </div>
       <div className="flex-1 overflow-y-auto p-3">
-        {outcome || pending ? (
-          <div role="status" aria-live="polite" aria-label="Whip results">
-            <WhipReportBody pending={pending} outcome={outcome} />
-          </div>
-        ) : (
+        {showPicker ? (
           <TitlebarWhipTargetPicker
             targets={targets}
             targetsLoading={targetsLoading}
@@ -197,10 +212,11 @@ function WhipPopoverBody({
             onSelectAll={() => {
               setSelection((prev) => selectAllWhipTargets(prev));
             }}
-            count={count}
-            pending={pending}
-            onWhip={onWhip}
           />
+        ) : (
+          <div role="status" aria-live="polite" aria-label="Whip results">
+            <WhipReportBody pending={pending} outcome={outcome} />
+          </div>
         )}
       </div>
     </div>

--- a/erun-ui/playwright/fixtures/erunApp.ts
+++ b/erun-ui/playwright/fixtures/erunApp.ts
@@ -72,17 +72,25 @@ export const test = base.extend<{
 // spec that seeds its own env config directly (rather than through the
 // fixtures above) can key its wait to the same observable precondition
 // instead of a single fixed-timeout reload+waitFor.
+//
+// timeoutMs defaults to the budget every other caller relies on. A spec that
+// seeds an unusually large population before calling this (many environments
+// and/or orchestrators in one go) makes each reload genuinely more expensive
+// to resolve and render, not just slower to observe -- titlebar-whip-panel-
+// layout.spec.ts's realistic-population case (erun#1748) widens it for that
+// reason rather than accepting a marginal budget tuned for a single-row wait.
 export async function waitForSeededRow(
   app: AppShell,
   tenant: string,
   environment: string,
+  timeoutMs = 30_000,
 ): Promise<void> {
   await expect(async () => {
     await app.reloadEnvironments();
     await app.sidebar
       .envRowButton(tenant, environment)
       .waitFor({ state: 'visible', timeout: 2_000 });
-  }).toPass({ timeout: 30_000 });
+  }).toPass({ timeout: timeoutMs });
 }
 
 export { expect };

--- a/erun-ui/playwright/fixtures/seedRoot.ts
+++ b/erun-ui/playwright/fixtures/seedRoot.ts
@@ -593,6 +593,35 @@ export function removeTenant(tenant: string): void {
   fs.rmSync(path.join(erunConfigDir(), tenant), { recursive: true, force: true });
 }
 
+// addOrchestrators appends throwaway orchestrator entries directly to the
+// top-level user config.yaml -- the same shape seedBaseline() writes for
+// SEED_ORCHESTRATOR -- so a spec can stage a realistic population (erun#1748:
+// the field report was 7 orchestrators, 9+ environments) without depending on
+// whatever another spec in this worker happened to leave behind.
+// `orchestrators:` is the file's last top-level key, so a plain append keeps
+// the YAML list valid. WhipTargets reads this file fresh on every call, so no
+// reload/wait is needed after writing it. Returns a restore function that
+// puts the file back exactly as found.
+export function addOrchestrators(ids: string[], tenant: string, environment: string): () => void {
+  const configPath = path.join(erunConfigDir(), 'config.yaml');
+  const before = fs.readFileSync(configPath, 'utf8');
+  const entries = ids
+    .map(
+      (id) =>
+        `  - id: ${id}\n` +
+        `    name: ${id}\n` +
+        '    environments:\n' +
+        `      - tenant: ${tenant}\n` +
+        `        environment: ${environment}\n` +
+        `        directory: ${repoDir()}\n`,
+    )
+    .join('');
+  fs.appendFileSync(configPath, entries);
+  return () => {
+    fs.writeFileSync(configPath, before);
+  };
+}
+
 // removeIsolatedRoot deletes the whole suite-owned root. Only roots the
 // suite recognizably created are removed, so a caller-provided custom path
 // is never destroyed by accident.

--- a/erun-ui/playwright/tests/titlebar-whip-action.spec.ts
+++ b/erun-ui/playwright/tests/titlebar-whip-action.spec.ts
@@ -154,6 +154,25 @@ test('the whip control renders a pending state and then every target with its ow
   await expect(app.titlebar.whipReportHeading()).toBeHidden();
 });
 
+test('the whip action renders outside the scrollable target list and states the selected count', async ({
+  app,
+}) => {
+  // erun#1748: the action used to be a sibling AFTER the scrollable target
+  // list, so a long enough population pushed it below the fold. It now lives
+  // in the popover header, a sibling BEFORE the scrollable region -- assert
+  // the structure directly (not just that it's visible today, which would
+  // also pass with the old, buggy layout at this small seeded population).
+  await app.sidebar.openEnvironment(SEED_TENANT, SEED_ENV_ALPHA);
+  await app.titlebar.whipButton().click();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
+
+  const scrollRegion = app.titlebar.whipPanel().locator('.overflow-y-auto').first();
+  await expect(scrollRegion.getByRole('button', { name: /^Whip \d+ target/ })).toHaveCount(0);
+
+  await app.titlebar.whipTargetCheckbox(SEED_ORCHESTRATOR).check();
+  await expect(app.titlebar.whipRunButton()).toHaveText('Whip 2 targets');
+});
+
 test('the control stays reachable from an orchestrator tab, not only an environment tab', async ({
   app,
 }) => {

--- a/erun-ui/playwright/tests/titlebar-whip-panel-layout.spec.ts
+++ b/erun-ui/playwright/tests/titlebar-whip-panel-layout.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '../fixtures/erunApp.js';
+import { expect, test, waitForSeededRow } from '../fixtures/erunApp.js';
 import {
   addOrchestrators,
   removeTenant,
@@ -20,9 +20,36 @@ import {
 const ENVIRONMENT_COUNT = 9;
 const ORCHESTRATOR_COUNT = 7;
 
+// whipCountText mirrors Titlebar.WhipAction.tsx's own whipButtonLabel: the
+// pluralization the primary action renders for a given selected count.
+function whipCountText(count: number): string {
+  return `Whip ${String(count)} target${count === 1 ? '' : 's'}`;
+}
+
+// whipCheckedCount counts however many target rows the popover renders
+// checked right now. The suite's baseline seeds a default tenant/environment
+// (`defaulttenant: pw`, pw's `defaultenvironment: alpha`), so a fresh boot's
+// sidebar focus -- and therefore Whip's preselected default target -- is not
+// guaranteed to be empty; backend-side sessions persisting across specs in
+// the same worker (playwright/AGENTS.md) mean the exact starting selection
+// is not under this spec's control either (mirrors titlebar-whip-action.spec
+// .ts's own whipCountLabel helper, built for the same reason). Reading the
+// real starting count, rather than assuming zero, is how this spec proves a
+// single manual check widens the selection by exactly one without depending
+// on ambient state it does not own.
+async function whipCheckedCount(app: import('../pages/index.js').AppShell): Promise<number> {
+  return app.titlebar.whipPanel().locator('[role="checkbox"][aria-checked="true"]').count();
+}
+
 test('a realistic population keeps the whip action reachable without scrolling', async ({
   app,
 }, testInfo) => {
+  // This spec's seed is far larger than the default single-row case the
+  // suite's global 30s per-test timeout is tuned for (root AGENTS.md's "no
+  // flaky tests" gate needs this to be a real budget increase, not a race
+  // against the whole-test clock the widened waitForSeededRow call below
+  // would still lose).
+  test.setTimeout(90_000);
   const tenant = uniqueEnvironmentName(testInfo.title);
   const firstEnvironment = 'env-0';
   const lastEnvironment = `env-${String(ENVIRONMENT_COUNT - 1)}`;
@@ -41,20 +68,25 @@ test('a realistic population keeps the whip action reachable without scrolling',
     // WhipTargets reads the config tree fresh on every call (no reload/wait
     // needed), but the sidebar itself only picks up new rows via fsnotify --
     // reload it so the population is visibly staged before driving the panel.
-    await app.reloadEnvironments();
-    await app.sidebar
-      .envRowButton(tenant, lastEnvironment)
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    // This spec's seed (9 environments plus 7 orchestrators written in one
+    // batch) is far larger than any other waitForSeededRow caller's, so a
+    // reload here genuinely costs more to resolve and render -- widen the
+    // budget rather than share the single-row default.
+    await waitForSeededRow(app, tenant, lastEnvironment, 60_000);
 
     await app.titlebar.whipButton().click();
 
     // Tick one target near the top of the now-long list -- the reported
     // click -- and the primary action must already be reachable, with no
-    // scroll of any kind performed to find it.
+    // scroll of any kind performed to find it. This freshly seeded target
+    // cannot already be checked, so whatever the popover started with, one
+    // manual check must widen it by exactly one.
     const firstTarget = `${tenant}/${firstEnvironment}`;
+    await expect(app.titlebar.whipTargetCheckbox(firstTarget)).not.toBeChecked();
+    const startingChecked = await whipCheckedCount(app);
     await app.titlebar.whipTargetCheckbox(firstTarget).check();
     await expect(app.titlebar.whipRunButton()).toBeVisible();
-    await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
+    await expect(app.titlebar.whipRunButton()).toHaveText(whipCountText(startingChecked + 1));
 
     // Structural proof, not just a visual one: the action is a sibling of the
     // scrollable target list, never a descendant of it, so target count can

--- a/erun-ui/playwright/tests/titlebar-whip-panel-layout.spec.ts
+++ b/erun-ui/playwright/tests/titlebar-whip-panel-layout.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '../fixtures/erunApp.js';
+import {
+  addOrchestrators,
+  removeTenant,
+  seedEnvironment,
+  seedTenant,
+  uniqueEnvironmentName,
+} from '../fixtures/seedRoot.js';
+
+// erun#1748: with a realistic population (the field report: 7 orchestrators,
+// 9+ environments spread across the operator's real tenants), the whip
+// popover's target list fills its own 40vh scroll region, and the primary
+// action used to sit below that scroll region -- reachable only by scrolling
+// the whole panel. This spec builds that population directly (rather than
+// depending on whatever another spec in this worker happened to leave
+// behind) so the assertions hold regardless of run order, and proves: the
+// action is reachable with no scroll, it still carries the selected-target
+// count, and the three select-all controls stay on one row at that scale.
+
+const ENVIRONMENT_COUNT = 9;
+const ORCHESTRATOR_COUNT = 7;
+
+test('a realistic population keeps the whip action reachable without scrolling', async ({
+  app,
+}, testInfo) => {
+  const tenant = uniqueEnvironmentName(testInfo.title);
+  const firstEnvironment = 'env-0';
+  const lastEnvironment = `env-${String(ENVIRONMENT_COUNT - 1)}`;
+  const environments = Array.from({ length: ENVIRONMENT_COUNT }, (_, i) => `env-${String(i)}`);
+  seedTenant(tenant, firstEnvironment);
+  for (const environment of environments) {
+    seedEnvironment(tenant, environment);
+  }
+  const orchestratorIds = Array.from(
+    { length: ORCHESTRATOR_COUNT },
+    (_, i) => `${tenant}-orch-${String(i)}`,
+  );
+  const restoreOrchestrators = addOrchestrators(orchestratorIds, tenant, firstEnvironment);
+
+  try {
+    // WhipTargets reads the config tree fresh on every call (no reload/wait
+    // needed), but the sidebar itself only picks up new rows via fsnotify --
+    // reload it so the population is visibly staged before driving the panel.
+    await app.reloadEnvironments();
+    await app.sidebar
+      .envRowButton(tenant, lastEnvironment)
+      .waitFor({ state: 'visible', timeout: 30_000 });
+
+    await app.titlebar.whipButton().click();
+
+    // Tick one target near the top of the now-long list -- the reported
+    // click -- and the primary action must already be reachable, with no
+    // scroll of any kind performed to find it.
+    const firstTarget = `${tenant}/${firstEnvironment}`;
+    await app.titlebar.whipTargetCheckbox(firstTarget).check();
+    await expect(app.titlebar.whipRunButton()).toBeVisible();
+    await expect(app.titlebar.whipRunButton()).toHaveText('Whip 1 target');
+
+    // Structural proof, not just a visual one: the action is a sibling of the
+    // scrollable target list, never a descendant of it, so target count can
+    // never push it below the fold again.
+    const scrollRegion = app.titlebar.whipPanel().locator('.overflow-y-auto').first();
+    await expect(scrollRegion.getByRole('button', { name: /^Whip \d+ target/ })).toHaveCount(0);
+
+    // The three select-all controls occupy one row even at this population --
+    // the specific reported wrapping failure was two-then-one across three
+    // rows. Same top y-coordinate is a direct assertion on the layout, not
+    // merely that three buttons exist.
+    const orchestratorsBox = await app.titlebar.selectAllOrchestratorsButton().boundingBox();
+    const environmentsBox = await app.titlebar.selectAllEnvironmentsButton().boundingBox();
+    const allBox = await app.titlebar.selectAllButton().boundingBox();
+    expect(orchestratorsBox).not.toBeNull();
+    expect(environmentsBox).not.toBeNull();
+    expect(allBox).not.toBeNull();
+    expect(Math.abs((orchestratorsBox?.y ?? 0) - (environmentsBox?.y ?? 0))).toBeLessThan(2);
+    expect(Math.abs((orchestratorsBox?.y ?? 0) - (allBox?.y ?? 0))).toBeLessThan(2);
+
+    // Each icon control still resolves by its own accessible label -- a bare,
+    // unlabeled icon would fail these very locators (Titlebar.ts's
+    // selectAll*Button() methods query getByRole('button', { name: ... })).
+    await expect(app.titlebar.selectAllOrchestratorsButton()).toBeVisible();
+    await expect(app.titlebar.selectAllEnvironmentsButton()).toBeVisible();
+    await expect(app.titlebar.selectAllButton()).toBeVisible();
+
+    // Reported visually -- captured visually. animations: 'disabled' finishes
+    // the popover's own open transition before capturing, so the shot is
+    // never a frozen mid-fade frame.
+    await app.page.screenshot({
+      path: 'test-results/titlebar-whip-panel-layout-realistic-population.png',
+      animations: 'disabled',
+    });
+  } finally {
+    restoreOrchestrators();
+    removeTenant(tenant);
+  }
+});


### PR DESCRIPTION
## Summary
- Moves the whip action out of the bottom of the popover into the header (beside the title/close button), so it never sits below the 40vh scrollable target list — reachable with zero scrolling regardless of population size.
- Replaces the three wrapping "Select all …" text buttons with icon+tooltip buttons (`Bot`/`Server`/`ListChecks`, mirroring the sidebar's own icon vocabulary) so they stay on one row instead of wrapping two-then-one.
- Adds `titlebar-whip-panel-layout.spec.ts`, which seeds a realistic population (7 orchestrators, 9 environments — the field report's numbers, plus the suite's own baseline population) and proves structurally (not just visually) that the action is a sibling of the scroll region, never a descendant, and that the three select-all icons share one row (same y-coordinate) at that scale.

## What the new spec found and fixed along the way
The first version of that spec asserted `Whip 1 target` after checking exactly one box, assuming nothing was preselected. That assumption was wrong: the suite's own baseline seeds `defaulttenant: pw` / pw's `defaultenvironment: alpha`, so a fresh boot's sidebar focus — and therefore Whip's preselected default target — is never guaranteed empty. Checking one box actually produced `Whip 2 targets` (the preselected `pw/alpha` plus the box just checked), which the screenshot artifact confirms. This wasn't a picker bug — checking one box only ever adds one target — so the fix is in the test: it now reads the popover's actual starting checked-count and asserts the manual check widens it by exactly one, rather than assuming a hardcoded starting point it doesn't control.

The same spec's unusually large seed (9 environments + 7 orchestrators written in one batch) also made its initial `reload+waitFor` for the last seeded row noticeably more expensive than any other caller of the shared `waitForSeededRow` helper, causing intermittent timeouts under load. `waitForSeededRow` now takes an optional timeout (default unchanged for all other callers), and this spec widens both that budget and its own `test.setTimeout` to match its seed size.

## Test plan
- [x] `erun-ui/playwright/run.sh` (full suite, ×2 clean after the fix): 460 passed, 0 failed.
- [x] `make check`: golangci-lint 0 issues (all modules), `go test` green (erun-ui, erun-common, erun-cli, erun-mcp, erun-backend-api), integration suite green (92.4s), coverage 75.7% (≥75.6% floor).
- [x] Screenshot artifact captured: `erun-ui/playwright/test-results/titlebar-whip-panel-layout-realistic-population.png` — action in the header, three select-all icons aligned on one row, no scrolling performed.

Closes #1748