### PR TITLE
Guard every FitAddon.fit() call against a near-zero container

### DIFF
--- a/erun-ui/frontend/src/app/TerminalController.ts
+++ b/erun-ui/frontend/src/app/TerminalController.ts
@@ -30,6 +30,7 @@ import {
   trimChunksToBudget,
 } from './terminalBuffers';
 import { TerminalClipboard } from './terminalClipboard';
+import { safeFit } from './terminalFit';
 import { scheduleTerminalFocus } from './terminalFocus';
 import { applyTerminalLayoutVars } from './terminalLayoutVars';
 import { installTerminalLinkHandling } from './terminalLinkHandling';
@@ -129,7 +130,7 @@ export class TerminalController {
   }
 
   fitTerminal(): void {
-    this.fitAddon?.fit();
+    safeFit(this.fitAddon);
     this.publishTerminalDims();
   }
 
@@ -200,7 +201,7 @@ export class TerminalController {
     this.serializeAddon = new SerializeAddon();
     this.terminal.loadAddon(this.serializeAddon);
     this.terminal.open(elements.terminalRoot);
-    this.fitAddon.fit();
+    safeFit(this.fitAddon);
     this.publishTerminalDims();
     this.pathLinkProviderDisposable = installTerminalLinkHandling(this.terminal);
 
@@ -427,7 +428,7 @@ export class TerminalController {
 
   private runTerminalResize(): void {
     this.applyLayoutVars();
-    this.fitAddon?.fit();
+    safeFit(this.fitAddon);
     this.publishTerminalDims();
     const sessionId = store.getState().terminal.sessionId;
     if (sessionId > 0 && this.terminal) {

--- a/erun-ui/frontend/src/app/terminalFit.test.ts
+++ b/erun-ui/frontend/src/app/terminalFit.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { MIN_FIT_COLS, MIN_FIT_ROWS, safeFit } from './terminalFit';
+
+function fakeFitAddon(proposed: { cols: number; rows: number } | undefined) {
+  let fitCount = 0;
+  return {
+    fitCount: () => fitCount,
+    proposeDimensions: () => proposed,
+    fit: () => {
+      fitCount += 1;
+    },
+  };
+}
+
+test('a zero-width container proposal is skipped, never applied', () => {
+  const fitAddon = fakeFitAddon({ cols: 0, rows: 0 });
+  const ran = safeFit(fitAddon as never);
+  assert.equal(ran, false);
+  assert.equal(fitAddon.fitCount(), 0);
+});
+
+test('a proposal below the column floor is skipped even with a healthy row count', () => {
+  const fitAddon = fakeFitAddon({ cols: MIN_FIT_COLS - 1, rows: 40 });
+  const ran = safeFit(fitAddon as never);
+  assert.equal(ran, false);
+  assert.equal(fitAddon.fitCount(), 0);
+});
+
+test('a proposal below the row floor is skipped even with a healthy column count', () => {
+  const fitAddon = fakeFitAddon({ cols: 120, rows: MIN_FIT_ROWS - 1 });
+  const ran = safeFit(fitAddon as never);
+  assert.equal(ran, false);
+  assert.equal(fitAddon.fitCount(), 0);
+});
+
+test('a proposal at exactly the floor is trusted and applied', () => {
+  const fitAddon = fakeFitAddon({ cols: MIN_FIT_COLS, rows: MIN_FIT_ROWS });
+  const ran = safeFit(fitAddon as never);
+  assert.equal(ran, true);
+  assert.equal(fitAddon.fitCount(), 1);
+});
+
+test('no proposal at all (element not yet in the DOM) is skipped', () => {
+  const fitAddon = fakeFitAddon(undefined);
+  const ran = safeFit(fitAddon as never);
+  assert.equal(ran, false);
+  assert.equal(fitAddon.fitCount(), 0);
+});
+
+test('a missing fit addon is a no-op rather than a throw', () => {
+  assert.equal(safeFit(null), false);
+  assert.equal(safeFit(undefined), false);
+});
+
+test('a skipped fit is retried and succeeds once the container is measurable again', () => {
+  let proposed: { cols: number; rows: number } | undefined = { cols: 2, rows: 1 };
+  const fitAddon = {
+    fitCount: 0,
+    proposeDimensions: () => proposed,
+    fit() {
+      this.fitCount += 1;
+    },
+  };
+
+  // First attempt: the container is still mid-transition, near-zero.
+  assert.equal(safeFit(fitAddon as never), false);
+  assert.equal(fitAddon.fitCount, 0);
+
+  // The transition settles at a real size; the next attempt (the same
+  // resize path retrying on the next observed size change) fits normally.
+  proposed = { cols: 132, rows: 42 };
+  assert.equal(safeFit(fitAddon as never), true);
+  assert.equal(fitAddon.fitCount, 1);
+});

--- a/erun-ui/frontend/src/app/terminalFit.ts
+++ b/erun-ui/frontend/src/app/terminalFit.ts
@@ -1,0 +1,34 @@
+import type { FitAddon } from '@xterm/addon-fit';
+
+// FitAddon.proposeDimensions() floors its own answer at 2 cols / 1 row rather
+// than ever reporting zero, so a container that is hidden, mid-layout, or not
+// yet painted still proposes a handful of columns -- and fit() applies that
+// proposal unconditionally, calling terminal.resize() with it. xterm reflows
+// the *viewport* on a resize, but scrollback keeps the wrap it was written
+// with, so applying a bad proposal permanently mangles every line already on
+// screen. MIN_FIT_COLS/MIN_FIT_ROWS mark the smallest proposal trusted to
+// reflect a real layout rather than a measurement caught mid-transition: no
+// shell prompt or TUI frame renders legibly below them, and this app's own
+// grid never intentionally lays the terminal out that small (MIN_MAIN_PANE_WIDTH
+// in state.ts holds <main> at 360px+, an order of magnitude more columns).
+export const MIN_FIT_COLS = 10;
+export const MIN_FIT_ROWS = 3;
+
+// safeFit resizes the terminal to match its container, but skips the call
+// entirely when the proposed dimensions are too small to trust, leaving the
+// terminal at its last good size. A skipped fit costs nothing: the container
+// stays under a live ResizeObserver, so the next real size change (the
+// transition finishing, the container becoming visible) proposes a fresh
+// measurement and retries. Returns whether the fit ran, so callers/tests can
+// tell a skip from a fit that left dimensions unchanged.
+export function safeFit(fitAddon: FitAddon | null | undefined): boolean {
+  if (!fitAddon) {
+    return false;
+  }
+  const proposed = fitAddon.proposeDimensions();
+  if (!proposed || proposed.cols < MIN_FIT_COLS || proposed.rows < MIN_FIT_ROWS) {
+    return false;
+  }
+  fitAddon.fit();
+  return true;
+}

--- a/erun-ui/frontend/src/app/terminalReattachRepaint.test.ts
+++ b/erun-ui/frontend/src/app/terminalReattachRepaint.test.ts
@@ -71,19 +71,26 @@ function fakeTerminal(cols: number, rows: number) {
   };
 }
 
-function harness() {
+function harness(
+  proposeDimensions: () => { cols: number; rows: number } | undefined = () => ({
+    cols: 120,
+    rows: 40,
+  }),
+  afterRestore: () => void = noop,
+) {
   const terminal = fakeTerminal(120, 40);
   fitCount = 0;
   const repaint = new TerminalReattachRepaint({
     getTerminal: () => terminal as never,
     getFitAddon: () =>
       ({
+        proposeDimensions,
         fit: () => {
           fitCount += 1;
         },
       }) as never,
     activeSessionId: () => 7,
-    afterRestore: noop,
+    afterRestore,
   });
   return { terminal, repaint };
 }
@@ -167,4 +174,28 @@ test('without input the cycle still completes, so the repaint is not simply disa
   mock.timers.tick(650);
   assert.equal(terminal.rows, 40, 'the hold must restore on its own when nobody types');
   assert.equal(fitCount, 1);
+});
+
+test('restore skips fit() when the container is momentarily unmeasurable, but still restores geometry', () => {
+  let afterRestoreCalls = 0;
+  const { terminal, repaint } = harness(
+    () => ({ cols: 2, rows: 1 }), // the container mid-transition FitAddon.fit() would otherwise apply
+    () => {
+      afterRestoreCalls += 1;
+    },
+  );
+  repaint.schedule(7);
+
+  mock.timers.tick(1300);
+  assert.equal(terminal.rows, 26, 'expected the shrink to be applied');
+  mock.timers.tick(650);
+
+  // term.resize(cols, rows) already restores the pre-shrink geometry directly,
+  // independent of fit(); the guard only stops the *extra* re-measure from
+  // clobbering it with a bad proposal.
+  assert.equal(terminal.cols, 120);
+  assert.equal(terminal.rows, 40, 'the hold must restore even though fit() was skipped');
+  assert.equal(fitCount, 0, 'fit() must not run against an unusable proposal');
+  assert.equal(afterRestoreCalls, 1, 'afterRestore still runs so dims are republished either way');
+  assert.deepEqual(lastResizeCall(), [7, 120, 40]);
 });

--- a/erun-ui/frontend/src/app/terminalReattachRepaint.ts
+++ b/erun-ui/frontend/src/app/terminalReattachRepaint.ts
@@ -3,6 +3,7 @@ import type { Terminal } from '@xterm/xterm';
 import { noop } from 'erun-kit';
 
 import { ResizeSession } from '../../wailsjs/go/main/App';
+import { safeFit } from './terminalFit';
 
 interface ReattachRepaintDeps {
   getTerminal: () => Terminal | null;
@@ -153,7 +154,7 @@ export class TerminalReattachRepaint {
       return;
     }
     term.resize(cols, rows);
-    fitAddon.fit();
+    safeFit(fitAddon);
     this.deps.afterRestore();
     void ResizeSession(sessionId, term.cols, term.rows).catch(noop);
     this.cycling = false;

--- a/erun-ui/playwright/tests/terminal-fit-guard.spec.ts
+++ b/erun-ui/playwright/tests/terminal-fit-guard.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '../fixtures/erunApp.js';
+import type { Page, Request } from '@playwright/test';
+import type { AppShell } from '../pages/index.js';
+
+// Regression for #1767: FitAddon.fit() applied whatever the container
+// proposed, even a container caught mid layout-change reporting a couple of
+// columns (the report's trigger was the sidebar going 220px -> 280px). xterm
+// rewraps scrollback at whatever width it's resized to, so that one bad fit
+// permanently mangled everything already on screen. The guard (safeFit,
+// erun-ui/frontend/src/app/terminalFit.ts) skips a fit whose proposal is too
+// small to trust; this spec forces the pane's real FitAddon parent through
+// exactly that near-zero state and proves the skip, the later recovery once
+// the container is measurable again, and that scrollback survives.
+//
+// The exact race that produced a near-zero reading during a real sidebar drag
+// is a browser-timing artifact, not something a deterministic spec should
+// depend on hitting. Forcing the pane's measured size directly exercises the
+// same application code path (ResizeObserver -> queueTerminalResize ->
+// runTerminalResize -> safeFit) against the same shape of bad measurement,
+// without relying on a race.
+test.describe('terminal fit guard against a near-zero container (#1767)', () => {
+  test('a near-zero container mid-resize is skipped and the buffer survives; the next real size retries it', async ({
+    app,
+    page,
+    seededEnv,
+  }) => {
+    const { tenant, environment } = seededEnv;
+    await app.sidebar.openEnvironment(tenant, environment);
+    const localTab = page.getByRole('tab', { name: 'Local', exact: true });
+    await localTab.waitFor({ state: 'visible' });
+    await localTab.click();
+
+    const sessionId = await discoverSelectedSessionId(app, page);
+    expect(sessionId).toBeGreaterThan(0);
+
+    const anchor = `anchor-${'x'.repeat(120)}`;
+    await emitTerminalOutput(page, sessionId, `${anchor}\r\nmore output\r\n`);
+    await expect.poll(() => rowsText(page)).toContain(anchor);
+
+    const colsBefore = await readTerminalCols(page);
+    expect(colsBefore).toBeGreaterThan(0);
+
+    // Force the FitAddon's own measured parent (#erun-terminal-pane) down to
+    // the couple-of-columns proposal a mid-transition container reports.
+    // Shrinking it also shrinks the observed `.terminal` child (w-full/h-full),
+    // so the app's existing ResizeObserver fires exactly as it would for a
+    // real layout change.
+    const skippedResize = waitForNextResizeSession(page);
+    await setTerminalPaneOverrideSize(page, { width: 20, height: 20 });
+    await skippedResize;
+
+    // Skipped, not applied: cols/rows are unchanged and the anchor line is
+    // still intact at full width, not rewrapped into a column of fragments.
+    expect(await readTerminalCols(page)).toBe(colsBefore);
+    expect(await rowsText(page)).toContain(anchor);
+
+    // The transition settling at its real size is itself the retry: the same
+    // observer fires again, and this time the proposal is trustworthy.
+    const recoveredResize = waitForNextResizeSession(page);
+    await setTerminalPaneOverrideSize(page, null);
+    await recoveredResize;
+
+    expect(await readTerminalCols(page)).toBe(colsBefore);
+    expect(await rowsText(page)).toContain(anchor);
+  });
+});
+
+interface InvokeCall {
+  method: string;
+  args: unknown[];
+}
+
+function parseInvoke(req: Request): InvokeCall | null {
+  if (req.method() !== 'POST' || !req.url().endsWith('/__erun_invoke')) {
+    return null;
+  }
+  let body: { method?: string; args?: unknown[] } | null = null;
+  try {
+    body = req.postDataJSON() as { method?: string; args?: unknown[] } | null;
+  } catch {
+    return null;
+  }
+  return body?.method ? { method: body.method, args: body.args ?? [] } : null;
+}
+
+// The app always calls ResizeSession at the end of its resize path, whether or
+// not the fit itself ran -- so it's a reliable "the debounced resize handling
+// finished" signal for both the skip and the recovery below.
+function waitForNextResizeSession(page: Page): Promise<Request> {
+  return page.waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession', {
+    timeout: 60_000,
+  });
+}
+
+async function discoverSelectedSessionId(app: AppShell, page: Page): Promise<number> {
+  const waitForResize = page
+    .waitForRequest((req) => parseInvoke(req)?.method === 'ResizeSession')
+    .catch(() => null);
+  await app.titlebar.toggleButton().click();
+  const resize = await waitForResize;
+  await app.titlebar.toggleButton().click();
+  const id = resize ? parseInvoke(resize)?.args[0] : undefined;
+  return typeof id === 'number' ? id : 0;
+}
+
+// Mirrors what the Go PTY stream emits so the test drives the real output
+// path. btoa is safe here only because every staged byte is < 256.
+async function emitTerminalOutput(page: Page, sessionId: number, raw: string): Promise<void> {
+  await page.evaluate(
+    (payload) => {
+      const runtime = (
+        window as unknown as {
+          runtime: { EventsEmit: (name: string, ...args: unknown[]) => void };
+        }
+      ).runtime;
+      runtime.EventsEmit('terminal-output', {
+        sessionId: payload.sessionId,
+        data: btoa(payload.raw),
+      });
+    },
+    { sessionId, raw },
+  );
+}
+
+// FitAddon.proposeDimensions() reads the computed size of the `.terminal`
+// element's parent (#erun-terminal-pane), not `.terminal` itself -- an inline
+// style here is what a real momentarily-tiny layout would look like to it.
+// `.terminal` is `w-full h-full` inside it, so this also changes what
+// TerminalController's own ResizeObserver (which watches `.terminal`) sees,
+// firing the real resize path exactly as a genuine layout change would.
+async function setTerminalPaneOverrideSize(
+  page: Page,
+  size: { width: number; height: number } | null,
+): Promise<void> {
+  await page.evaluate((s) => {
+    const pane = document.getElementById('erun-terminal-pane');
+    if (!pane) {
+      return;
+    }
+    if (s === null) {
+      pane.style.removeProperty('width');
+      pane.style.removeProperty('height');
+    } else {
+      pane.style.width = `${String(s.width)}px`;
+      pane.style.height = `${String(s.height)}px`;
+    }
+  }, size);
+}
+
+// A changed column count is the observable proof that a refit ran.
+async function readTerminalCols(page: Page): Promise<number> {
+  return await page.evaluate(() => {
+    const el = document.querySelector<HTMLElement>('.terminal');
+    const raw = el?.dataset.terminalCols ?? '';
+    return raw ? Number.parseInt(raw, 10) : 0;
+  });
+}
+
+// The visible viewport's rendered text -- enough to tell a real line apart
+// from the "one character per row" shape a bad rewrap produces, without
+// needing to scroll: the two staged lines are recent enough to still be on
+// screen.
+async function rowsText(page: Page): Promise<string> {
+  return await page.evaluate(
+    () => document.querySelector('.xterm-rows')?.textContent?.replace(/\s+/g, '') ?? '',
+  );
+}


### PR DESCRIPTION
## Summary

- `FitAddon.fit()` applies whatever the terminal's container proposes, and a container caught mid layout-change (the reported case: sidebar 220px → 280px) can propose only a couple of columns — `proposeDimensions()` floors at 2 cols / 1 row rather than ever reporting zero. xterm rewraps scrollback at that width, and unlike the viewport reflow, the wrap is never undone, so one bad fit permanently mangles everything already on screen.
- Added `safeFit()` (`erun-ui/frontend/src/app/terminalFit.ts`), which checks `FitAddon.proposeDimensions()` before calling `fit()` and skips the resize when the proposal is under `MIN_FIT_COLS`/`MIN_FIT_ROWS` (10 cols / 3 rows — no shell prompt or TUI renders legibly below that, and this app's own grid never intentionally lays the terminal out anywhere close to that small). A skipped fit leaves the terminal at its last good size; the container's existing `ResizeObserver` retries on the very next real size change, so nothing new is needed to remember and re-apply a deferred fit.
- Guarded **four** call sites, not the three the issue named: `TerminalController.ts`'s `mount()`, `fitTerminal()`, and `runTerminalResize()`, plus a fourth found while auditing every `.fit()` call in the module — `terminalReattachRepaint.ts`'s `restore()`, which re-fits after undoing its shrink-and-restore repaint cycle.

## UX Impact Review Checklist

1. **Affected paths.** Terminal pane resize (layout panel toggles, window resize, sidebar width changes) and the AI/orchestrator reattach-repaint cycle.
2. **User-visible sequence.** No new visible states — the fix only prevents a destructive resize from being applied; the terminal pane continues to resize normally on every real size change.
3. **State-without-affordance.** N/A — no new state is introduced.
4–6. **Status/feedback/consistency.** N/A — this is a correctness fix with no new UI surface.
7. **Heuristic pass.** Nielsen #1 (visibility of system status) is actually strengthened: a skipped fit means the operator's scrollback stays legible instead of being silently corrupted with no error shown.
8. **Playwright coverage.** New spec `erun-ui/playwright/tests/terminal-fit-guard.spec.ts` forces the terminal's FitAddon-measured container to a near-zero size (mirroring the reported sidebar transition), proves the fit is skipped and scrollback survives intact, then proves the next real size change retries and succeeds.

## Test plan

- [x] `erun-ui/frontend`: `yarn typecheck && yarn lint && yarn format:check && yarn test` — all green (304 unit tests pass, including 7 new `terminalFit.test.ts` cases and a new `terminalReattachRepaint.test.ts` case for the fourth call site).
- [x] Manually reverted the guard in `runTerminalResize()` and confirmed the new Playwright spec fails (cols collapse to 2) — then restored the fix and confirmed it passes, proving the spec actually catches the regression.
- [ ] `make check` (running).
- [ ] Full Playwright suite (`./playwright/run.sh --build`) (running).

Closes #1767