### PR TITLE
Baseline-align sidebar hover card label/value rows

### DIFF
--- a/erun-ui/frontend/src/components/app/Sidebar.EnvHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.EnvHoverCard.tsx
@@ -6,6 +6,7 @@ import { summarizeEnvironmentUsage } from '@/app/environmentUsageSummary';
 import type { EnvironmentIndicator } from '@/components/app/Sidebar.helpers';
 import {
   HOVER_CARD_CAPTION_CLASS,
+  HOVER_CARD_CAPTION_SIZE_CLASS,
   HoverCardBadge,
   HoverCardMuted,
   HoverCardRow,
@@ -122,7 +123,7 @@ export function EnvHoverCard({
             <EnvTypeBadge isLocal={isLocal} isHost={isHost} />
           </div>
         </div>
-        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 px-3 py-2.5">
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1.5 px-3 py-2.5">
           <HoverCardRow label="Version">
             {runtimeVersion ? (
               <span className="font-mono tabular-nums">{runtimeVersion}</span>
@@ -198,7 +199,7 @@ function UsageState({
       <span
         className={
           summary.stale
-            ? 'flex items-center gap-1 text-xs text-amber-700 dark:text-amber-400'
+            ? `flex items-center gap-1 ${HOVER_CARD_CAPTION_SIZE_CLASS} text-amber-700 dark:text-amber-400`
             : HOVER_CARD_CAPTION_CLASS
         }
       >

--- a/erun-ui/frontend/src/components/app/Sidebar.HoverCardRow.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.HoverCardRow.tsx
@@ -24,7 +24,13 @@ import * as React from 'react';
 // fourth size/face combination -- it earns its emphasis by weight only
 // (font-medium), the same way a row's own name can (see OrchestratorHoverCard
 // environment names).
-export const HOVER_CARD_CAPTION_CLASS = 'text-xs text-muted-foreground';
+// Exported separately from HOVER_CARD_CAPTION_CLASS so a caption-sized line
+// that needs its own text color (the amber stale/usage-warning variants) can
+// still share the one size declaration instead of restating `text-xs` --
+// concatenating the full caption class would fight that same variant's color
+// override for the `color` property at equal specificity.
+export const HOVER_CARD_CAPTION_SIZE_CLASS = 'text-xs';
+export const HOVER_CARD_CAPTION_CLASS = `${HOVER_CARD_CAPTION_SIZE_CLASS} text-muted-foreground`;
 
 export function HoverCardRow({
   label,

--- a/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
+++ b/erun-ui/frontend/src/components/app/Sidebar.OrchestratorHoverCard.tsx
@@ -9,6 +9,7 @@ import { orchestratorNudgeSummary } from '@/app/orchestratorNudgeSummary';
 import type { OrchestratorInfo } from '@/app/slices/orchestratorsSlice';
 import {
   HOVER_CARD_CAPTION_CLASS,
+  HOVER_CARD_CAPTION_SIZE_CLASS,
   HoverCardBadge,
   HoverCardMuted,
   HoverCardRow,
@@ -95,7 +96,7 @@ export function OrchestratorHoverCard({
             {orchestrator.transient && <HoverCardBadge>Transient</HoverCardBadge>}
           </div>
         </div>
-        <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 px-3 py-2.5">
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-3 gap-y-1.5 px-3 py-2.5">
           <HoverCardRow label="Status">{running ? 'Running' : 'Stopped'}</HoverCardRow>
           {running && orchestrator.restartRequired && (
             <HoverCardRow label="Restart">
@@ -209,7 +210,7 @@ function OrchestratorEnvironments({
                 <span
                   className={
                     line.usageStale
-                      ? 'block truncate text-xs tabular-nums text-amber-700 dark:text-amber-400'
+                      ? `block truncate tabular-nums ${HOVER_CARD_CAPTION_SIZE_CLASS} text-amber-700 dark:text-amber-400`
                       : `block truncate tabular-nums ${HOVER_CARD_CAPTION_CLASS}`
                   }
                 >

--- a/erun-ui/playwright/tests/sidebar-hovercard-baseline-alignment.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-hovercard-baseline-alignment.spec.ts
@@ -1,0 +1,206 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/erunApp.js';
+import { SEED_ENV_ALPHA, SEED_ORCHESTRATOR, SEED_TENANT } from '../fixtures/seedRoot.js';
+
+// erun#1759: HoverCardRow (Sidebar.HoverCardRow.tsx) renders a 12px `dt` and
+// a 14px `dd` as siblings in a grid row, and neither sidebar hover card's
+// `dl` set `items-baseline` -- CSS grid's default `align-items: stretch`
+// let each cell fill the row, so each line sat at the top of its own cell
+// and the two font sizes' text baselines landed a couple of pixels apart in
+// every row of both cards.
+//
+// This asserts the fix geometrically -- measured text baselines actually
+// coincide -- rather than checking the `items-baseline` class string is
+// present anywhere, mirroring titlebar-whip-panel-layout.spec.ts's own
+// boundingBox()-based layout assertion for the same reason: a class on the
+// wrong element, or one overridden later in the cascade, would still pass a
+// string check.
+
+interface RowGeometry {
+  dtBottom: number;
+  ddTop: number;
+  dtBaseline: number;
+  ddBaseline: number;
+}
+
+// rowGeometry finds the row labeled `label` inside `card` and measures both
+// its `dt` and `dd`. The baseline of each is found by walking into the
+// first blockified child the way the browser's own "baseline of a box"
+// algorithm does -- a `<span>` becomes a block-level box the instant it is a
+// grid/flex item, which is exactly what HoverCardRow's stacked multi-line
+// values (Usage, Doing) do -- so a stacked value is measured at its first
+// line's baseline, not its own bottom edge. A zero-size, baseline-aligned
+// marker appended into that anchor lands its own top edge exactly on the
+// line's baseline; this is a standard DOM technique, not an approximation
+// from font metrics.
+async function rowGeometry(card: Locator, label: string): Promise<RowGeometry> {
+  return card.evaluate((root, label) => {
+    function contentAnchor(start: Element): Element {
+      let el = start;
+      for (let i = 0; i < 5; i += 1) {
+        const kids = Array.from(el.childNodes).filter(
+          (node) => !(node.nodeType === Node.TEXT_NODE && !node.textContent?.trim()),
+        );
+        const first = kids[0];
+        if (!first || first.nodeType !== Node.ELEMENT_NODE) {
+          break;
+        }
+        const display = window.getComputedStyle(first as Element).display;
+        if (display !== 'block' && display !== 'grid' && display !== 'flex') {
+          break;
+        }
+        el = first as Element;
+      }
+      return el;
+    }
+    function baselineTop(el: Element): number {
+      const anchor = contentAnchor(el);
+      const marker = document.createElement('span');
+      marker.style.cssText = 'display:inline-block;width:0;height:0;vertical-align:baseline';
+      anchor.appendChild(marker);
+      const top = marker.getBoundingClientRect().top;
+      marker.remove();
+      return top;
+    }
+    const dt = Array.from(root.querySelectorAll('dt')).find(
+      (element) => element.textContent?.trim() === label,
+    );
+    if (!dt) {
+      throw new Error(`no dt labeled "${label}"`);
+    }
+    const dd = dt.nextElementSibling;
+    if (!dd || dd.tagName !== 'DD') {
+      throw new Error(`dt labeled "${label}" has no dd sibling`);
+    }
+    return {
+      dtBottom: dt.getBoundingClientRect().bottom,
+      ddTop: dd.getBoundingClientRect().top,
+      dtBaseline: baselineTop(dt),
+      ddBaseline: baselineTop(dd),
+    };
+  }, label);
+}
+
+const RUNNING_SESSION_ID = 4242;
+
+function orchestratorSnapshot(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: SEED_ORCHESTRATOR,
+    name: SEED_ORCHESTRATOR,
+    environments: [],
+    tenants: [],
+    directories: [],
+    sessionId: RUNNING_SESSION_ID,
+    status: 'running',
+    busy: false,
+    busyAtUnix: 0,
+    transient: false,
+    shellRunning: false,
+    shellCommand: '',
+    shellStartedAtUnix: 0,
+    ...overrides,
+  };
+}
+
+async function stubOrchestratorList(page: Page, body: Record<string, unknown>): Promise<void> {
+  await page.route('**/__erun_invoke', async (route, request) => {
+    const parsed = JSON.parse(request.postData() ?? '{}') as { method?: string };
+    if (parsed.method === 'ListOrchestrators') {
+      return route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [body] }),
+      });
+    }
+    await route.continue();
+  });
+}
+
+test.describe('sidebar hover card baseline alignment (#1759)', () => {
+  test('the environment card aligns a single-line label and value to one baseline', async ({
+    app,
+  }) => {
+    await app.reboot();
+    await app.sidebar.hoverEnvironmentRow(SEED_TENANT, SEED_ENV_ALPHA);
+    const card = app.sidebar.envHoverCard(SEED_TENANT, SEED_ENV_ALPHA);
+    await expect(card).toBeVisible();
+    // seedEnvironment pins every seeded env's runtimeversion to 1.0.0, so the
+    // Version row always renders the version, never the "Not set" empty case.
+    await expect(card).toContainText('1.0.0');
+
+    const geometry = await rowGeometry(card, 'Version');
+    expect(Math.abs(geometry.dtBaseline - geometry.ddBaseline)).toBeLessThan(1.5);
+  });
+
+  test('the orchestrator card aligns a single-line label and value to one baseline', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      orchestratorSnapshot({ busy: true, busyAtUnix: Math.floor(Date.now() / 1000) - 60 }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+    const card = app.sidebar.orchestratorHoverCard(SEED_ORCHESTRATOR);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Working, for');
+
+    const geometry = await rowGeometry(card, 'Doing');
+    expect(Math.abs(geometry.dtBaseline - geometry.ddBaseline)).toBeLessThan(1.5);
+  });
+
+  test('the orchestrator card aligns a stacked, multi-line value to the label baseline', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      orchestratorSnapshot({
+        busy: true,
+        busyAtUnix: Math.floor(Date.now() / 1000) - 60,
+        shellRunning: true,
+        shellCommand: 'gradle build',
+        shellStartedAtUnix: Math.floor(Date.now() / 1000) - 30,
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+    const card = app.sidebar.orchestratorHoverCard(SEED_ORCHESTRATOR);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Working, for');
+    await expect(card).toContainText('Shell running');
+
+    // The "Doing" dd now stacks two lines (busy + shell). Baseline alignment
+    // applies to the row's first line, not the value's own bottom edge.
+    const geometry = await rowGeometry(card, 'Doing');
+    expect(Math.abs(geometry.dtBaseline - geometry.ddBaseline)).toBeLessThan(1.5);
+  });
+
+  test('the orchestrator card keeps the wide Environments row stacked, not baseline-shoved', async ({
+    app,
+    page,
+  }) => {
+    await stubOrchestratorList(
+      page,
+      orchestratorSnapshot({
+        environments: [{ tenant: SEED_TENANT, environment: SEED_ENV_ALPHA, directory: '/tmp/a' }],
+      }),
+    );
+    await app.reboot();
+
+    await app.sidebar.orchestratorRowButton(SEED_ORCHESTRATOR).hover();
+    const card = app.sidebar.orchestratorHoverCard(SEED_ORCHESTRATOR);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(SEED_ENV_ALPHA);
+
+    // The "wide" variant col-spans both dt and dd, so they land in separate
+    // grid rows rather than sharing one -- items-baseline has no sibling to
+    // align them against, and the label must still render fully above the
+    // value it labels.
+    const geometry = await rowGeometry(card, 'Environments');
+    expect(geometry.dtBottom).toBeLessThanOrEqual(geometry.ddTop + 1);
+  });
+});


### PR DESCRIPTION
## Summary

- `HoverCardRow` (`Sidebar.HoverCardRow.tsx`) renders each row's 12px `dt` and 14px `dd` as CSS grid siblings. Neither hover card's `dl` set `items-baseline`, so grid's default `align-items: stretch` let each cell fill the row height and the two font sizes' text baselines landed a couple of pixels apart in every row of both cards. Fixed by adding `items-baseline` to both `dl` grids (`Sidebar.EnvHoverCard.tsx`, `Sidebar.OrchestratorHoverCard.tsx`).
- Split `HOVER_CARD_CAPTION_CLASS`'s size declaration out into `HOVER_CARD_CAPTION_SIZE_CLASS` so the amber stale/usage-warning caption variants can keep the shared 12px size without fighting the color override at equal specificity (concatenating the full caption class would have lost that fight).
- Both containers affected — `Sidebar.EnvHoverCard.tsx` and `Sidebar.OrchestratorHoverCard.tsx` — since both compose the same `HoverCardRow` grid. The env card had the identical omission as the orchestrator card, not a distinct one; same root cause, same one-line fix in each.
- The 10px `HoverCardBadge` pill (Host/Local/Transient) is unaffected: it lives in each card's header, a separate `flex items-center` row above the `dl`, never inside the grid this fix touches. No baseline-alignment change applies to it.

## Test plan

- [x] New spec `erun-ui/playwright/tests/sidebar-hovercard-baseline-alignment.spec.ts`: measures actual DOM text baselines via a zero-size baseline-aligned marker (not a class-string check) for a single-line row on each card, a stacked multi-line value, and the wide `Environments` row that col-spans into its own grid row. All 4 pass; measured baseline delta is exactly 0px on both cards.
- [x] `make check` — green.
- [x] Full `erun-ui/playwright` suite — 465 passed, 1 failed. The one failure (`titlebar-whip-panel-layout.spec.ts`) is the known #1772 resource-contention flake (passes in isolation, unrelated to this change) and is being fixed on another branch.

Closes #1759