### PR TITLE
Stop the orchestrator card asserting an unfounded "Not open here"

### DIFF
--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.test.ts
@@ -70,16 +70,35 @@ test('an outage reads as outage even while otherwise reachable and busy', () => 
   assert.notEqual(line.status, 'Busy — holding: x');
 });
 
-test('never observed (no activity at all) reads unreachable, not idle', () => {
+// The orchestrator card used to reuse the desktop's own reachability reading
+// and render it as a confident "Not open here", which read as a claim about
+// the *orchestrator's* reach even though the desktop's local forward has
+// nothing to do with a host-side orchestrator's own MCP client. The desktop
+// genuinely has no reading here (no local forward, no answer from any
+// fallback channel either), so the honest line says only what the desktop
+// itself observed — never that the environment is closed to anyone else —
+// and it says so about "this desktop" explicitly rather than with a bare,
+// unscoped "not open".
+test('never observed (no activity at all) reads as no signal from this desktop, not a confident "not open"', () => {
   const line = orchestratorEnvironmentLine(env());
-  assert.equal(line.state, 'unreachable');
+  assert.equal(line.state, 'no-forward');
   assert.notEqual(line.state, 'idle');
+  assert.notEqual(line.state, 'busy');
+  assert.equal(line.status, 'No forward from this desktop');
+  assert.notEqual(line.status, 'Not open here');
+  assert.ok(!/\bnot open\b/i.test(line.status), 'must not assert a bare "not open"');
+  assert.ok(
+    /this desktop/i.test(line.status),
+    'must scope the claim to the desktop, not the orchestrator',
+  );
 });
 
-// An environment held busy by an agent driving it from elsewhere (a CLI
-// orchestrator, another machine over MCP) must not read as "not open here"
-// just because this desktop never opened a local forward to it. The poller
-// now asks such an environment directly and can still find it busy.
+// An orchestrator actively driving a linked environment (a lease held from
+// elsewhere, a CLI session, another machine over MCP) must never read as "Not
+// open here" — that string used to fire whenever this desktop itself had no
+// local forward, which said nothing true about whether the *orchestrator*
+// could reach the environment. The poller now asks such an environment
+// directly and can still find it busy.
 test('a lease held by a session driving the environment from elsewhere still reads busy', () => {
   const line = orchestratorEnvironmentLine(
     env({
@@ -110,7 +129,7 @@ test('a failed attempt to reach an unopened environment reads distinctly from ne
     }),
   );
   assert.equal(line.state, 'check-failed');
-  assert.notEqual(line.state, 'unreachable');
+  assert.notEqual(line.state, 'no-forward');
   assert.notEqual(line.state, 'idle');
   assert.ok(
     line.status.toLowerCase().includes('open it'),

--- a/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
+++ b/erun-ui/frontend/src/app/orchestratorEnvironmentActivity.ts
@@ -5,19 +5,33 @@ import type { StatusDotState } from '@/components/app/Sidebar.StatusDot';
 // orchestratorEnvironmentLine reduces one linked environment's joined
 // activity (environment_activity.go's poller, via OrchestratorEnvRef.activity)
 // to the one line the hover card renders for it. The reduction is deliberately
-// not a single boolean: outage and unreachable read as the same "nothing here"
+// not a single boolean: outage and no-forward read as the same "nothing here"
 // to a naive summary, but they are different operator situations (a forward
 // that died vs. one that was never opened), and observed=false must not
 // collapse into idle just because busy is also false -- that would report a
 // state nobody actually confirmed. checkFailed is the same split applied to an
 // environment with no local forward: the poller still asks it directly (over
 // its own runtime pod), so a failed attempt to answer is its own state, not a
-// re-use of "unreachable" — an environment nobody opened here can be busy
-// right now, so "unreachable" must stay reserved for one nothing has ever
+// re-use of "no-forward" — an environment nobody opened here can be busy
+// right now, so "no-forward" must stay reserved for one nothing has ever
 // asked.
+//
+// Every field this reduces is the *desktop's* observation (see
+// environment_activity.go's own doc comment) -- this card is titled with the
+// orchestrator, not the desktop, and an orchestrator is a host-side session
+// with its own MCP client and its own connections, independent of whatever
+// local forward this desktop happens to have open. So no branch here may
+// claim anything about the *orchestrator's* reach: "no-forward" states only
+// what the desktop itself could establish, never that the environment is
+// closed to anyone else, and its wording says "this desktop" rather than a
+// bare "not open" for exactly that reason. checkFailed already gets this
+// right — it says "can't confirm", not "unreachable" — because a
+// real attempt that came back empty is honest uncertainty, not a confident
+// negative; no-forward is the same idea applied to the case where the desktop
+// never had a channel to ask through at all.
 export type OrchestratorEnvironmentState =
   | 'outage'
-  | 'unreachable'
+  | 'no-forward'
   | 'check-failed'
   | 'unknown'
   | 'busy'
@@ -29,7 +43,7 @@ export interface OrchestratorEnvironmentLine {
   state: OrchestratorEnvironmentState;
   status: string;
   // dot is omitted for the three states with no shared StatusDotGlyph shape
-  // (unreachable, check-failed, unknown) rather than reusing 'stopped' or
+  // (no-forward, check-failed, unknown) rather than reusing 'stopped' or
   // 'failed' for them and losing the distinction those exist to preserve.
   dot?: StatusDotState;
   // usage is the compact CPU/memory figure from the usage sweep's cached
@@ -63,8 +77,8 @@ export function orchestratorEnvironmentLine(env: OrchestratorEnvRef): Orchestrat
     // Not the same silence as never asking: this desktop has no local
     // forward, so it asked the environment directly instead, and the attempt
     // itself did not come back. Naming the action (open it) is what the plain
-    // "Not open here" line below cannot do for an environment that might be
-    // busy right now and simply could not confirm it from here.
+    // "no forward" line below cannot do for an environment that might be busy
+    // right now and simply could not be confirmed from this desktop.
     return {
       key,
       name,
@@ -75,7 +89,20 @@ export function orchestratorEnvironmentLine(env: OrchestratorEnvRef): Orchestrat
     };
   }
   if (!activity?.reachable) {
-    return { key, name, state: 'unreachable', status: 'Not open here', usage, usageStale };
+    // The desktop has no local forward to this environment and no other
+    // channel came back with an answer either -- it genuinely has nothing to
+    // report, not a confirmed "closed" (that would be checkFailed above, or
+    // outage). Naming "this desktop" keeps the line honest: an orchestrator is
+    // a separate host-side client, so its own reach is unknown from this
+    // reading, never asserted false by it.
+    return {
+      key,
+      name,
+      state: 'no-forward',
+      status: 'No forward from this desktop',
+      usage,
+      usageStale,
+    };
   }
   if (!activity.observed) {
     return {

--- a/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
+++ b/erun-ui/playwright/tests/sidebar-orchestrator-hover-card-activity.spec.ts
@@ -193,7 +193,15 @@ test.describe('orchestrator hover card environment and pacing state', () => {
     });
   });
 
-  test('an environment never opened from this desktop reads unreachable, not idle', async ({
+  // This card is titled with the *orchestrator*, a host-side session with its
+  // own MCP client, so a line here must never assert anything about the
+  // orchestrator's own reach -- only what this desktop itself observed. An
+  // environment with no activity reading at all (no local forward, and no
+  // answer from the pod-exec fallback either) is genuinely unknown from the
+  // orchestrator's point of view, not confirmed closed, so the line names the
+  // desktop explicitly rather than asserting a bare "not open" that would
+  // read as a claim about the orchestrator.
+  test('an environment with no reading from this desktop names the desktop, not a bare "not open"', async ({
     app,
     page,
   }) => {
@@ -214,11 +222,12 @@ test.describe('orchestrator hover card environment and pacing state', () => {
     // own turn state, which must not be confused with this environment's
     // activity state.
     const environmentRow = dialog.locator('dd').filter({ hasText: 'acme / never-opened' });
-    await expect(environmentRow).toContainText('Not open here');
+    await expect(environmentRow).toContainText('No forward from this desktop');
+    await expect(environmentRow).not.toContainText('Not open here');
     await expect(environmentRow).not.toContainText('Idle');
 
     await dialog.screenshot({
-      path: '/home/erun/.erun/outputs/1383-visual/unreachable-environment.png',
+      path: '/home/erun/.erun/outputs/1383-visual/no-forward-environment.png',
     });
   });
 


### PR DESCRIPTION
## Summary
- The orchestrator hover card reused the environment-activity poller's desktop-forward reading for its linked-environment lines, so an environment this desktop had no local forward to read as a confident "Not open here" even while the orchestrator itself was actively driving it through its own MCP client.

## What signal does the orchestrator have for its own reachability?

None. The desktop has no channel that observes a host-side orchestrator's own MCP-client connectivity to an environment. The only signal available anywhere in this surface is `environment_activity.go`'s poller — the desktop's own local port-forward, with a `kubectl exec` pod fallback when there's no forward — and that signal describes what *this desktop* can see, never what the orchestrator can reach. The fix does not add a new signal (plumbing the orchestrator's own per-environment connection state through the session was scoped out in #1761 as a much larger change than the defect warrants); it stops presenting the desktop-only signal as if it answered the orchestrator's own question.

## Where this diverges from the sidebar derivation

The sidebar's environment rows (`Sidebar.helpers.ts`) read the exact same desktop-forward data, and "Not open"/"not opened here" stays correct and unchanged there — a sidebar row legitimately *is* a statement about this desktop's own list. `orchestratorEnvironmentActivity.ts` reused that identical reduction (`outage` → `checkFailed` → `!reachable` → `!observed` → `busy` → idle) for a card titled by the *orchestrator*, not the desktop, and the reused wording ("Not open here") reads as a claim about the orchestrator on that surface even though the underlying data never said anything about the orchestrator at all. The fix only renames the orchestrator-card branch and its wording (`unreachable` → `no-forward`, "Not open here" → "No forward from this desktop"); the sidebar's own derivation, states, and wording are untouched.

## What an unknown relationship renders as

`state: 'no-forward'`, rendered as **"No forward from this desktop"** — distinct from `check-failed` ("can't confirm": a real attempt over the pod-exec fallback that came back empty) and from `outage` (a forward that was open and died). It is deliberately not phrased as a negative about the orchestrator ("closed", "unreachable") — it says only that this desktop has no reading, leaving the orchestrator's actual reach genuinely unknown rather than asserted false.

## Test plan
- [x] `orchestratorEnvironmentActivity.test.ts`: the derivation matrix still keeps `outage`/`checkFailed`/`no-forward` as three distinct outcomes, and the no-forward branch's wording is asserted not to claim anything about the orchestrator.
- [x] `sidebar-orchestrator-hover-card-activity.spec.ts`: the card renders "No forward from this desktop" instead of "Not open here" for the reported scenario (no local forward, pod-exec fallback also empty), while the orchestrator is otherwise visibly driving those environments.
- [x] `yarn typecheck` and `yarn test` (296 passed) on the rebased branch.

Closes #1761