### PR TITLE
Retry a torn config read instead of rendering it as zero environments

### DIFF
--- a/erun-common/config.go
+++ b/erun-common/config.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/adrg/xdg"
 	"gopkg.in/yaml.v3"
@@ -813,23 +814,15 @@ func LoadERunConfig() (ERunConfig, string, error) {
 		return config, configFilePath, ErrNoUserDataFolder
 	}
 
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		return config, configFilePath, ErrNotInitialized
-	}
-
-	// A zero-length file is the residue of an interrupted non-atomic
-	// write. Treating it as "successfully loaded empty config" lets
-	// the next writer rebuild a fresh ERunConfig{} with only the
-	// field it cares about, silently dropping every other section.
-	// Surface it as corruption so callers route into the doctor
-	// recovery path instead.
-	if len(bytes.TrimSpace(data)) == 0 {
-		return config, configFilePath, ErrConfigCorrupted
-	}
-
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return config, configFilePath, ErrConfigCorrupted
+	// A zero-length or unparseable file is the residue of an interrupted
+	// write, possibly one not even erun's own -- loadConfigFile retries it a
+	// few times before giving up. Treating it as "successfully loaded empty
+	// config" lets the next writer rebuild a fresh ERunConfig{} with only the
+	// field it cares about, silently dropping every other section, so a read
+	// that never recovers is surfaced as corruption instead, routing callers
+	// into the doctor recovery path.
+	if err := loadConfigFile(configFilePath, &config); err != nil {
+		return config, configFilePath, err
 	}
 
 	return config, configFilePath, nil
@@ -886,17 +879,8 @@ func LoadTenantConfig(tenant string) (TenantConfig, string, error) {
 		return config, configFilePath, ErrNoUserDataFolder
 	}
 
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		return config, configFilePath, ErrNotInitialized
-	}
-
-	if len(bytes.TrimSpace(data)) == 0 {
-		return config, configFilePath, ErrConfigCorrupted
-	}
-
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return config, configFilePath, ErrConfigCorrupted
+	if err := loadConfigFile(configFilePath, &config); err != nil {
+		return config, configFilePath, err
 	}
 
 	return NormalizeTenantConfig(config), configFilePath, nil
@@ -992,17 +976,8 @@ func LoadEnvConfig(tenant, envName string) (EnvConfig, string, error) {
 		return config, configFilePath, ErrNoUserDataFolder
 	}
 
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		return config, configFilePath, ErrNotInitialized
-	}
-
-	if len(bytes.TrimSpace(data)) == 0 {
-		return config, configFilePath, ErrConfigCorrupted
-	}
-
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return config, configFilePath, ErrConfigCorrupted
+	if err := loadConfigFile(configFilePath, &config); err != nil {
+		return config, configFilePath, err
 	}
 
 	return config, configFilePath, nil
@@ -1078,17 +1053,8 @@ func LoadProjectConfig(projectRoot string) (ProjectConfig, string, error) {
 		return config, "", err
 	}
 
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		return config, configFilePath, ErrNotInitialized
-	}
-
-	if len(bytes.TrimSpace(data)) == 0 {
-		return config, configFilePath, ErrConfigCorrupted
-	}
-
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return config, configFilePath, fmt.Errorf("%w: %v", ErrConfigCorrupted, err)
+	if err := loadConfigFile(configFilePath, &config); err != nil {
+		return config, configFilePath, err
 	}
 
 	return config, configFilePath, nil
@@ -1175,4 +1141,44 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	}
 	committed = true
 	return nil
+}
+
+// configReadRetryAttempts/configReadRetrySleep bound how long a read waits out
+// a torn write before surfacing ErrConfigCorrupted. writeFileAtomic makes erun's
+// own writers atomic, but a reader still has to tolerate a write it does not
+// control -- an external editor saving in place, another process's own
+// non-atomic writer, a crash mid-write -- and a torn read from any of those is
+// transient by construction: it resolves itself within microseconds, well
+// under this budget. A file that still fails to parse after every retry is
+// genuinely corrupt, not merely caught mid-write.
+const (
+	configReadRetryAttempts = 5
+	configReadRetrySleep    = 20 * time.Millisecond
+)
+
+// loadConfigFile reads path and unmarshals it into out, retrying through
+// configReadRetryAttempts when the file is momentarily empty or fails to
+// parse. Every Load*Config function in this file routes its read through
+// here so the retry policy lives in one place. A missing file is a real
+// absence (ErrNotInitialized) and is never retried; an empty or unparseable
+// file is retried and, if it never recovers, reported as ErrConfigCorrupted.
+func loadConfigFile(path string, out any) error {
+	var lastErr error
+	for attempt := 0; attempt < configReadRetryAttempts; attempt++ {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return ErrNotInitialized
+		}
+		if len(bytes.TrimSpace(data)) == 0 {
+			lastErr = ErrConfigCorrupted
+		} else if err := yaml.Unmarshal(data, out); err != nil {
+			lastErr = fmt.Errorf("%w: %v", ErrConfigCorrupted, err)
+		} else {
+			return nil
+		}
+		if attempt < configReadRetryAttempts-1 {
+			time.Sleep(configReadRetrySleep)
+		}
+	}
+	return lastErr
 }

--- a/erun-common/config_atomic_test.go
+++ b/erun-common/config_atomic_test.go
@@ -1,0 +1,148 @@
+package eruncommon
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWriteFileAtomicNeverExposesPartialContentToConcurrentReaders is the
+// regression for erun#1774's first acceptance criterion: a concurrent writer
+// must never let a reader observe a partial document. writeFileAtomic's
+// write-to-temp-then-rename contract is what every Save*Config function in
+// config.go already routes through; this pins that a reader racing a stream
+// of writes only ever sees one complete write's content, never a mix.
+func TestWriteFileAtomicNeverExposesPartialContentToConcurrentReaders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	valueA := []byte(strings.Repeat("a", 4096) + "\n")
+	valueB := []byte(strings.Repeat("b", 8192) + "\n")
+	if err := writeFileAtomic(path, valueA, 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	var done atomic.Bool
+	var badReads atomic.Int64
+	writerDone := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	go func() {
+		defer close(writerDone)
+		for i := 0; !done.Load(); i++ {
+			value := valueA
+			if i%2 == 1 {
+				value = valueB
+			}
+			if err := writeFileAtomic(path, value, 0o644); err != nil {
+				t.Errorf("concurrent write failed: %v", err)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer close(readerDone)
+		for !done.Load() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				// A rename mid-open can race ENOENT on some filesystems; that
+				// is not the defect under test (a torn/partial document is).
+				continue
+			}
+			if !bytes.Equal(data, valueA) && !bytes.Equal(data, valueB) {
+				badReads.Add(1)
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	done.Store(true)
+	<-writerDone
+	<-readerDone
+
+	if n := badReads.Load(); n != 0 {
+		t.Fatalf("observed %d torn/partial reads racing writeFileAtomic", n)
+	}
+}
+
+// TestLoadConfigFileRetriesATornReadThenSucceeds is the regression for the
+// second acceptance criterion: a reader that hits a torn read recovers
+// rather than failing the request. It seeds the on-disk residue of an
+// interrupted write (a zero-length file, config.go's own documented torn-read
+// signature) and heals it mid-retry-budget, mirroring how quickly a real
+// concurrent writer's rename actually resolves the race.
+func TestLoadConfigFileRetriesATornReadThenSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("seed torn (zero-length) file: %v", err)
+	}
+
+	healed := make(chan struct{})
+	go func() {
+		defer close(healed)
+		time.Sleep(configReadRetrySleep * 2)
+		if err := writeFileAtomic(path, []byte("name: healed\n"), 0o644); err != nil {
+			t.Errorf("heal write failed: %v", err)
+		}
+	}()
+
+	var config EnvConfig
+	if err := loadConfigFile(path, &config); err != nil {
+		t.Fatalf("expected the retry to observe the healed write, got: %v", err)
+	}
+	if config.Name != "healed" {
+		t.Fatalf("unexpected config after a healed retry: %+v", config)
+	}
+	<-healed
+}
+
+// TestLoadConfigFileGenuinelyCorruptFileStillFails proves the retry budget
+// does not mask a real corruption: a file that never becomes valid YAML must
+// still surface ErrConfigCorrupted, and within a bounded time rather than
+// retrying forever.
+func TestLoadConfigFileGenuinelyCorruptFileStillFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("not: [valid yaml"), 0o644); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+
+	var config EnvConfig
+	start := time.Now()
+	err := loadConfigFile(path, &config)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrConfigCorrupted) {
+		t.Fatalf("expected ErrConfigCorrupted for a file that never becomes valid, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected the retry budget to be bounded, took: %v", elapsed)
+	}
+}
+
+// TestLoadConfigFileMissingFileReturnsNotInitializedImmediately confirms a
+// missing file is treated as a real absence, not a torn read, and is never
+// retried -- retrying it would only slow down every ordinary "not yet
+// initialized" path (e.g. ListEnvConfigs skipping an unconfigured entry).
+func TestLoadConfigFileMissingFileReturnsNotInitializedImmediately(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	var config EnvConfig
+	start := time.Now()
+	err := loadConfigFile(path, &config)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("expected ErrNotInitialized for a missing file, got: %v", err)
+	}
+	if elapsed > 50*time.Millisecond {
+		t.Fatalf("expected no retry delay for a missing file, took: %v", elapsed)
+	}
+}

--- a/erun-integration/testdata/list/corrupted_env_config_errors.txt
+++ b/erun-integration/testdata/list/corrupted_env_config_errors.txt
@@ -1,2 +1,2 @@
 audit: erun list
-config file cannot be unmarshaled
+config file cannot be unmarshaled: yaml: line 1: did not find expected ',' or '}'

--- a/erun-integration/testdata/list/corrupted_tenant_config_errors.txt
+++ b/erun-integration/testdata/list/corrupted_tenant_config_errors.txt
@@ -1,2 +1,2 @@
 audit: erun list
-config file cannot be unmarshaled
+config file cannot be unmarshaled: yaml: line 1: did not find expected ',' or '}'

--- a/erun-integration/testdata/upgrade/dry_run_corrupt_tenant_config_fails.txt
+++ b/erun-integration/testdata/upgrade/dry_run_corrupt_tenant_config_fails.txt
@@ -1,4 +1,4 @@
 audit: erun upgrade --dry-run
 upgrade: tenant= environment= version-override= force=false
-upgrade: plan resolution failed: config file cannot be unmarshaled
-config file cannot be unmarshaled
+upgrade: plan resolution failed: config file cannot be unmarshaled: yaml: line 1: did not find expected ',' or '}'
+config file cannot be unmarshaled: yaml: line 1: did not find expected ',' or '}'

--- a/erun-ui/app_test.go
+++ b/erun-ui/app_test.go
@@ -120,6 +120,40 @@ func TestLoadStateFirstRunNeverRendersBareCLIInstruction(t *testing.T) {
 	}
 }
 
+// TestLoadStateConfigCorruptedRendersDistinctFromEmptyList is the regression
+// for erun#1774: a torn/corrupt config file must not surface as "zero
+// environments configured" (which the sidebar renders identically to a
+// genuinely empty install), and the raw yaml/unmarshal error text must never
+// reach the caller -- it crosses the headless HTTP bridge verbatim into a
+// browser console otherwise (headlessserver.handleInvoke writes err.Error()
+// into the response body).
+func TestLoadStateConfigCorruptedRendersDistinctFromEmptyList(t *testing.T) {
+	app := NewApp(erunUIDeps{
+		store: stubUIStore{
+			listTenantsErr: eruncommon.ErrConfigCorrupted,
+		},
+		findProjectRoot:  func() (string, string, error) { return "", "", eruncommon.ErrNotInGitRepository },
+		resolveBuildInfo: func() eruncommon.BuildInfo { return eruncommon.BuildInfo{Version: "1.0.50"} },
+	})
+
+	state, err := app.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+	if !state.ConfigUnreadable {
+		t.Fatal("expected ConfigUnreadable=true so the sidebar renders a distinct state from a genuine empty list")
+	}
+	if state.Tenants == nil {
+		t.Fatal("expected a non-nil Tenants slice so the frontend's boot-time iteration and JSON marshaling both stay safe")
+	}
+	if len(state.Tenants) != 0 {
+		t.Fatalf("expected zero tenants (the read genuinely failed), got: %+v", state.Tenants)
+	}
+	if strings.Contains(state.Message, "unmarshal") || strings.Contains(state.Message, "yaml:") {
+		t.Fatalf("expected no raw unmarshal error text in the message, got: %q", state.Message)
+	}
+}
+
 func TestLoadStateUsesTenantSpecificDeployableVersionSuggestions(t *testing.T) {
 	projectRoot := t.TempDir()
 	app := NewApp(erunUIDeps{

--- a/erun-ui/frontend/src/app/bootThunks.ts
+++ b/erun-ui/frontend/src/app/bootThunks.ts
@@ -1,4 +1,4 @@
-import type { UITenant } from '@/types';
+import type { UIState, UITenant } from '@/types';
 
 import { stateApi } from './api/stateApi';
 import { planEnvActivitySeed } from './envActivitySeed';
@@ -62,6 +62,26 @@ function noSelectionBootMessage(tenants: UITenant[]): string {
     : 'Create your first environment from the left pane.';
 }
 
+// reportBootLoadOutcome handles the two "stop here and just show a message"
+// outcomes getInitialState can carry: a config read that never resolved
+// (configUnreadable) even after erun-common's own retries, reported as an
+// error rather than the neutral empty-state message below so the operator
+// does not mistake a read failure for having no environments; and a plain
+// informational message (e.g. the first-run empty state). Returns true when
+// it dispatched one, so boot() knows to stop rather than continuing into
+// orchestrator/selection restore.
+function reportBootLoadOutcome(dispatch: AppDispatch, loaded: UIState): boolean {
+  if (loaded.configUnreadable) {
+    dispatch(showTerminalError(loaded.message ?? 'Some configuration could not be read.'));
+    return true;
+  }
+  if (loaded.message !== undefined && loaded.message !== '') {
+    dispatch(showTerminalMessage(loaded.message));
+    return true;
+  }
+  return false;
+}
+
 // boot deliberately does not seed the env-init dialog's kubectl context
 // list — that dialog owns and refreshes its own.
 export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) => {
@@ -86,8 +106,7 @@ export const boot = (): AppThunk<Promise<void>> => async (dispatch, getState) =>
     // build/deploy/release with no record until now; report it once, right
     // after the state it interrupted has loaded (erun#1214).
     await dispatch(loadInterruptedActivityNotice());
-    if (loaded.message !== undefined && loaded.message !== '') {
-      dispatch(showTerminalMessage(loaded.message));
+    if (reportBootLoadOutcome(dispatch, loaded)) {
       return;
     }
 
@@ -133,6 +152,15 @@ export const reloadStateAfterEnvironmentChange =
     );
     try {
       const loaded = await request.unwrap();
+      // A degraded read carries an empty tenants list for a reason other
+      // than "the environment really has none" — replacing the sidebar's
+      // already-good list with that empty one would be the same silent
+      // collapse this reload exists to avoid. Keep the current list and
+      // report the failure instead.
+      if (loaded.configUnreadable) {
+        dispatch(showTerminalError(loaded.message ?? 'Some configuration could not be read.'));
+        return;
+      }
       const current = getState().tenants;
       dispatch(setTenants(loaded.tenants));
       dispatch(setCloudProviders(loaded.cloudProviders ?? current.cloudProviders));

--- a/erun-ui/frontend/src/types.ts
+++ b/erun-ui/frontend/src/types.ts
@@ -162,6 +162,11 @@ export interface UIState {
   versionSuggestions?: UIVersionSuggestion[];
   versionSuggestionNotices?: UIVersionSuggestionNotice[];
   cloudProviders?: UICloudProviderStatus[];
+  // configUnreadable is set when one or more config files could not be read
+  // (e.g. a torn write) even after erun-common's own retries, so tenants is
+  // empty for a reason other than "no environments configured" — render this
+  // distinctly rather than falling into the empty-state affordance.
+  configUnreadable?: boolean;
 }
 
 export interface UIIdleStatus {

--- a/erun-ui/state_handlers.go
+++ b/erun-ui/state_handlers.go
@@ -35,6 +35,24 @@ func (a *App) LoadState() (uiState, error) {
 				VersionSuggestionNotices: notices,
 			}, nil
 		}
+		if errors.Is(err, eruncommon.ErrConfigCorrupted) {
+			// A torn or genuinely corrupt config file is not "zero
+			// environments configured" -- rendering it that way tells the
+			// operator their tenants are gone when they are merely unread,
+			// and the underlying yaml error is an implementation detail that
+			// must not reach the browser (it crosses the headless HTTP
+			// bridge as a raw response/console message otherwise). Return a
+			// successful, degraded state instead of propagating err, so the
+			// sidebar can render a distinct "could not read configuration"
+			// notice rather than the empty-state affordance above.
+			info := a.deps.resolveBuildInfo()
+			return uiState{
+				Tenants:          []uiTenant{},
+				Build:            buildDetailsFrom(info),
+				ConfigUnreadable: true,
+				Message:          "Some configuration could not be read. Run `erun doctor` to inspect and repair it, then reload.",
+			}, nil
+		}
 		return uiState{}, err
 	}
 	info := a.deps.resolveBuildInfo()

--- a/erun-ui/ui_model.go
+++ b/erun-ui/ui_model.go
@@ -10,6 +10,12 @@ type uiState struct {
 	VersionSuggestions       []uiVersion             `json:"versionSuggestions,omitempty"`
 	VersionSuggestionNotices []uiVersionNotice       `json:"versionSuggestionNotices,omitempty"`
 	CloudProviders           []uiCloudProviderStatus `json:"cloudProviders,omitempty"`
+	// ConfigUnreadable is set when one or more config files could not be read
+	// (e.g. a torn write) even after erun-common's own retries, so Tenants is
+	// empty for a reason other than "no environments configured". The
+	// sidebar must render this distinctly from a genuine empty state rather
+	// than showing "Create your first environment" for a read failure.
+	ConfigUnreadable bool `json:"configUnreadable,omitempty"`
 }
 
 type uiTenant struct {


### PR DESCRIPTION
## Summary
- Every `Load*Config` reader in `erun-common/config.go` (root, tenant, env, project) now shares one retrying read path (`loadConfigFile`) that recovers from a transient torn read — the residue of a write it doesn't control (an external editor, another process, a crash mid-write) — instead of surfacing `ErrConfigCorrupted` on the first attempt. Writes were already atomic (`writeFileAtomic`: temp file + rename); this closes the read side of the same contract.
- `erun-ui`'s `LoadState` no longer propagates the raw yaml/unmarshal error when a config stays unreadable after retries: it returns a degraded `uiState` (`ConfigUnreadable`) instead, so the headless HTTP bridge never leaks the raw parse error into an HTTP response/browser console, and the sidebar renders a distinct "could not read configuration" notice rather than the empty-state "Create your first environment" affordance.
- `reloadStateAfterEnvironmentChange` no longer overwrites a good tenant list with an empty one on a degraded read; it keeps the current list and surfaces the failure.
- Unified the four readers' unmarshal-failure wrapping (all now include the underlying yaml detail, matching `LoadProjectConfig`'s prior behavior) — updated the three `erun-integration` goldens whose captured CLI text changed as a result.

## Root cause (erun#1774)
Diagnosing erun#1772's "flaky" whip-panel spec showed 0 rows on all 11 attempts, alongside a `config file cannot be unmarshaled` 500 from `reloadStateAfterEnvironmentChange`. Not a timing issue — a read that errors outright, collapsed into "zero environments" with the raw parse error leaking to the browser console.

## Test plan
- [x] `go test ./...` in `erun-common` (incl. new `-race` regression tests: concurrent writer never observed as partial, torn read retried then recovers, genuinely corrupt file still fails within a bounded time, missing file returns `ErrNotInitialized` immediately) and `erun-ui`.
- [x] New `TestLoadStateConfigCorruptedRendersDistinctFromEmptyList` in `erun-ui/app_test.go`: `LoadState` succeeds with `ConfigUnreadable=true` and no raw unmarshal text in `Message`.
- [x] `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn build && yarn test` all green.
- [x] Two consecutive full `erun-ui/playwright/run.sh` runs, **467 passed / 0 failed each**, with no timeout widened — this branch was cut from clean `main`, so erun#1772's `titlebar-whip-panel-layout.spec.ts` spec passed on its original (unwidened) budgets both times, confirming the diagnosis end to end.
- [x] `make check` green, including `erun-integration` (goldens regenerated via `--update-golden` for the three scenarios whose captured error text gained the yaml detail).

Closes #1774