### PR TITLE
Surface ssh/git/kubectl stderr instead of a bare exit status

### DIFF
--- a/erun-cli/cmd/doctor.go
+++ b/erun-cli/cmd/doctor.go
@@ -318,6 +318,9 @@ func runDeployRecoveryActions(ctx common.Context, promptRunner PromptRunner, req
 		}
 		output, runErr := common.RunDeployRecovery(ctx, req, action)
 		if runErr != nil {
+			if detail := strings.TrimSpace(output); detail != "" {
+				return fmt.Errorf("%w: %s", runErr, detail)
+			}
 			return runErr
 		}
 		if !ctx.DryRun {

--- a/erun-common/deploy.go
+++ b/erun-common/deploy.go
@@ -3865,12 +3865,20 @@ func checkKubernetesDeploymentWithContext(ctx Context, params KubernetesDeployme
 		return false, output, nil
 	}
 
-	detail := kubernetesDeploymentCheckFailureDetail(output)
-	trimmed := strings.TrimSpace(output)
-	if trimmed == "" {
+	detail := kubernetesDeploymentCheckFailureDetail(output, kubectlContext)
+	sanitized := sanitizeKubectlFailureOutput(output)
+	// The sanitized sentence is what reaches the operator; kubectl's raw
+	// combined output still goes to the per-env trace log (ActivateEnvTrace
+	// tees it unconditionally, so this reaches disk regardless of terminal
+	// verbosity) so the full diagnostic is never actually lost, only kept out
+	// of a surface too narrow to show it.
+	if trimmedRaw := strings.TrimSpace(output); trimmedRaw != "" {
+		ctx.Logger.Debug("kubectl deployment check raw output: " + trimmedRaw)
+	}
+	if sanitized == "" {
 		return false, output, fmt.Errorf("could not determine whether deployment %q is deployed (%s): %w", params.Name, detail, err)
 	}
-	return false, output, fmt.Errorf("could not determine whether deployment %q is deployed (%s): %s", params.Name, detail, trimmed)
+	return false, output, fmt.Errorf("could not determine whether deployment %q is deployed (%s): %s", params.Name, detail, sanitized)
 }
 
 // kubernetesDeploymentCheckFailureDetail names why a kubectl deployment
@@ -3879,8 +3887,12 @@ func checkKubernetesDeploymentWithContext(ctx Context, params KubernetesDeployme
 // API server, credentials or permissions refused) from an error it does not
 // recognize. Neither is evidence the deployment is absent. Reuses
 // isKubernetesContextMissingMessage for the context-missing case it already
-// covers instead of a second matcher for the same signal.
-func kubernetesDeploymentCheckFailureDetail(output string) string {
+// covers instead of a second matcher for the same signal. Names the
+// kubectl context for the unreachable-API-server case (erun#1766): erun
+// already knows it from its own configuration, so the message can identify
+// the target cluster without depending on a substring of kubectl's own
+// output surviving whatever later truncates the message for display.
+func kubernetesDeploymentCheckFailureDetail(output, kubectlContext string) string {
 	if isKubernetesContextMissingMessage(output) {
 		return "the configured kubernetes context was not found in kubeconfig"
 	}
@@ -3891,6 +3903,9 @@ func kubernetesDeploymentCheckFailureDetail(output string) string {
 		strings.Contains(message, "no such host"),
 		strings.Contains(message, "i/o timeout"),
 		strings.Contains(message, "no configuration has been provided"):
+		if kubectlContext = strings.TrimSpace(kubectlContext); kubectlContext != "" {
+			return fmt.Sprintf("the kubernetes api server could not be reached (context %q)", kubectlContext)
+		}
 		return "the kubernetes api server could not be reached"
 	case strings.Contains(message, "forbidden"),
 		strings.Contains(message, "unauthorized"),
@@ -3900,6 +3915,46 @@ func kubernetesDeploymentCheckFailureDetail(output string) string {
 	default:
 		return "kubectl returned an error erun does not recognize"
 	}
+}
+
+// klogFramePattern matches the severity+timestamp+goroutine-id+source-location
+// prefix klog stamps on every line it emits (e.g. `E0831 13:46:43.793908
+// 10289 memcache.go:265]`). None of it is operator-relevant: the
+// severity/timestamp duplicate context the caller's own message already
+// carries, and the goroutine id and Go source file are internal to
+// kubectl/client-go.
+var klogFramePattern = regexp.MustCompile(`^[EWIF]\d{4} \d{2}:\d{2}:\d{2}\.\d+\s+\d+ \S+\.go:\d+\]\s*`)
+
+// klogUnhandledErrorPattern extracts the inner err="..." sentence klog's
+// "Unhandled Error" wrapper carries -- the one piece of a klog line an
+// operator can act on. The capture is greedy so it consumes through the
+// line's real closing quote rather than stopping at an escaped `\"` inside
+// the nested message.
+var klogUnhandledErrorPattern = regexp.MustCompile(`^"Unhandled Error"\s+err="(.*)"$`)
+
+// sanitizeKubectlFailureOutput reduces kubectl's raw combined output to the
+// one sentence an operator can act on, rather than pasting a klog line
+// verbatim (erun#1766: a toast rendered that line at a fixed width, so the
+// goroutine id and source location survived while the API server address --
+// the one piece of the message that actually named a cause -- was what got
+// cut off). It scans from the last non-blank line backward, strips klog's
+// frame if present, and unwraps an "Unhandled Error" carrier down to its
+// err= text; a line with neither shape is returned frame-stripped as-is, so
+// an unrecognized failure still reaches the operator rather than
+// disappearing. Returns "" only when there is truly nothing to show.
+func sanitizeKubectlFailureOutput(raw string) string {
+	lines := strings.Split(strings.TrimRight(raw, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(klogFramePattern.ReplaceAllString(lines[i], ""))
+		if line == "" {
+			continue
+		}
+		if match := klogUnhandledErrorPattern.FindStringSubmatch(line); match != nil {
+			return strings.ReplaceAll(match[1], `\"`, `"`)
+		}
+		return line
+	}
+	return ""
 }
 
 // KubernetesDeploymentAbsentMessageMarker is the fixed substring every
@@ -3962,6 +4017,9 @@ func deploymentMatchesExpectedSettings(ctx Context, params KubernetesDeploymentC
 	ctx.TraceCommand("", "kubectl", args...)
 	output, err := Command("kubectl", args...).CombinedOutput()
 	if err != nil {
+		if sanitized := sanitizeKubectlFailureOutput(string(output)); sanitized != "" {
+			return false, fmt.Errorf("failed to inspect deployment %q: %w: %s", params.Name, err, sanitized)
+		}
 		return false, fmt.Errorf("failed to inspect deployment %q: %w", params.Name, err)
 	}
 

--- a/erun-common/deploy_kubernetes_check_test.go
+++ b/erun-common/deploy_kubernetes_check_test.go
@@ -2,6 +2,7 @@ package eruncommon
 
 import (
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -98,6 +99,97 @@ func TestCheckKubernetesDeploymentWithContextUnreachableAPIServer(t *testing.T) 
 	}
 	if strings.Count(err.Error(), "exit status") > 1 {
 		t.Fatalf("exit status must not be doubled, got: %v", err)
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextSanitizesKlogFrame is erun#1766: the
+// operator-facing message must carry the cause klog's "Unhandled Error" line
+// names (the unreachable address) without the frame around it (severity,
+// timestamp, goroutine id, Go source location) that survives a fixed-width
+// toast while the address gets truncated away.
+func TestCheckKubernetesDeploymentWithContextSanitizesKlogFrame(t *testing.T) {
+	klogLine := `E0831 13:46:43.793908   10289 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://127.0.0.1:6443/api?timeout=32s\": dial tcp 127.0.0.1:6443: connect: connection refused"`
+	writeKubectlStub(t, klogLine, 1)
+	deployed, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "petios-devops"}, "orbstack")
+	if deployed {
+		t.Fatalf("deployed = true, want false when the api server is unreachable")
+	}
+	if err == nil {
+		t.Fatalf("expected an error naming the unreachable cluster, got nil")
+	}
+	message := err.Error()
+	if strings.Contains(message, "memcache.go") {
+		t.Fatalf("error must not carry klog's Go source location, got: %v", message)
+	}
+	if strings.Contains(message, "13:46:43.793908") {
+		t.Fatalf("error must not carry klog's timestamp, got: %v", message)
+	}
+	if regexp.MustCompile(`\b10289\b`).MatchString(message) {
+		t.Fatalf("error must not carry klog's goroutine id, got: %v", message)
+	}
+	if !strings.Contains(message, "127.0.0.1:6443") {
+		t.Fatalf("error must keep the address that names the unreachable target, got: %v", message)
+	}
+	if !strings.Contains(message, "connection refused") {
+		t.Fatalf("error must keep the cause sentence, got: %v", message)
+	}
+	if !strings.Contains(message, `context "orbstack"`) {
+		t.Fatalf("error must name the kube context from erun's own configuration, got: %v", message)
+	}
+}
+
+// TestCheckKubernetesDeploymentWithContextReportsExitStatusPlainlyWhenKubectlWroteNothing
+// covers the empty-output case: a failure with nothing captured must still
+// name the exit status rather than an empty sanitized fragment.
+func TestCheckKubernetesDeploymentWithContextReportsExitStatusPlainlyWhenKubectlWroteNothing(t *testing.T) {
+	writeKubectlStub(t, "", 1)
+	_, _, err := checkKubernetesDeploymentWithContext(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"}, "")
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Fatalf("error must still name the exit status when kubectl wrote nothing, got: %v", err.Error())
+	}
+}
+
+// TestSanitizeKubectlFailureOutputStripsKlogFrame locks the helper itself
+// against the two shapes it must handle: an "Unhandled Error" carrier (unwrap
+// to the err= sentence) and a plain klog line with no such carrier (frame
+// stripped, rest kept verbatim).
+func TestSanitizeKubectlFailureOutputStripsKlogFrame(t *testing.T) {
+	got := sanitizeKubectlFailureOutput(`E0831 13:46:43.793908   10289 memcache.go:265] "Unhandled Error" err="dial tcp 127.0.0.1:6443: connect: connection refused"`)
+	want := "dial tcp 127.0.0.1:6443: connect: connection refused"
+	if got != want {
+		t.Fatalf("sanitizeKubectlFailureOutput() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeKubectlFailureOutputStripsFrameWithNoErrCarrier(t *testing.T) {
+	got := sanitizeKubectlFailureOutput(`W0831 09:00:00.000000       1 warnings.go:70] some deprecation notice`)
+	want := "some deprecation notice"
+	if got != want {
+		t.Fatalf("sanitizeKubectlFailureOutput() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeKubectlFailureOutputReturnsEmptyForBlankInput(t *testing.T) {
+	if got := sanitizeKubectlFailureOutput("   \n\n  "); got != "" {
+		t.Fatalf("sanitizeKubectlFailureOutput() = %q, want empty", got)
+	}
+}
+
+// TestDeploymentMatchesExpectedSettingsIncludesKubectlOutput is erun#1768's
+// pattern applied to the settings-match inspection: kubectl's combined output
+// is already captured, and the caller used to discard it entirely in favor of
+// the content-free "exit status N" a bare "%w" wrap renders.
+func TestDeploymentMatchesExpectedSettingsIncludesKubectlOutput(t *testing.T) {
+	writeKubectlStub(t, `Error from server (NotFound): deployments.apps "frs-devops" not found`, 1)
+	_, err := deploymentMatchesExpectedSettings(testTraceContext(false), KubernetesDeploymentCheckParams{Name: "frs-devops"})
+	if err == nil {
+		t.Fatal("expected an error for a failing kubectl invocation")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error must include kubectl's own output, got: %v", err)
 	}
 }
 

--- a/erun-common/doctor.go
+++ b/erun-common/doctor.go
@@ -150,10 +150,16 @@ func runDoctorKubectl(args []string, stdout io.Writer) (string, error) {
 
 func normalizeDoctorKubectlError(req ShellLaunchParams, stderr string, err error) error {
 	diagnostic := doctorKubectlDiagnostic(req, stderr)
-	if diagnostic == "" {
-		return err
-	}
 	stderr = strings.TrimSpace(stderr)
+	if diagnostic == "" {
+		// No recognized cause, but kubectl's own stderr was still captured --
+		// include it rather than falling back to the bare "%w" (which renders
+		// as content-free "exit status N") that this branch used to return.
+		if stderr == "" {
+			return err
+		}
+		return fmt.Errorf("%w: %s", err, stderr)
+	}
 	if stderr == "" {
 		return fmt.Errorf("%s: %w", diagnostic, err)
 	}

--- a/erun-common/exec_commit.go
+++ b/erun-common/exec_commit.go
@@ -275,6 +275,9 @@ func gitStagedFiles(ctx Context, root string) ([]string, error) {
 	ctx.TraceCommand("", "git", args...)
 	output, err := Command("git", args...).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return nil, fmt.Errorf("%w: %s", err, stderr)
+		}
 		return nil, err
 	}
 	return splitNULSeparatedPaths(output), nil
@@ -297,6 +300,9 @@ func gitChangedWorkingTreeFiles(ctx Context, root string) ([]string, error) {
 		ctx.TraceCommand("", "git", traceArgs...)
 		output, err := Command("git", traceArgs...).Output()
 		if err != nil {
+			if stderr := stderrFromExitError(err); stderr != "" {
+				return fmt.Errorf("%w: %s", err, stderr)
+			}
 			return err
 		}
 		for _, path := range splitNULSeparatedPaths(output) {

--- a/erun-common/exec_commit_stderr_test.go
+++ b/erun-common/exec_commit_stderr_test.go
@@ -1,0 +1,50 @@
+package eruncommon
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeGitStub points ERUN_GIT_BIN at a script that prints stderr and exits
+// non-zero, so a test can drive a failing git invocation deterministically
+// rather than depending on a real git's own version-specific non-repo wording.
+func writeGitStub(t *testing.T, stderr string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/git-stub"
+	script := "#!/bin/sh\ncat <<'EOF' >&2\n" + stderr + "\nEOF\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git stub: %v", err)
+	}
+	t.Setenv("ERUN_GIT_BIN", path)
+}
+
+// TestGitStagedFilesIncludesGitStderr and
+// TestGitChangedWorkingTreeFilesIncludesGitStderr are erun#1768's pattern
+// applied to the git-backed commit helpers: git's own stderr is already
+// captured onto exec.ExitError.Stderr by Output(), and the caller-visible
+// message must include it instead of the content-free "exit status N" a bare
+// "%w" wrap renders.
+func TestGitStagedFilesIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: not a git repository (or any of the parent directories): .git", 128)
+	_, err := gitStagedFiles(testTraceContext(false), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestGitChangedWorkingTreeFilesIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: not a git repository (or any of the parent directories): .git", 128)
+	_, err := gitChangedWorkingTreeFiles(testTraceContext(false), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/exec_gate_merge.go
+++ b/erun-common/exec_gate_merge.go
@@ -185,6 +185,9 @@ func gitResolveRef(ctx Context, root, ref string) (string, error) {
 	ctx.TraceCommand("", "git", "-C", root, "rev-parse", ref)
 	output, err := Command("git", "-C", root, "rev-parse", ref).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, stderr)
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil

--- a/erun-common/exec_gate_merge_stderr_test.go
+++ b/erun-common/exec_gate_merge_stderr_test.go
@@ -1,0 +1,22 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGitResolveRefIncludesGitStderr is erun#1768's pattern applied to the
+// merge-gate's own ref resolution: git's stderr is already captured onto
+// exec.ExitError.Stderr by Output(), and the caller wraps only "%w" (which
+// renders as the content-free "exit status N") around the bare error this
+// used to return.
+func TestGitResolveRefIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: ambiguous argument 'nonexistent-ref': unknown revision or path not in the working tree.", 128)
+	_, err := gitResolveRef(testTraceContext(false), t.TempDir(), "nonexistent-ref")
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "ambiguous argument") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/release.go
+++ b/erun-common/release.go
@@ -524,6 +524,9 @@ func gitRemoteTagExists(ctx Context, projectRoot, remote, tag string) (bool, err
 	ctx.TraceCommand("", "git", "-C", projectRoot, "ls-remote", "--tags", "--refs", remote, "refs/tags/"+tag)
 	output, err := Command("git", "-C", projectRoot, "ls-remote", "--tags", "--refs", remote, "refs/tags/"+tag).CombinedOutput()
 	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return false, fmt.Errorf("%w: %s", err, detail)
+		}
 		return false, err
 	}
 	return strings.TrimSpace(string(output)) != "", nil
@@ -540,6 +543,9 @@ func gitResolvedRef(ctx Context, projectRoot, ref string) (string, bool, error) 
 	if errors.As(err, &exitErr) && exitErr.ExitCode() != 0 {
 		return "", false, nil
 	}
+	if detail := strings.TrimSpace(string(output)); detail != "" {
+		return "", false, fmt.Errorf("%w: %s", err, detail)
+	}
 	return "", false, err
 }
 
@@ -547,6 +553,9 @@ func GitCurrentBranch(ctx Context, projectRoot string) (string, error) {
 	ctx.TraceCommand("", "git", "-C", projectRoot, "rev-parse", "--abbrev-ref", "HEAD")
 	output, err := Command("git", "-C", projectRoot, "rev-parse", "--abbrev-ref", "HEAD").Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, stderr)
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
@@ -556,6 +565,9 @@ func GitShortCommit(ctx Context, projectRoot string) (string, error) {
 	ctx.TraceCommand("", "git", "-C", projectRoot, "rev-parse", "--short", "HEAD")
 	output, err := Command("git", "-C", projectRoot, "rev-parse", "--short", "HEAD").Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, stderr)
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
@@ -598,6 +610,9 @@ func gitWorktreeClean(ctx Context, projectRoot string) (bool, error) {
 	ctx.TraceCommand("", "git", "-C", projectRoot, "status", "--porcelain", "--untracked-files=no")
 	output, err := Command("git", "-C", projectRoot, "status", "--porcelain", "--untracked-files=no").CombinedOutput()
 	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return false, fmt.Errorf("%w: %s", err, detail)
+		}
 		return false, err
 	}
 	return strings.TrimSpace(string(output)) == "", nil
@@ -1477,6 +1492,9 @@ func syncMarketplaceReleaseSHA(ctx Context, spec ReleasePackagingSyncSpec) (Rele
 	}
 	output, err := Command("git", "-C", spec.ProjectRoot, "rev-parse", ref).CombinedOutput()
 	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return ReleaseFileUpdate{}, false, fmt.Errorf("resolve release tag %q: %w: %s", ref, err, detail)
+		}
 		return ReleaseFileUpdate{}, false, fmt.Errorf("resolve release tag %q: %w", ref, err)
 	}
 	sha := strings.TrimSpace(string(output))

--- a/erun-common/release_remote.go
+++ b/erun-common/release_remote.go
@@ -235,6 +235,9 @@ func gitIsAncestorOfHead(projectRoot, commit string) (bool, error) {
 func gitCommitSubject(projectRoot, commit string) (string, error) {
 	output, err := Command("git", "-C", projectRoot, "show", "-s", "--format=%s", commit).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, stderr)
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
@@ -249,6 +252,9 @@ func gitCommitSubject(projectRoot, commit string) (string, error) {
 func findCommitsBySubjectInRange(projectRoot, revRange, subject string) ([]string, error) {
 	output, err := Command("git", "-C", projectRoot, "log", "--format=%H%x01%s", revRange).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return nil, fmt.Errorf("%w: %s", err, stderr)
+		}
 		return nil, err
 	}
 	var matches []string
@@ -264,6 +270,9 @@ func findCommitsBySubjectInRange(projectRoot, revRange, subject string) ([]strin
 func gitTagAnnotationSubject(projectRoot, tag string) (string, error) {
 	output, err := Command("git", "-C", projectRoot, "for-each-ref", "--format=%(contents:subject)", "refs/tags/"+tag).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, stderr)
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil

--- a/erun-common/release_remote_stderr_test.go
+++ b/erun-common/release_remote_stderr_test.go
@@ -1,0 +1,44 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// These are erun#1768's pattern applied to the release tag-replay helpers:
+// git's stderr is already captured onto exec.ExitError.Stderr by Output(),
+// and each caller (findReplayedReleaseTagCommit, moveReleaseTagOnto) folds
+// the bare error straight into an operator-facing message, so dropping the
+// stderr here means that message never carries it either.
+func TestGitCommitSubjectIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: bad object deadbeef", 128)
+	_, err := gitCommitSubject(t.TempDir(), "deadbeef")
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "bad object deadbeef") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestFindCommitsBySubjectInRangeIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: bad revision 'FETCH_HEAD..HEAD'", 128)
+	_, err := findCommitsBySubjectInRange(t.TempDir(), "FETCH_HEAD..HEAD", "some subject")
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "bad revision") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestGitTagAnnotationSubjectIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: unable to resolve refs/tags/v1.0.0", 128)
+	_, err := gitTagAnnotationSubject(t.TempDir(), "v1.0.0")
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "unable to resolve") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/release_repo_claim.go
+++ b/erun-common/release_repo_claim.go
@@ -229,6 +229,9 @@ func writeReleaseRepoClaimBlob(ctx Context, projectRoot, environment string, hol
 	cmd.Stdin = strings.NewReader(string(data))
 	output, err := cmd.Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return "", fmt.Errorf("%w: %s", err, stderr)
+		}
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
@@ -291,6 +294,9 @@ func loadReleaseRepoClaimRecord(ctx Context, projectRoot, remote, ref, version s
 	}
 	output, err := Command("git", "-C", projectRoot, "cat-file", "-p", probe).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return releaseRepoClaimRecord{}, fmt.Errorf("%w: %s", err, stderr)
+		}
 		return releaseRepoClaimRecord{}, err
 	}
 	var record releaseRepoClaimRecord

--- a/erun-common/release_repo_claim_stderr_test.go
+++ b/erun-common/release_repo_claim_stderr_test.go
@@ -1,0 +1,48 @@
+package eruncommon
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWriteReleaseRepoClaimBlobIncludesGitStderr and
+// TestLoadReleaseRepoClaimRecordCatFileIncludesGitStderr are erun#1768's
+// pattern applied to the release-claim CAS helpers: git's stderr is already
+// captured onto exec.ExitError.Stderr by Output(), and each caller (
+// takeReleaseRepoClaim/claimReleaseVersion) used to discard it in favor of
+// the content-free "exit status N" a bare "%w" wrap renders.
+func TestWriteReleaseRepoClaimBlobIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: could not write blob object", 128)
+	now := time.Now()
+	_, err := writeReleaseRepoClaimBlob(testTraceContext(false), t.TempDir(), "prod",
+		EnvironmentActivityLeaseHolder{Tenant: "acme"}, now, now)
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "could not write blob object") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestLoadReleaseRepoClaimRecordCatFileIncludesGitStderr(t *testing.T) {
+	// The fetch itself must succeed so the failure is isolated to the
+	// cat-file read; the stub answers every git invocation with the same
+	// script, so make fetch a no-op success and only cat-file fail.
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$*\" in\n  *cat-file*) echo 'fatal: Not a valid object name probe-ref' >&2; exit 128 ;;\n  *) exit 0 ;;\nesac\n"
+	path := dir + "/git-stub"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write git stub: %v", err)
+	}
+	t.Setenv("ERUN_GIT_BIN", path)
+
+	_, err := loadReleaseRepoClaimRecord(testTraceContext(false), t.TempDir(), "origin", "refs/release-claims/prod", "1.0.0")
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "Not a valid object name") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/release_stderr_test.go
+++ b/erun-common/release_stderr_test.go
@@ -1,0 +1,85 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// These are erun#1768's pattern applied to release.go's git-backed helpers:
+// git's stderr is already captured (onto exec.ExitError.Stderr for Output(),
+// or directly in CombinedOutput()'s own return value), and each caller used
+// to discard it in favor of the content-free "exit status N" a bare "%w"
+// wrap renders.
+func TestGitRemoteTagExistsIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: 'not-a-remote' does not appear to be a git repository", 128)
+	_, err := gitRemoteTagExists(testTraceContext(false), t.TempDir(), "not-a-remote", "v1.0.0")
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "does not appear to be a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestGitResolvedRefIncludesGitOutputForNonExitError(t *testing.T) {
+	// gitResolvedRef treats every *exec.ExitError with a nonzero exit code as
+	// "ref does not exist" (ok=false, err=nil) by design -- only a non-exit
+	// failure (e.g. the git binary itself missing) reaches the bare-error
+	// path, so point ERUN_GIT_BIN at a binary that cannot run at all.
+	t.Setenv("ERUN_GIT_BIN", t.TempDir()+"/does-not-exist")
+	_, ok, err := gitResolvedRef(testTraceContext(false), t.TempDir(), "HEAD")
+	if ok {
+		t.Fatal("expected ok=false when git could not even be started")
+	}
+	if err == nil {
+		t.Fatal("expected an error when git could not even be started")
+	}
+}
+
+func TestGitCurrentBranchIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: not a git repository (or any of the parent directories): .git", 128)
+	_, err := GitCurrentBranch(testTraceContext(false), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestGitShortCommitIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: not a git repository (or any of the parent directories): .git", 128)
+	_, err := GitShortCommit(testTraceContext(false), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestGitWorktreeCleanIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: not a git repository (or any of the parent directories): .git", 128)
+	_, err := gitWorktreeClean(testTraceContext(false), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}
+
+func TestSyncMarketplaceReleaseSHAIncludesGitStderr(t *testing.T) {
+	writeGitStub(t, "fatal: ambiguous argument 'v1.0.0^{}': unknown revision or path not in the working tree.", 128)
+	_, _, err := syncMarketplaceReleaseSHA(testTraceContext(false), ReleasePackagingSyncSpec{
+		ProjectRoot:     t.TempDir(),
+		Version:         "1.0.0",
+		MarketplacePath: "marketplace.yaml",
+	})
+	if err == nil {
+		t.Fatal("expected an error for a failing git invocation")
+	}
+	if !strings.Contains(err.Error(), "ambiguous argument") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/stop.go
+++ b/erun-common/stop.go
@@ -255,6 +255,9 @@ func readAttachedAppSessions(ctx Context, target RuntimeScaleTarget) ([]RemoteAp
 	ctx.TraceCommand("", "kubectl", args...)
 	output, err := Command("kubectl", args...).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return nil, fmt.Errorf("%w: %s", err, stderr)
+		}
 		return nil, err
 	}
 	return ParseRemoteAppSessionHeartbeats(string(output)), nil

--- a/erun-common/stop_stderr_test.go
+++ b/erun-common/stop_stderr_test.go
@@ -1,0 +1,23 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReadAttachedAppSessionsIncludesKubectlStderr is erun#1768's pattern
+// applied to the stop path's attached-session probe: kubectl's stderr is
+// already captured onto exec.ExitError.Stderr by Output(), and
+// traceAttachedAppSessions folds the returned error's message straight into
+// an operator-visible trace line, so dropping the stderr here means that
+// trace line never carries it either.
+func TestReadAttachedAppSessionsIncludesKubectlStderr(t *testing.T) {
+	writeKubectlStub(t, `Error from server (NotFound): deployments.apps "acme-prod" not found`, 1)
+	_, err := readAttachedAppSessions(testTraceContext(false), RuntimeScaleTarget{Tenant: "acme", Environment: "prod", ReleaseName: "acme-prod"})
+	if err == nil {
+		t.Fatal("expected an error for a failing kubectl invocation")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("error must include kubectl's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/work_clone_reclaim.go
+++ b/erun-common/work_clone_reclaim.go
@@ -296,6 +296,9 @@ func gitCommitsAhead(ctx Context, dir, base, tip string) (int, error) {
 	ctx.TraceCommand("", "git", "-C", dir, "rev-list", "--count", rangeSpec)
 	output, err := Command("git", "-C", dir, "rev-list", "--count", rangeSpec).Output()
 	if err != nil {
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return 0, fmt.Errorf("%w: %s", err, stderr)
+		}
 		return 0, err
 	}
 	count, convErr := strconv.Atoi(strings.TrimSpace(string(output)))

--- a/erun-common/work_clone_reclaim_stderr_test.go
+++ b/erun-common/work_clone_reclaim_stderr_test.go
@@ -1,0 +1,23 @@
+package eruncommon
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGitCommitsAheadIncludesGitStderr is erun#1768's pattern applied to the
+// reclaim decision's own comparison: git's stderr is already captured onto
+// exec.ExitError.Stderr by Output(), and decideBranchWorkCloneReclaim folds
+// the returned error's %v straight into the operator-facing Reason field, so
+// dropping the stderr there means the reclaim decision's own explanation
+// never carries it either.
+func TestGitCommitsAheadIncludesGitStderr(t *testing.T) {
+	nonRepo := t.TempDir()
+	_, err := gitCommitsAhead(testTraceContext(false), nonRepo, "a", "b")
+	if err == nil {
+		t.Fatal("expected an error for a non-git directory")
+	}
+	if !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("error must include git's own stderr, got: %v", err)
+	}
+}

--- a/erun-common/workspace_sync.go
+++ b/erun-common/workspace_sync.go
@@ -255,9 +255,25 @@ func remoteOutputsFiles(ctx context.Context, hostAlias, outputsRemote string) ([
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == remoteOutputsDirAbsentExitCode {
 			return nil, nil
 		}
+		if stderr := stderrFromExitError(err); stderr != "" {
+			return nil, fmt.Errorf("list remote outputs: %w: %s", err, stderr)
+		}
 		return nil, fmt.Errorf("list remote outputs: %w", err)
 	}
 	return parseWorkspaceSyncPathList(output), nil
+}
+
+// stderrFromExitError trims the stderr exec.Cmd.Output() captures onto a
+// failed *exec.ExitError, so a caller that wrapped only "%w" (which renders
+// as the content-free "exit status N") can include the process's own
+// diagnostic instead. Returns "" for a non-ExitError (e.g. context
+// cancellation) or an ExitError with nothing on stderr.
+func stderrFromExitError(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return ""
 }
 
 // pruneLocalArtifacts deletes host artifact files no longer present in the pod so

--- a/erun-common/workspace_sync_outputs_test.go
+++ b/erun-common/workspace_sync_outputs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -74,6 +75,40 @@ func TestSyncOutputsArtifactsStillPrunesRemovedArtifactOnSuccessfulListing(t *te
 	}
 	if _, statErr := os.Stat(filepath.Join(artifactsLocal, "keep.exe")); statErr != nil {
 		t.Fatalf("expected the newly listed artifact to be present: %v", statErr)
+	}
+}
+
+// TestRemoteOutputsFilesIncludesSSHStderrInsteadOfBareExitStatus is erun#1768:
+// cmd.Output() already captures ssh's own diagnostic onto exitErr.Stderr, so a
+// failure must surface it rather than the content-free "exit status 255" that
+// %w alone renders.
+func TestRemoteOutputsFilesIncludesSSHStderrInsteadOfBareExitStatus(t *testing.T) {
+	stubWorkspaceSyncSSHForOutputs(t)
+	t.Setenv(workspaceSyncStubOutputsExitEnv, "255")
+	t.Setenv(workspaceSyncStubOutputsStderrEnv, "ssh: connect to host pod port 22: Connection refused")
+
+	_, err := remoteOutputsFiles(context.Background(), "pod", "/home/agent/outputs")
+	if err == nil {
+		t.Fatal("expected the ssh failure to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "Connection refused") {
+		t.Fatalf("error %q does not include ssh's own diagnostic", err.Error())
+	}
+}
+
+// TestRemoteOutputsFilesReportsExitStatusPlainlyWhenSSHWroteNoStderr covers the
+// case where ssh (or find) failed with nothing on stderr: the message must
+// still name the exit status rather than emit an empty, misleading fragment.
+func TestRemoteOutputsFilesReportsExitStatusPlainlyWhenSSHWroteNoStderr(t *testing.T) {
+	stubWorkspaceSyncSSHForOutputs(t)
+	t.Setenv(workspaceSyncStubOutputsExitEnv, "255")
+
+	_, err := remoteOutputsFiles(context.Background(), "pod", "/home/agent/outputs")
+	if err == nil {
+		t.Fatal("expected the ssh failure to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "exit status 255") {
+		t.Fatalf("error %q should still name the exit status when ssh wrote nothing to stderr", err.Error())
 	}
 }
 

--- a/erun-common/workspace_sync_pass_test.go
+++ b/erun-common/workspace_sync_pass_test.go
@@ -17,16 +17,17 @@ import (
 // always correct, and the listing it was handed was not.
 
 const (
-	workspaceSyncSSHStubEnv         = "ERUN_COMMON_TEST_SSH_STUB"
-	workspaceSyncStubIndexEnv       = "ERUN_COMMON_TEST_SSH_STUB_INDEX"
-	workspaceSyncStubMissingEnv     = "ERUN_COMMON_TEST_SSH_STUB_MISSING"
-	workspaceSyncStubStatEnv        = "ERUN_COMMON_TEST_SSH_STUB_STAT"
-	workspaceSyncStubOutputsEnv     = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS"
-	workspaceSyncStubOutputsExitEnv = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS_EXIT"
-	workspaceSyncStubArchiveEnv     = "ERUN_COMMON_TEST_SSH_STUB_ARCHIVE"
-	workspaceSyncStubGateEnv        = "ERUN_COMMON_TEST_SSH_STUB_GATE"
-	workspaceSyncStubTruncateEnv    = "ERUN_COMMON_TEST_SSH_STUB_TRUNCATE"
-	workspaceSyncStubFetchMarkerEnv = "ERUN_COMMON_TEST_SSH_STUB_FETCH_MARKER"
+	workspaceSyncSSHStubEnv           = "ERUN_COMMON_TEST_SSH_STUB"
+	workspaceSyncStubIndexEnv         = "ERUN_COMMON_TEST_SSH_STUB_INDEX"
+	workspaceSyncStubMissingEnv       = "ERUN_COMMON_TEST_SSH_STUB_MISSING"
+	workspaceSyncStubStatEnv          = "ERUN_COMMON_TEST_SSH_STUB_STAT"
+	workspaceSyncStubOutputsEnv       = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS"
+	workspaceSyncStubOutputsExitEnv   = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS_EXIT"
+	workspaceSyncStubOutputsStderrEnv = "ERUN_COMMON_TEST_SSH_STUB_OUTPUTS_STDERR"
+	workspaceSyncStubArchiveEnv       = "ERUN_COMMON_TEST_SSH_STUB_ARCHIVE"
+	workspaceSyncStubGateEnv          = "ERUN_COMMON_TEST_SSH_STUB_GATE"
+	workspaceSyncStubTruncateEnv      = "ERUN_COMMON_TEST_SSH_STUB_TRUNCATE"
+	workspaceSyncStubFetchMarkerEnv   = "ERUN_COMMON_TEST_SSH_STUB_FETCH_MARKER"
 )
 
 // TestMain doubles as the stub `ssh` binary: the test executable is copied onto
@@ -85,6 +86,9 @@ func runWorkspaceSyncSSHStubOutputsListing() int {
 		n, convErr := strconv.Atoi(code)
 		if convErr != nil {
 			return 1
+		}
+		if stderr := os.Getenv(workspaceSyncStubOutputsStderrEnv); stderr != "" {
+			_, _ = os.Stderr.WriteString(stderr)
 		}
 		return n
 	}

--- a/erun-integration/doctor_test.go
+++ b/erun-integration/doctor_test.go
@@ -68,6 +68,32 @@ func TestDoctor(t *testing.T) {
 		golden.Equal(t, "doctor/dry_run_rollback_traces_helm_rollback", normalize.Apply(result.Combined))
 	})
 
+	t.Run("real_run_rollback_failure_reports_helm_stderr", func(t *testing.T) {
+		// erun#1768: RunDeployRecovery's rollback branch always captured
+		// helm's combined output, but runDeployRecoveryActions (the CLI
+		// caller) used to discard it on failure and return the bare error
+		// -- a real rollback failure read as a content-free "exit status
+		// 1" with no explanation of why. It must instead carry helm's own
+		// message.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		fixture.StubBinaryWithScript(t, stubs, "helm", strings.Join([]string{
+			`case "$1" in`,
+			`  status) printf '%s\n' 'NAME: team-devops' 'STATUS: deployed' ;;`,
+			`  rollback) echo 'Error: release: "team-devops": release has no rollback candidate' >&2; exit 1 ;;`,
+			`esac`,
+			`exit 0`,
+		}, "\n"))
+		stubDoctorKubectl(t, stubs, "")
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "helm", "kubectl")...)
+		result := erun.Run(t, []string{"doctor", "team", "dev", "--rollback"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected a non-zero exit for a failed rollback, got 0: %s", result.Combined)
+		}
+		golden.Equal(t, "doctor/real_run_rollback_failure_reports_helm_stderr", normalize.Apply(result.Combined))
+	})
+
 	t.Run("dry_run_clear_pending_helm_traces_kubectl_delete", func(t *testing.T) {
 		// Exercises the deploy-recovery action: --clear-pending-helm
 		// --dry-run must trace the `kubectl delete secrets,configmaps -l
@@ -1417,6 +1443,45 @@ func TestDoctor(t *testing.T) {
 			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
 		}
 		golden.Equal(t, "doctor/real_run_storage_unhealthy_diagnostic_error", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_unrecognized_wait_failure_still_reports_kubectl_stderr", func(t *testing.T) {
+		// erun#1768: kubectl wait fails with a cause doctorKubectlDiagnostic
+		// does not recognize (neither the disk-i/o-error nor the
+		// namespace-lookup-failed shape above matches). Before the fix,
+		// normalizeDoctorKubectlError's unrecognized-cause branch discarded
+		// the captured stderr and returned the bare wrapped error, so the
+		// degraded report read "could not read: exit status 1" with no
+		// explanation. It must instead carry kubectl's own message.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		stubDoctorHelmStatus(t, stubs, "deployed")
+		stubDoctorKubectl(t, stubs, `echo 'Error from server: etcdserver: request timed out' >&2; exit 1`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "helm", "kubectl")...)
+		result := erun.Run(t, []string{"doctor", "team", "dev", "--prune-images"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/real_run_unrecognized_wait_failure_still_reports_kubectl_stderr", normalize.Apply(result.Combined))
+	})
+
+	t.Run("real_run_unrecognized_wait_failure_with_no_stderr_reports_exit_status_plainly", func(t *testing.T) {
+		// erun#1768's empty-stderr case: when kubectl wait fails with
+		// nothing captured on stderr, normalizeDoctorKubectlError has
+		// nothing to add, so the degraded report must still name the exit
+		// status plainly rather than emitting a blank fragment.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		stubs := filepath.Join(setup.Cwd, "stubs")
+		stubDoctorHelmStatus(t, stubs, "deployed")
+		stubDoctorKubectl(t, stubs, `exit 1`)
+		envVars := append(setup.Env(), fixture.StubEnv(stubs, "helm", "kubectl")...)
+		result := erun.Run(t, []string{"doctor", "team", "dev", "--prune-images"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode != 0 {
+			t.Fatalf("exit %d: %s", result.ExitCode, result.Combined)
+		}
+		golden.Equal(t, "doctor/real_run_unrecognized_wait_failure_with_no_stderr_reports_exit_status_plainly", normalize.Apply(result.Combined))
 	})
 
 	t.Run("repair_config_recovers_cloud_context_real_run", func(t *testing.T) {

--- a/erun-integration/open_test.go
+++ b/erun-integration/open_test.go
@@ -183,6 +183,23 @@ func stubKubectlGenericError(t *testing.T, setup env.Setup) []string {
 	return append(envVars, openHostOSOverride)
 }
 
+// stubKubectlKlogFramedError reproduces erun#1766's real captured toast
+// verbatim: client-go's klog "Unhandled Error" carrier around the same
+// connection-refused cause stubKubectlGenericError uses, framed with the
+// severity/timestamp/goroutine-id/source-location an operator can never act
+// on.
+func stubKubectlKlogFramedError(t *testing.T, setup env.Setup) []string {
+	t.Helper()
+	stubs := setup.Cwd + "/stubs"
+	fixture.StubBinaryAdvanced(t, stubs, "kubectl", fixture.StubBinarySpec{
+		Stderr:   `E0831 13:46:43.793908   10289 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"https://127.0.0.1:6443/api?timeout=32s\": dial tcp 127.0.0.1:6443: connect: connection refused"`,
+		ExitCode: 1,
+	})
+	stubLsofNoHolder(t, stubs)
+	envVars := append(setup.Env(), fixture.StubEnv(stubs, "kubectl", "lsof", "ps")...)
+	return append(envVars, openHostOSOverride)
+}
+
 // stubLsofNoHolder keeps the adopt-or-conflict probe silent in scenarios that
 // don't drive it, so a developer's leftover `kubectl port-forward` on an erun
 // default port can't fire the probe mid-scenario and corrupt the golden.
@@ -479,6 +496,28 @@ func TestOpen(t *testing.T) {
 			t.Fatalf("a check that could not ask the cluster must never read as absence, got:\n%s", result.Combined)
 		}
 		golden.Equal(t, "open/no_shell_real_run_check_unreachable_errors_without_claiming_absence", normalize.Apply(result.Combined))
+	})
+
+	t.Run("no_shell_real_run_check_unreachable_sanitizes_klog_framed_error", func(t *testing.T) {
+		// erun#1766: the same unreachable-cluster path above, but with the
+		// exact klog "Unhandled Error" shape client-go actually emits
+		// (severity, timestamp, goroutine id, Go source location wrapping
+		// the real cause). Before the fix, checkKubernetesDeploymentWithContext
+		// pasted this verbatim, so the operator-facing error carried
+		// kubectl-internal noise around the one sentence that named the
+		// unreachable address. It must instead read as the cause alone,
+		// with the kube context named from erun's own config.
+		setup := env.New(t)
+		fixture.SeedTenantEnv(t, setup, "team", "dev")
+		envVars := stubKubectlKlogFramedError(t, setup)
+		result := erun.Run(t, []string{"open", "team", "dev", "--no-shell", "--no-alias-prompt"}, erun.RunOptions{Cwd: setup.Cwd, Env: envVars})
+		if result.ExitCode == 0 {
+			t.Fatalf("expected non-zero exit when the deployment check could not resolve an answer, got 0:\n%s", result.Combined)
+		}
+		if strings.Contains(result.Combined, "is not deployed") {
+			t.Fatalf("a check that could not ask the cluster must never read as absence, got:\n%s", result.Combined)
+		}
+		golden.Equal(t, "open/no_shell_real_run_check_unreachable_sanitizes_klog_framed_error", normalize.Apply(result.Combined))
 	})
 
 	t.Run("alias_prompt_skipped_when_alias_configured", func(t *testing.T) {

--- a/erun-integration/testdata/doctor/real_run_rollback_failure_reports_helm_stderr.txt
+++ b/erun-integration/testdata/doctor/real_run_rollback_failure_reports_helm_stderr.txt
@@ -1,0 +1,20 @@
+Target: team/dev
+== Execution modes ==
+aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
+
+== Helm release status ==
+NAME: team-devops
+STATUS: deployed
+
+== Pods ==
+NAME                READY   STATUS    RESTARTS
+team-devops-pod-1   2/2     Running   0
+
+If the release is stuck pending or an image failed to pull, re-run `erun deploy --force` to rebuild and redeploy, or clear the pending release.
+Running: Roll back to the last successful revision
+audit: erun doctor --rollback team dev
+trace-log: appending the full trace to <TMP>
+==> Doctor team/dev
+==> Doctor failed team/dev: exit status 1: Error: release: "team-devops": release has no rollback candidate
+exit status 1: Error: release: "team-devops": release has no rollback candidate

--- a/erun-integration/testdata/doctor/real_run_unrecognized_wait_failure_still_reports_kubectl_stderr.txt
+++ b/erun-integration/testdata/doctor/real_run_unrecognized_wait_failure_still_reports_kubectl_stderr.txt
@@ -1,0 +1,23 @@
+Target: team/dev
+== Execution modes ==
+aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
+
+== Helm release status ==
+NAME: team-devops
+STATUS: deployed
+
+== Pods ==
+NAME                READY   STATUS    RESTARTS
+team-devops-pod-1   2/2     Running   0
+
+If the release is stuck pending or an image failed to pull, re-run `erun deploy --force` to rebuild and redeploy, or clear the pending release.
+== Docker storage ==
+could not read: exit status 1: Error from server: etcdserver: request timed out
+The runtime pod is not reachable for this check; see the helm release status and pod state reported above for why, then retry once it is running.
+
+Skipping the requested prune action(s) for the same reason.
+audit: erun doctor --prune-images team dev
+trace-log: appending the full trace to <TMP>
+==> Doctor team/dev
+==> Doctor done team/dev

--- a/erun-integration/testdata/doctor/real_run_unrecognized_wait_failure_with_no_stderr_reports_exit_status_plainly.txt
+++ b/erun-integration/testdata/doctor/real_run_unrecognized_wait_failure_with_no_stderr_reports_exit_status_plainly.txt
@@ -1,0 +1,23 @@
+Target: team/dev
+== Execution modes ==
+aws-sts: subprocess
+aws-sts-web-identity-token: subprocess
+
+== Helm release status ==
+NAME: team-devops
+STATUS: deployed
+
+== Pods ==
+NAME                READY   STATUS    RESTARTS
+team-devops-pod-1   2/2     Running   0
+
+If the release is stuck pending or an image failed to pull, re-run `erun deploy --force` to rebuild and redeploy, or clear the pending release.
+== Docker storage ==
+could not read: exit status 1
+The runtime pod is not reachable for this check; see the helm release status and pod state reported above for why, then retry once it is running.
+
+Skipping the requested prune action(s) for the same reason.
+audit: erun doctor --prune-images team dev
+trace-log: appending the full trace to <TMP>
+==> Doctor team/dev
+==> Doctor done team/dev

--- a/erun-integration/testdata/open/no_shell_real_run_check_unreachable_errors_without_claiming_absence.txt
+++ b/erun-integration/testdata/open/no_shell_real_run_check_unreachable_errors_without_claiming_absence.txt
@@ -1,1 +1,1 @@
-could not determine whether deployment "team-devops" is deployed (the kubernetes api server could not be reached): Unable to connect to the server: dial tcp <VERSION>.1:443: i/o timeout
+could not determine whether deployment "team-devops" is deployed (the kubernetes api server could not be reached (context "test-context")): Unable to connect to the server: dial tcp <VERSION>.1:443: i/o timeout

--- a/erun-integration/testdata/open/no_shell_real_run_check_unreachable_sanitizes_klog_framed_error.txt
+++ b/erun-integration/testdata/open/no_shell_real_run_check_unreachable_sanitizes_klog_framed_error.txt
@@ -1,0 +1,1 @@
+could not determine whether deployment "team-devops" is deployed (the kubernetes api server could not be reached (context "test-context")): couldn't get current server API group list: Get "https://<LOOPBACK>:6443/api?timeout=32s": dial tcp <LOOPBACK>:6443: connect: connection refused


### PR DESCRIPTION
## Summary

Two halves of the same story — #1474's fix ("classify the failure and include the tool's own output") landing incompletely — covered in one PR since #1768 is explicitly framed as a sweep for the shape #1474 left uncovered, and #1766's sanitizing rule is the one #1768's fix (1) is told to share.

- **#1768**: `remoteOutputsFiles` (`erun-common/workspace_sync.go`) ran ssh via `cmd.Output()`, which populates `exitErr.Stderr`, and discarded it when wrapping the error — `exit status 255` with no explanation. Fixed, then swept every `cmd.Output()`/`cmd.Run()`/`cmd.CombinedOutput()` call in `erun-common` and `erun-ui` for the same shape. Found 21 more confirmed instances (git/helm/kubectl callers across `doctor.go`, `exec_commit.go`, `release.go`, `release_remote.go`, `release_repo_claim.go`, `work_clone_reclaim.go`, `exec_gate_merge.go`, `deploy.go`, and the CLI's rollback-recovery wrapper in `erun-cli/cmd/doctor.go`) and fixed all of them the same way. A `stderrFromExitError` helper (`erun-common/workspace_sync.go`) is the shared extraction; sites already correctly including captured output were left untouched.
- **#1766**: the kubectl deployment check correctly names its cause (`the kubernetes api server could not be reached`) but then pasted client-go's klog line verbatim — severity, timestamp, goroutine id, and Go source location survive a fixed-width toast while the address the message actually needed gets truncated away. Chose **sanitize at the boundary** (strip the klog frame, keep the `err=` sentence) over splitting the surfaces, consistent with `friendlyRuntimeResizeError`'s existing shape and with how #1760/#1775 handle unsafe/noisy content reaching an operator. Also names the kube context from erun's own config rather than depending on a substring of kubectl's own text surviving truncation. The raw output still reaches the per-env trace log (`ctx.Logger.Debug`, mirrored unconditionally regardless of terminal verbosity) so sanitizing what reaches the operator does not lose the diagnostic.

## Full sweep results

21 BUG sites fixed (stderr/output was captured but discarded on wrap) — see commit 1 for the full list. Also reviewed and intentionally left unchanged:
- **NO-CAPTURE** (6 sites: `release_disk_headroom.go:50`, `build_configured_fingerprint.go:92`, `release_remote.go:224`, `release.go:572`, `build_docker_commands.go:377`, `release_repo_claim.go:289`) — `.Run()` with no `Stdout`/`Stderr` ever wired, so there is nothing to consult; the fix would be adding capture, a different (and separately scoped) change.
- **SILENT** (majority of the remainder) — the error never reaches an operator-facing message at all (best-effort degrade, documented fallback), so it isn't this defect's shape.
- **OK** (the rest) — already includes captured stderr/output, or streams live to `ctx.Stdout`/`ctx.Stderr` before a bare error returns.

## Test plan

- [x] `erun-common`: new unit tests per fixed call site (ssh, git, kubectl, helm stderr-inclusion; empty-stderr plain-exit-status case; klog-frame stripping)
- [x] `erun-integration`: new real-run scenarios — `doctor/real_run_unrecognized_wait_failure_still_reports_kubectl_stderr`, `doctor/real_run_unrecognized_wait_failure_with_no_stderr_reports_exit_status_plainly`, `doctor/real_run_rollback_failure_reports_helm_stderr`, `open/no_shell_real_run_check_unreachable_sanitizes_klog_framed_error`; existing golden `open/no_shell_real_run_check_unreachable_errors_without_claiming_absence` updated for the new context-naming text (an intended behavior change, not a regression)
- [x] `go test ./...` green in `erun-common`, `erun-cli`, `erun-ui`, `erun-integration`
- [x] `make check` green on a fresh (non-cached) run — frontend, chart tests, full integration suite, coverage gate (75.7% ≥ 75.6%)

Closes #1768
Closes #1766