### PR TITLE
Refuse cross-environment MCP calls; wait out a startup port-forward race

### DIFF
--- a/erun-common/mcp_client.go
+++ b/erun-common/mcp_client.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Client side of the per-environment MCP edge. The JSON-RPC round-trip is
@@ -181,6 +182,22 @@ type mcpSession struct {
 	// recovering suppresses a nested re-handshake or tunnel retry so one bad
 	// request costs at most one retry.
 	recovering bool
+	// awaitStartup opts this session into postOnce's bounded first-request wait
+	// (see postOnce). Only the stdio proxy sets it: a relayed client's own
+	// initialize is the one call it will never repeat later in the session if
+	// refused, unlike the typed CLI/desktop callers (CallMCPTool/ListMCPTools),
+	// which already have their own active recovery -- reattaching the
+	// port-forward and retrying -- so a passive wait there would only make an
+	// ordinary "not open" call slower without fixing anything the active
+	// recovery does not already fix.
+	awaitStartup bool
+	// startupWaited marks whether postOnce has already given this session's
+	// first request its bounded wait for the local port to come up. Set on the
+	// first attempt regardless of outcome, so only that one request ever waits.
+	startupWaited bool
+	// startupWait overrides mcpStartupReachabilityWait for tests that need a
+	// bound short enough to run quickly; zero means use the production bound.
+	startupWait time.Duration
 	// notice reports a recovery the caller would otherwise never see; nil when
 	// the caller has nowhere to put diagnostics.
 	notice func(string)
@@ -188,8 +205,10 @@ type mcpSession struct {
 
 // newMCPSession prepares the transport without performing the handshake, so a
 // relay that forwards a client's own initialize can share the header, session,
-// and framing rules with the typed callers.
-func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion string, idleProbe bool) (*mcpSession, error) {
+// and framing rules with the typed callers. awaitStartup is passed straight
+// through to the session -- see mcpSession.awaitStartup for who should (and
+// should not) set it.
+func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion string, idleProbe, awaitStartup bool) (*mcpSession, error) {
 	endpoint = strings.TrimSpace(endpoint)
 	if endpoint == "" {
 		return nil, fmt.Errorf("MCP endpoint is required")
@@ -209,6 +228,7 @@ func newMCPSession(endpoint string, mintToken MCPTokenMinter, clientVersion stri
 		client:        &http.Client{},
 		idleProbe:     idleProbe,
 		localPort:     localMCPEndpointPort(endpoint),
+		awaitStartup:  awaitStartup,
 	}, nil
 }
 
@@ -231,8 +251,14 @@ func localMCPEndpointPort(endpoint string) int {
 	return port
 }
 
+// openMCPSession backs the typed CLI/desktop callers (CallMCPTool,
+// ListMCPTools), which already reattach the port-forward and retry on
+// ErrMCPEndpointUnreachable (see callMCPToolWithReattach in erun-cli), so it
+// does not opt into postOnce's passive startup wait -- doing so would only
+// make an ordinary "not open yet" call slower, not fix anything the active
+// reattach does not already fix.
 func openMCPSession(ctx context.Context, endpoint string, mintToken MCPTokenMinter, clientVersion string, idleProbe bool) (*mcpSession, error) {
-	session, err := newMCPSession(endpoint, mintToken, clientVersion, idleProbe)
+	session, err := newMCPSession(endpoint, mintToken, clientVersion, idleProbe, false)
 	if err != nil {
 		return nil, err
 	}
@@ -357,8 +383,16 @@ func (s *mcpSession) report(message string) {
 // dead: the caller's context deadline (or, with none, no bound at all) would
 // otherwise be the only thing that ever ends the wait. A port nothing holds at
 // all is a different, ordinary case (no port-forward was ever established) and
-// is left to the real request's own dial failure, unchanged.
+// is left to the real request's own dial failure -- except on a session with
+// awaitStartup set, whose very first attempt gets a bounded wait first (see
+// awaitLocalMCPEndpointReachable): a relayed client that spawned this session
+// moments before its own `erun open` finished establishing the forward
+// otherwise fails its one and only initialize call, and most MCP clients never
+// repeat that call later in the session -- unlike every subsequent request,
+// which postRaw's own tunnel-recovery retry above already covers once a
+// session is live.
 func (s *mcpSession) postOnce(ctx context.Context, body []byte) ([]byte, error) {
+	s.awaitStartupOnce(ctx)
 	if s.localPort > 0 && !CanReachLocalMCPEndpoint(s.localPort) && LocalPortIsBound(s.localPort) {
 		return nil, s.staleTunnelError()
 	}
@@ -386,6 +420,27 @@ func (s *mcpSession) postOnce(ctx context.Context, body []byte) ([]byte, error) 
 		return nil, err
 	}
 	return decodeMCPReply(resp)
+}
+
+// startupReachabilityWait is the bound postOnce's first-attempt wait uses:
+// startupWait when a test has overridden it, otherwise the production
+// default.
+func (s *mcpSession) startupReachabilityWait() time.Duration {
+	if s.startupWait > 0 {
+		return s.startupWait
+	}
+	return mcpStartupReachabilityWait
+}
+
+// awaitStartupOnce gives this session's first request a bounded wait for the
+// local port to come up (see postOnce's own comment for why only the first
+// request gets it), and marks the session so no later request waits again.
+func (s *mcpSession) awaitStartupOnce(ctx context.Context) {
+	if !s.awaitStartup || s.localPort <= 0 || s.startupWaited {
+		return
+	}
+	s.startupWaited = true
+	awaitLocalMCPEndpointReachable(ctx, s.localPort, s.startupReachabilityWait())
 }
 
 func (s *mcpSession) newRequest(ctx context.Context, body []byte, token string) (*http.Request, error) {

--- a/erun-common/mcp_client_test.go
+++ b/erun-common/mcp_client_test.go
@@ -1,0 +1,164 @@
+package eruncommon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestPostOnceWaitsForAForwardThatComesUpAfterStartup is the regression test
+// for the reconnect gap: an MCP client's very first request (its own
+// initialize call) used to fail outright when the local port-forward wasn't
+// up yet at session start, and most MCP clients never repeat that call later
+// in the session, so the environment stayed unreachable for the whole session
+// even after `erun open` brought the forward up moments later. postOnce's
+// bounded wait on a session's first attempt (see
+// awaitLocalMCPEndpointReachable) closes that window: this test starts the
+// session against a port nothing holds yet, brings up a listener on that
+// exact port shortly after the request is already in flight, and asserts the
+// request succeeds instead of failing immediately.
+func TestPostOnceWaitsForAForwardThatComesUpAfterStartup(t *testing.T) {
+	port := reserveLoopbackPort(t)
+
+	session, err := newMCPSession(MCPLocalEndpoint(port), func() (string, error) { return "test-token", nil }, "test", false, true)
+	if err != nil {
+		t.Fatalf("newMCPSession: %v", err)
+	}
+	// Shrink the bound so a real regression (no wait at all) fails this test
+	// promptly rather than only within the production 20s bound.
+	session.startupWait = 5 * time.Second
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(300 * time.Millisecond)
+		serveOnLoopbackPort(t, port, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		})
+	}()
+	t.Cleanup(func() { <-done })
+
+	begin := time.Now()
+	_, err = session.postOnce(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	elapsed := time.Since(begin)
+
+	// mcpStatusError turns the 401 this handler answers with into
+	// ErrMCPUnauthorized -- that is success for this test's purposes: it proves
+	// the request reached the edge instead of failing on the earlier dial.
+	if !errors.Is(err, ErrMCPUnauthorized) {
+		t.Fatalf("expected the request to reach the now-up endpoint (unauthorized), got: %v", err)
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("request took %s -- did not return as soon as the endpoint came up", elapsed)
+	}
+}
+
+// TestPostOnceStillFailsPromptlyWhenNothingEverAnswers guards the other side:
+// an environment that is genuinely not open must not hang forever -- it must
+// still fail with the ordinary unreachable error, just after (at most) the
+// bounded wait, and only on this one first attempt.
+func TestPostOnceStillFailsPromptlyWhenNothingEverAnswers(t *testing.T) {
+	port := reserveLoopbackPort(t)
+
+	session, err := newMCPSession(MCPLocalEndpoint(port), func() (string, error) { return "test-token", nil }, "test", false, true)
+	if err != nil {
+		t.Fatalf("newMCPSession: %v", err)
+	}
+	session.startupWait = 300 * time.Millisecond
+
+	begin := time.Now()
+	_, err = session.postOnce(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	elapsed := time.Since(begin)
+
+	if err == nil {
+		t.Fatal("expected an unreachable error when nothing ever answers")
+	}
+	if elapsed < 300*time.Millisecond {
+		t.Fatalf("request failed after only %s -- the wait should still have run once", elapsed)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("request took %s -- the bounded wait did not bound anything", elapsed)
+	}
+
+	// A second attempt on the same session must not wait again -- only the
+	// first ever attempt gets the startup grace period.
+	begin = time.Now()
+	_, err = session.postOnce(context.Background(), []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`))
+	elapsed = time.Since(begin)
+	if err == nil {
+		t.Fatal("expected the second attempt to also fail (nothing is listening)")
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("second attempt took %s -- it should not have waited again", elapsed)
+	}
+}
+
+// TestOpenMCPSessionDoesNotWaitForStartup guards the scoping: the typed
+// CLI/desktop path (openMCPSession, behind CallMCPTool/ListMCPTools) already
+// has its own active recovery -- reattaching the port-forward and retrying --
+// so it must not opt into postOnce's passive wait, which would only make an
+// ordinary "not open yet" call slower for no benefit. Only the stdio proxy
+// (RunMCPStdioProxy) should ever wait.
+func TestOpenMCPSessionDoesNotWaitForStartup(t *testing.T) {
+	port := reserveLoopbackPort(t)
+
+	begin := time.Now()
+	session, err := openMCPSession(context.Background(), MCPLocalEndpoint(port), func() (string, error) { return "test-token", nil }, "test", false)
+	elapsed := time.Since(begin)
+
+	if err == nil {
+		t.Fatal("expected the handshake to fail against a port nothing is listening on")
+	}
+	if !errors.Is(err, ErrMCPEndpointUnreachable) {
+		t.Fatalf("expected an unreachable error, got: %v", err)
+	}
+	if session != nil {
+		t.Fatalf("expected no session on handshake failure, got %+v", session)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("handshake took %s -- the typed CLI/desktop path must fail fast, not wait for startup", elapsed)
+	}
+}
+
+func reserveLoopbackPort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve loopback port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("release reserved port: %v", err)
+	}
+	return port
+}
+
+func serveOnLoopbackPort(t *testing.T, port int, handler http.HandlerFunc) {
+	t.Helper()
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("listen on reserved port %d: %v", port, err)
+	}
+	server := &http.Server{Handler: handler}
+	t.Cleanup(func() { _ = server.Close() })
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	waitForLocalPortReachable(t, port)
+}
+
+func waitForLocalPortReachable(t *testing.T, port int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if CanReachLocalMCPEndpoint(port) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("server on port %d never became reachable", port)
+}

--- a/erun-common/mcp_proxy.go
+++ b/erun-common/mcp_proxy.go
@@ -51,7 +51,10 @@ func RunMCPStdioProxy(ctx context.Context, params MCPStdioProxyParams) error {
 	// Never an idle probe: an MCP client relayed through this proxy is actively
 	// driving the environment (an agent, an operator's tool call), not asking a
 	// diagnostic question, so its calls must register as activity like any other.
-	session, err := newMCPSession(params.Endpoint, params.MintToken, params.ClientVersion, false)
+	// awaitStartup is set: unlike the typed CLI/desktop callers, a relayed
+	// client's own initialize has no active reattach behind it, and is the one
+	// call the client will not repeat later if refused (see mcpSession.awaitStartup).
+	session, err := newMCPSession(params.Endpoint, params.MintToken, params.ClientVersion, false, true)
 	if err != nil {
 		return err
 	}

--- a/erun-common/mcp_reachability.go
+++ b/erun-common/mcp_reachability.go
@@ -1,6 +1,7 @@
 package eruncommon
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -15,6 +16,42 @@ const localMCPProbeTimeout = 1500 * time.Millisecond
 // localPortDialTimeout bounds the "is anything holding this port" check, which
 // only completes a TCP handshake against loopback.
 const localPortDialTimeout = 200 * time.Millisecond
+
+// mcpStartupReachabilityWait bounds awaitLocalMCPEndpointReachable: long
+// enough to cover the ordinary gap between an MCP client session starting and
+// `erun open` finishing the port-forward it depends on, short enough that a
+// genuinely unopened environment still fails within one request rather than
+// hanging the client's handshake indefinitely.
+const mcpStartupReachabilityWait = 20 * time.Second
+
+// mcpStartupReachabilityPoll is how often awaitLocalMCPEndpointReachable
+// re-probes while waiting.
+const mcpStartupReachabilityPoll = 500 * time.Millisecond
+
+// awaitLocalMCPEndpointReachable blocks until the local port answers, wait
+// elapses, or ctx ends -- whichever comes first. It never returns an error and
+// does not report which of those happened: the caller's own dial (or its own
+// already-bound-but-dead check) is what actually decides the request's
+// outcome, so a still-unreachable port after this wait simply proceeds to
+// fail exactly as it would have without the wait, only later.
+func awaitLocalMCPEndpointReachable(ctx context.Context, port int, wait time.Duration) {
+	if port <= 0 || CanReachLocalMCPEndpoint(port) {
+		return
+	}
+	deadline := time.Now().Add(wait)
+	ticker := time.NewTicker(mcpStartupReachabilityPoll)
+	defer ticker.Stop()
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if CanReachLocalMCPEndpoint(port) {
+				return
+			}
+		}
+	}
+}
 
 // LocalMCPEndpoint is the loopback URL a port-forward exposes an environment's
 // MCP edge on.

--- a/erun-mcp/cross_environment_sweep_test.go
+++ b/erun-mcp/cross_environment_sweep_test.go
@@ -1,0 +1,199 @@
+package erunmcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	eruncommon "github.com/sophium/erun/erun-common"
+)
+
+// TestCrossEnvironmentToolsRefuseAForeignEnvironment sweeps every remaining
+// MCP tool that accepts tenant/environment but never checked them against
+// this server's own bound environment: doctor, observe, usage,
+// expose, unexpose, and terraform each resolved (or silently defaulted) a
+// caller-supplied tenant/environment on their own, independent of the
+// resolveLocalTarget/scopedTenantEnv guard every other tool in this module
+// already applied. Preview:true keeps each call from reaching kubectl/helm --
+// the refusal must happen before any of that, which this also proves, since a
+// downstream error would be a different message than assertRefusedForeignTarget
+// checks for.
+func TestCrossEnvironmentToolsRefuseAForeignEnvironment(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"},
+		Store:   usageTestStore("tenant-a", "dev"),
+	}
+	ctx := context.Background()
+
+	_, _, err := doctorTool(runtime)(ctx, nil, DoctorInput{Tenant: "tenant-b", Environment: "prod", Preview: true})
+	assertRefusedForeignTarget(t, "doctor", err)
+
+	_, _, err = observeTool(runtime)(ctx, nil, ObserveInput{Tenant: "tenant-b", Environment: "prod", Preview: true})
+	assertRefusedForeignTarget(t, "observe", err)
+
+	_, _, err = usageTool(runtime)(ctx, nil, UsageInput{Tenant: "tenant-b", Environment: "prod", Preview: true})
+	assertRefusedForeignTarget(t, "usage", err)
+
+	_, _, err = exposeTool(runtime)(ctx, nil, ExposeInput{
+		Tenant: "tenant-b", Environment: "prod", Service: "api", IP: "127.0.0.1", Preview: true,
+	})
+	assertRefusedForeignTarget(t, "expose", err)
+
+	_, _, err = unexposeTool(runtime)(ctx, nil, UnexposeInput{Tenant: "tenant-b", Environment: "prod", Preview: true})
+	assertRefusedForeignTarget(t, "unexpose", err)
+
+	_, _, err = terraformTool(runtime)(ctx, nil, TerraformInput{
+		Tenant: "tenant-b", Environment: "prod", Operation: "plan", Preview: true,
+	})
+	assertRefusedForeignTarget(t, "terraform", err)
+}
+
+// TestDoctorObserveUsageAcceptTheirOwnScope is the flip side: restating or
+// omitting tenant/environment must keep working exactly as before, since
+// plenty of existing callers pass them redundantly.
+func TestDoctorObserveUsageAcceptTheirOwnScope(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "tenant-a", Environment: "dev"},
+		Store:   usageTestStore("tenant-a", "dev"),
+	}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"omitted", "", ""},
+		{"restated", "tenant-a", "dev"},
+	} {
+		t.Run("doctor/"+tc.name, func(t *testing.T) {
+			if _, _, err := doctorTool(runtime)(ctx, nil, DoctorInput{Tenant: tc.tenant, Environment: tc.environment, Preview: true}); err != nil {
+				t.Errorf("doctor refused its own scope: %v", err)
+			}
+		})
+		t.Run("observe/"+tc.name, func(t *testing.T) {
+			if _, _, err := observeTool(runtime)(ctx, nil, ObserveInput{Tenant: tc.tenant, Environment: tc.environment, Preview: true}); err != nil {
+				t.Errorf("observe refused its own scope: %v", err)
+			}
+		})
+		t.Run("usage/"+tc.name, func(t *testing.T) {
+			if _, _, err := usageTool(runtime)(ctx, nil, UsageInput{Tenant: tc.tenant, Environment: tc.environment, Preview: true}); err != nil {
+				t.Errorf("usage refused its own scope: %v", err)
+			}
+		})
+	}
+}
+
+// TestExposeAndUnexposeAcceptTheirOwnScope mirrors the doctor/observe/usage
+// coverage above for the two tools that resolve their target via
+// resolveLocalTarget directly rather than through an OpenResult. ServicesZone
+// and PlatformNamespace are supplied explicitly (mirroring the CLI's
+// --services-zone/--platform-namespace) so the call needs no project on disk.
+func TestExposeAndUnexposeAcceptTheirOwnScope(t *testing.T) {
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "acme", Environment: "dev"},
+		Store: listToolStore{
+			envConfigs: map[string]eruncommon.EnvConfig{
+				"acme/dev": {Name: "dev", Type: eruncommon.EnvironmentTypeRuntime, KubernetesContext: "test-context"},
+			},
+		},
+	}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"omitted", "", ""},
+		{"restated", "acme", "dev"},
+	} {
+		t.Run("expose/"+tc.name, func(t *testing.T) {
+			_, _, err := exposeTool(runtime)(ctx, nil, ExposeInput{
+				Tenant: tc.tenant, Environment: tc.environment,
+				Service: "api", IP: "127.0.0.1",
+				ServicesZone: "zone.test", PlatformNamespace: "ns-test",
+				Preview: true,
+			})
+			if err != nil {
+				t.Errorf("expose refused its own scope: %v", err)
+			}
+		})
+		t.Run("unexpose/"+tc.name, func(t *testing.T) {
+			_, _, err := unexposeTool(runtime)(ctx, nil, UnexposeInput{
+				Tenant: tc.tenant, Environment: tc.environment,
+				ServicesZone: "zone.test", PlatformNamespace: "ns-test",
+				Preview: true,
+			})
+			if err != nil {
+				t.Errorf("unexpose refused its own scope: %v", err)
+			}
+		})
+	}
+}
+
+// terraformTestStore adds ResolveEffectiveKubernetesContext to listToolStore,
+// the one extra method eruncommon.TerraformStore needs beyond OpenStore; the
+// terraform tool falls back to a real eruncommon.ConfigStore (reading this
+// machine's actual ~/.config/erun) when the wired store does not implement
+// TerraformStore, which is not what a hermetic test wants.
+type terraformTestStore struct {
+	listToolStore
+}
+
+func (terraformTestStore) ResolveEffectiveKubernetesContext(_, configured string) string {
+	return configured
+}
+
+// TestTerraformAcceptsItsOwnScope exercises terraform's full resolveLocalTarget
+// -> RunTerraform round trip against a real (temp-dir) terraform root, since
+// ValidateTenantName rejects the hyphenated placeholder tenants used above --
+// terraform is the one swept tool that validates the tenant name itself.
+func TestTerraformAcceptsItsOwnScope(t *testing.T) {
+	projectRoot := t.TempDir()
+	terraformDir := filepath.Join(projectRoot, "terraform-acme", "dev")
+	if err := os.MkdirAll(terraformDir, 0o755); err != nil {
+		t.Fatalf("mkdir terraform root: %v", err)
+	}
+
+	runtime := RuntimeConfig{
+		Context: RuntimeContext{Tenant: "acme", Environment: "dev", RepoPath: projectRoot},
+		Store: terraformTestStore{listToolStore{
+			envConfigs: map[string]eruncommon.EnvConfig{
+				"acme/dev": {Name: "dev", Type: eruncommon.EnvironmentTypeLocalAgent},
+			},
+		}},
+	}
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"omitted", "", ""},
+		{"restated", "acme", "dev"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, output, err := terraformTool(runtime)(ctx, nil, TerraformInput{
+				Tenant: tc.tenant, Environment: tc.environment, Operation: "plan", Preview: true,
+			})
+			if err != nil {
+				t.Fatalf("terraform refused its own scope: %v", err)
+			}
+			if output.Executed {
+				t.Errorf("expected preview to trace without executing, got %+v", output.CommandOutput)
+			}
+		})
+	}
+}

--- a/erun-mcp/doctor.go
+++ b/erun-mcp/doctor.go
@@ -12,8 +12,8 @@ import (
 )
 
 type DoctorInput struct {
-	Tenant                     string                   `json:"tenant,omitempty" jsonschema:"optional explicit tenant override"`
-	Environment                string                   `json:"environment,omitempty" jsonschema:"optional explicit environment override"`
+	Tenant                     string                   `json:"tenant,omitempty" jsonschema:"optional explicit tenant override; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment                string                   `json:"environment,omitempty" jsonschema:"optional explicit environment override; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	PruneImages                bool                     `json:"pruneImages,omitempty" jsonschema:"when true, prune unused Docker images"`
 	PruneBuildCache            bool                     `json:"pruneBuildCache,omitempty" jsonschema:"when true, prune unused BuildKit cache"`
 	PruneContainers            bool                     `json:"pruneContainers,omitempty" jsonschema:"when true, prune stopped Docker containers"`
@@ -87,7 +87,7 @@ func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx erunc
 	if fatal || onlyRootConfigDoctorInput(input) {
 		return report, nil
 	}
-	restoreWasTheWholeRequest, err := runDoctorEnvConfigRestore(input, runCtx, report)
+	restoreWasTheWholeRequest, err := runDoctorEnvConfigRestore(runtime, input, runCtx, report)
 	if err != nil {
 		return report, err
 	}
@@ -102,24 +102,26 @@ func runDoctorToolCommand(runtime RuntimeConfig, input DoctorInput, runCtx erunc
 
 // runDoctorEnvConfigRestore runs the backup-restore leg when one was asked for,
 // reporting whether it was the whole request and nothing else needs to run.
-func runDoctorEnvConfigRestore(input DoctorInput, runCtx eruncommon.Context, report *DoctorRootConfigReport) (bool, error) {
+func runDoctorEnvConfigRestore(runtime RuntimeConfig, input DoctorInput, runCtx eruncommon.Context, report *DoctorRootConfigReport) (bool, error) {
 	selector := strings.TrimSpace(input.RestoreEnvConfigFromBackup)
 	if selector == "" {
 		return false, nil
 	}
-	if err := restoreDoctorEnvConfigFromBackup(runCtx, input, selector, report); err != nil {
+	if err := restoreDoctorEnvConfigFromBackup(runtime, runCtx, input, selector, report); err != nil {
 		return false, err
 	}
 	return onlyEnvConfigRestoreInput(input), nil
 }
 
 // restoreDoctorEnvConfigFromBackup recovers a changed or corrupted env config
-// from a backup before any tenant/env work runs against it.
-func restoreDoctorEnvConfigFromBackup(runCtx eruncommon.Context, input DoctorInput, selector string, report *DoctorRootConfigReport) error {
-	tenant := strings.TrimSpace(input.Tenant)
-	environment := strings.TrimSpace(input.Environment)
-	if tenant == "" || environment == "" {
-		return errors.New("restoreEnvConfigFromBackup requires explicit tenant and environment")
+// from a backup before any tenant/env work runs against it. tenant/environment
+// resolve through resolveLocalTarget so a backup restore, like every other
+// tenant/env action in this module, can never be pointed at an environment
+// this server's pod does not itself run.
+func restoreDoctorEnvConfigFromBackup(runtime RuntimeConfig, runCtx eruncommon.Context, input DoctorInput, selector string, report *DoctorRootConfigReport) error {
+	tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+	if err != nil {
+		return err
 	}
 	livePath, err := eruncommon.EnvConfigPath(tenant, environment)
 	if err != nil {
@@ -436,40 +438,17 @@ func writeDoctorOutput(runCtx eruncommon.Context, stdout, stderr string) error {
 	return nil
 }
 
+// resolveDoctorOpenResult resolves tenant/environment through
+// resolveLocalTarget -- the same refusal every other typed MCP tool in this
+// module applies -- before asking the store to resolve the rest of the
+// OpenResult, so doctor's tenant/env actions can never be pointed at a
+// different environment than the one this server's pod actually runs in.
 func resolveDoctorOpenResult(runtime RuntimeConfig, input DoctorInput) (eruncommon.OpenResult, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	environment := strings.TrimSpace(input.Environment)
-	switch {
-	case tenant != "" && environment != "":
-		return eruncommon.ResolveDoctorTarget(runtime.Store, eruncommon.OpenParams{
-			Tenant:      tenant,
-			Environment: environment,
-		})
-	case tenant != "":
-		return eruncommon.ResolveDoctorTarget(runtime.Store, eruncommon.OpenParams{
-			Tenant:                tenant,
-			UseDefaultEnvironment: true,
-		})
-	case environment != "":
-		return eruncommon.ResolveDoctorTarget(runtime.Store, eruncommon.OpenParams{
-			Environment:      environment,
-			UseDefaultTenant: true,
-		})
+	tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+	if err != nil {
+		return eruncommon.OpenResult{}, err
 	}
-
-	runtimeTenant := strings.TrimSpace(runtime.Context.Tenant)
-	runtimeEnvironment := strings.TrimSpace(runtime.Context.Environment)
-	if runtimeTenant != "" && runtimeEnvironment != "" {
-		return eruncommon.ResolveDoctorTarget(runtime.Store, eruncommon.OpenParams{
-			Tenant:      runtimeTenant,
-			Environment: runtimeEnvironment,
-		})
-	}
-
-	return eruncommon.ResolveDoctorTarget(runtime.Store, eruncommon.OpenParams{
-		UseDefaultTenant:      true,
-		UseDefaultEnvironment: true,
-	})
+	return eruncommon.ResolveDoctorTarget(runtime.Store, eruncommon.OpenParams{Tenant: tenant, Environment: environment})
 }
 
 func doctorActionsFromInput(input DoctorInput) []eruncommon.DoctorAction {

--- a/erun-mcp/exec.go
+++ b/erun-mcp/exec.go
@@ -22,11 +22,15 @@ type RawInput struct {
 	Stdin   string            `json:"stdin,omitempty" jsonschema:"optional stdin to pass to the command; only used in the foreground (wait true)"`
 	Dir     string            `json:"dir,omitempty" jsonschema:"working directory to run from, absolute or relative to the runtime repo root; defaults to the runtime repo root"`
 	Env     map[string]string `json:"env,omitempty" jsonschema:"additional KEY=VALUE environment for the command, on top of what it inherits from the runtime pod; only valid with wait false, since a foreground call already runs in this process's own environment with nothing to extend it with. Values land in the job supervisor's argv, visible to anything that can list processes in this environment, so this is not where secrets belong; PATH, LD_PRELOAD, and a few other names that could redirect what the job executes are refused, as is any ERUN_ name"`
-	// Tenant/Environment, and Name/ID, address a backgrounded command the way
-	// job_start's did; ignored in the foreground, where there is no handle to
-	// address and this server's own context already applies.
-	Tenant          string `json:"tenant,omitempty" jsonschema:"tenant whose environment runs the backgrounded command; only used with wait false. Defaults to the server tenant context, and must match it: this server only acts on its own environment"`
-	Environment     string `json:"environment,omitempty" jsonschema:"environment to run the backgrounded command in; only used with wait false. Defaults to the server environment context, and must match it: this server only acts on its own environment"`
+	// Tenant/Environment must match this server's own scope in both modes (see
+	// resolveLocalTarget/scopedTenantEnv): in the foreground there is no handle
+	// to address, so a value here is validated but otherwise unused, this
+	// server's own context already applies; a mismatch is refused rather than
+	// silently run locally anyway, which is what let a caller believe a
+	// foreground exec_raw had reached a different environment when it had not.
+	// Name/ID address a backgrounded command the way job_start's did.
+	Tenant          string `json:"tenant,omitempty" jsonschema:"tenant whose environment runs the command; defaults to the server tenant context, and must match it: this server only acts on its own environment. In the foreground (wait true) this is validated but otherwise unused, since the command always runs in this process"`
+	Environment     string `json:"environment,omitempty" jsonschema:"environment to run the command in; defaults to the server environment context, and must match it: this server only acts on its own environment. In the foreground (wait true) this is validated but otherwise unused, since the command always runs in this process"`
 	Name            string `json:"name,omitempty" jsonschema:"what the backgrounded command is, shown wherever the environment reports as busy; only used with wait false. Defaults to exec_raw"`
 	ID              string `json:"id,omitempty" jsonschema:"handle to address the backgrounded command by; only used with wait false. Defaults to name, so re-running the same named command keeps one stable handle"`
 	MaxOutputBytes  int64  `json:"maxOutputBytes,omitempty" jsonschema:"cap on captured output in bytes for a backgrounded command; past it output is dropped and the job reports outputTruncated. Only used with wait false. Defaults to 16777216"`
@@ -53,6 +57,9 @@ func rawTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, 
 }
 
 func execRawForeground(runtime RuntimeConfig, input RawInput) (JobEnvelopeOutput, error) {
+	if _, _, err := scopedTenantEnv(input.Tenant, input.Environment, runtime); err != nil {
+		return JobEnvelopeOutput{}, err
+	}
 	traceOutput := new(bytes.Buffer)
 	ctx := runtimeCallContext(input.Preview, input.Verbosity, strings.NewReader(input.Stdin), traceOutput, traceOutput)
 

--- a/erun-mcp/exec_test.go
+++ b/erun-mcp/exec_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -90,6 +91,62 @@ func TestRawToolRefusesEnvInTheForeground(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected a refusal: env only applies to a backgrounded command")
+	}
+}
+
+// TestRawToolRefusesForeignEnvironmentInTheForeground guards the exact gap
+// this was filed for: exec_raw's foreground path (wait true, the default)
+// ran a command locally and reported success even when tenant/environment
+// named a different environment, since nothing checked them. A caller whose
+// first probe was something as generic as `echo hello` had no way to notice
+// it had run in the wrong place; only printing the hostname revealed it.
+func TestRawToolRefusesForeignEnvironmentInTheForeground(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell command")
+	}
+	handler := rawTool(normalizeRuntimeConfig(RuntimeConfig{Context: RuntimeContext{Tenant: "erun", Environment: "code1", RepoPath: t.TempDir()}}))
+
+	_, _, err := handler(context.Background(), nil, RawInput{
+		Command:     []string{"true"},
+		Tenant:      "erun",
+		Environment: "build",
+	})
+	if err == nil {
+		t.Fatal("exec_raw accepted a foreign environment in the foreground instead of refusing it")
+	}
+	if !strings.Contains(err.Error(), "erun/code1") || !strings.Contains(err.Error(), "erun/build") {
+		t.Errorf("refusal should name both the server's own scope (erun/code1) and the requested one (erun/build), got: %v", err)
+	}
+}
+
+// TestRawToolAcceptsItsOwnScopeInTheForeground is the flip side of the refusal
+// above: restating or omitting tenant/environment in the foreground must keep
+// working exactly as before, since plenty of existing callers pass them
+// redundantly.
+func TestRawToolAcceptsItsOwnScopeInTheForeground(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell command")
+	}
+	handler := rawTool(normalizeRuntimeConfig(RuntimeConfig{Context: RuntimeContext{Tenant: "erun", Environment: "code1", RepoPath: t.TempDir()}}))
+
+	for _, tc := range []struct {
+		name        string
+		tenant      string
+		environment string
+	}{
+		{"omitted", "", ""},
+		{"restated", "erun", "code1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := handler(context.Background(), nil, RawInput{
+				Command:     []string{"true"},
+				Tenant:      tc.tenant,
+				Environment: tc.environment,
+			})
+			if err != nil {
+				t.Fatalf("exec_raw refused its own scope (%s): %v", tc.name, err)
+			}
+		})
 	}
 }
 

--- a/erun-mcp/expose.go
+++ b/erun-mcp/expose.go
@@ -9,8 +9,8 @@ import (
 )
 
 type ExposeInput struct {
-	Tenant       string `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the MCP runtime context tenant"`
-	Environment  string `json:"environment,omitempty" jsonschema:"environment name; defaults to the MCP runtime context environment"`
+	Tenant       string `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment  string `json:"environment,omitempty" jsonschema:"environment name; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Service      string `json:"service" jsonschema:"required logical service name; becomes the hostname label and routes to the tenant-scoped in-namespace Service <tenant>-<service> (e.g. api -> frs-api)"`
 	ProjectRoot  string `json:"projectRoot,omitempty" jsonschema:"project root holding the platform config (.erun/config.yaml); defaults to the runtime repo path"`
 	IP           string `json:"ip" jsonschema:"required ingress IP the per-env wildcard record points at (e.g. 127.0.0.1 for a local cluster, the public LB IP for remote)"`
@@ -47,8 +47,10 @@ type ExposeInput struct {
 
 func exposeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, ExposeInput) (*mcp.CallToolResult, JobEnvelopeOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input ExposeInput) (*mcp.CallToolResult, JobEnvelopeOutput, error) {
-		tenant := firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant))
-		environment := firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment))
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, JobEnvelopeOutput{}, err
+		}
 		projectRoot := firstNonEmpty(strings.TrimSpace(input.ProjectRoot), strings.TrimSpace(runtime.Context.RepoPath))
 
 		exposeStore, ok := any(runtime.Store).(eruncommon.ExposeStore)

--- a/erun-mcp/observe.go
+++ b/erun-mcp/observe.go
@@ -15,8 +15,8 @@ type ObserveSecretCheckInput struct {
 }
 
 type ObserveInput struct {
-	Tenant      string                    `json:"tenant,omitempty" jsonschema:"tenant whose environment should be observed; defaults to the server tenant context"`
-	Environment string                    `json:"environment,omitempty" jsonschema:"environment to observe; defaults to the server environment context"`
+	Tenant      string                    `json:"tenant,omitempty" jsonschema:"tenant whose environment should be observed; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string                    `json:"environment,omitempty" jsonschema:"environment to observe; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	Secrets     []ObserveSecretCheckInput `json:"secrets,omitempty" jsonschema:"named Secret/key pairs to check for presence, without reading their values"`
 	Preview     bool                      `json:"preview,omitempty" jsonschema:"when true, resolve and trace the kubectl calls that would run without executing them"`
 	Verbosity   int                       `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
@@ -49,26 +49,15 @@ func observeSecretChecksFromInput(inputs []ObserveSecretCheckInput) []eruncommon
 	return checks
 }
 
-// resolveObserveOpenResult mirrors resolveDoctorOpenResult's explicit ->
-// partial -> runtime-context -> default fallback chain, so `observe` resolves
-// tenant/environment/namespace the same way every other typed MCP tool does.
+// resolveObserveOpenResult resolves tenant/environment through
+// resolveLocalTarget -- the same refusal every other typed MCP tool in this
+// module applies -- before asking the store to resolve the rest of the
+// OpenResult, so `observe` can never be pointed at a different environment
+// than the one this server's pod actually runs in.
 func resolveObserveOpenResult(runtime RuntimeConfig, input ObserveInput) (eruncommon.OpenResult, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	environment := strings.TrimSpace(input.Environment)
-	switch {
-	case tenant != "" && environment != "":
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, Environment: environment})
-	case tenant != "":
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, UseDefaultEnvironment: true})
-	case environment != "":
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Environment: environment, UseDefaultTenant: true})
+	tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+	if err != nil {
+		return eruncommon.OpenResult{}, err
 	}
-
-	runtimeTenant := strings.TrimSpace(runtime.Context.Tenant)
-	runtimeEnvironment := strings.TrimSpace(runtime.Context.Environment)
-	if runtimeTenant != "" && runtimeEnvironment != "" {
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: runtimeTenant, Environment: runtimeEnvironment})
-	}
-
-	return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{UseDefaultTenant: true, UseDefaultEnvironment: true})
+	return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, Environment: environment})
 }

--- a/erun-mcp/runtime.go
+++ b/erun-mcp/runtime.go
@@ -199,10 +199,32 @@ func runtimeFindProjectRoot(runtime RuntimeContext, workDir string) (string, str
 // refusing it, because the result then asserts a target the work never reached
 // and the caller is left holding written evidence that it worked (#1195).
 func resolveLocalTarget(runtime RuntimeConfig, tenant, environment string) (string, string, error) {
-	serverTenant := strings.TrimSpace(runtime.Context.Tenant)
-	serverEnvironment := strings.TrimSpace(runtime.Context.Environment)
-	requestedTenant := strings.TrimSpace(tenant)
-	requestedEnvironment := strings.TrimSpace(environment)
+	resolvedTenant, resolvedEnvironment, err := matchOrDefaultLocalTarget(
+		strings.TrimSpace(runtime.Context.Tenant), strings.TrimSpace(runtime.Context.Environment),
+		tenant, environment,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	if resolvedTenant == "" || resolvedEnvironment == "" {
+		return "", "", errMissingLocalTarget(resolvedTenant == "", resolvedEnvironment == "")
+	}
+	return resolvedTenant, resolvedEnvironment, nil
+}
+
+// matchOrDefaultLocalTarget is the refusal check shared by resolveLocalTarget
+// and scopedTenantEnv: a caller-supplied tenant/environment that names a
+// different environment than this server's own is refused, naming both the
+// server's own scope and the requested one, and pointing at the remedy --
+// call that environment's own MCP edge -- rather than silently substituting
+// the local environment for the requested one. A field left empty by the
+// caller defaults to the server's own identity rather than being required;
+// resolveLocalTarget layers the "both must resolve" requirement on top of
+// that, scopedTenantEnv does not, since some of its callers have no
+// tenant/environment work to do at all.
+func matchOrDefaultLocalTarget(serverTenant, serverEnvironment, requestedTenant, requestedEnvironment string) (tenant, environment string, err error) {
+	requestedTenant = strings.TrimSpace(requestedTenant)
+	requestedEnvironment = strings.TrimSpace(requestedEnvironment)
 	tenantMismatch := requestedTenant != "" && serverTenant != "" && requestedTenant != serverTenant
 	environmentMismatch := requestedEnvironment != "" && serverEnvironment != "" && requestedEnvironment != serverEnvironment
 	if tenantMismatch || environmentMismatch {
@@ -212,12 +234,7 @@ func resolveLocalTarget(runtime RuntimeConfig, tenant, environment string) (stri
 			firstNonEmpty(requestedTenant, serverTenant), firstNonEmpty(requestedEnvironment, serverEnvironment),
 		)
 	}
-	resolvedTenant := firstNonEmpty(requestedTenant, serverTenant)
-	resolvedEnvironment := firstNonEmpty(requestedEnvironment, serverEnvironment)
-	if resolvedTenant == "" || resolvedEnvironment == "" {
-		return "", "", errMissingLocalTarget(resolvedTenant == "", resolvedEnvironment == "")
-	}
-	return resolvedTenant, resolvedEnvironment, nil
+	return firstNonEmpty(requestedTenant, serverTenant), firstNonEmpty(requestedEnvironment, serverEnvironment), nil
 }
 
 // errMissingLocalTarget names exactly what is missing (tenant, environment,

--- a/erun-mcp/tenant_scope.go
+++ b/erun-mcp/tenant_scope.go
@@ -1,27 +1,17 @@
 package erunmcp
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 // scopedTenantEnv confines a per-env MCP server to its own tenant/environment: a
 // caller-supplied tenant/environment that differs from the pod's identity is
-// refused rather than silently honored.
+// refused rather than silently honored (see matchOrDefaultLocalTarget, which
+// resolveLocalTarget also builds on). Unlike resolveLocalTarget, an unresolved
+// target -- both server and caller silent -- is not an error here: some
+// callers (doctor's root-config-only actions) have no tenant/environment work
+// to do at all, so the empty pair simply passes through.
 func scopedTenantEnv(inputTenant, inputEnv string, runtime RuntimeConfig) (tenant, environment string, err error) {
-	tenant = strings.TrimSpace(runtime.Context.Tenant)
-	environment = strings.TrimSpace(runtime.Context.Environment)
-	if t := strings.TrimSpace(inputTenant); t != "" && tenant != "" && t != tenant {
-		return "", "", fmt.Errorf("this MCP server is scoped to tenant %q; refusing to operate on tenant %q", tenant, t)
-	}
-	if e := strings.TrimSpace(inputEnv); e != "" && environment != "" && e != environment {
-		return "", "", fmt.Errorf("this MCP server is scoped to environment %q; refusing to operate on environment %q", environment, e)
-	}
-	if tenant == "" {
-		tenant = strings.TrimSpace(inputTenant)
-	}
-	if environment == "" {
-		environment = strings.TrimSpace(inputEnv)
-	}
-	return tenant, environment, nil
+	return matchOrDefaultLocalTarget(
+		strings.TrimSpace(runtime.Context.Tenant), strings.TrimSpace(runtime.Context.Environment),
+		inputTenant, inputEnv,
+	)
 }

--- a/erun-mcp/tenant_scope_test.go
+++ b/erun-mcp/tenant_scope_test.go
@@ -1,6 +1,9 @@
 package erunmcp
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestScopedTenantEnv(t *testing.T) {
 	pod := RuntimeConfig{Context: RuntimeContext{Tenant: "acme", Environment: "prod"}}
@@ -16,6 +19,7 @@ func TestScopedTenantEnv(t *testing.T) {
 		{name: "mismatched tenant is refused", inTenant: "evil", inEnv: "prod", runtime: pod, wantErr: true},
 		{name: "mismatched environment is refused", inTenant: "acme", inEnv: "staging", runtime: pod, wantErr: true},
 		{name: "unconfigured pod falls back to the input", inTenant: "acme", inEnv: "prod", runtime: RuntimeConfig{}, wantTenant: "acme", wEnv: "prod"},
+		{name: "unconfigured pod and unconfigured input resolve to nothing, without error", runtime: RuntimeConfig{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -33,5 +37,23 @@ func TestScopedTenantEnv(t *testing.T) {
 				t.Fatalf("got tenant=%q env=%q, want %q/%q", tenant, env, tc.wantTenant, tc.wEnv)
 			}
 		})
+	}
+}
+
+// TestScopedTenantEnvRefusalNamesBothScopesAndTheRemedy guards the message
+// quality this fix depends on: a caller reading the error must be able to
+// tell which environment the pod actually serves, which one it asked for
+// instead, and what to do about it (call that environment's own edge), not
+// just that something was refused.
+func TestScopedTenantEnvRefusalNamesBothScopesAndTheRemedy(t *testing.T) {
+	pod := RuntimeConfig{Context: RuntimeContext{Tenant: "erun", Environment: "code1"}}
+	_, _, err := scopedTenantEnv("erun", "build", pod)
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	for _, want := range []string{"erun/code1", "erun/build", "own MCP edge"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal should mention %q, got: %v", want, err)
+		}
 	}
 }

--- a/erun-mcp/terraform.go
+++ b/erun-mcp/terraform.go
@@ -11,8 +11,8 @@ import (
 
 type TerraformInput struct {
 	Operation   string   `json:"operation" jsonschema:"required terraform operation: init (download providers, wire state, record the provider lock — run once before the others), apply (fmt/plan/apply), plan (read-only), or destroy"`
-	Tenant      string   `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the MCP runtime context tenant"`
-	Environment string   `json:"environment,omitempty" jsonschema:"environment name; defaults to the MCP runtime context environment"`
+	Tenant      string   `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string   `json:"environment,omitempty" jsonschema:"environment name; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ProjectRoot string   `json:"projectRoot,omitempty" jsonschema:"project root holding terraform-<tenant>/ or <tenant>-devops/terraform-<tenant>/ (or the paths.terraform base from .erun/config.yaml); defaults to the runtime repo path"`
 	Confirm     string   `json:"confirm,omitempty" jsonschema:"for apply/destroy: restate the environment name to confirm the mutation; required to apply, ignored for plan and preview"`
 	ExtraArgs   []string `json:"extraArgs,omitempty" jsonschema:"extra args passed through to terraform plan"`
@@ -23,8 +23,10 @@ type TerraformInput struct {
 
 func terraformTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, TerraformInput) (*mcp.CallToolResult, JobEnvelopeOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input TerraformInput) (*mcp.CallToolResult, JobEnvelopeOutput, error) {
-		tenant := firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant))
-		environment := firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment))
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, JobEnvelopeOutput{}, err
+		}
 		projectRoot := firstNonEmpty(strings.TrimSpace(input.ProjectRoot), strings.TrimSpace(runtime.Context.RepoPath))
 
 		terraformStore, ok := any(runtime.Store).(eruncommon.TerraformStore)

--- a/erun-mcp/unexpose.go
+++ b/erun-mcp/unexpose.go
@@ -9,8 +9,8 @@ import (
 )
 
 type UnexposeInput struct {
-	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the MCP runtime context tenant"`
-	Environment string `json:"environment,omitempty" jsonschema:"environment name; defaults to the MCP runtime context environment"`
+	Tenant      string `json:"tenant,omitempty" jsonschema:"tenant name; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment string `json:"environment,omitempty" jsonschema:"environment name; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	ProjectRoot string `json:"projectRoot,omitempty" jsonschema:"project root holding the platform config (.erun/config.yaml); defaults to the runtime repo path"`
 	Preview     bool   `json:"preview,omitempty" jsonschema:"when true, resolve and print the planned action without executing it"`
 	Verbosity   int    `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
@@ -30,8 +30,10 @@ type UnexposeInput struct {
 
 func unexposeTool(runtime RuntimeConfig) func(context.Context, *mcp.CallToolRequest, UnexposeInput) (*mcp.CallToolResult, JobEnvelopeOutput, error) {
 	return func(_ context.Context, _ *mcp.CallToolRequest, input UnexposeInput) (*mcp.CallToolResult, JobEnvelopeOutput, error) {
-		tenant := firstNonEmpty(strings.TrimSpace(input.Tenant), strings.TrimSpace(runtime.Context.Tenant))
-		environment := firstNonEmpty(strings.TrimSpace(input.Environment), strings.TrimSpace(runtime.Context.Environment))
+		tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+		if err != nil {
+			return nil, JobEnvelopeOutput{}, err
+		}
 		projectRoot := firstNonEmpty(strings.TrimSpace(input.ProjectRoot), strings.TrimSpace(runtime.Context.RepoPath))
 
 		exposeStore, ok := any(runtime.Store).(eruncommon.ExposeStore)

--- a/erun-mcp/usage.go
+++ b/erun-mcp/usage.go
@@ -3,7 +3,6 @@ package erunmcp
 import (
 	"context"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -11,8 +10,8 @@ import (
 )
 
 type UsageInput struct {
-	Tenant          string  `json:"tenant,omitempty" jsonschema:"tenant whose environment's usage should be read; defaults to the server tenant context"`
-	Environment     string  `json:"environment,omitempty" jsonschema:"environment whose usage should be read; defaults to the server environment context"`
+	Tenant          string  `json:"tenant,omitempty" jsonschema:"tenant whose environment's usage should be read; defaults to the server tenant context, and must match it: this server only acts on its own environment"`
+	Environment     string  `json:"environment,omitempty" jsonschema:"environment whose usage should be read; defaults to the server environment context, and must match it: this server only acts on its own environment"`
 	IntervalSeconds float64 `json:"intervalSeconds,omitempty" jsonschema:"CPU sample window in seconds (clamped to 0.1-30, default 1): usage is read, the window elapses, then it is read again so utilisation is a rate rather than a meaningless cumulative counter"`
 	Preview         bool    `json:"preview,omitempty" jsonschema:"when true, resolve and trace the kubectl exec call that would run without executing it"`
 	Verbosity       int     `json:"verbosity,omitempty" jsonschema:"feedback level matching CLI -v semantics"`
@@ -60,26 +59,15 @@ func usageIntervalFromSeconds(seconds float64) time.Duration {
 	return time.Duration(seconds * float64(time.Second))
 }
 
-// resolveUsageOpenResult mirrors resolveObserveOpenResult's explicit ->
-// partial -> runtime-context -> default fallback chain, so `usage` resolves
-// tenant/environment the same way every other typed MCP tool does.
+// resolveUsageOpenResult resolves tenant/environment through
+// resolveLocalTarget -- the same refusal every other typed MCP tool in this
+// module applies -- before asking the store to resolve the rest of the
+// OpenResult, so `usage` can never be pointed at a different environment than
+// the one this server's pod actually runs in.
 func resolveUsageOpenResult(runtime RuntimeConfig, input UsageInput) (eruncommon.OpenResult, error) {
-	tenant := strings.TrimSpace(input.Tenant)
-	environment := strings.TrimSpace(input.Environment)
-	switch {
-	case tenant != "" && environment != "":
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, Environment: environment})
-	case tenant != "":
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, UseDefaultEnvironment: true})
-	case environment != "":
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Environment: environment, UseDefaultTenant: true})
+	tenant, environment, err := resolveLocalTarget(runtime, input.Tenant, input.Environment)
+	if err != nil {
+		return eruncommon.OpenResult{}, err
 	}
-
-	runtimeTenant := strings.TrimSpace(runtime.Context.Tenant)
-	runtimeEnvironment := strings.TrimSpace(runtime.Context.Environment)
-	if runtimeTenant != "" && runtimeEnvironment != "" {
-		return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: runtimeTenant, Environment: runtimeEnvironment})
-	}
-
-	return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{UseDefaultTenant: true, UseDefaultEnvironment: true})
+	return eruncommon.ResolveOpen(runtime.Store, eruncommon.OpenParams{Tenant: tenant, Environment: environment})
 }


### PR DESCRIPTION
Closes #1782.

## Why

Four environments were linked to an orchestrator mid-session, their MCP servers failed the session-start handshake, and they stayed unusable for the whole session even after `erun open` brought the forwards up and the edges answered `HTTP 200`.

Trying to route around it exposed the more dangerous half:

```
mcp__erun-build__exec_raw(tenant: "erun", environment: "code1",
                          command: ["sh","-c","hostname; printenv ERUN_ENVIRONMENT"])
→ erun-devops-7596bcf9d4-tplw5
  ERUN_ENVIRONMENT=build
```

It ran in `build` and reported success. The first probe was `echo hello`, which returned `hello` and looked like proof the routing worked — only printing the hostname revealed it had not. An orchestrator trusting that probe would dispatch agent jobs into environments already running other work, colliding with a live agent in someone else's worktree.

An argument accepted and disregarded is worse than one rejected, because the caller reads a success.

## Half 2 — refuse the mismatch (the one that must land)

- **`exec_raw`'s foreground path** (`wait: true`, the default — exactly the repro above) never validated `tenant`/`environment` at all. It now refuses a mismatch via `scopedTenantEnv`.
- **`doctor`, `observe`, `usage`** resolved a caller-supplied tenant/environment through the store with no check against the server's own bound identity.
- **`expose`, `unexpose`, `terraform`** silently defaulted a mismatched value (`firstNonEmpty`, no refusal).

All six now go through `resolveLocalTarget`.

- The two near-duplicate guards (`resolveLocalTarget`, `scopedTenantEnv`) are merged into one shared `matchOrDefaultLocalTarget`, so the refusal message and behaviour cannot drift apart again — the same class of split that #1783 found between the CLI and MCP pin paths.
- **`platform_*` tools were checked and deliberately excluded**: they act on a remote platform's own resources by ID via a cloud alias, not on this pod's local environment, so there is no "wrong pod" to refuse.

Matching values keep working exactly as before — many existing callers pass them redundantly.

This follows the precedent #1741 already set, which refuses a runtime environment's terraform from another environment's pod and ships a golden named `refuses_runtime_environment_from_a_different_environments_pod`.

## Half 1 — reachable after all

The reconnect gap turned out not to be purely a client concern. `erun-common/mcp_client.go`'s session now gives a stdio-proxy session's first request (the client's `initialize`) a bounded 20s wait for the local port-forward to come up — scoped so it does not slow the CLI's own `mcp call`/`mcp tools`, which already have active reattach-and-retry.

That makes the remedy the error message already promises actually work.

## Gate

`make check`: all six Go modules `0 issues.`, `Tests 192 passed (192)`, `ok coverage 75.8% (>= 75.6%)`, exit 0.